### PR TITLE
Core clr fixes

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/ClrRuntime.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrRuntime.cs
@@ -206,7 +206,8 @@ namespace Microsoft.Diagnostics.Runtime
 
                     if (version.Major == 4 && version.Minor >= 6)
                         return false;
-                } else if (ClrInfo.Flavor == ClrFlavor.CoreCLR)
+                }
+                else if (ClrInfo.Flavor == ClrFlavor.CoreCLR)
                 {
                     return false;
                 }

--- a/src/Microsoft.Diagnostics.Runtime/ClrRuntime.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrRuntime.cs
@@ -206,6 +206,9 @@ namespace Microsoft.Diagnostics.Runtime
 
                     if (version.Major == 4 && version.Minor >= 6)
                         return false;
+                } else if (ClrInfo.Flavor == ClrFlavor.CoreCLR)
+                {
+                    return false;
                 }
 
                 return true;

--- a/src/Microsoft.Diagnostics.Runtime/Desktop/heap.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Desktop/heap.cs
@@ -997,9 +997,12 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
             {
                 if (_mscorlib == null)
                 {
-                    foreach (ClrModule module in DesktopRuntime.Modules)
+                    String moduleName = Runtime.ClrInfo.Flavor == ClrFlavor.CoreCLR
+                        ? "System.Private.CoreLib"
+                        : "mscorlib";
+                    foreach ( ClrModule module in DesktopRuntime.Modules)
                     {
-                        if (module.Name.Contains("mscorlib"))
+                        if (module.Name.Contains(moduleName))
                         {
                             _mscorlib = module;
                             break;

--- a/src/Microsoft.Diagnostics.Runtime/Desktop/heap.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Desktop/heap.cs
@@ -997,12 +997,13 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
             {
                 if (_mscorlib == null)
                 {
-                    String moduleName = Runtime.ClrInfo.Flavor == ClrFlavor.CoreCLR
+                    string moduleName = Runtime.ClrInfo.Flavor == ClrFlavor.CoreCLR
                         ? "System.Private.CoreLib"
                         : "mscorlib";
-                    foreach ( ClrModule module in DesktopRuntime.Modules)
+                    
+                    foreach (ClrModule module in DesktopRuntime.Modules)
                     {
-                        if (module.Name.Contains(moduleName))
+                        if (module.Name.Contains(moduleName, StringComparison.OrdinalIgnoreCase))
                         {
                             _mscorlib = module;
                             break;


### PR DESCRIPTION
Minor improvements to getting ClrMD working more correctly on CoreCLR memory dumps:
* Use the v4.6 GC heap walking code
* Look for basic types in System.Private.CoreLib rather than on mscorlib