### PR TITLE
Make sure handles are returned only once

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime.Tests/GCHandleTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/GCHandleTests.cs
@@ -1,9 +1,6 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Microsoft.Diagnostics.Runtime.Tests
 {
@@ -20,7 +17,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
                 ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
 
                 List<ClrHandle> handles = new List<ClrHandle>();
-                
+
                 bool cont;
                 do
                 {
@@ -44,6 +41,26 @@ namespace Microsoft.Diagnostics.Runtime.Tests
 
                 // We create at least this many handles in the test, plus the runtime uses some.
                 Assert.IsTrue(handles.Count > 4);
+            }
+        }
+
+        [TestMethod]
+        public void EnsureAllItemsAreUnique()
+        {
+            // Making sure that handles are returned only once
+            var handles = new HashSet<ClrHandle>();
+
+            using (DataTarget dt = TestTargets.GCHandles.LoadFullDump())
+            {
+                ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
+
+                foreach (var handle in runtime.EnumerateHandles())
+                {
+                    Assert.IsTrue(handles.Add(handle));
+                }
+
+                // Make sure we had at least one AsyncPinned handle
+                Assert.IsTrue(handles.Any(h => h.HandleType == HandleType.AsyncPinned));
             }
         }
     }

--- a/src/Microsoft.Diagnostics.Runtime.Tests/Targets/GCHandles.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/Targets/GCHandles.cs
@@ -14,11 +14,8 @@ class GCHandles
         string weak = "weak";
         GCHandle.Alloc(weak, GCHandleType.Weak);
 
-        //var a = new System.Net.Sockets.SocketAsyncEventArgs();
-        //a.SetBuffer(new byte[10], 0, 10);
-
         NativeOverlapped nativeOverlapped;
-        
+
         unsafe
         {
             nativeOverlapped = *new System.Threading.Overlapped().UnsafePack((u, bytes, overlap) => { }, "state");

--- a/src/Microsoft.Diagnostics.Runtime.Tests/Targets/GCHandles.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/Targets/GCHandles.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Threading;
 using System.Runtime.InteropServices;
 
 class GCHandles
@@ -13,11 +14,22 @@ class GCHandles
         string weak = "weak";
         GCHandle.Alloc(weak, GCHandleType.Weak);
 
+        //var a = new System.Net.Sockets.SocketAsyncEventArgs();
+        //a.SetBuffer(new byte[10], 0, 10);
+
+        NativeOverlapped nativeOverlapped;
+        
+        unsafe
+        {
+            nativeOverlapped = *new System.Threading.Overlapped().UnsafePack((u, bytes, overlap) => { }, "state");
+        }
+
         string weakLong = "weakLong";
         GCHandle.Alloc(weak, GCHandleType.WeakTrackResurrection);
 
         throw new Exception();
 
+        GC.KeepAlive(nativeOverlapped);
         GC.KeepAlive(weak);
         GC.KeepAlive(weakLong);
     }

--- a/src/Microsoft.Diagnostics.Runtime.Tests/TestTargets.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/TestTargets.cs
@@ -143,7 +143,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             }
 
             cp.GenerateInMemory = false;
-            cp.CompilerOptions = IntPtr.Size == 4 ? "/platform:x86" : "/platform:x64";
+            cp.CompilerOptions = "/unsafe " + (IntPtr.Size == 4 ? "/platform:x86" : "/platform:x64");
 
             cp.IncludeDebugInformation = true;
             cp.OutputAssembly = destination;

--- a/src/Microsoft.Diagnostics.Runtime/Desktop/v45runtime.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Desktop/v45runtime.cs
@@ -138,7 +138,6 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
                     if (handle != null)
                     {
                         _handles.Add(handle);
-                        yield return handle;
                     }
                 }
 


### PR DESCRIPTION
When dealing with AsyncPinned handles with a state, the v45runtime.EnumerateHandleWorker method returned the interior handle twice