### PR TITLE
Expose ErrorType through public ClrHeap property

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/ClrHeap.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrHeap.cs
@@ -169,6 +169,11 @@ namespace Microsoft.Diagnostics.Runtime
         public abstract ClrType Free { get; }
 
         /// <summary>
+        /// Returns the ClrType representing an invalid type.
+        /// </summary>
+        public abstract ClrType ErrorType { get; }
+
+        /// <summary>
         /// Enumerate the roots in the process.
         /// </summary>
         /// <param name="enumerateStatics">True if we should enumerate static variables.  Enumerating with statics 
@@ -786,11 +791,14 @@ namespace Microsoft.Diagnostics.Runtime
         private bool _canWalkHeap;
         private int _pointerSize;
 
+        public override ClrType ErrorType { get; }
+
         public HeapBase(RuntimeBase runtime)
         {
             _canWalkHeap = runtime.CanWalkHeap;
             MemoryReader = new MemoryReader(runtime.DataReader, 0x10000);
             _pointerSize = runtime.PointerSize;
+            ErrorType = new ErrorType(this);
         }
 
         public override ulong GetMethodTable(ulong obj)

--- a/src/Microsoft.Diagnostics.Runtime/Desktop/heap.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Desktop/heap.cs
@@ -22,7 +22,6 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
             // Prepopulate a few important method tables.
             _arrayType = new Lazy<ClrType>(CreateArrayType);
             _exceptionType = new Lazy<ClrType>(() => GetTypeByMethodTable(DesktopRuntime.ExceptionMethodTable, 0, 0));
-            ErrorType = new ErrorType(this);
 
             StringType = DesktopRuntime.StringMethodTable != 0 ? GetTypeByMethodTable(DesktopRuntime.StringMethodTable, 0, 0) : ErrorType;
             ObjectType = DesktopRuntime.ObjectMethodTable != 0 ? GetTypeByMethodTable(DesktopRuntime.ObjectMethodTable, 0, 0) : ErrorType;
@@ -958,7 +957,7 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
         private ExtendedArray<ulong> _gcRefs;
 
         internal DesktopRuntimeBase DesktopRuntime { get; private set; }
-        internal BaseDesktopHeapType ErrorType { get; private set; }
+        
         internal ClrType ObjectType { get; private set; }
         internal ClrType StringType { get; private set; }
         internal ClrType ValueType { get; private set; }
@@ -1033,7 +1032,7 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
                         break;
                 }
             }
-            return _basicTypes[(int)elType]; ;
+            return _basicTypes[(int)elType];
         }
 
         private void InitBasicTypes()


### PR DESCRIPTION
I made a change to expose ErrorType through a public property of ClrHeap.

I needed this because I had a similar `UnknownType` concept in ClrMD.Extensions that was deriving from ClrType. It's no longer possible to derive from ClrType because of the internal abstract GCDesc property. Instead of defining my own `UnknownType` class, it's cleaner to reuse `ErrorType`.