### PR TITLE
Patch for a bug on SOS side when retrieving a method's signature

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime.Tests/MethodTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/MethodTests.cs
@@ -84,5 +84,27 @@ namespace Microsoft.Diagnostics.Runtime.Tests
                 Assert.AreEqual(methodDesc, method.EnumerateMethodDescs().Single());
             }
         }
-    }
+
+        /// <summary>
+        /// This test tests a patch in v45runtime.GetNameForMD(ulong md) that
+        /// corrects an error from sos
+        /// </summary>
+        [TestMethod]
+        public void CompleteSignatureIsRetrievedForMethodsWithGenericParameters()
+        {
+            using (DataTarget dt = TestTargets.AppDomains.LoadFullDump())
+            {
+                ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
+
+                ClrModule module = runtime.GetModule("sharedlibrary.dll");
+                ClrType type = module.GetTypeByName("Foo");
+
+                ClrMethod genericMethod = type.GetMethod("GenericBar");
+
+                string methodName = genericMethod.GetFullSignature();
+
+                Assert.AreEqual(')', methodName.Last());
+            }
+        }
+	}
 }

--- a/src/Microsoft.Diagnostics.Runtime.Tests/Targets/SharedLibrary.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/Targets/SharedLibrary.cs
@@ -1,4 +1,6 @@
-﻿public class Foo
+﻿using System;
+
+public class Foo
 {
     int i = 42;
     string s = "string";
@@ -12,4 +14,5 @@
     public void Bar() { }
     public void Baz() { }
     public int Baz(int i) { return i; }
+    public T5 GenericBar<T1, T2, T3, T4, T5>(Func<T1, T2, T3, T4, T5> a) { return a(default(T1), default(T2), default(T3), default(T4)); }
 }


### PR DESCRIPTION
#66 Patch for a bug on SOS side when retrieving a method's signature

Sometimes, when the target method has parameters with generic types the first call to GetMethodDescName sets an incorrect value into pNeeded.

In those cases, a second call directly after the first returns the correct value.

+ unit test