### PR TITLE
Apply DllImportSearchPath.LegacyBehavior to dbgeng/dbghelp PInvoke defs.

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/Desktop/helpers.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Desktop/helpers.cs
@@ -360,6 +360,9 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
         private const int VS_FIXEDFILEINFO_size = 0x34;
         public static short IMAGE_DIRECTORY_ENTRY_COM_DESCRIPTOR = 14;
 
+#if !V2_SUPPORT
+        [DefaultDllImportSearchPaths(DllImportSearchPath.LegacyBehavior)]
+#endif
         [DllImport("dbgeng.dll")]
         internal static extern uint DebugCreate(ref Guid InterfaceId, [MarshalAs(UnmanagedType.IUnknown)] out object Interface);
         [UnmanagedFunctionPointer(CallingConvention.StdCall)]
@@ -374,12 +377,21 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
 
 
 
+#if !V2_SUPPORT
+        [DefaultDllImportSearchPaths(DllImportSearchPath.LegacyBehavior)]
+#endif
         [DllImport("dbghelp.dll")]
         internal static extern IntPtr ImageDirectoryEntryToData(IntPtr mapping, bool mappedAsImage, short directoryEntry, out uint size);
 
+#if !V2_SUPPORT
+        [DefaultDllImportSearchPaths(DllImportSearchPath.LegacyBehavior)]
+#endif
         [DllImport("dbghelp.dll")]
         public static extern IntPtr ImageRvaToVa(IntPtr mapping, IntPtr baseAddr, uint rva, IntPtr lastRvaSection);
 
+#if !V2_SUPPORT
+        [DefaultDllImportSearchPaths(DllImportSearchPath.LegacyBehavior)]
+#endif
         [DllImport("dbghelp.dll")]
         public static extern IntPtr ImageNtHeader(IntPtr imageBase);
 

--- a/src/Microsoft.Diagnostics.Runtime/Utilities/SymbolPath.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Utilities/SymbolPath.cs
@@ -474,6 +474,9 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
         internal const int SSRVOPT_DWORDPTR = 0x004;
         internal const int SSRVOPT_GUIDPTR = 0x0008;
 
+#if !V2_SUPPORT
+        [DefaultDllImportSearchPaths(DllImportSearchPath.LegacyBehavior)]
+#endif
         [DllImport("dbghelp.dll", CharSet = CharSet.Unicode, SetLastError = true), SuppressUnmanagedCodeSecurityAttribute]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool SymFindFileInPathW(
@@ -490,6 +493,9 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
             );
 
         // Useful for the findCallback parameter of SymFindFileInPathW
+#if !V2_SUPPORT
+        [DefaultDllImportSearchPaths(DllImportSearchPath.LegacyBehavior)]
+#endif
         [DllImport("dbghelp.dll", CharSet = CharSet.Unicode, SetLastError = true), SuppressUnmanagedCodeSecurityAttribute]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool SymSrvGetFileIndexesW(
@@ -499,6 +505,9 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
             ref int val2,
             int flags);
 
+#if !V2_SUPPORT
+        [DefaultDllImportSearchPaths(DllImportSearchPath.LegacyBehavior)]
+#endif
         [DllImport("dbghelp.dll", CharSet = CharSet.Unicode, SetLastError = true), SuppressUnmanagedCodeSecurityAttribute]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool SymInitializeW(
@@ -506,11 +515,17 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
             string UserSearchPath,
             [MarshalAs(UnmanagedType.Bool)] bool fInvadeProcess);
 
+#if !V2_SUPPORT
+        [DefaultDllImportSearchPaths(DllImportSearchPath.LegacyBehavior)]
+#endif
         [DllImport("dbghelp.dll", SetLastError = true), SuppressUnmanagedCodeSecurityAttribute]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool SymCleanup(
             IntPtr hProcess);
 
+#if !V2_SUPPORT
+        [DefaultDllImportSearchPaths(DllImportSearchPath.LegacyBehavior)]
+#endif
         [DllImport("dbghelp.dll", CharSet = CharSet.Unicode, SetLastError = true), SuppressUnmanagedCodeSecurityAttribute]
         internal static extern ulong SymLoadModuleExW(
             IntPtr hProcess,
@@ -523,12 +538,18 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
             uint Flags
          );
 
+#if !V2_SUPPORT
+        [DefaultDllImportSearchPaths(DllImportSearchPath.LegacyBehavior)]
+#endif
         [DllImport("dbghelp.dll", SetLastError = true), SuppressUnmanagedCodeSecurityAttribute]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool SymUnloadModule64(
             IntPtr hProcess,
             ulong BaseOfDll);
 
+#if !V2_SUPPORT
+        [DefaultDllImportSearchPaths(DllImportSearchPath.LegacyBehavior)]
+#endif
         [DllImport("dbghelp.dll", CharSet = CharSet.Unicode, SetLastError = true), SuppressUnmanagedCodeSecurityAttribute]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool SymGetLineFromAddrW64(
@@ -538,6 +559,9 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
             ref IMAGEHLP_LINE64 Line
         );
 
+#if !V2_SUPPORT
+        [DefaultDllImportSearchPaths(DllImportSearchPath.LegacyBehavior)]
+#endif
         [DllImport("dbghelp.dll", CharSet = CharSet.Unicode, SetLastError = true), SuppressUnmanagedCodeSecurityAttribute]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool SymFromAddrW(
@@ -596,6 +620,9 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
             public UInt64 Address;
         };
 
+#if !V2_SUPPORT
+        [DefaultDllImportSearchPaths(DllImportSearchPath.LegacyBehavior)]
+#endif
         [DllImport("dbghelp.dll", CharSet = CharSet.Unicode, SetLastError = true), SuppressUnmanagedCodeSecurityAttribute]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool SymRegisterCallbackW64(
@@ -659,11 +686,17 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
             SYMOPT_UNDNAME = 0x00000002,
         };
 
+#if !V2_SUPPORT
+        [DefaultDllImportSearchPaths(DllImportSearchPath.LegacyBehavior)]
+#endif
         [DllImport("dbghelp.dll", SetLastError = true), SuppressUnmanagedCodeSecurityAttribute]
         internal static extern SymOptions SymSetOptions(
             SymOptions SymOptions
             );
 
+#if !V2_SUPPORT
+        [DefaultDllImportSearchPaths(DllImportSearchPath.LegacyBehavior)]
+#endif
         [DllImport("dbghelp.dll", SetLastError = true), SuppressUnmanagedCodeSecurityAttribute]
         internal static extern SymOptions SymGetOptions();
 
@@ -672,6 +705,9 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
         internal const int MAX_PATH = 260;
 
         // Src Server API
+#if !V2_SUPPORT
+        [DefaultDllImportSearchPaths(DllImportSearchPath.LegacyBehavior)]
+#endif
         [DllImport("dbghelp.dll", CharSet = CharSet.Unicode, SetLastError = true), SuppressUnmanagedCodeSecurityAttribute]
         internal static extern bool SymGetSourceFileW(
             IntPtr hProcess,
@@ -681,6 +717,9 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
             StringBuilder filePathRet,
             int filePathRetSize);
 
+#if !V2_SUPPORT
+        [DefaultDllImportSearchPaths(DllImportSearchPath.LegacyBehavior)]
+#endif
         [DllImport("dbghelp.dll", CharSet = CharSet.Unicode, SetLastError = true), SuppressUnmanagedCodeSecurityAttribute]
         internal static extern IntPtr SymSetHomeDirectoryW(
              IntPtr hProcess,


### PR DESCRIPTION
Some projects that use ClrMd have two modes of operation:

1.	Standalone mode.
2.	Hosted as an extension inside another program (such as windbg).

In standalone mode, I distribute a copy of the core debugger binaries
(dbgeng.dll, dbghelp.dll, et al) along with my binaries. But when I’m in
"hosted" mode, I need my code, including ClrMd, to use the
dbgeng.dll/dbghelp.dll that are already loaded into the process (instead of
loading a separate copy--the ones I redist).

To make this happen, I added a DefaultDllImportSearchPaths attribute to key
PInvoke definitions.