### PR TITLE
Various fixes

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime.Tests/HeapTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/HeapTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             using (DataTarget dt = TestTargets.Types.LoadFullDump())
             {
                 ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
-                ClrHeap heap = runtime.GetHeap();
+                ClrHeap heap = runtime.Heap;
 
                 int count = 0;
                 foreach (ulong obj in heap.EnumerateObjectAddresses())
@@ -36,7 +36,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             using (DataTarget dt = TestTargets.Types.LoadFullDump(GCMode.Server))
             {
                 ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
-                ClrHeap heap = runtime.GetHeap();
+                ClrHeap heap = runtime.Heap;
 
                 Assert.IsTrue(runtime.ServerGC);
                 
@@ -50,7 +50,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             using (DataTarget dt = TestTargets.Types.LoadFullDump(GCMode.Workstation))
             {
                 ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
-                ClrHeap heap = runtime.GetHeap();
+                ClrHeap heap = runtime.Heap;
 
                 Assert.IsFalse(runtime.ServerGC);
 

--- a/src/Microsoft.Diagnostics.Runtime.Tests/ModuleTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/ModuleTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             using (DataTarget dt = TestTargets.Types.LoadFullDump())
             {
                 ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
-                ClrHeap heap = runtime.GetHeap();
+                ClrHeap heap = runtime.Heap;
 
                 ClrModule shared = runtime.GetModule("sharedlibrary.dll");
                 Assert.IsNotNull(shared.GetTypeByName("Foo"));

--- a/src/Microsoft.Diagnostics.Runtime.Tests/PdbTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/PdbTests.cs
@@ -14,12 +14,34 @@ namespace Microsoft.Diagnostics.Runtime.Tests
     public class PdbTests
     {
         [TestMethod]
+        public void PdbEqualityTest()
+        {
+            // Ensure all methods in our source file is in the pdb.
+            using (DataTarget dt = TestTargets.NestedException.LoadFullDump())
+            {
+                ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
+
+                PdbInfo[] allPdbs = runtime.Modules.Where(m => m.Pdb != null).Select(m => m.Pdb).ToArray();
+                Assert.IsTrue(allPdbs.Length > 1);
+
+                for (int i = 0; i < allPdbs.Length; i++)
+                {
+                    Assert.IsTrue(allPdbs[i].Equals(allPdbs[i]));
+                    for (int j = i + 1; j < allPdbs.Length; j++)
+                    {
+                        Assert.IsFalse(allPdbs[i].Equals(allPdbs[j]));
+                        Assert.IsFalse(allPdbs[j].Equals(allPdbs[i]));
+                    }
+                }
+
+            }
+        }
+
+        [TestMethod]
         public void PdbGuidAgeTest()
         {
-            int pdbAge;
-            Guid pdbSignature;
-            PdbReader.GetPdbProperties(TestTargets.NestedException.Pdb, out pdbSignature, out pdbAge);
-            
+            PdbReader.GetPdbProperties(TestTargets.NestedException.Pdb, out Guid pdbSignature, out int pdbAge);
+
             // Ensure we get the same answer a different way.
             using (PdbReader pdbReader = new PdbReader(TestTargets.NestedException.Pdb))
             {

--- a/src/Microsoft.Diagnostics.Runtime.Tests/TypeTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/TypeTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             using (DataTarget dt = TestTargets.Types.LoadFullDump())
             {
                 ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
-                ClrHeap heap = runtime.GetHeap();
+                ClrHeap heap = runtime.Heap;
 
                 ClrStaticField field = runtime.GetModule("types.exe").GetTypeByName("Types").GetStaticFieldByName("s_i");
 
@@ -42,7 +42,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             using (DataTarget dt = TestTargets.AppDomains.LoadFullDump())
             {
                 ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
-                ClrHeap heap = runtime.GetHeap();
+                ClrHeap heap = runtime.Heap;
 
                 // Ensure that we always have a component for every array type.
                 foreach (ulong obj in heap.EnumerateObjectAddresses())
@@ -78,7 +78,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             using (DataTarget dt = TestTargets.Types.LoadFullDump())
             {
                 ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
-                ClrHeap heap = runtime.GetHeap();
+                ClrHeap heap = runtime.Heap;
 
                 foreach (ulong obj in heap.EnumerateObjectAddresses())
                 {
@@ -104,7 +104,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             using (DataTarget dt = TestTargets.AppDomains.LoadFullDump())
             {
                 ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
-                ClrHeap heap = runtime.GetHeap();
+                ClrHeap heap = runtime.Heap;
 
                 ClrType[] types = (from obj in heap.EnumerateObjectAddresses()
                                    let t = heap.GetObjectType(obj)
@@ -130,7 +130,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             using (DataTarget dt = TestTargets.Types.LoadFullDump())
             {
                 ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
-                ClrHeap heap = runtime.GetHeap();
+                ClrHeap heap = runtime.Heap;
 
                 var fooRoots = from root in heap.EnumerateRoots()
                                where root.Type.Name == "Foo"
@@ -167,7 +167,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             using (DataTarget dt = TestTargets.AppDomains.LoadFullDump())
             {
                 ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
-                ClrHeap heap = runtime.GetHeap();
+                ClrHeap heap = runtime.Heap;
 
                 HashSet<ulong> methodTables = (from obj in heap.EnumerateObjectAddresses()
                                                let type = heap.GetObjectType(obj)
@@ -193,7 +193,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             using (DataTarget dt = TestTargets.Types.LoadFullDump())
             {
                 ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
-                ClrHeap heap = runtime.GetHeap();
+                ClrHeap heap = runtime.Heap;
 
                 foreach (ClrType type in heap.EnumerateObjectAddresses().Select(obj => heap.GetObjectType(obj)).Unique())
                 {
@@ -225,7 +225,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             using (DataTarget dt = TestTargets.AppDomains.LoadFullDump())
             {
                 ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
-                ClrHeap heap = runtime.GetHeap();
+                ClrHeap heap = runtime.Heap;
 
                 int i = 0;
                 foreach (ulong obj in heap.EnumerateObjectAddresses())
@@ -272,7 +272,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             using (DataTarget dt = TestTargets.AppDomains.LoadFullDump())
             {
                 ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
-                ClrHeap heap = runtime.GetHeap();
+                ClrHeap heap = runtime.Heap;
 
                 ulong[] fooObjects = (from obj in heap.EnumerateObjectAddresses()
                                       let t = heap.GetObjectType(obj)
@@ -323,7 +323,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             using (DataTarget dt = TestTargets.Types.LoadFullDump())
             {
                 ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
-                ClrHeap heap = runtime.GetHeap();
+                ClrHeap heap = runtime.Heap;
 
                 ClrAppDomain domain = runtime.AppDomains.Single();
 
@@ -365,7 +365,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             using (DataTarget dt = TestTargets.Types.LoadFullDump())
             {
                 ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
-                ClrHeap heap = runtime.GetHeap();
+                ClrHeap heap = runtime.Heap;
 
                 ClrAppDomain domain = runtime.AppDomains.Single();
 
@@ -400,7 +400,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             using (DataTarget dt = TestTargets.Types.LoadFullDump())
             {
                 ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
-                ClrHeap heap = runtime.GetHeap();
+                ClrHeap heap = runtime.Heap;
 
                 ClrAppDomain domain = runtime.AppDomains.Single();
 
@@ -420,7 +420,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             using (DataTarget dt = TestTargets.Types.LoadFullDump())
             {
                 ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
-                ClrHeap heap = runtime.GetHeap();
+                ClrHeap heap = runtime.Heap;
 
                 ClrAppDomain domain = runtime.AppDomains.Single();
 

--- a/src/Microsoft.Diagnostics.Runtime/ClrHeap.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrHeap.cs
@@ -119,6 +119,11 @@ namespace Microsoft.Diagnostics.Runtime
         }
 
         /// <summary>
+        /// Returns the ClrType representing free space on the GC heap.
+        /// </summary>
+        public abstract ClrType Free { get; }
+
+        /// <summary>
         /// Enumerate the roots in the process.
         /// </summary>
         /// <param name="enumerateStatics">True if we should enumerate static variables.  Enumerating with statics 

--- a/src/Microsoft.Diagnostics.Runtime/ClrRuntime.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrRuntime.cs
@@ -128,7 +128,13 @@ namespace Microsoft.Diagnostics.Runtime
         /// <summary>
         /// Gets the GC heap of the process.
         /// </summary>
+        [Obsolete("Use the Heap property instead.")]
         abstract public ClrHeap GetHeap();
+
+        /// <summary>
+        /// Gets the GC heap of the process.
+        /// </summary>
+        abstract public ClrHeap Heap { get; }
 
         /// <summary>
         /// Returns data on the CLR thread pool for this runtime.
@@ -984,7 +990,7 @@ namespace Microsoft.Diagnostics.Runtime
             }
 
             ClrAppDomain domain = GetAppDomainByAddress(thread.AppDomain);
-            ClrHeap heap = GetHeap();
+            ClrHeap heap = Heap;
             var mask = ((ulong)(PointerSize - 1));
             var cache = MemoryReader;
             cache.EnsureRangeInCache(stackBase);

--- a/src/Microsoft.Diagnostics.Runtime/ClrRuntime.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrRuntime.cs
@@ -139,6 +139,12 @@ namespace Microsoft.Diagnostics.Runtime
         /// <summary>
         /// Returns data on the CLR thread pool for this runtime.
         /// </summary>
+        virtual public ClrThreadPool ThreadPool { get { throw new NotImplementedException(); } }
+
+        /// <summary>
+        /// Returns data on the CLR thread pool for this runtime.
+        /// </summary>
+        [Obsolete("Use ThreadPool property instead.")]
         virtual public ClrThreadPool GetThreadPool() { throw new NotImplementedException(); }
 
         /// <summary>

--- a/src/Microsoft.Diagnostics.Runtime/Desktop/heap.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Desktop/heap.cs
@@ -18,12 +18,12 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
             Revision = runtime.Revision;
 
             // Prepopulate a few important method tables.
-            FreeType = GetTypeByMethodTable(DesktopRuntime.FreeMethodTable, 0, 0);
-            ((DesktopHeapType)FreeType).Shared = true;
+            _free = GetTypeByMethodTable(DesktopRuntime.FreeMethodTable, 0, 0);
+            ((DesktopHeapType)Free).Shared = true;
             ObjectType = GetTypeByMethodTable(DesktopRuntime.ObjectMethodTable, 0, 0);
             ArrayType = GetTypeByMethodTable(DesktopRuntime.ArrayMethodTable, DesktopRuntime.ObjectMethodTable, 0);
             ArrayType.ComponentType =  ObjectType;
-            ((BaseDesktopHeapType)FreeType).DesktopModule = (DesktopModule)ObjectType.Module;
+            ((BaseDesktopHeapType)Free).DesktopModule = (DesktopModule)ObjectType.Module;
             StringType = GetTypeByMethodTable(DesktopRuntime.StringMethodTable, 0, 0);
             ExceptionType = GetTypeByMethodTable(DesktopRuntime.ExceptionMethodTable, 0, 0);
             ErrorType = new ErrorType(this);
@@ -753,12 +753,14 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
 
         internal readonly ClrInterface[] EmptyInterfaceList = new ClrInterface[0];
         internal Dictionary<string, ClrInterface> Interfaces = new Dictionary<string, ClrInterface>();
+        private ClrType _free;
+
         internal DesktopRuntimeBase DesktopRuntime { get; private set; }
         internal BaseDesktopHeapType ErrorType { get; private set; }
         internal ClrType ObjectType { get; private set; }
         internal ClrType StringType { get; private set; }
         internal ClrType ValueType { get; private set; }
-        internal ClrType FreeType { get; private set; }
+        public override ClrType Free { get { return _free; } }
         internal ClrType ExceptionType { get; private set; }
         internal ClrType EnumType { get; set; }
         internal ClrType ArrayType { get; private set; }

--- a/src/Microsoft.Diagnostics.Runtime/Desktop/helpers.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Desktop/helpers.cs
@@ -166,7 +166,7 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
         public HandleTableWalker(DesktopRuntimeBase dac)
         {
             _runtime = dac;
-            _heap = dac.GetHeap();
+            _heap = dac.Heap;
             Handles = new List<ClrHandle>();
         }
         [UnmanagedFunctionPointer(CallingConvention.StdCall)]

--- a/src/Microsoft.Diagnostics.Runtime/Desktop/legacyruntime.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Desktop/legacyruntime.cs
@@ -585,7 +585,7 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
             if (_stackTrace == 0)
                 return result;
 
-            var heap = TryGetHeap();
+            var heap = (DesktopGCHeap)Heap;
             ClrType stackTraceType = heap.GetObjectType(_stackTrace);
 
             if (stackTraceType == null)

--- a/src/Microsoft.Diagnostics.Runtime/Desktop/lockinspection.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Desktop/lockinspection.cs
@@ -462,7 +462,7 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
 
         private ulong FindWaitHandle(ulong start, ulong stop, HashSet<string> eventTypes)
         {
-            ClrHeap heap = _runtime.GetHeap();
+            ClrHeap heap = _runtime.Heap;
             foreach (ulong obj in EnumerateObjectsOfTypes(start, stop, eventTypes))
                 return obj;
 
@@ -471,7 +471,7 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
 
         private ulong FindWaitObjects(ulong start, ulong stop, string typeName)
         {
-            ClrHeap heap = _runtime.GetHeap();
+            ClrHeap heap = _runtime.Heap;
             foreach (ulong obj in EnumerateObjectsOfType(start, stop, typeName))
                 return obj;
 
@@ -480,7 +480,7 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
 
         private IEnumerable<ulong> EnumerateObjectsOfTypes(ulong start, ulong stop, HashSet<string> types)
         {
-            ClrHeap heap = _runtime.GetHeap();
+            ClrHeap heap = _runtime.Heap;
             foreach (ulong ptr in EnumeratePointersInRange(start, stop))
             {
                 if (_runtime.ReadPointer(ptr, out ulong obj))
@@ -511,7 +511,7 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
 
         private IEnumerable<ulong> EnumerateObjectsOfType(ulong start, ulong stop, string typeName)
         {
-            ClrHeap heap = _runtime.GetHeap();
+            ClrHeap heap = _runtime.Heap;
             foreach (ulong ptr in EnumeratePointersInRange(start, stop))
             {
                 if (_runtime.ReadPointer(ptr, out ulong obj))
@@ -542,7 +542,7 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
 
         private bool FindThread(ulong start, ulong stop, out ulong threadAddr, out ClrThread target)
         {
-            ClrHeap heap = _runtime.GetHeap();
+            ClrHeap heap = _runtime.Heap;
             foreach (ulong obj in EnumerateObjectsOfType(start, stop, "System.Threading.Thread"))
             {
                 ClrType type = heap.GetObjectType(obj);

--- a/src/Microsoft.Diagnostics.Runtime/Desktop/methods.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Desktop/methods.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
             _attrs = attrs;
             _token = mdData.MDToken;
             _gcInfo = mdData.GCInfo;
-            var heap = runtime.GetHeap();
+            var heap = runtime.Heap;
             _type = (DesktopHeapType)heap.GetTypeByMethodTable(mdData.MethodTable, 0);
             _hotColdInfo = new HotColdRegions() { HotStart = _ip, HotSize = mdData.HotSize, ColdStart = mdData.ColdStart, ColdSize = mdData.ColdSize };
         }

--- a/src/Microsoft.Diagnostics.Runtime/Desktop/modules.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Desktop/modules.cs
@@ -145,7 +145,7 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
                 else
                 {
                     if (heap == null)
-                        heap = (DesktopGCHeap)_runtime.GetHeap();
+                        heap = (DesktopGCHeap)_runtime.Heap;
 
                     if (heap.GetTypeByMethodTable(pair.MethodTable, 0) == type)
                         return pair.MethodTable;
@@ -157,7 +157,7 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
 
         public override IEnumerable<ClrType> EnumerateTypes()
         {
-            var heap = (DesktopGCHeap)_runtime.GetHeap();
+            var heap = (DesktopGCHeap)_runtime.Heap;
             var mtList = _runtime.GetMethodTableList(_mapping.First().Value);
             if (_typesLoaded)
             {

--- a/src/Microsoft.Diagnostics.Runtime/Desktop/modules.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Desktop/modules.cs
@@ -236,7 +236,7 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
 
         internal override ulong GetDomainModule(ClrAppDomain domain)
         {
-            _runtime.InitDomains();
+            var domains = _runtime.AppDomains;
             if (domain == null)
             {
                 foreach (ulong addr in _mapping.Values)

--- a/src/Microsoft.Diagnostics.Runtime/Desktop/runtimebase.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Desktop/runtimebase.cs
@@ -234,10 +234,13 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
 
                 // Ensure we don't hit an infinite loop
                 HashSet<ulong> seen = new HashSet<ulong> { addr };
-                while (thread != null && !seen.Contains(thread.Next))
+                while (thread != null)
                 {
                     threads.Add(new DesktopThread(this, thread, addr, addr == finalizer));
                     addr = thread.Next;
+                    if (seen.Contains(addr))
+                        break;
+
                     seen.Add(addr);
                     thread = GetThread(addr);
                 }

--- a/src/Microsoft.Diagnostics.Runtime/Desktop/runtimebase.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Desktop/runtimebase.cs
@@ -20,22 +20,57 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
         v45
     }
 
+    struct DomainContainer
+    {
+        public List<ClrAppDomain> Domains;
+        public DesktopAppDomain System;
+        public DesktopAppDomain Shared;
+        public Dictionary<ulong, DesktopModule> Modules;
+        public Dictionary<string, DesktopModule> ModuleFiles;
+        public Dictionary<ulong, uint> ModuleSizes;
+    }
+
     abstract internal class DesktopRuntimeBase : RuntimeBase
     {
         #region Variables
         protected CommonMethodTables _commonMTs;
         private Dictionary<uint, ICorDebug.ICorDebugThread> _corDebugThreads;
-        private Dictionary<ulong, DesktopModule> _modules = new Dictionary<ulong, DesktopModule>();
-        private Dictionary<ulong, uint> _moduleSizes = null;
         private ClrModule[] _moduleList = null;
-        private Dictionary<string, DesktopModule> _moduleFiles = null;
-        private DesktopAppDomain _system, _shared;
-        private List<ClrAppDomain> _domains;
-        private List<ClrThread> _threads;
+        private Lazy<List<ClrThread>> _threads;
         private Lazy<DesktopGCHeap> _heap;
         private DesktopThreadPool _threadpool;
         private ErrorModule _errorModule;
+        private Lazy<DomainContainer> _appDomains;
         #endregion
+        
+        internal DesktopRuntimeBase(ClrInfo info, DataTargetImpl dt, DacLibrary lib)
+            : base(info, dt, lib)
+        {
+            _heap = new Lazy<DesktopGCHeap>(CreateHeap);
+            _threads = new Lazy<List<ClrThread>>(CreateThreadList);
+            _appDomains = new Lazy<DomainContainer>(CreateAppDomainList);
+        }
+
+
+        /// <summary>
+        /// Flushes the dac cache.  This function MUST be called any time you expect to call the same function
+        /// but expect different results.  For example, after walking the heap, you need to call Flush before
+        /// attempting to walk the heap again.
+        /// </summary>
+        public override void Flush()
+        {
+            OnRuntimeFlushed();
+
+            Revision++;
+            _dacInterface.Flush();
+            
+            MemoryReader = null;
+            _threadpool = null;
+            _moduleList = null;
+            _threads = new Lazy<List<ClrThread>>(CreateThreadList);
+            _appDomains = new Lazy<DomainContainer>(CreateAppDomainList);
+            _heap = new Lazy<DesktopGCHeap>(CreateHeap);
+        }
 
         internal int Revision { get; set; }
 
@@ -107,46 +142,6 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
             }
         }
 
-        internal DesktopModule GetModule(ulong module)
-        {
-            if (module == 0)
-                return null;
-
-            if (_modules.TryGetValue(module, out DesktopModule res))
-                return res;
-
-            IModuleData moduleData = GetModuleData(module);
-            if (moduleData == null)
-                return null;
-
-            string peFile = GetPEFileName(moduleData.PEFile);
-            string assemblyName = GetAssemblyName(moduleData.Assembly);
-
-            if (_moduleSizes == null)
-            {
-                _moduleSizes = new Dictionary<ulong, uint>();
-                foreach (var native in _dataReader.EnumerateModules())
-                    _moduleSizes[native.ImageBase] = native.FileSize;
-            }
-
-            if (_moduleFiles == null)
-                _moduleFiles = new Dictionary<string, DesktopModule>();
-
-            _moduleSizes.TryGetValue(moduleData.ImageBase, out uint size);
-            if (peFile == null)
-            {
-                res = new DesktopModule(this, module, moduleData, peFile, assemblyName, size);
-            }
-            else if (!_moduleFiles.TryGetValue(peFile, out res))
-            {
-                res = new DesktopModule(this, module, moduleData, peFile, assemblyName, size);
-                _moduleFiles[peFile] = res;
-            }
-
-            _modules[module] = res;
-            return res;
-        }
-
 
         public override CcwData GetCcwDataByAddress(ulong addr)
         {
@@ -187,61 +182,35 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
             return result;
         }
 
-        public override IList<ClrAppDomain> AppDomains
+        public override IList<ClrAppDomain> AppDomains => _appDomains.Value.Domains;
+        public override IList<ClrThread> Threads => _threads.Value;
+
+        private List<ClrThread> CreateThreadList()
         {
-            get
+            IThreadStoreData threadStore = GetThreadStoreData();
+            ulong finalizer = ulong.MaxValue - 1;
+            if (threadStore != null)
+                finalizer = threadStore.Finalizer;
+
+            List<ClrThread> threads = new List<ClrThread>();
+
+            ulong addr = GetFirstThread();
+            IThreadData thread = GetThread(addr);
+
+            // Ensure we don't hit an infinite loop
+            HashSet<ulong> seen = new HashSet<ulong> { addr };
+            while (thread != null)
             {
-                if (_domains == null)
-                    InitDomains();
+                threads.Add(new DesktopThread(this, thread, addr, addr == finalizer));
+                addr = thread.Next;
+                if (seen.Contains(addr))
+                    break;
 
-                return _domains;
+                seen.Add(addr);
+                thread = GetThread(addr);
             }
-        }
 
-        /// <summary>
-        /// Enumerates all managed threads in the process.  Only threads which have previously run managed
-        /// code will be enumerated.
-        /// </summary>
-        public override IList<ClrThread> Threads
-        {
-            get
-            {
-                if (_threads == null)
-                    InitThreads();
-
-                return _threads;
-            }
-        }
-
-        private void InitThreads()
-        {
-            if (_threads == null)
-            {
-                IThreadStoreData threadStore = GetThreadStoreData();
-                ulong finalizer = ulong.MaxValue - 1;
-                if (threadStore != null)
-                    finalizer = threadStore.Finalizer;
-
-                List<ClrThread> threads = new List<ClrThread>();
-
-                ulong addr = GetFirstThread();
-                IThreadData thread = GetThread(addr);
-
-                // Ensure we don't hit an infinite loop
-                HashSet<ulong> seen = new HashSet<ulong> { addr };
-                while (thread != null)
-                {
-                    threads.Add(new DesktopThread(this, thread, addr, addr == finalizer));
-                    addr = thread.Next;
-                    if (seen.Contains(addr))
-                        break;
-
-                    seen.Add(addr);
-                    thread = GetThread(addr);
-                }
-
-                _threads = threads;
-            }
+            return threads;
         }
 
         public ulong ExceptionMethodTable { get { return _commonMTs.ExceptionMethodTable; } }
@@ -300,80 +269,12 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
             _threadpool = new DesktopThreadPool(this, data);
             return _threadpool;
         }
-
-
-        /// <summary>
-        /// The address of the system domain in CLR.
-        /// </summary>
-        public ulong SystemDomainAddress
-        {
-            get
-            {
-                if (_domains == null)
-                    InitDomains();
-
-                if (_system == null)
-                    return 0;
-
-                return _system.Address;
-            }
-        }
-
-        /// <summary>
-        /// The address of the shared domain in CLR.
-        /// </summary>
-        public ulong SharedDomainAddress
-        {
-            get
-            {
-                if (_domains == null)
-                    InitDomains();
-
-                if (_shared == null)
-                    return 0;
-
-                return _shared.Address;
-            }
-        }
-
-        /// <summary>
-        /// The address of the system domain in CLR.
-        /// </summary>
-        public override ClrAppDomain SystemDomain
-        {
-            get
-            {
-                if (_domains == null)
-                    InitDomains();
-
-                return _system;
-            }
-        }
-
-        /// <summary>
-        /// The address of the shared domain in CLR.
-        /// </summary>
-        public override ClrAppDomain SharedDomain
-        {
-            get
-            {
-                if (_domains == null)
-                    InitDomains();
-
-                return _shared;
-            }
-        }
-
-        public bool IsSingleDomain
-        {
-            get
-            {
-                if (_domains == null)
-                    InitDomains();
-
-                return _domains.Count == 1;
-            }
-        }
+        
+        public ulong SystemDomainAddress => _appDomains.Value.System.Address;
+        public ulong SharedDomainAddress => _appDomains.Value.Shared.Address;
+        public override ClrAppDomain SystemDomain => _appDomains.Value.System;
+        public override ClrAppDomain SharedDomain => _appDomains.Value.Shared;
+        public bool IsSingleDomain => _appDomains.Value.Domains.Count == 1;
 
         public override ClrMethod GetMethodByHandle(ulong methodHandle)
         {
@@ -546,30 +447,6 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
             return null;
         }
 
-        /// <summary>
-        /// Flushes the dac cache.  This function MUST be called any time you expect to call the same function
-        /// but expect different results.  For example, after walking the heap, you need to call Flush before
-        /// attempting to walk the heap again.
-        /// </summary>
-        public override void Flush()
-        {
-            OnRuntimeFlushed();
-
-            Revision++;
-            _dacInterface.Flush();
-
-            _modules.Clear();
-            _moduleFiles = null;
-            _moduleSizes = null;
-            _domains = null;
-            _system = null;
-            _shared = null;
-            _threads = null;
-            MemoryReader = null;
-            _heap = new Lazy<DesktopGCHeap>(CreateHeap);
-            _threadpool = null;
-        }
-
         public override ClrMethod GetMethodByAddress(ulong ip)
         {
             IMethodDescData mdData = GetMDForIP(ip);
@@ -608,10 +485,8 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
         protected ClrThread GetThreadByStackAddress(ulong address)
         {
             Debug.Assert(address != 0);
-            if (_threads == null)
-                InitThreads();
 
-            foreach (ClrThread thread in _threads)
+            foreach (ClrThread thread in _threads.Value)
             {
                 ulong min = thread.StackBase;
                 ulong max = thread.StackLimit;
@@ -651,11 +526,8 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
             ulong thread = GetThreadFromThinlock(threadId);
             if (thread == 0)
                 return null;
-
-            if (_threads == null)
-                InitThreads();
-
-            foreach (var clrThread in _threads)
+            
+            foreach (var clrThread in _threads.Value)
                 if (clrThread.Address == thread)
                     return clrThread;
 
@@ -666,16 +538,24 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
         {
             get
             {
-                if (_domains == null)
-                    InitDomains();
-
                 if (_moduleList == null)
-                {
-                    HashSet<ClrModule> modules = new HashSet<ClrModule>(_modules.Values.Select(p => (ClrModule)p));
-                    _moduleList = modules.ToArray();
-                }
+                    _moduleList = UniqueModules(_appDomains.Value.Modules.Values).ToArray();
 
                 return _moduleList;
+            }
+        }
+
+        static IEnumerable<ClrModule> UniqueModules(Dictionary<ulong, DesktopModule>.ValueCollection self)
+        {
+            HashSet<DesktopModule> set = new HashSet<DesktopModule>();
+
+            foreach (DesktopModule value in self)
+            {
+                if (set.Contains(value))
+                    continue;
+
+                set.Add(value);
+                yield return (ClrModule)value;
             }
         }
 
@@ -701,40 +581,33 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
             }
         }
 
-        internal DesktopRuntimeBase(ClrInfo info, DataTargetImpl dt, DacLibrary lib)
-            : base(info, dt, lib)
-        {
-            _heap = new Lazy<DesktopGCHeap>(CreateHeap);
-        }
 
-        internal void InitDomains()
+        internal DomainContainer CreateAppDomainList()
         {
-            if (_domains != null)
-                return;
-
-            _modules.Clear();
-            _domains = new List<ClrAppDomain>();
+            Dictionary<ulong, DesktopModule> modules = new Dictionary<ulong, DesktopModule>();
+            Dictionary<string, DesktopModule> moduleFiles = new Dictionary<string, DesktopModule>();
+            Dictionary<ulong, uint> moduleSizes = _dataReader.EnumerateModules().ToDictionary(module => module.ImageBase, module => module.FileSize);
 
             IAppDomainStoreData ads = GetAppDomainStoreData();
             if (ads == null)
-                return;
+                return new DomainContainer();
 
             IList<ulong> domains = GetAppDomainList(ads.Count);
-            foreach (ulong domain in domains)
+            if (domains == null)
+                return new DomainContainer();
+
+            return new DomainContainer()
             {
-                DesktopAppDomain appDomain = InitDomain(domain);
-                if (appDomain != null)
-                    _domains.Add(appDomain);
-            }
-
-            _system = InitDomain(ads.SystemDomain, "System Domain");
-            _shared = InitDomain(ads.SharedDomain, "Shared Domain");
-
-            _moduleFiles = null;
-            _moduleSizes = null;
+                Domains = domains.Select(ad=>(ClrAppDomain)InitDomain(ad, modules, moduleFiles, moduleSizes)).Where(ad => ad != null).ToList(),
+                Shared = InitDomain(ads.SharedDomain, modules, moduleFiles, moduleSizes, "Shared Domain"),
+                System = InitDomain(ads.SystemDomain, modules, moduleFiles, moduleSizes, "System Domain"),
+                Modules = modules,
+                ModuleFiles = moduleFiles,
+                ModuleSizes = moduleSizes
+            };
         }
 
-        private DesktopAppDomain InitDomain(ulong domain, string name = null)
+        private DesktopAppDomain InitDomain(ulong domain, Dictionary<ulong, DesktopModule> modules, Dictionary<string, DesktopModule> moduleFiles, Dictionary<ulong, uint> moduleSizes, string name = null)
         {
             ulong[] bases = new ulong[1];
             IAppDomainData domainData = GetAppDomainData(domain);
@@ -755,7 +628,7 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
                     {
                         foreach (ulong module in GetModuleList(assembly, assemblyData.ModuleCount))
                         {
-                            DesktopModule clrModule = GetModule(module);
+                            DesktopModule clrModule = GetModule(module, modules, moduleFiles, moduleSizes);
                             if (clrModule != null)
                             {
                                 clrModule.AddMapping(appDomain, module);
@@ -769,19 +642,40 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
             return appDomain;
         }
 
-        private IEnumerable<DesktopModule> EnumerateImages()
+        private DesktopModule GetModule(ulong module, Dictionary<ulong, DesktopModule> modules, Dictionary<string, DesktopModule> moduleFiles, Dictionary<ulong, uint> moduleSizes)
         {
-            InitDomains();
-            foreach (var module in _modules.Values)
-                if (module.ImageBase != 0)
-                    yield return module;
+            if (module == 0)
+                return null;
+
+            if (modules.TryGetValue(module, out DesktopModule res))
+                return res;
+
+            IModuleData moduleData = GetModuleData(module);
+            if (moduleData == null)
+                return null;
+            
+            string peFile = GetPEFileName(moduleData.PEFile);
+            string assemblyName = GetAssemblyName(moduleData.Assembly);
+
+            moduleSizes.TryGetValue(moduleData.ImageBase, out uint size);
+
+            if (peFile == null)
+            {
+                res = new DesktopModule(this, module, moduleData, peFile, assemblyName, size);
+            }
+            else if (!moduleFiles.TryGetValue(peFile, out res))
+            {
+                res = new DesktopModule(this, module, moduleData, peFile, assemblyName, size);
+                moduleFiles[peFile] = res;
+            }
+
+            // We've modified the 'real' module list, so clear the cached version.
+            _moduleList = null;
+            modules[module] = res;
+            return res;
         }
 
-        private IEnumerable<ulong> EnumerateImageBases(IEnumerable<DesktopModule> modules)
-        {
-            foreach (var module in modules)
-                yield return module.ImageBase;
-        }
+        internal DesktopModule GetModule(ulong module) => GetModule(module, _appDomains.Value.Modules, _appDomains.Value.ModuleFiles, _appDomains.Value.ModuleSizes);
 
         /// <summary>
         /// 

--- a/src/Microsoft.Diagnostics.Runtime/Desktop/threadpool.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Desktop/threadpool.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
 
         private IEnumerable<ulong> EnumerateManagedThreadpoolObjects()
         {
-            _heap = _runtime.GetHeap();
+            _heap = _runtime.Heap;
 
             ClrModule mscorlib = GetMscorlib();
             if (mscorlib != null)

--- a/src/Microsoft.Diagnostics.Runtime/Desktop/threads.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Desktop/threads.cs
@@ -184,7 +184,7 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
                 if (!_runtime.ReadPointer(ex, out ex) || ex == 0)
                     return null;
 
-                return _runtime.GetHeap().GetExceptionObject(ex);
+                return _runtime.Heap.GetExceptionObject(ex);
             }
         }
         
@@ -314,7 +314,7 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
         {
             get
             {
-                ((DesktopGCHeap)_runtime.GetHeap()).InitLockInspection();
+                ((DesktopGCHeap)_runtime.Heap).InitLockInspection();
 
                 if (_blockingObjs == null)
                     return new BlockingObject[0];

--- a/src/Microsoft.Diagnostics.Runtime/Desktop/types.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Desktop/types.cs
@@ -1180,7 +1180,7 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
         {
             get
             {
-                return this == DesktopHeap.FreeType;
+                return this == DesktopHeap.Free;
             }
         }
 
@@ -1215,7 +1215,7 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
             }
         }
 
-        public override bool IsArray { get { return _componentSize != 0 && this != DesktopHeap.StringType && this != DesktopHeap.FreeType; } }
+        public override bool IsArray { get { return _componentSize != 0 && this != DesktopHeap.StringType && this != DesktopHeap.Free; } }
         public override bool ContainsPointers { get { return _containsPointers; } }
         public override bool IsString { get { return this == DesktopHeap.StringType; } }
 

--- a/src/Microsoft.Diagnostics.Runtime/Desktop/v45runtime.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Desktop/v45runtime.cs
@@ -215,10 +215,6 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
 
         internal override ulong[] GetAssemblyList(ulong appDomain, int count)
         {
-            // It's not valid to request an assembly list for the system domain in v4.5.
-            if (appDomain == SystemDomainAddress)
-                return new ulong[0];
-
             int needed;
             if (count <= 0)
             {

--- a/src/Microsoft.Diagnostics.Runtime/Desktop/v45runtime.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Desktop/v45runtime.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
                 int curr = _handles.Count;
                 for (int i = 0; i < fetched; i++)
                 {
-                    ClrHandle handle = new ClrHandle(this, GetHeap(), handles[i]);
+                    ClrHandle handle = new ClrHandle(this, Heap, handles[i]);
                     _handles.Add(handle);
 
                     handle = handle.GetInteriorHandle();
@@ -126,7 +126,7 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
             ClrAppDomain domain = GetAppDomainByAddress(thread.AppDomain);
             if (handleEnum != null)
             {
-                var heap = GetHeap();
+                var heap = Heap;
                 StackRefData[] refs = new StackRefData[1024];
 
                 const int GCInteriorFlag = 1;
@@ -662,7 +662,7 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
             if (_stackTrace == 0)
                 return result;
 
-            ClrHeap heap = GetHeap();
+            ClrHeap heap = Heap;
             ClrType stackTraceType = heap.GetObjectType(_stackTrace);
             if (stackTraceType == null || !stackTraceType.IsArray)
                 return result;

--- a/src/Microsoft.Diagnostics.Runtime/Native/NativeHeap.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Native/NativeHeap.cs
@@ -22,6 +22,8 @@ namespace Microsoft.Diagnostics.Runtime.Native
         private ISymbolProvider _symProvider;
         private Dictionary<NativeModule, ISymbolResolver> _resolvers = new Dictionary<NativeModule, ISymbolResolver>();
 
+        public override ClrType Free => _free;
+
         internal class NativeStackFrame : ClrStackFrame
         {
             private ulong _ip;

--- a/src/Microsoft.Diagnostics.Runtime/Native/NativeModule.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Native/NativeModule.cs
@@ -132,7 +132,7 @@ namespace Microsoft.Diagnostics.Runtime.Native
 
         public override IEnumerable<ClrType> EnumerateTypes()
         {
-            foreach (var type in _runtime.GetHeap().EnumerateTypes())
+            foreach (var type in _runtime.Heap.EnumerateTypes())
                 if (type.Module == this)
                     yield return type;
         }

--- a/src/Microsoft.Diagnostics.Runtime/Native/NativeRoots.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Native/NativeRoots.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Diagnostics.Runtime.Native
 
         public NativeHandleRootWalker(NativeRuntime runtime, bool dependentHandleSupport)
         {
-            _heap = runtime.GetHeap();
+            _heap = runtime.Heap;
             _domain = runtime.GetRhAppDomain();
             _dependentSupport = dependentHandleSupport;
         }
@@ -80,7 +80,7 @@ namespace Microsoft.Diagnostics.Runtime.Native
         {
             Roots = new List<ClrRoot>(128);
             _runtime = resolveStatics ? runtime : null;
-            _heap = _runtime.GetHeap();
+            _heap = _runtime.Heap;
         }
 
         public void Callback(IntPtr token, ulong addr, ulong obj, int pinned, int interior)
@@ -302,7 +302,7 @@ namespace Microsoft.Diagnostics.Runtime.Native
             _name = name;
             _pinned = pinned;
             _interior = interior;
-            _type = runtime.GetHeap().GetObjectType(obj);
+            _type = runtime.Heap.GetObjectType(obj);
             _appDomain = runtime.GetRhAppDomain();
         }
     }

--- a/src/Microsoft.Diagnostics.Runtime/Native/NativeRuntime.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Native/NativeRuntime.cs
@@ -121,6 +121,7 @@ namespace Microsoft.Diagnostics.Runtime.Native
             throw new NotImplementedException();
         }
         
+        [Obsolete]
         override public ClrThreadPool GetThreadPool() { throw new NotImplementedException(); }
 
         internal ClrAppDomain GetRhAppDomain()

--- a/src/Microsoft.Diagnostics.Runtime/datatarget.cs
+++ b/src/Microsoft.Diagnostics.Runtime/datatarget.cs
@@ -351,6 +351,51 @@ namespace Microsoft.Diagnostics.Runtime
             Guid = guid;
             Revision = rev;
         }
+
+        /// <summary>
+        /// GetHashCode implementation.
+        /// </summary>
+        /// <returns></returns>
+        public override int GetHashCode()
+        {
+            return Guid.GetHashCode() ^ Revision;
+        }
+
+        /// <summary>
+        /// Override for Equals.  Returns true if the guid, age, and filenames equal.  Note that this compares only the 
+        /// </summary>
+        /// <param name="obj"></param>
+        /// <returns>True if the objects match, false otherwise.</returns>
+        public override bool Equals(object obj)
+        {
+            if (obj == null)
+                return false;
+
+            if (ReferenceEquals(this, obj))
+                return true;
+
+            if (obj is PdbInfo rhs)
+            {
+
+                if (Revision == rhs.Revision && Guid == rhs.Guid)
+                {
+                    string lhsFilename = Path.GetFileName(FileName);
+                    string rhsFilename = Path.GetFileName(rhs.FileName);
+                    return lhsFilename.Equals(rhsFilename, StringComparison.OrdinalIgnoreCase);
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// To string implementation.
+        /// </summary>
+        /// <returns>Printing friendly version.</returns>
+        public override string ToString()
+        {
+            return $"{Guid} {Revision} {FileName}";
+        }
     }
 
     /// <summary>

--- a/src/Samples/WindbgExtension/DumpHeap.cs
+++ b/src/Samples/WindbgExtension/DumpHeap.cs
@@ -19,7 +19,7 @@ namespace WindbgExtension
             // Use ClrMD as normal, but ONLY cache the copy of ClrRuntime (this.Runtime).  All other
             // types you get out of ClrMD (such as ClrHeap, ClrTypes, etc) should be discarded and
             // reobtained every run.
-            ClrHeap heap = Runtime.GetHeap();
+            ClrHeap heap = Runtime.Heap;
 
             var stats = from obj in heap.EnumerateObjectAddresses()
                         let t = heap.GetObjectType(obj)


### PR DESCRIPTION
-Fixed memory leak in PEBuffer
-Fixed an issue where we don't enumerate a thread when there is a cycle in threads.
-Added a property for the 'Free' type to ClrHeap.
-Added common overrides for PdbInfo to make it play nicer in collections.