### PR TITLE
Update debugger interop with stuff from latest dbgeng.h/cvconst.h headers.

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/Debugger/Enums.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Debugger/Enums.cs
@@ -9,37 +9,44 @@ namespace Microsoft.Diagnostics.Runtime.Interop
 {
     public enum SymTag : uint
     {
-        Null,
-        Exe,
-        Compiland,
-        CompilandDetails,
-        CompilandEnv,
-        Function,
-        Block,
-        Data,
-        Annotation,
-        Label,
-        PublicSymbol,
-        UDT,
-        Enum,
-        FunctionType,
-        PointerType,
-        ArrayType,
-        BaseType,
-        Typedef,
-        BaseClass,
-        Friend,
-        FunctionArgType,
-        FuncDebugStart,
-        FuncDebugEnd,
-        UsingNamespace,
-        VTableShape,
-        VTable,
-        Custom,
-        Thunk,
-        CustomType,
-        ManagedType,
-        Dimension,
+        Null,                //  0
+        Exe,                 //  1
+        Compiland,           //  2
+        CompilandDetails,    //  3
+        CompilandEnv,        //  4
+        Function,            //  5
+        Block,               //  6
+        Data,                //  7
+        Annotation,          //  8
+        Label,               //  9
+        PublicSymbol,        // 10
+        UDT,                 // 11
+        Enum,                // 12
+        FunctionType,        // 13
+        PointerType,         // 14
+        ArrayType,           // 15
+        BaseType,            // 16
+        Typedef,             // 17
+        BaseClass,           // 18
+        Friend,              // 19
+        FunctionArgType,     // 20
+        FuncDebugStart,      // 21
+        FuncDebugEnd,        // 22
+        UsingNamespace,      // 23
+        VTableShape,         // 24
+        VTable,              // 25
+        Custom,              // 26
+        Thunk,               // 27
+        CustomType,          // 28
+        ManagedType,         // 29
+        Dimension,           // 30
+        CallSite,            // 31
+        InlineSite,          // 32
+        BaseInterface,       // 33
+        VectorType,          // 34
+        MatrixType,          // 35
+        HLSLType,            // 36
+        SymTagMax
     }
 
     public enum DEBUG_REQUEST : uint
@@ -460,6 +467,7 @@ namespace Microsoft.Diagnostics.Runtime.Interop
     [Flags]
     public enum DEBUG_EVENT : uint
     {
+        NONE = 0,
         BREAKPOINT = 1,
         EXCEPTION = 2,
         CREATE_THREAD = 4,
@@ -500,23 +508,23 @@ namespace Microsoft.Diagnostics.Runtime.Interop
     [Flags]
     public enum DEBUG_CDS_REFRESH : uint
     {
-        EVALUATE = 1,
-        EXECUTE = 2,
-        EXECUTECOMMANDFILE = 3,
-        ADDBREAKPOINT = 4,
-        REMOVEBREAKPOINT = 5,
-        WRITEVIRTUAL = 6,
-        WRITEVIRTUALUNCACHED = 7,
-        WRITEPHYSICAL = 8,
-        WRITEPHYSICAL2 = 9,
-        SETVALUE = 10,
-        SETVALUE2 = 11,
-        SETSCOPE = 12,
-        SETSCOPEFRAMEBYINDEX = 13,
+        EVALUATE                 =  1,
+        EXECUTE                  =  2,
+        EXECUTECOMMANDFILE       =  3,
+        ADDBREAKPOINT            =  4,
+        REMOVEBREAKPOINT         =  5,
+        WRITEVIRTUAL             =  6,
+        WRITEVIRTUALUNCACHED     =  7,
+        WRITEPHYSICAL            =  8,
+        WRITEPHYSICAL2           =  9,
+        SETVALUE                 = 10,
+        SETVALUE2                = 11,
+        SETSCOPE                 = 12,
+        SETSCOPEFRAMEBYINDEX     = 13,
         SETSCOPEFROMJITDEBUGINFO = 14,
-        SETSCOPEFROMSTOREDEVENT = 15,
-        INLINESTEP = 16,
-        INLINESTEP_PSEUDO = 17,
+        SETSCOPEFROMSTOREDEVENT  = 15,
+        INLINESTEP               = 16,
+        INLINESTEP_PSEUDO        = 17,
     }
 
     [Flags]

--- a/src/Microsoft.Diagnostics.Runtime/Debugger/IDebugClient6.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Debugger/IDebugClient6.cs
@@ -1,0 +1,531 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Text;
+using System.Runtime.InteropServices;
+
+#pragma warning disable 1591
+
+namespace Microsoft.Diagnostics.Runtime.Interop
+{
+    [ComImport, InterfaceType(ComInterfaceType.InterfaceIsIUnknown), Guid("e3acb9d7-7ec2-4f0c-a0da-e81e0cbbe628")]
+    public interface IDebugClient6 : IDebugClient5
+    {
+        /* IDebugClient */
+
+        [PreserveSig]
+        new int AttachKernel(
+            [In] DEBUG_ATTACH Flags,
+            [In, MarshalAs(UnmanagedType.LPStr)] string ConnectOptions);
+
+        [PreserveSig]
+        new int GetKernelConnectionOptions(
+            [Out, MarshalAs(UnmanagedType.LPStr)] StringBuilder Buffer,
+            [In] Int32 BufferSize,
+            [Out] out UInt32 OptionsSize);
+
+        [PreserveSig]
+        new int SetKernelConnectionOptions(
+            [In, MarshalAs(UnmanagedType.LPStr)] string Options);
+
+        [PreserveSig]
+        new int StartProcessServer(
+            [In] DEBUG_CLASS Flags,
+            [In, MarshalAs(UnmanagedType.LPStr)] string Options,
+            [In] IntPtr Reserved);
+
+        [PreserveSig]
+        new int ConnectProcessServer(
+            [In, MarshalAs(UnmanagedType.LPStr)] string RemoteOptions,
+            [Out] out UInt64 Server);
+
+        [PreserveSig]
+        new int DisconnectProcessServer(
+            [In] UInt64 Server);
+
+        [PreserveSig]
+        new int GetRunningProcessSystemIds(
+            [In] UInt64 Server,
+            [Out, MarshalAs(UnmanagedType.LPArray)] UInt32[] Ids,
+            [In] UInt32 Count,
+            [Out] out UInt32 ActualCount);
+
+        [PreserveSig]
+        new int GetRunningProcessSystemIdByExecutableName(
+            [In] UInt64 Server,
+            [In, MarshalAs(UnmanagedType.LPStr)] string ExeName,
+            [In] DEBUG_GET_PROC Flags,
+            [Out] out UInt32 Id);
+
+        [PreserveSig]
+        new int GetRunningProcessDescription(
+            [In] UInt64 Server,
+            [In] UInt32 SystemId,
+            [In] DEBUG_PROC_DESC Flags,
+            [Out, MarshalAs(UnmanagedType.LPStr)] StringBuilder ExeName,
+            [In] Int32 ExeNameSize,
+            [Out] out UInt32 ActualExeNameSize,
+            [Out, MarshalAs(UnmanagedType.LPStr)] StringBuilder Description,
+            [In] Int32 DescriptionSize,
+            [Out] out UInt32 ActualDescriptionSize);
+
+        [PreserveSig]
+        new int AttachProcess(
+            [In] UInt64 Server,
+            [In] UInt32 ProcessID,
+            [In] DEBUG_ATTACH AttachFlags);
+
+        [PreserveSig]
+        new int CreateProcess(
+            [In] UInt64 Server,
+            [In, MarshalAs(UnmanagedType.LPStr)] string CommandLine,
+            [In] DEBUG_CREATE_PROCESS Flags);
+
+        [PreserveSig]
+        new int CreateProcessAndAttach(
+            [In] UInt64 Server,
+            [In, MarshalAs(UnmanagedType.LPStr)] string CommandLine,
+            [In] DEBUG_CREATE_PROCESS Flags,
+            [In] UInt32 ProcessId,
+            [In] DEBUG_ATTACH AttachFlags);
+
+        [PreserveSig]
+        new int GetProcessOptions(
+            [Out] out DEBUG_PROCESS Options);
+
+        [PreserveSig]
+        new int AddProcessOptions(
+            [In] DEBUG_PROCESS Options);
+
+        [PreserveSig]
+        new int RemoveProcessOptions(
+            [In] DEBUG_PROCESS Options);
+
+        [PreserveSig]
+        new int SetProcessOptions(
+            [In] DEBUG_PROCESS Options);
+
+        [PreserveSig]
+        new int OpenDumpFile(
+            [In, MarshalAs(UnmanagedType.LPStr)] string DumpFile);
+
+        [PreserveSig]
+        new int WriteDumpFile(
+            [In, MarshalAs(UnmanagedType.LPStr)] string DumpFile,
+            [In] DEBUG_DUMP Qualifier);
+
+        [PreserveSig]
+        new int ConnectSession(
+            [In] DEBUG_CONNECT_SESSION Flags,
+            [In] UInt32 HistoryLimit);
+
+        [PreserveSig]
+        new int StartServer(
+            [In, MarshalAs(UnmanagedType.LPStr)] string Options);
+
+        [PreserveSig]
+        new int OutputServer(
+            [In] DEBUG_OUTCTL OutputControl,
+            [In, MarshalAs(UnmanagedType.LPStr)] string Machine,
+            [In] DEBUG_SERVERS Flags);
+
+        [PreserveSig]
+        new int TerminateProcesses();
+
+        [PreserveSig]
+        new int DetachProcesses();
+
+        [PreserveSig]
+        new int EndSession(
+            [In] DEBUG_END Flags);
+
+        [PreserveSig]
+        new int GetExitCode(
+            [Out] out UInt32 Code);
+
+        [PreserveSig]
+        new int DispatchCallbacks(
+            [In] UInt32 Timeout);
+
+        [PreserveSig]
+        new int ExitDispatch(
+            [In, MarshalAs(UnmanagedType.Interface)] IDebugClient Client);
+
+        [PreserveSig]
+        new int CreateClient(
+            [Out, MarshalAs(UnmanagedType.Interface)] out IDebugClient Client);
+
+        [PreserveSig]
+        new int GetInputCallbacks(
+            [Out, MarshalAs(UnmanagedType.Interface)] out IDebugInputCallbacks Callbacks);
+
+        [PreserveSig]
+        new int SetInputCallbacks(
+            [In, MarshalAs(UnmanagedType.Interface)] IDebugInputCallbacks Callbacks);
+
+        /* GetOutputCallbacks could a conversion thunk from the debugger engine so we can't specify a specific interface */
+
+        [PreserveSig]
+        new int GetOutputCallbacks(
+            [Out] out IntPtr Callbacks);
+
+        /* We may have to pass a debugger engine conversion thunk back in so we can't specify a specific interface */
+
+        [PreserveSig]
+        new int SetOutputCallbacks(
+            [In] IntPtr Callbacks);
+
+        [PreserveSig]
+        new int GetOutputMask(
+            [Out] out DEBUG_OUTPUT Mask);
+
+        [PreserveSig]
+        new int SetOutputMask(
+            [In] DEBUG_OUTPUT Mask);
+
+        [PreserveSig]
+        new int GetOtherOutputMask(
+            [In, MarshalAs(UnmanagedType.Interface)] IDebugClient Client,
+            [Out] out DEBUG_OUTPUT Mask);
+
+        [PreserveSig]
+        new int SetOtherOutputMask(
+            [In, MarshalAs(UnmanagedType.Interface)] IDebugClient Client,
+            [In] DEBUG_OUTPUT Mask);
+
+        [PreserveSig]
+        new int GetOutputWidth(
+            [Out] out UInt32 Columns);
+
+        [PreserveSig]
+        new int SetOutputWidth(
+            [In] UInt32 Columns);
+
+        [PreserveSig]
+        new int GetOutputLinePrefix(
+            [Out, MarshalAs(UnmanagedType.LPStr)] StringBuilder Buffer,
+            [In] Int32 BufferSize,
+            [Out] out UInt32 PrefixSize);
+
+        [PreserveSig]
+        new int SetOutputLinePrefix(
+            [In, MarshalAs(UnmanagedType.LPStr)] string Prefix);
+
+        [PreserveSig]
+        new int GetIdentity(
+            [Out, MarshalAs(UnmanagedType.LPStr)] StringBuilder Buffer,
+            [In] Int32 BufferSize,
+            [Out] out UInt32 IdentitySize);
+
+        [PreserveSig]
+        new int OutputIdentity(
+            [In] DEBUG_OUTCTL OutputControl,
+            [In] UInt32 Flags,
+            [In, MarshalAs(UnmanagedType.LPStr)] string Format);
+
+        /* GetEventCallbacks could a conversion thunk from the debugger engine so we can't specify a specific interface */
+
+        [PreserveSig]
+        new int GetEventCallbacks(
+            [Out] out IntPtr Callbacks);
+
+        /* We may have to pass a debugger engine conversion thunk back in so we can't specify a specific interface */
+
+        [PreserveSig]
+        new int SetEventCallbacks(
+            [In] IntPtr Callbacks);
+
+        [PreserveSig]
+        new int FlushCallbacks();
+
+        /* IDebugClient2 */
+
+        [PreserveSig]
+        new int WriteDumpFile2(
+            [In, MarshalAs(UnmanagedType.LPStr)] string DumpFile,
+            [In] DEBUG_DUMP Qualifier,
+            [In] DEBUG_FORMAT FormatFlags,
+            [In, MarshalAs(UnmanagedType.LPStr)] string Comment);
+
+        [PreserveSig]
+        new int AddDumpInformationFile(
+            [In, MarshalAs(UnmanagedType.LPStr)] string InfoFile,
+            [In] DEBUG_DUMP_FILE Type);
+
+        [PreserveSig]
+        new int EndProcessServer(
+            [In] UInt64 Server);
+
+        [PreserveSig]
+        new int WaitForProcessServerEnd(
+            [In] UInt32 Timeout);
+
+        [PreserveSig]
+        new int IsKernelDebuggerEnabled();
+
+        [PreserveSig]
+        new int TerminateCurrentProcess();
+
+        [PreserveSig]
+        new int DetachCurrentProcess();
+
+        [PreserveSig]
+        new int AbandonCurrentProcess();
+
+        /* IDebugClient3 */
+
+        [PreserveSig]
+        new int GetRunningProcessSystemIdByExecutableNameWide(
+            [In] UInt64 Server,
+            [In, MarshalAs(UnmanagedType.LPWStr)] string ExeName,
+            [In] DEBUG_GET_PROC Flags,
+            [Out] out UInt32 Id);
+
+        [PreserveSig]
+        new int GetRunningProcessDescriptionWide(
+            [In] UInt64 Server,
+            [In] UInt32 SystemId,
+            [In] DEBUG_PROC_DESC Flags,
+            [Out, MarshalAs(UnmanagedType.LPWStr)] StringBuilder ExeName,
+            [In] Int32 ExeNameSize,
+            [Out] out UInt32 ActualExeNameSize,
+            [Out, MarshalAs(UnmanagedType.LPWStr)] StringBuilder Description,
+            [In] Int32 DescriptionSize,
+            [Out] out UInt32 ActualDescriptionSize);
+
+        [PreserveSig]
+        new int CreateProcessWide(
+            [In] UInt64 Server,
+            [In, MarshalAs(UnmanagedType.LPWStr)] string CommandLine,
+            [In] DEBUG_CREATE_PROCESS CreateFlags);
+
+        [PreserveSig]
+        new int CreateProcessAndAttachWide(
+            [In] UInt64 Server,
+            [In, MarshalAs(UnmanagedType.LPWStr)] string CommandLine,
+            [In] DEBUG_CREATE_PROCESS CreateFlags,
+            [In] UInt32 ProcessId,
+            [In] DEBUG_ATTACH AttachFlags);
+
+        /* IDebugClient4 */
+
+        [PreserveSig]
+        new int OpenDumpFileWide(
+            [In, MarshalAs(UnmanagedType.LPWStr)] string FileName,
+            [In] UInt64 FileHandle);
+
+        [PreserveSig]
+        new int WriteDumpFileWide(
+            [In, MarshalAs(UnmanagedType.LPWStr)] string DumpFile,
+            [In] UInt64 FileHandle,
+            [In] DEBUG_DUMP Qualifier,
+            [In] DEBUG_FORMAT FormatFlags,
+            [In, MarshalAs(UnmanagedType.LPWStr)] string Comment);
+
+        [PreserveSig]
+        new int AddDumpInformationFileWide(
+            [In, MarshalAs(UnmanagedType.LPWStr)] string FileName,
+            [In] UInt64 FileHandle,
+            [In] DEBUG_DUMP_FILE Type);
+
+        [PreserveSig]
+        new int GetNumberDumpFiles(
+            [Out] out UInt32 Number);
+
+        [PreserveSig]
+        new int GetDumpFile(
+            [In] UInt32 Index,
+            [Out, MarshalAs(UnmanagedType.LPStr)] StringBuilder Buffer,
+            [In] Int32 BufferSize,
+            [Out] out UInt32 NameSize,
+            [Out] out UInt64 Handle,
+            [Out] out UInt32 Type);
+
+        [PreserveSig]
+        new int GetDumpFileWide(
+            [In] UInt32 Index,
+            [Out, MarshalAs(UnmanagedType.LPWStr)] StringBuilder Buffer,
+            [In] Int32 BufferSize,
+            [Out] out UInt32 NameSize,
+            [Out] out UInt64 Handle,
+            [Out] out UInt32 Type);
+
+        /* IDebugClient5 */
+
+        [PreserveSig]
+        new int AttachKernelWide(
+            [In] DEBUG_ATTACH Flags,
+            [In, MarshalAs(UnmanagedType.LPWStr)] string ConnectOptions);
+
+        [PreserveSig]
+        new int GetKernelConnectionOptionsWide(
+            [Out, MarshalAs(UnmanagedType.LPWStr)] StringBuilder Buffer,
+            [In] Int32 BufferSize,
+            [Out] out UInt32 OptionsSize);
+
+        [PreserveSig]
+        new int SetKernelConnectionOptionsWide(
+            [In, MarshalAs(UnmanagedType.LPWStr)] string Options);
+
+        [PreserveSig]
+        new int StartProcessServerWide(
+            [In] DEBUG_CLASS Flags,
+            [In, MarshalAs(UnmanagedType.LPWStr)] string Options,
+            [In] IntPtr Reserved);
+
+        [PreserveSig]
+        new int ConnectProcessServerWide(
+            [In, MarshalAs(UnmanagedType.LPWStr)] string RemoteOptions,
+            [Out] out UInt64 Server);
+
+        [PreserveSig]
+        new int StartServerWide(
+            [In, MarshalAs(UnmanagedType.LPWStr)] string Options);
+
+        [PreserveSig]
+        new int OutputServersWide(
+            [In] DEBUG_OUTCTL OutputControl,
+            [In, MarshalAs(UnmanagedType.LPWStr)] string Machine,
+            [In] DEBUG_SERVERS Flags);
+
+        /* GetOutputCallbacks could a conversion thunk from the debugger engine so we can't specify a specific interface */
+
+        [PreserveSig]
+        new int GetOutputCallbacksWide(
+            [Out] out IntPtr Callbacks);
+
+        /* We may have to pass a debugger engine conversion thunk back in so we can't specify a specific interface */
+
+        [PreserveSig]
+        new int SetOutputCallbacksWide(
+            [In] IntPtr Callbacks);
+
+        [PreserveSig]
+        new int GetOutputLinePrefixWide(
+            [Out, MarshalAs(UnmanagedType.LPWStr)] StringBuilder Buffer,
+            [In] Int32 BufferSize,
+            [Out] out UInt32 PrefixSize);
+
+        [PreserveSig]
+        new int SetOutputLinePrefixWide(
+            [In, MarshalAs(UnmanagedType.LPWStr)] string Prefix);
+
+        [PreserveSig]
+        new int GetIdentityWide(
+            [Out, MarshalAs(UnmanagedType.LPWStr)] StringBuilder Buffer,
+            [In] Int32 BufferSize,
+            [Out] out UInt32 IdentitySize);
+
+        [PreserveSig]
+        new int OutputIdentityWide(
+            [In] DEBUG_OUTCTL OutputControl,
+            [In] UInt32 Flags,
+            [In, MarshalAs(UnmanagedType.LPWStr)] string Machine);
+
+        /* GetEventCallbacks could a conversion thunk from the debugger engine so we can't specify a specific interface */
+
+        [PreserveSig]
+        new int GetEventCallbacksWide(
+            [Out] out IntPtr Callbacks);
+
+        /* We may have to pass a debugger engine conversion thunk back in so we can't specify a specific interface */
+
+        [PreserveSig]
+        new int SetEventCallbacksWide(
+            [In] IntPtr Callbacks);
+
+        [PreserveSig]
+        new int CreateProcess2(
+            [In] UInt64 Server,
+            [In, MarshalAs(UnmanagedType.LPStr)] string CommandLine,
+            [In] ref DEBUG_CREATE_PROCESS_OPTIONS OptionsBuffer,
+            [In] UInt32 OptionsBufferSize,
+            [In, MarshalAs(UnmanagedType.LPStr)] string InitialDirectory,
+            [In, MarshalAs(UnmanagedType.LPStr)] string Environment);
+
+        [PreserveSig]
+        new int CreateProcess2Wide(
+            [In] UInt64 Server,
+            [In, MarshalAs(UnmanagedType.LPWStr)] string CommandLine,
+            [In] ref DEBUG_CREATE_PROCESS_OPTIONS OptionsBuffer,
+            [In] UInt32 OptionsBufferSize,
+            [In, MarshalAs(UnmanagedType.LPWStr)] string InitialDirectory,
+            [In, MarshalAs(UnmanagedType.LPWStr)] string Environment);
+
+        [PreserveSig]
+        new int CreateProcessAndAttach2(
+            [In] UInt64 Server,
+            [In, MarshalAs(UnmanagedType.LPStr)] string CommandLine,
+            [In] ref DEBUG_CREATE_PROCESS_OPTIONS OptionsBuffer,
+            [In] UInt32 OptionsBufferSize,
+            [In, MarshalAs(UnmanagedType.LPStr)] string InitialDirectory,
+            [In, MarshalAs(UnmanagedType.LPStr)] string Environment,
+            [In] UInt32 ProcessId,
+            [In] DEBUG_ATTACH AttachFlags);
+
+        [PreserveSig]
+        new int CreateProcessAndAttach2Wide(
+            [In] UInt64 Server,
+            [In, MarshalAs(UnmanagedType.LPWStr)] string CommandLine,
+            [In] ref DEBUG_CREATE_PROCESS_OPTIONS OptionsBuffer,
+            [In] UInt32 OptionsBufferSize,
+            [In, MarshalAs(UnmanagedType.LPWStr)] string InitialDirectory,
+            [In, MarshalAs(UnmanagedType.LPWStr)] string Environment,
+            [In] UInt32 ProcessId,
+            [In] DEBUG_ATTACH AttachFlags);
+
+        [PreserveSig]
+        new int PushOutputLinePrefix(
+            [In, MarshalAs(UnmanagedType.LPStr)] string NewPrefix,
+            [Out] out UInt64 Handle);
+
+        [PreserveSig]
+        new int PushOutputLinePrefixWide(
+            [In, MarshalAs(UnmanagedType.LPWStr)] string NewPrefix,
+            [Out] out UInt64 Handle);
+
+        [PreserveSig]
+        new int PopOutputLinePrefix(
+            [In] UInt64 Handle);
+
+        [PreserveSig]
+        new int GetNumberInputCallbacks(
+            [Out] out UInt32 Count);
+
+        [PreserveSig]
+        new int GetNumberOutputCallbacks(
+            [Out] out UInt32 Count);
+
+        [PreserveSig]
+        new int GetNumberEventCallbacks(
+            [In] DEBUG_EVENT Flags,
+            [Out] out UInt32 Count);
+
+        [PreserveSig]
+        new int GetQuitLockString(
+            [Out, MarshalAs(UnmanagedType.LPStr)] StringBuilder Buffer,
+            [In] Int32 BufferSize,
+            [Out] out UInt32 StringSize);
+
+        [PreserveSig]
+        new int SetQuitLockString(
+            [In, MarshalAs(UnmanagedType.LPStr)] string LockString);
+
+        [PreserveSig]
+        new int GetQuitLockStringWide(
+            [Out, MarshalAs(UnmanagedType.LPWStr)] StringBuilder Buffer,
+            [In] Int32 BufferSize,
+            [Out] out UInt32 StringSize);
+
+        [PreserveSig]
+        new int SetQuitLockStringWide(
+            [In, MarshalAs(UnmanagedType.LPWStr)] string LockString);
+
+        /* IDebugClient6 */
+
+        [PreserveSig]
+        int SetEventContextCallbacks(
+            [In] IntPtr Callbacks);
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/Debugger/IDebugControl.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Debugger/IDebugControl.cs
@@ -421,13 +421,13 @@ namespace Microsoft.Diagnostics.Runtime.Interop
 
         [PreserveSig]
         int GetWindbgExtensionApis32(
-            [In, Out] ref WINDBG_EXTENSION_APIS32 Api);
+            [In, Out] ref WINDBG_EXTENSION_APIS Api);
 
         /* Must be In and Out as the nSize member has to be initialized */
 
         [PreserveSig]
         int GetWindbgExtensionApis64(
-            [In, Out] ref WINDBG_EXTENSION_APIS64 Api);
+            [In, Out] ref WINDBG_EXTENSION_APIS Api);
 
         /* Must be In and Out as the nSize member has to be initialized */
 

--- a/src/Microsoft.Diagnostics.Runtime/Debugger/IDebugControl2.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Debugger/IDebugControl2.cs
@@ -421,13 +421,13 @@ namespace Microsoft.Diagnostics.Runtime.Interop
 
         [PreserveSig]
         new int GetWindbgExtensionApis32(
-            [In, Out] ref WINDBG_EXTENSION_APIS32 Api);
+            [In, Out] ref WINDBG_EXTENSION_APIS Api);
 
         /* Must be In and Out as the nSize member has to be initialized */
 
         [PreserveSig]
         new int GetWindbgExtensionApis64(
-            [In, Out] ref WINDBG_EXTENSION_APIS64 Api);
+            [In, Out] ref WINDBG_EXTENSION_APIS Api);
 
         /* Must be In and Out as the nSize member has to be initialized */
 

--- a/src/Microsoft.Diagnostics.Runtime/Debugger/IDebugControl3.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Debugger/IDebugControl3.cs
@@ -421,13 +421,13 @@ namespace Microsoft.Diagnostics.Runtime.Interop
 
         [PreserveSig]
         new int GetWindbgExtensionApis32(
-            [In, Out] ref WINDBG_EXTENSION_APIS32 Api);
+            [In, Out] ref WINDBG_EXTENSION_APIS Api);
 
         /* Must be In and Out as the nSize member has to be initialized */
 
         [PreserveSig]
         new int GetWindbgExtensionApis64(
-            [In, Out] ref WINDBG_EXTENSION_APIS64 Api);
+            [In, Out] ref WINDBG_EXTENSION_APIS Api);
 
         /* Must be In and Out as the nSize member has to be initialized */
 

--- a/src/Microsoft.Diagnostics.Runtime/Debugger/IDebugControl4.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Debugger/IDebugControl4.cs
@@ -421,13 +421,13 @@ namespace Microsoft.Diagnostics.Runtime.Interop
 
         [PreserveSig]
         new int GetWindbgExtensionApis32(
-            [In, Out] ref WINDBG_EXTENSION_APIS32 Api);
+            [In, Out] ref WINDBG_EXTENSION_APIS Api);
 
         /* Must be In and Out as the nSize member has to be initialized */
 
         [PreserveSig]
         new int GetWindbgExtensionApis64(
-            [In, Out] ref WINDBG_EXTENSION_APIS64 Api);
+            [In, Out] ref WINDBG_EXTENSION_APIS Api);
 
         /* Must be In and Out as the nSize member has to be initialized */
 

--- a/src/Microsoft.Diagnostics.Runtime/Debugger/IDebugControl5.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Debugger/IDebugControl5.cs
@@ -421,13 +421,13 @@ namespace Microsoft.Diagnostics.Runtime.Interop
 
         [PreserveSig]
         new int GetWindbgExtensionApis32(
-            [In, Out] ref WINDBG_EXTENSION_APIS32 Api);
+            [In, Out] ref WINDBG_EXTENSION_APIS Api);
 
         /* Must be In and Out as the nSize member has to be initialized */
 
         [PreserveSig]
         new int GetWindbgExtensionApis64(
-            [In, Out] ref WINDBG_EXTENSION_APIS64 Api);
+            [In, Out] ref WINDBG_EXTENSION_APIS Api);
 
         /* Must be In and Out as the nSize member has to be initialized */
 

--- a/src/Microsoft.Diagnostics.Runtime/Debugger/IDebugControl6.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Debugger/IDebugControl6.cs
@@ -421,13 +421,13 @@ namespace Microsoft.Diagnostics.Runtime.Interop
 
         [PreserveSig]
         new int GetWindbgExtensionApis32(
-            [In, Out] ref WINDBG_EXTENSION_APIS32 Api);
+            [In, Out] ref WINDBG_EXTENSION_APIS Api);
 
         /* Must be In and Out as the nSize member has to be initialized */
 
         [PreserveSig]
         new int GetWindbgExtensionApis64(
-            [In, Out] ref WINDBG_EXTENSION_APIS64 Api);
+            [In, Out] ref WINDBG_EXTENSION_APIS Api);
 
         /* Must be In and Out as the nSize member has to be initialized */
 

--- a/src/Microsoft.Diagnostics.Runtime/Debugger/IDebugEventContextCallbacks.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Debugger/IDebugEventContextCallbacks.cs
@@ -1,0 +1,116 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.InteropServices;
+
+#pragma warning disable 1591
+
+namespace Microsoft.Diagnostics.Runtime.Interop
+{
+    [ComImport, InterfaceType(ComInterfaceType.InterfaceIsIUnknown), Guid("61a4905b-23f9-4247-b3c5-53d087529ab7")]
+    public unsafe interface IDebugEventContextCallbacks
+    {
+        [PreserveSig]
+        int GetInterestMask(
+            [Out] out DEBUG_EVENT Mask);
+
+        [PreserveSig]
+        int Breakpoint(
+            [In, MarshalAs(UnmanagedType.Interface)] IDebugBreakpoint2 Bp,
+            [In] DEBUG_EVENT_CONTEXT* Context,
+            [In] uint ContextSize);
+
+        [PreserveSig]
+        int Exception(
+            [In] ref EXCEPTION_RECORD64 Exception,
+            [In] UInt32 FirstChance,
+            [In] DEBUG_EVENT_CONTEXT* Context,
+            [In] uint ContextSize);
+
+        [PreserveSig]
+        int CreateThread(
+            [In] UInt64 Handle,
+            [In] UInt64 DataOffset,
+            [In] UInt64 StartOffset,
+            [In] DEBUG_EVENT_CONTEXT* Context,
+            [In] uint ContextSize);
+
+        [PreserveSig]
+        int ExitThread(
+            [In] UInt32 ExitCode,
+            [In] DEBUG_EVENT_CONTEXT* Context,
+            [In] uint ContextSize);
+
+        [PreserveSig]
+        int CreateProcess(
+            [In] UInt64 ImageFileHandle,
+            [In] UInt64 Handle,
+            [In] UInt64 BaseOffset,
+            [In] UInt32 ModuleSize,
+            [In, MarshalAs(UnmanagedType.LPWStr)] string ModuleName,
+            [In, MarshalAs(UnmanagedType.LPWStr)] string ImageName,
+            [In] UInt32 CheckSum,
+            [In] UInt32 TimeDateStamp,
+            [In] UInt64 InitialThreadHandle,
+            [In] UInt64 ThreadDataOffset,
+            [In] UInt64 StartOffset,
+            [In] DEBUG_EVENT_CONTEXT* Context,
+            [In] uint ContextSize);
+
+        [PreserveSig]
+        int ExitProcess(
+            [In] UInt32 ExitCode,
+            [In] DEBUG_EVENT_CONTEXT* Context,
+            [In] uint ContextSize);
+
+        [PreserveSig]
+        int LoadModule(
+            [In] UInt64 ImageFileHandle,
+            [In] UInt64 BaseOffset,
+            [In] UInt32 ModuleSize,
+            [In, MarshalAs(UnmanagedType.LPWStr)] string ModuleName,
+            [In, MarshalAs(UnmanagedType.LPWStr)] string ImageName,
+            [In] UInt32 CheckSum,
+            [In] UInt32 TimeDateStamp,
+            [In] DEBUG_EVENT_CONTEXT* Context,
+            [In] uint ContextSize);
+
+        [PreserveSig]
+        int UnloadModule(
+            [In, MarshalAs(UnmanagedType.LPWStr)] string ImageBaseName,
+            [In] UInt64 BaseOffset,
+            [In] DEBUG_EVENT_CONTEXT* Context,
+            [In] uint ContextSize);
+
+        [PreserveSig]
+        int SystemError(
+            [In] UInt32 Error,
+            [In] UInt32 Level,
+            [In] DEBUG_EVENT_CONTEXT* Context,
+            [In] uint ContextSize);
+
+        [PreserveSig]
+        int SessionStatus(
+            [In] DEBUG_SESSION Status);
+
+        [PreserveSig]
+        int ChangeDebuggeeState(
+            [In] DEBUG_CDS Flags,
+            [In] UInt64 Argument,
+            [In] DEBUG_EVENT_CONTEXT* Context,
+            [In] uint ContextSize);
+
+        [PreserveSig]
+        int ChangeEngineState(
+            [In] DEBUG_CES Flags,
+            [In] UInt64 Argument,
+            [In] DEBUG_EVENT_CONTEXT* Context,
+            [In] uint ContextSize);
+
+        [PreserveSig]
+        int ChangeSymbolState(
+            [In] DEBUG_CSS Flags,
+            [In] UInt64 Argument);
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/Debugger/IDebugSymbols3.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Debugger/IDebugSymbols3.cs
@@ -783,6 +783,7 @@ namespace Microsoft.Diagnostics.Runtime.Interop
             [Out] out UInt32 RegionsAvail
             );
 
+        [Obsolete( "Do not use: no longer implemented.", true )]
         [PreserveSig]
         int GetSymbolEntryBySymbolEntry(
             [In, MarshalAs(UnmanagedType.LPStruct)] DEBUG_MODULE_AND_ID FromId,

--- a/src/Microsoft.Diagnostics.Runtime/Debugger/IDebugSymbols4.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Debugger/IDebugSymbols4.cs
@@ -783,6 +783,7 @@ namespace Microsoft.Diagnostics.Runtime.Interop
             [Out] out UInt32 RegionsAvail
             );
 
+        [Obsolete( "Do not use: no longer implemented.", true )]
         [PreserveSig]
         new int GetSymbolEntryBySymbolEntry(
             [In, MarshalAs(UnmanagedType.LPStruct)] DEBUG_MODULE_AND_ID FromId,

--- a/src/Microsoft.Diagnostics.Runtime/Debugger/IDebugSymbols5.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Debugger/IDebugSymbols5.cs
@@ -783,6 +783,7 @@ namespace Microsoft.Diagnostics.Runtime.Interop
             [Out] out UInt32 RegionsAvail
             );
 
+        [Obsolete( "Do not use: no longer implemented.", true )]
         [PreserveSig]
         new int GetSymbolEntryBySymbolEntry(
             [In, MarshalAs(UnmanagedType.LPStruct)] DEBUG_MODULE_AND_ID FromId,

--- a/src/Microsoft.Diagnostics.Runtime/Debugger/Structs.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Debugger/Structs.cs
@@ -381,24 +381,7 @@ namespace Microsoft.Diagnostics.Runtime.Interop
     }
 
     [StructLayout(LayoutKind.Sequential)]
-    public struct WINDBG_EXTENSION_APIS32
-    {
-        public UInt32 nSize;
-        public IntPtr lpOutputRoutine;
-        public IntPtr lpGetExpressionRoutine;
-        public IntPtr lpGetSymbolRoutine;
-        public IntPtr lpDisasmRoutine;
-        public IntPtr lpCheckControlCRoutine;
-        public IntPtr lpReadProcessMemoryRoutine;
-        public IntPtr lpWriteProcessMemoryRoutine;
-        public IntPtr lpGetThreadContextRoutine;
-        public IntPtr lpSetThreadContextRoutine;
-        public IntPtr lpIoctlRoutine;
-        public IntPtr lpStackTraceRoutine;
-    }
-
-    [StructLayout(LayoutKind.Sequential)]
-    public struct WINDBG_EXTENSION_APIS64
+    public struct WINDBG_EXTENSION_APIS/*32 or 64; both are defined the same in managed code*/
     {
         public UInt32 nSize;
         public IntPtr lpOutputRoutine;
@@ -1058,6 +1041,12 @@ namespace Microsoft.Diagnostics.Runtime.Interop
     }
 
     [StructLayout(LayoutKind.Sequential)]
+    public struct DEBUG_LAST_EVENT_INFO_EXIT_PROCESS
+    {
+        public uint ExitCode;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
     public struct DEBUG_LAST_EVENT_INFO_LOAD_MODULE
     {
         public ulong Base;
@@ -1075,5 +1064,26 @@ namespace Microsoft.Diagnostics.Runtime.Interop
     {
         public uint Error;
         public uint Level;
+    }
+
+    [StructLayout(LayoutKind.Explicit)]
+    public struct DEBUG_LAST_EVENT_INFO
+    {
+        [FieldOffset(0)] public DEBUG_LAST_EVENT_INFO_BREAKPOINT Breakpoint;
+        [FieldOffset(0)] public DEBUG_LAST_EVENT_INFO_EXCEPTION Exception;
+        [FieldOffset(0)] public DEBUG_LAST_EVENT_INFO_EXIT_THREAD ExitThread;
+        [FieldOffset(0)] public DEBUG_LAST_EVENT_INFO_EXIT_PROCESS ExitProcess;
+        [FieldOffset(0)] public DEBUG_LAST_EVENT_INFO_LOAD_MODULE LoadModule;
+        [FieldOffset(0)] public DEBUG_LAST_EVENT_INFO_UNLOAD_MODULE UnloadModule;
+        [FieldOffset(0)] public DEBUG_LAST_EVENT_INFO_SYSTEM_ERROR SystemError;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct DEBUG_EVENT_CONTEXT
+    {
+        public uint Size;
+        public uint ProcessEngineId;
+        public uint ThreadEngineId;
+        public uint FrameEngineId;
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/Desktop/legacyruntime.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Desktop/legacyruntime.cs
@@ -669,7 +669,7 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
             IMethodDescData result = GetMethodDescData(DacRequests.METHODDESC_IP_DATA, ip);
             if (result != null)
                 return result;
-            
+
             ulong methodDesc = GetMethodDescFromIp(ip);
             if (methodDesc != 0)
                 return GetMethodDescData(DacRequests.METHODDESC_DATA, ip);
@@ -1733,7 +1733,7 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
         public short wNumStaticFields;
         public uint dwClassDomainNeutralIndex;
         public uint dwAttrClass; // cached metadata
-        public uint token; // Metadata token    
+        public uint token; // Metadata token
 
         public ulong addrFirstField; // If non-null, you can retrieve more
 
@@ -2117,7 +2117,7 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
         public short wNumThreadStaticFields;
         public uint dwClassDomainNeutralIndex;
         public uint dwAttrClass; // cached metadata
-        public uint token; // Metadata token    
+        public uint token; // Metadata token
 
         public ulong addrFirstField; // If non-null, you can retrieve more
 

--- a/src/Microsoft.Diagnostics.Runtime/Desktop/threads.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Desktop/threads.cs
@@ -420,27 +420,27 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
         {
             //TS_Unknown                = 0x00000000,    // threads are initialized this way
 
-            TS_AbortRequested = 0x00000001,    // Abort the thread
-            TS_GCSuspendPending = 0x00000002,    // waiting to get to safe spot for GC
-            TS_UserSuspendPending = 0x00000004,    // user suspension at next opportunity
-            TS_DebugSuspendPending = 0x00000008,    // Is the debugger suspending threads?
-                                                    //TS_GCOnTransitions        = 0x00000010,    // Force a GC on stub transitions (GCStress only)
+            TS_AbortRequested         = 0x00000001,    // Abort the thread
+            TS_GCSuspendPending       = 0x00000002,    // waiting to get to safe spot for GC
+            TS_UserSuspendPending     = 0x00000004,    // user suspension at next opportunity
+            TS_DebugSuspendPending    = 0x00000008,    // Is the debugger suspending threads?
+            //TS_GCOnTransitions        = 0x00000010,    // Force a GC on stub transitions (GCStress only)
 
             //TS_LegalToJoin            = 0x00000020,    // Is it now legal to attempt a Join()
             //TS_YieldRequested         = 0x00000040,    // The task should yield
             //TS_Hijacked               = 0x00000080,    // Return address has been hijacked
             //TS_BlockGCForSO           = 0x00000100,    // If a thread does not have enough stack, WaitUntilGCComplete may fail.
-            // Either GC suspension will wait until the thread has cleared this bit,
-            // Or the current thread is going to spin if GC has suspended all threads.
-            TS_Background = 0x00000200,    // Thread is a background thread
-            TS_Unstarted = 0x00000400,    // Thread has never been started
-            TS_Dead = 0x00000800,    // Thread is dead
+                                                       // Either GC suspension will wait until the thread has cleared this bit,
+                                                       // Or the current thread is going to spin if GC has suspended all threads.
+            TS_Background             = 0x00000200,    // Thread is a background thread
+            TS_Unstarted              = 0x00000400,    // Thread has never been started
+            TS_Dead                   = 0x00000800,    // Thread is dead
 
             //TS_WeOwn                  = 0x00001000,    // Exposed object initiated this thread
-            TS_CoInitialized = 0x00002000,    // CoInitialize has been called for this thread
+            TS_CoInitialized          = 0x00002000,    // CoInitialize has been called for this thread
 
-            TS_InSTA = 0x00004000,    // Thread hosts an STA
-            TS_InMTA = 0x00008000,    // Thread is part of the MTA
+            TS_InSTA                  = 0x00004000,    // Thread hosts an STA
+            TS_InMTA                  = 0x00008000,    // Thread is part of the MTA
 
             // Some bits that only have meaning for reporting the state to clients.
             //TS_ReportDead             = 0x00010000,    // in WaitForOtherThreads()
@@ -451,22 +451,22 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
             //TS_DebugWillSync          = 0x00100000,    // Debugger will wait for this thread to sync
 
             //TS_StackCrawlNeeded       = 0x00200000,    // A stackcrawl is needed on this thread, such as for thread abort
-            // See comment for s_pWaitForStackCrawlEvent for reason.
+                                                       // See comment for s_pWaitForStackCrawlEvent for reason.
 
             //TS_SuspendUnstarted       = 0x00400000,    // latch a user suspension on an unstarted thread
 
-            TS_Aborted = 0x00800000,    // is the thread aborted?
-            TS_TPWorkerThread = 0x01000000,    // is this a threadpool worker thread?
+            TS_Aborted                = 0x00800000,    // is the thread aborted?
+            TS_TPWorkerThread         = 0x01000000,    // is this a threadpool worker thread?
 
             //TS_Interruptible          = 0x02000000,    // sitting in a Sleep(), Wait(), Join()
             //TS_Interrupted            = 0x04000000,    // was awakened by an interrupt APC. !!! This can be moved to TSNC
 
-            TS_CompletionPortThread = 0x08000000,    // Completion port thread
+            TS_CompletionPortThread   = 0x08000000,    // Completion port thread
 
-            TS_AbortInitiated = 0x10000000,    // set when abort is begun
+            TS_AbortInitiated         = 0x10000000,    // set when abort is begun
 
             //TS_Finalized              = 0x20000000,    // The associated managed Thread object has been finalized.
-            // We can clean up the unmanaged part now.
+                                                       // We can clean up the unmanaged part now.
 
             //TS_FailStarted            = 0x40000000,    // The thread fails during startup.
             //TS_Detached               = 0x80000000,    // Thread was detached by DllMain

--- a/src/Microsoft.Diagnostics.Runtime/Microsoft.Diagnostics.Runtime.csproj
+++ b/src/Microsoft.Diagnostics.Runtime/Microsoft.Diagnostics.Runtime.csproj
@@ -64,6 +64,7 @@
     <Compile Include="Debugger\IDebugClient3.cs" />
     <Compile Include="Debugger\IDebugClient4.cs" />
     <Compile Include="Debugger\IDebugClient5.cs" />
+    <Compile Include="Debugger\IDebugClient6.cs" />
     <Compile Include="Debugger\IDebugControl.cs" />
     <Compile Include="Debugger\IDebugControl2.cs" />
     <Compile Include="Debugger\IDebugControl3.cs" />
@@ -76,6 +77,7 @@
     <Compile Include="Debugger\IDebugDataSpaces4.cs" />
     <Compile Include="Debugger\IDebugEventCallbacks.cs" />
     <Compile Include="Debugger\IDebugEventCallbacksWide.cs" />
+    <Compile Include="Debugger\IDebugEventContextCallbacks.cs" />
     <Compile Include="Debugger\IDebugInputCallbacks.cs" />
     <Compile Include="Debugger\IDebugOutputCallbacks.cs" />
     <Compile Include="Debugger\IDebugOutputCallbacks2.cs" />

--- a/src/Microsoft.Diagnostics.Runtime/Utilities/SymbolPath.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Utilities/SymbolPath.cs
@@ -225,7 +225,7 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
         }
         /// <summary>
         /// Create a new symbol path which first search all machine local locations (either explicit location or symbol server cache locations)
-        /// folloed by all non-local symbol server.   This produces better behavior (If you can find it locally it will be fast)
+        /// followed by all non-local symbol server.   This produces better behavior (If you can find it locally it will be fast)
         /// </summary>
         public SymPath CacheFirst()
         {

--- a/src/Microsoft.Diagnostics.Runtime/Utilities/pefile.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Utilities/pefile.cs
@@ -248,7 +248,7 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
 
     /// <summary>
     /// A PEHeader is a reader of the data at the begining of a PEFile.    If the header bytes of a 
-    /// PEFile are read or mapped into memory, this class can parse it when given a poitner to it. 
+    /// PEFile are read or mapped into memory, this class can parse it when given a pointer to it.
     /// It can read both 32 and 64 bit PE files.  
     /// </summary>
     public unsafe sealed class PEHeader


### PR DESCRIPTION
Also collapse the managed definition of WINDBG_EXTENSION_APIS32 and
WINDBG_EXTENSION_APIS64, since they are defined the same.