### PR TITLE
Changes to ClrMD to be able to extract data from Basic types on MiniDumps

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/Desktop/fields.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Desktop/fields.cs
@@ -963,4 +963,197 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
 
         public override IList<ClrInstanceField> Fields => new ClrInstanceField[0];
     }
+    class PrimitiveType : BaseDesktopHeapType
+    {
+        public PrimitiveType(DesktopGCHeap heap, ClrElementType type)
+            : base(0, heap, heap.DesktopRuntime.ErrorModule, 0)
+        {
+            ElementType = type;
+        }
+
+        public override int BaseSize
+        {
+            get
+            {
+                return DesktopInstanceField.GetSize(this, ElementType);
+            }
+        }
+
+        public override ClrType BaseType
+        {
+            get
+            {
+                return DesktopHeap.ValueType;
+            }
+        }
+
+        public override int ElementSize
+        {
+            get
+            {
+                return DesktopInstanceField.GetSize(this, ElementType);
+            }
+        }
+
+        public override ClrHeap Heap
+        {
+            get
+            {
+                return DesktopHeap;
+            }
+        }
+
+        public override IList<ClrInterface> Interfaces
+        {
+            get
+            {
+                return new ClrInterface[0];
+            }
+        }
+
+        public override bool IsAbstract
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        public override bool IsFinalizable
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        public override bool IsInterface
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        public override bool IsInternal
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        public override bool IsPrivate
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        public override bool IsProtected
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        public override bool IsPublic
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        public override bool IsSealed
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        public override uint MetadataToken
+        {
+            get
+            {
+                return 0;
+            }
+        }
+
+        public override ulong MethodTable
+        {
+            get
+            {
+                return 0;
+            }
+        }
+
+        public override string Name
+        {
+            get
+            {
+                return ElementType.ToString();
+            }
+        }
+
+        public override IEnumerable<ulong> EnumerateMethodTables()
+        {
+            return new ulong[0];
+        }
+
+        public override void EnumerateRefsOfObject(ulong objRef, Action<ulong, int> action)
+        {
+        }
+
+        public override void EnumerateRefsOfObjectCarefully(ulong objRef, Action<ulong, int> action)
+        {
+        }
+
+        public override ulong GetArrayElementAddress(ulong objRef, int index)
+        {
+            throw new InvalidOperationException();
+        }
+
+        public override object GetArrayElementValue(ulong objRef, int index)
+        {
+            throw new InvalidOperationException();
+        }
+
+        public override int GetArrayLength(ulong objRef)
+        {
+            throw new InvalidOperationException();
+        }
+
+        public override ClrInstanceField GetFieldByName(string name)
+        {
+            return null;
+        }
+
+        public override bool GetFieldForOffset(int fieldOffset, bool inner, out ClrInstanceField childField, out int childFieldOffset)
+        {
+            childField = null;
+            childFieldOffset = 0;
+            return false;
+        }
+
+        public override ulong GetSize(ulong objRef)
+        {
+            return 0;
+        }
+
+        public override ClrStaticField GetStaticFieldByName(string name)
+        {
+            return null;
+        }
+
+        internal override ulong GetModuleAddress(ClrAppDomain domain)
+        {
+            return 0;
+        }
+
+        public override IList<ClrInstanceField> Fields => new ClrInstanceField[0];
+    }
 }

--- a/src/Microsoft.Diagnostics.Runtime/Desktop/fields.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Desktop/fields.cs
@@ -991,7 +991,7 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
         {
             get
             {
-                return DesktopInstanceField.GetSize(this, ElementType);
+                return 0;
             }
         }
 
@@ -1095,7 +1095,7 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
         {
             get
             {
-                return ElementType.ToString();
+                return GetElementTypeName();
             }
         }
 
@@ -1155,5 +1155,58 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
         }
 
         public override IList<ClrInstanceField> Fields => new ClrInstanceField[0];
+
+        private string GetElementTypeName()
+        {
+            switch (ElementType)
+            {
+                case ClrElementType.Boolean:
+                    return "System.Boolean";
+
+                case ClrElementType.Char:
+                    return "System.Char";
+
+                case ClrElementType.Int8:
+                    return "System.SByte";
+
+                case ClrElementType.UInt8:
+                    return "System.Byte";
+
+                case ClrElementType.Int16:
+                    return "System.Int16";
+
+                case ClrElementType.UInt16:
+                    return "System.UInt16";
+
+                case ClrElementType.Int32:
+                    return "System.Int32";
+
+                case ClrElementType.UInt32:
+                    return "System.UInt32";
+
+                case ClrElementType.Int64:
+                    return "System.Int64";
+
+                case ClrElementType.UInt64:
+                    return "System.UInt64";
+
+                case ClrElementType.Float:
+                    return "System.Single";
+
+                case ClrElementType.Double:
+                    return "System.Double";
+
+                case ClrElementType.NativeInt:
+                    return "System.IntPtr";
+
+                case ClrElementType.NativeUInt:
+                    return "System.UIntPtr";
+
+                case ClrElementType.Struct:
+                    return "Sytem.ValueType";
+            }
+
+            return ElementType.ToString();
+        }
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/Desktop/heap.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Desktop/heap.cs
@@ -1010,7 +1010,31 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
                 InitBasicTypes();
 
 
-            return _basicTypes[(int)elType];
+            var ret = _basicTypes[(int)elType];
+            if (ret == null && this.DesktopRuntime.DataReader.IsMinidump)
+            {
+                switch (elType)
+                {
+                    case ClrElementType.Boolean:
+                    case ClrElementType.Char:
+                    case ClrElementType.Double:
+                    case ClrElementType.Float:
+                    case ClrElementType.Pointer:
+                    case ClrElementType.NativeInt:
+                    case ClrElementType.FunctionPointer:
+                    case ClrElementType.NativeUInt:
+                    case ClrElementType.Int16:
+                    case ClrElementType.Int32:
+                    case ClrElementType.Int64:
+                    case ClrElementType.Int8:
+                    case ClrElementType.UInt16:
+                    case ClrElementType.UInt32:
+                    case ClrElementType.UInt64:
+                    case ClrElementType.UInt8:
+                        return new PrimitiveType(this, elType);
+                }
+            }
+            return ret;
         }
 
         private void InitBasicTypes()

--- a/src/Microsoft.Diagnostics.Runtime/Desktop/heap.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Desktop/heap.cs
@@ -1009,9 +1009,7 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
             if (_basicTypes == null)
                 InitBasicTypes();
 
-
-            var ret = _basicTypes[(int)elType];
-            if (ret == null && this.DesktopRuntime.DataReader.IsMinidump)
+            if (_basicTypes[(int)elType] == null && this.DesktopRuntime.DataReader.IsMinidump)
             {
                 switch (elType)
                 {
@@ -1031,10 +1029,11 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
                     case ClrElementType.UInt32:
                     case ClrElementType.UInt64:
                     case ClrElementType.UInt8:
-                        return new PrimitiveType(this, elType);
+                        _basicTypes[(int)elType] = new PrimitiveType(this, elType);
+                        break;
                 }
             }
-            return ret;
+            return _basicTypes[(int)elType]; ;
         }
 
         private void InitBasicTypes()
@@ -1153,7 +1152,8 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
                 }
             }
 
-            Debug.Assert(DesktopRuntime.DataReader.IsMinidump || count == 14);
+            Debug.Assert(DesktopRuntime.DataReader.IsMinidump || count == 14);           
+
         }
 
         internal BaseDesktopHeapType CreatePointerType(BaseDesktopHeapType innerType, ClrElementType clrElementType, string nameHint)

--- a/src/Microsoft.Diagnostics.Runtime/Desktop/runtimebase.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Desktop/runtimebase.cs
@@ -504,7 +504,7 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
         #region Internal Functions
         protected ClrThread GetThreadByStackAddress(ulong address)
         {
-            Debug.Assert(address != 0);
+            Debug.Assert(address != 0 || _dataReader.IsMinidump);
 
             foreach (ClrThread thread in _threads.Value)
             {

--- a/src/Microsoft.Diagnostics.Runtime/Desktop/v45runtime.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Desktop/v45runtime.cs
@@ -736,7 +736,11 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
                 if (!ReadPointer(dataPtr + (ulong)(2 * IntPtr.Size), out ulong md))
                     break;
 
-                if (i == 0)
+                if (i == 0 && sp != 0)
+                    thread = (DesktopThread)GetThreadByStackAddress(sp);
+
+                // it seems that the first frame often has 0 for IP and SP.  Try the 2nd frame as well
+                if (i == 1 && thread == null && sp != 0)
                     thread = (DesktopThread)GetThreadByStackAddress(sp);
 
                 result.Add(new DesktopStackFrame(this, thread, ip, sp, md));


### PR DESCRIPTION

Add new BaseDesktopHeapType class named PrimitiveType to host ValueTypes such as Int32/Int16/Bool/Char/Pointer/Etc.

Modify GetBasicType() to return a PrimitiveType object when InitBasicTypes() fails to load the type from mscorlib.  This happens in all MiniDumps.

All the information to be able to extract this data is available to ClrMD, this patch allows us to get this Basic information even when InitBasictypes() can not find the types in a MiniDump.

This allows us to get the same information !sos.do gets in Minidumps.

Example:
!sos.do:

Fields:
      MT    Field   Offset                 Type VT     Attr    Value Name
...
640a32b4  4000010       34        System.String  0 instance 02cba4ec _source
00000000  4000011       44        System.IntPtr  1 instance        0 _xptrs
00000000  4000012       48         System.Int32  1 instance -532462766 _xcode
00000000  4000013       4c       System.UIntPtr  1 instance 64a59864 _ipForWatsonBuckets
00000000  4000014       38 ...ializationManager  0 instance 02cba4d0 _safeSerializationManager

!mex.do2 with these changes:

0:000> !do2 0x02cb6c24
0x02cb6c24 System.UnauthorizedAccessException
  ...
  0030  _source                   : 02cba4ec <invalid object>
  0034  _safeSerializationManager : 02cba4d0 <invalid object>
  0038  _remoteStackIndex         : 0 (Int32)
  003c  _HResult                  : -2147024891 (Int32)
  0040  _xptrs                    : 00000000 (NativeInt)
  0044  _xcode                    : -532462766 (Int32)
  0048  _ipForWatsonBuckets       : 64a59864 (NativeUInt)

Prior to these changes, it was not possible to get these values using CLRmd.