### PR TITLE
Fix COM release AV

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/ClrRuntime.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrRuntime.cs
@@ -823,6 +823,18 @@ namespace Microsoft.Diagnostics.Runtime
             _dataReader = dataTarget.DataReader;
         }
 
+        public void RegisterComObjectForRelease(object o)
+        {
+            if (o != null)
+                _library.AddToReleaseList(o);
+        }
+
+        public void RegisterIModuleForRelease(IModuleData module)
+        {
+            if (module != null)
+                RegisterComObjectForRelease(module.LegacyMetaDataImport);
+        }
+
         public override DataTarget DataTarget
         {
             get { return _dataTarget; }

--- a/src/Microsoft.Diagnostics.Runtime/Desktop/legacyruntime.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Desktop/legacyruntime.cs
@@ -269,10 +269,15 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
             if (addr == 0)
                 return null;
 
+            IModuleData result = null;
             if (CLRVersion == DesktopVersion.v2)
-                return Request<IModuleData, V2ModuleData>(DacRequests.MODULE_DATA, addr);
+                result = Request<IModuleData, V2ModuleData>(DacRequests.MODULE_DATA, addr);
+            else
+                result = Request<IModuleData, V4ModuleData>(DacRequests.MODULE_DATA, addr);
 
-            return Request<IModuleData, V4ModuleData>(DacRequests.MODULE_DATA, addr);
+            // Only needed in legacy runtime since v4.5 and on do not return this interface.
+            RegisterIModuleForRelease(result);
+            return result;
         }
 
         internal override ulong GetModuleForMT(ulong mt)
@@ -378,6 +383,7 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
         internal override IMetadata GetMetadataImport(ulong module)
         {
             IModuleData data = GetModuleData(module);
+            RegisterIModuleForRelease(data);
 
             if (data != null && data.LegacyMetaDataImport != null)
                 return data.LegacyMetaDataImport as IMetadata;

--- a/src/Microsoft.Diagnostics.Runtime/Desktop/v45runtime.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Desktop/v45runtime.cs
@@ -480,6 +480,7 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
             if (module == 0 || _sos.GetModule(module, out obj) < 0)
                 return null;
 
+            RegisterComObjectForRelease(obj);
             return obj as IMetadata;
         }
 


### PR DESCRIPTION
We were not fully releasing all interfaces before unloading the dac library, leading to AVs in RCW cleanup.