### PR TITLE
flush _modules and _moduleFiles in DesktopRuntimeBase

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/Desktop/runtimebase.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Desktop/runtimebase.cs
@@ -71,6 +71,8 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
             
             MemoryReader = null;
             _moduleList = null;
+            _modules = new Dictionary<ulong, DesktopModule>();
+            _moduleFiles = new Dictionary<string, DesktopModule>();
             _threads = new Lazy<List<ClrThread>>(CreateThreadList);
             _appDomains = new Lazy<DomainContainer>(CreateAppDomainList);
             _heap = new Lazy<DesktopGCHeap>(CreateHeap);


### PR DESCRIPTION
Possible bug: _modules and _moduleFiles in DesktopRuntimeBase is not Flush'ed. So, it's impossible, e.g. get stack traces twice without recreating ClrRuntime

Repro:
```
using (var dt = DataTarget.AttachToProcess(pid, msTimeout, AttachFlag.Passive))
{
    var runtime = dt.ClrVersions[0].CreateRuntime();
    runtime.Threads.Select(x => x.StackTrace).ToArray();
    runtime.Flush();
    runtime.Threads.Select(x => x.StackTrace).ToArray();
}
```
Result:
```
Unhandled Exception: Microsoft.Diagnostics.Runtime.ClrDiagnosticsException: You must not reuse any object other than ClrRuntime after calling flush!
ClrModule revision (0) != ClrRuntime revision (1).
   at Microsoft.Diagnostics.Runtime.ClrDiagnosticsException.ThrowRevisionError(Int32 revision, Int32 runtimeRevision)
   at Microsoft.Diagnostics.Runtime.Desktop.DesktopModule.GetMetadataImport()
```

This PR fix it