### PR TITLE
Fix for proper finalization queue detection in .net 4.0+ dumps

### DIFF
--- a/Src/Microsoft.Diagnostics.Runtime.Tests/FinalizationQueueTests.cs
+++ b/Src/Microsoft.Diagnostics.Runtime.Tests/FinalizationQueueTests.cs
@@ -1,0 +1,47 @@
+﻿using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Diagnostics.Runtime.Tests
+{
+    [TestClass]
+    public class FinalizationQueueTests
+    {
+        [TestMethod]
+        public void TestAllFinalizableObjects()
+        {
+            using (var dt = TestTargets.FinalizationQueue.LoadFullDump())
+            {
+                var runtime = dt.ClrVersions.Single().CreateRuntime();
+                var targetObjectsCount = 0;
+                
+                foreach (var address in runtime.Heap.EnumerateFinalizableObjectAddresses())
+                {
+                    var type = runtime.Heap.GetObjectType(address);
+                    if (type.Name == typeof(DieFastA).FullName)
+                        targetObjectsCount++;
+                }
+        
+                Assert.AreEqual(FinalizationQueueTarget.ObjectsCountA, targetObjectsCount);
+            }
+        }
+        
+        [TestMethod]
+        public void TestFinalizerQueueObjects()
+        {
+            using (var dt = TestTargets.FinalizationQueue.LoadFullDump())
+            {
+                var runtime = dt.ClrVersions.Single().CreateRuntime();
+                var targetObjectsCount = 0;
+                
+                foreach (var address in runtime.EnumerateFinalizerQueueObjectAddresses())
+                {
+                    var type = runtime.Heap.GetObjectType(address);
+                    if (type.Name == typeof(DieFastB).FullName)
+                        targetObjectsCount++;
+                }
+        
+                Assert.AreEqual(FinalizationQueueTarget.ObjectsCountB, targetObjectsCount);
+            }
+        }
+    }
+}

--- a/Src/Microsoft.Diagnostics.Runtime.Tests/Targets/FinalizationQueue.cs
+++ b/Src/Microsoft.Diagnostics.Runtime.Tests/Targets/FinalizationQueue.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+
+public class FinalizationQueueTarget
+{
+  public const int ObjectsCountA = 42;
+  public const int ObjectsCountB = 13;
+  
+  private static readonly ICollection<object> _objects = new List<object>();
+  
+  public static void Main(params string[] args)
+  {
+    for (var i = 0; i < ObjectsCountA; i++)
+      _objects.Add(new DieFastA());
+    
+    Console.WriteLine(new DieHard());
+    GC.Collect();
+    
+    for (var i = 0; i < ObjectsCountB; i++)
+      Console.WriteLine(new DieFastB());
+    GC.Collect();
+    
+    throw new Exception();
+  }
+}
+
+public class DieHard
+{
+  private static readonly WaitHandle _handle = new ManualResetEvent(false);
+
+  ~DieHard()
+  {
+    _handle.WaitOne();
+  }
+}
+
+public class DieFastA
+{
+  ~DieFastA()
+  {
+    Console.WriteLine(GetHashCode());
+  }
+}
+
+public class DieFastB
+{
+  ~DieFastB()
+  {
+    Console.WriteLine(GetHashCode());
+  }
+}

--- a/src/Microsoft.Diagnostics.Runtime.Tests/Microsoft.Diagnostics.Runtime.Tests.csproj
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/Microsoft.Diagnostics.Runtime.Tests.csproj
@@ -44,6 +44,7 @@
   <ItemGroup>
     <Compile Include="AppDomainTests.cs" />
     <Compile Include="Debugger.cs" />
+    <Compile Include="FinalizationQueueTests.cs" />
     <Compile Include="GCHandleTests.cs" />
     <None Include="project.json" />
     <None Include="Targets\GCHandles.cs">
@@ -55,6 +56,9 @@
     <None Include="Targets\GCRoot.cs">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <Compile Include="Targets\FinalizationQueue.cs">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Compile>
     <Compile Include="TypeTests.cs" />
     <Compile Include="MinidumpTests.cs" />
     <Compile Include="ModuleTests.cs" />

--- a/src/Microsoft.Diagnostics.Runtime.Tests/Microsoft.Diagnostics.Runtime.Tests.csproj
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/Microsoft.Diagnostics.Runtime.Tests.csproj
@@ -56,7 +56,7 @@
     <None Include="Targets\GCRoot.cs">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
-    <Compile Include="Targets\FinalizationQueue.cs">
+    <None Include="Targets\FinalizationQueue.cs">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Compile>
     <Compile Include="TypeTests.cs" />

--- a/src/Microsoft.Diagnostics.Runtime.Tests/TestTargets.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/TestTargets.cs
@@ -30,6 +30,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         static Lazy<TestTarget> _gcHandles = new Lazy<TestTarget>(() => new TestTarget("GCHandles.cs"));
         static Lazy<TestTarget> _types = new Lazy<TestTarget>(() => new TestTarget("Types.cs"));
         static Lazy<TestTarget> _appDomains = new Lazy<TestTarget>(() => new TestTarget("AppDomains.cs", NestedException));
+        static Lazy<TestTarget> _finalizationQueue = new Lazy<TestTarget>(() => new TestTarget("FinalizationQueue.cs"));
 
         public static TestTarget GCRoot { get { return _gcroot.Value; } }
         public static TestTarget NestedException { get { return _nestedException.Value; } }
@@ -37,6 +38,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         public static TestTarget GCHandles { get { return _gcHandles.Value; } }
         public static TestTarget Types { get { return _types.Value; } }
         public static TestTarget AppDomains { get { return _appDomains.Value; } }
+        public static TestTarget FinalizationQueue { get { return _finalizationQueue.Value; } }
     }
 
     public class TestTarget

--- a/src/Microsoft.Diagnostics.Runtime/ClrRuntime.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrRuntime.cs
@@ -975,7 +975,7 @@ namespace Microsoft.Diagnostics.Runtime
             {
                 foreach (SubHeap heap in heaps)
                 {
-                    foreach (ulong objAddr in GetPointersInRange(heap.FQStart, heap.FQStop))
+                    foreach (ulong objAddr in GetPointersInRange(heap.FQRootsStart, heap.FQRootsStop))
                     {
                         if (objAddr != 0)
                             yield return objAddr;

--- a/src/Microsoft.Diagnostics.Runtime/Desktop/heap.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Desktop/heap.cs
@@ -217,7 +217,7 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
             {
                 foreach (SubHeap heap in heaps)
                 {
-                    foreach (ulong obj in DesktopRuntime.GetPointersInRange(heap.FQLiveStart, heap.FQLiveStop))
+                    foreach (ulong obj in DesktopRuntime.GetPointersInRange(heap.FQAllObjectsStart, heap.FQAllObjectsStop))
                     {
                         if (obj == 0)
                             continue;

--- a/src/Microsoft.Diagnostics.Runtime/Desktop/legacyruntime.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Desktop/legacyruntime.cs
@@ -2049,25 +2049,24 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
             get { return generation_table0.AllocContextLimit; }
         }
 
-
-        public ulong FQAllObjectsStop
+        public ulong FQAllObjectsStart
         {
-            get { return finalization_fill_pointers5; }
+            get { return finalization_fill_pointers0; }
         }
 
-        public ulong FQAllObjectsStart
+        public ulong FQAllObjectsStop
         {
             get { return finalization_fill_pointers3; }
         }
 
         public ulong FQRootsStart
         {
-            get { return finalization_fill_pointers0; }
+            get { return finalization_fill_pointers3; }
         }
 
-        public ulong FQRootsEnd
+        public ulong FQRootsStop
         {
-            get { return finalization_fill_pointers3; }
+            get { return finalization_fill_pointers5; }
         }
 
         public ulong Gen0Start
@@ -2587,22 +2586,22 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
 
         public ulong FQAllObjectsStart
         {
-            get { return finalization_fill_pointers3; }
+            get { return finalization_fill_pointers0; }
         }
 
         public ulong FQAllObjectsStop
         {
-            get { return finalization_fill_pointers5; }
+            get { return finalization_fill_pointers3; }
         }
 
         public ulong FQRootsStart
         {
-            get { return finalization_fill_pointers0; }
+            get { return finalization_fill_pointers3; }
         }
 
-        public ulong FQRootsEnd
+        public ulong FQRootsStop
         {
-            get { return finalization_fill_pointers3; }
+            get { return finalization_fill_pointers5; }
         }
 
         public ulong Gen0Start

--- a/src/Microsoft.Diagnostics.Runtime/Desktop/legacyruntime.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Desktop/legacyruntime.cs
@@ -2584,46 +2584,26 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
         {
             get { return generation_table0.AllocContextLimit; }
         }
+
         public ulong FQAllObjectsStart
         {
-            get { return finalization_fill_pointers0; }
+            get { return finalization_fill_pointers3; }
         }
 
         public ulong FQAllObjectsStop
         {
-            get { return finalization_fill_pointers3; }
+            get { return finalization_fill_pointers5; }
         }
-
 
         public ulong FQRootsStart
         {
-            get { return finalization_fill_pointers3; }
+            get { return finalization_fill_pointers0; }
         }
 
         public ulong FQRootsEnd
         {
-            get { return finalization_fill_pointers6; }
+            get { return finalization_fill_pointers3; }
         }
-
-        //public ulong FQStop
-        //{
-        //    get { return finalization_fill_pointers6; }
-        //}
-
-        //public ulong FQStart
-        //{
-        //    get { return finalization_fill_pointers3; }
-        //}
-
-        //public ulong FQLiveStart
-        //{
-        //    get { return finalization_fill_pointers0; }
-        //}
-
-        //public ulong FQLiveEnd
-        //{
-        //    get { return finalization_fill_pointers4; }
-        //}
 
         public ulong Gen0Start
         {

--- a/src/Microsoft.Diagnostics.Runtime/Desktop/runtimebase.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Desktop/runtimebase.cs
@@ -1242,10 +1242,10 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
         internal ulong Gen2Start { get { return ActualHeap.Gen2Start; } }
         internal ulong FirstLargeSegment { get { return ActualHeap.FirstLargeHeapSegment; } }
         internal ulong FirstSegment { get { return ActualHeap.FirstHeapSegment; } }
-        internal ulong FQStart { get { return ActualHeap.FQAllObjectsStart; } }
-        internal ulong FQStop { get { return ActualHeap.FQAllObjectsStop; } }
-        internal ulong FQLiveStart { get { return ActualHeap.FQRootsStart; } }
-        internal ulong FQLiveStop { get { return ActualHeap.FQRootsEnd; } }
+        internal ulong FQAllObjectsStart { get { return ActualHeap.FQAllObjectsStart; } }
+        internal ulong FQAllObjectsStop { get { return ActualHeap.FQAllObjectsStop; } }
+        internal ulong FQRootsStart { get { return ActualHeap.FQRootsStart; } }
+        internal ulong FQRootsStop { get { return ActualHeap.FQRootsStop; } }
 
         internal SubHeap(IHeapDetails heap, int heapNum, Dictionary<ulong,ulong> allocPointers)
         {
@@ -1359,7 +1359,7 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
         ulong FQAllObjectsStart { get; }
         ulong FQAllObjectsStop { get; }
         ulong FQRootsStart { get; }
-        ulong FQRootsEnd { get; }
+        ulong FQRootsStop { get; }
     }
 
     internal interface IGCInfo

--- a/src/Microsoft.Diagnostics.Runtime/Native/NativeDac.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Native/NativeDac.cs
@@ -411,24 +411,24 @@ namespace Microsoft.Diagnostics.Runtime.Native
             get { return generation_table0.AllocContextLimit; }
         }
 
-        public ulong FQAllObjectsStop
-        {
-            get { return finalization_fill_pointers5; }
-        }
-
         public ulong FQAllObjectsStart
-        {
-            get { return finalization_fill_pointers4; }
-        }
-
-        public ulong FQRootsStart
         {
             get { return finalization_fill_pointers0; }
         }
 
-        public ulong FQRootsEnd
+        public ulong FQAllObjectsStop
         {
             get { return finalization_fill_pointers3; }
+        }
+
+        public ulong FQRootsStart
+        {
+            get { return finalization_fill_pointers4; }
+        }
+
+        public ulong FQRootsStop
+        {
+            get { return finalization_fill_pointers5; }
         }
 
         public ulong Gen0Start


### PR DESCRIPTION
Region pointers for "all finalizable objects" and "objects in finalization queue" were mixed up and swapped several times across the code.
This resulted in incorrect processing of data obtained from `V4HeapDetails`.

The fix attempts to bring unified naming for FQ-related stuff and consistent behaviour for all `IHeapDetails` implementations.
The usecase in question was covered by tests, but it would also be nice to get a review due to the lack of docs for `finalization_fill_pointers[i]`.