### PR TITLE
Fixes issue Microsoft/clrmd#44

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/Utilities/SymbolLocator.Async.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Utilities/SymbolLocator.Async.cs
@@ -503,7 +503,8 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
         /// <returns>A task indicating when the copy is completed.</returns>
         protected override void CopyStreamToFile(Stream stream, string fullSrcPath, string fullDestPath, long size)
         {
-            CopyStreamToFileAsync(stream, fullSrcPath, fullDestPath, size).Wait();
+            var task = Task.Run(async () => { await CopyStreamToFileAsync(stream, fullSrcPath, fullDestPath, size); });
+            task.Wait();
         }
 
         /// <summary>


### PR DESCRIPTION
This resolves issue with deadlocks because of the infinite `Wait`on `SynchronizationContext`within applications, for example, in WPF. 

As written in the comment, the issue Microsoft/clrmd#44 can be also fixed by using `ConfigureAwait(false)` on all async or by migrating public API to async - but those changes are much bigger.
