### PR TITLE
find the nearest line, previously was always returning last

### DIFF
--- a/src/Samples/FileAndLineNumbers/Program.cs
+++ b/src/Samples/FileAndLineNumbers/Program.cs
@@ -74,6 +74,8 @@ static class Extensions
                     nearest.File = sequenceCollection.File.Name;
                     nearest.Line = (int)point.LineBegin;
                 }
+                
+                distance = dist;
             }
         }
 


### PR DESCRIPTION
Hi!

I have been using part of the code from samples (found it in [msos](https://github.com/goldshtn/msos) project) to display the disassembly code for BenchmarkDotNet and I have realized, that always the last line of source code was printed.

The bug fix was trivial: when you find smaller distance, set the current distance to it. So far the value of distance was always int.Max, so the value of if (dist < distance) was always true, so the loop was going to the end, and returning the last line.