### PR TITLE
Provide optimized heap method to compute class histogram

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime.sln
+++ b/src/Microsoft.Diagnostics.Runtime.sln
@@ -15,6 +15,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FileAndLineNumbers", "Sampl
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GCRootDemo", "Samples\GCRootDemo\GCRootDemo.csproj", "{AB227B1A-25FA-4CF1-B2AE-B41AFCF5E182}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ClassHistogram", "Samples\ClassHistogram\ClassHistogram.csproj", "{B6E56382-F6FB-4764-A5FD-4905908F7D03}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -125,6 +127,26 @@ Global
 		{AB227B1A-25FA-4CF1-B2AE-B41AFCF5E182}.Release|x64.Build.0 = Release|Any CPU
 		{AB227B1A-25FA-4CF1-B2AE-B41AFCF5E182}.Release|x86.ActiveCfg = Release|Any CPU
 		{AB227B1A-25FA-4CF1-B2AE-B41AFCF5E182}.Release|x86.Build.0 = Release|Any CPU
+		{B6E56382-F6FB-4764-A5FD-4905908F7D03}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B6E56382-F6FB-4764-A5FD-4905908F7D03}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B6E56382-F6FB-4764-A5FD-4905908F7D03}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{B6E56382-F6FB-4764-A5FD-4905908F7D03}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{B6E56382-F6FB-4764-A5FD-4905908F7D03}.Debug|Win32.ActiveCfg = Debug|Any CPU
+		{B6E56382-F6FB-4764-A5FD-4905908F7D03}.Debug|Win32.Build.0 = Debug|Any CPU
+		{B6E56382-F6FB-4764-A5FD-4905908F7D03}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B6E56382-F6FB-4764-A5FD-4905908F7D03}.Debug|x64.Build.0 = Debug|Any CPU
+		{B6E56382-F6FB-4764-A5FD-4905908F7D03}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B6E56382-F6FB-4764-A5FD-4905908F7D03}.Debug|x86.Build.0 = Debug|Any CPU
+		{B6E56382-F6FB-4764-A5FD-4905908F7D03}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B6E56382-F6FB-4764-A5FD-4905908F7D03}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B6E56382-F6FB-4764-A5FD-4905908F7D03}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{B6E56382-F6FB-4764-A5FD-4905908F7D03}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{B6E56382-F6FB-4764-A5FD-4905908F7D03}.Release|Win32.ActiveCfg = Release|Any CPU
+		{B6E56382-F6FB-4764-A5FD-4905908F7D03}.Release|Win32.Build.0 = Release|Any CPU
+		{B6E56382-F6FB-4764-A5FD-4905908F7D03}.Release|x64.ActiveCfg = Release|Any CPU
+		{B6E56382-F6FB-4764-A5FD-4905908F7D03}.Release|x64.Build.0 = Release|Any CPU
+		{B6E56382-F6FB-4764-A5FD-4905908F7D03}.Release|x86.ActiveCfg = Release|Any CPU
+		{B6E56382-F6FB-4764-A5FD-4905908F7D03}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -133,5 +155,9 @@ Global
 		{3FCA8012-3BAD-41E4-91F4-534AA9A44F96} = {FB574D76-776A-4E41-A203-317A2AA35607}
 		{EA92F1E6-3F34-48F8-8B0A-F2BBC19220EF} = {FB574D76-776A-4E41-A203-317A2AA35607}
 		{AB227B1A-25FA-4CF1-B2AE-B41AFCF5E182} = {FB574D76-776A-4E41-A203-317A2AA35607}
+		{B6E56382-F6FB-4764-A5FD-4905908F7D03} = {FB574D76-776A-4E41-A203-317A2AA35607}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {3FC1853B-ABE3-4FDB-95E7-10D773C686AD}
 	EndGlobalSection
 EndGlobal

--- a/src/Samples/ClassHistogram/App.config
+++ b/src/Samples/ClassHistogram/App.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2"/>
+    </startup>
+</configuration>

--- a/src/Samples/ClassHistogram/ClassHistogram.csproj
+++ b/src/Samples/ClassHistogram/ClassHistogram.csproj
@@ -1,0 +1,63 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{B6E56382-F6FB-4764-A5FD-4905908F7D03}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>ClassHistogram</RootNamespace>
+    <AssemblyName>ClassHistogram</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Microsoft.Diagnostics.Runtime.Tests\Microsoft.Diagnostics.Runtime.Tests.csproj">
+      <Project>{c23b51c4-2475-4fc6-9b3a-27d0a2b99b0f}</Project>
+      <Name>Microsoft.Diagnostics.Runtime.Tests</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\Microsoft.Diagnostics.Runtime\Microsoft.Diagnostics.Runtime.csproj">
+      <Project>{a82126ca-23aa-41f1-8586-a5938d44d0a7}</Project>
+      <Name>Microsoft.Diagnostics.Runtime</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/src/Samples/ClassHistogram/Program.cs
+++ b/src/Samples/ClassHistogram/Program.cs
@@ -1,0 +1,67 @@
+﻿using Microsoft.Diagnostics.Runtime;
+using Microsoft.Diagnostics.Runtime.Tests;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ClassHistogram
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            // build a "class histogram" (i.e. !dumpheap -stat in WinDBG+sos)
+            // in an optimized way
+            using (DataTarget dt = TestTargets.Types.LoadFullDump())
+            {
+                ClrRuntime runtime = dt.ClrVersions[0].CreateRuntime();
+                ClrHeap heap = runtime.Heap;
+
+                var statistics = new Dictionary<ClrType, TypeEntry>(32768);
+                int objectCount = 0;
+
+                // build the class histogram: count and cumulated size of instances per type
+                foreach (var objDetails in heap.EnumerateObjectDetails())
+                {
+                    ulong address = objDetails.Item1;
+                    ulong mt = objDetails.Item2;
+                    ClrType type = objDetails.Item3;
+                    ulong size = objDetails.Item4;
+
+                    TypeEntry entry;
+                    if (!statistics.TryGetValue(type, out entry))
+                    {
+                        entry = new TypeEntry()
+                        {
+                            TypeName = type.Name,
+                            MethodTable = mt,
+                            Size = 0
+                        };
+                        statistics[type] = entry;
+                    }
+                    entry.Count++;
+                    entry.Size += size;
+                    objectCount++;
+                }
+
+                // display a la !dumpheap -stat
+                var sortedStatistics = 
+                    from entry in statistics.Values
+                    orderby entry.Size
+                    select entry;
+                Console.WriteLine("{0,12} {1,12} {2,12} {3}", "MT", "Count", "TotalSize", "Class Name");
+                foreach (var entry in sortedStatistics)
+                    Console.WriteLine($"{entry.MethodTable,12:X12} {entry.Size,12:D} {entry.Count,12:D} {entry.TypeName}");
+                Console.WriteLine($"Total {objectCount} objects");
+            }
+        }
+    }
+
+    class TypeEntry
+    {
+        public string TypeName;
+        public ulong MethodTable;
+        public int Count;
+        public ulong Size;
+    }
+}

--- a/src/Samples/ClassHistogram/Properties/AssemblyInfo.cs
+++ b/src/Samples/ClassHistogram/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("ClassHistogram")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("ClassHistogram")]
+[assembly: AssemblyCopyright("Copyright ©  2018")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("b6e56382-f6fb-4764-a5fd-4905908f7d03")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]


### PR DESCRIPTION
After profiling on large heaps, the expensive calls to GetObjectType and GetSize are responsible for most of the work. This code change avoids duplicated calls to these expensive methods.
--> ~30% gain on large heaps during tests on 16+ GB memory dumps