### PR TITLE
Don't free the dac lib when the app is exiting

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/DacLibrary.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacLibrary.cs
@@ -94,6 +94,8 @@ namespace Microsoft.Diagnostics.Runtime
 
         ~DacLibrary()
         {
+            if (Environment.HasShutdownStarted)
+                return;
             if (_library != IntPtr.Zero)
                 DataTarget.PlatformFunctions.FreeLibrary(_library);
         }


### PR DESCRIPTION
https://github.com/Microsoft/clrmd/issues/126

This issue happens when the app is exiting. Other dtors assume that their dtor is called before the dac lib dtor but this isn't true when the app is exiting.