### PR TITLE
added System.Threading.Monitor.ReliableEnter as waiter method to be detected

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/Desktop/lockinspection.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Desktop/lockinspection.cs
@@ -306,6 +306,7 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
                         case "TryEnter":
                         case "ReliableEnterTimeout":
                         case "TryEnterTimeout":
+                        case "ReliableEnter":
                         case "Enter":
                             if (type.Name == "System.Threading.Monitor")
                             {


### PR DESCRIPTION
added System.Threading.Monitor.ReliableEnter as waiter method to be detected

Monitor.Enter can be inlined by JIT compiler and we won't see Monitor.Enter in stacktrace. So we have to check for ReliableEnter explicitly.