### PR TITLE
Fix build.cmd so it works correctly for paths containing a space

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -2,4 +2,4 @@
 
 if not exist bin mkdir bin
 
-"%SystemRoot%\Microsoft.NET\Framework\v4.0.30319\MSBuild.exe" src\Microsoft.Diagnostics.Runtime.sln /p:OutDir=%~dp0\bin /nologo /m /v:m /nr:false /flp:verbosity=normal;LogFile=bin\msbuild.log %*
+"%SystemRoot%\Microsoft.NET\Framework\v4.0.30319\MSBuild.exe" src\Microsoft.Diagnostics.Runtime.sln /p:OutDir="%~dp0\bin" /nologo /m /v:m /nr:false /flp:verbosity=normal;LogFile=bin\msbuild.log %*


### PR DESCRIPTION
This PR contains a small fix for ``build.cmd`` so it works correctly when the repo is checked out to a path containing a space.