### PR TITLE
Add ref counting to DacLibrary to prevent AV when app is exiting

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/ClrRuntime.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrRuntime.cs
@@ -16,8 +16,10 @@ namespace Microsoft.Diagnostics.Runtime
     /// Represents a single runtime in a target process or crash dump.  This serves as the primary
     /// entry point for getting diagnostic information.
     /// </summary>
-    public abstract class ClrRuntime
+    public abstract class ClrRuntime : IDisposable
     {
+        private bool _disposed;
+
         /// <summary>
         /// In .NET native crash dumps, we have a list of serialized exceptions objects. This property expose them as ClrException objects.
         /// </summary>
@@ -299,6 +301,23 @@ namespace Microsoft.Diagnostics.Runtime
                 default:
                     return null;
             }
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposed)
+            {
+                DacLibrary.Release();
+                _disposed = true;
+            }
+        }
+
+        ~ClrRuntime() => Dispose(false);
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/CallableCOMWrapper.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/CallableCOMWrapper.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
 
         protected IntPtr Self { get; }
         private IUnknownVTable* _unknownVTable;
-        private readonly GCHandle _library;
+        private readonly DacLibrary _library;
 
         protected void* _vtable => _unknownVTable + 1;
 
@@ -39,7 +39,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
 
             Self = pCorrectUnknown;
             _unknownVTable = *(IUnknownVTable**)pCorrectUnknown;
-            _library = GCHandle.Alloc(library);
+            _library = library.AddRef();
         }
 
         public void Release()
@@ -48,7 +48,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
                 _release = (ReleaseDelegate)Marshal.GetDelegateForFunctionPointer(_unknownVTable->Release, typeof(ReleaseDelegate));
 
             _release(Self);
-            _library.Free();
+            _library.Release();
         }
 
         public IntPtr QueryInterface(ref Guid riid)

--- a/src/Microsoft.Diagnostics.Runtime/RuntimeBase.cs
+++ b/src/Microsoft.Diagnostics.Runtime/RuntimeBase.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Diagnostics.Runtime
 
             ClrInfo = info;
             _dataTarget = dataTarget;
-            DacLibrary = lib;
+            DacLibrary = lib.AddRef();
             _dacInterface = DacLibrary.DacPrivateInterface;
             InitApi();
 


### PR DESCRIPTION
#126

This fixes an AV that can happen when the application is shutting down. CallableCOMWrapper holds a ref to the DAC lib, but the CallableCOMWrapper dtor assumes that the DAC lib dtor is always called after its own dtor. This is not always true when the app is shutting down.

ClrRuntime now implements IDisposable and has a dtor so DacLibrary can be freed.
