### PR TITLE
Clean up Release semantics for DacLibrary

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/ClrInfo.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrInfo.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Diagnostics.Runtime
             DacLibrary lib = new DacLibrary(_dataTarget, DacLibrary.TryGetDacPtr(clrDataProcess));
 
             // Figure out what version we are on.
-            if (lib.SOSDacInterface != null)
+            if (lib.GetSOSInterfaceNoAddRef() != null)
             {
                 return new V45Runtime(this, _dataTarget, lib);
             }
@@ -78,7 +78,7 @@ namespace Microsoft.Diagnostics.Runtime
             {
                 byte[] buffer = new byte[Marshal.SizeOf(typeof(V2HeapDetails))];
 
-                int val = lib.DacPrivateInterface.Request(DacRequests.GCHEAPDETAILS_STATIC_DATA, 0, null, (uint)buffer.Length, buffer);
+                int val = lib.InternalDacPrivateInterface.Request(DacRequests.GCHEAPDETAILS_STATIC_DATA, 0, null, (uint)buffer.Length, buffer);
                 if ((uint)val == 0x80070057)
                     return new LegacyRuntime(this, _dataTarget, lib, Desktop.DesktopVersion.v4, 10000);
                 else

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/ClrDataProcess.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/ClrDataProcess.cs
@@ -31,6 +31,10 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             _library = library;
         }
 
+        public ClrDataProcess(CallableCOMWrapper toClone) : base(toClone)
+        {
+        }
+
         public SOSDac GetSOSDacInterface()
         {
             IntPtr result = QueryInterface(ref SOSDac.IID_ISOSDac);

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/SOSDac.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/SOSDac.cs
@@ -24,6 +24,10 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             _library = library;
         }
 
+        public SOSDac(CallableCOMWrapper toClone) : base(toClone)
+        {
+        }
+
         const int CharBufferSize = 256;
         private byte[] _buffer = new byte[CharBufferSize];
 

--- a/src/Microsoft.Diagnostics.Runtime/Desktop/v45runtime.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Desktop/v45runtime.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
         protected override void InitApi()
         {
             if (_sos == null)
-                _sos = DacLibrary.SOSDacInterface;
+                _sos = DacLibrary.GetSOSInterfaceNoAddRef();
 
             Debug.Assert(_sos != null);
         }

--- a/src/Microsoft.Diagnostics.Runtime/Native/NativeRuntime.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Native/NativeRuntime.cs
@@ -46,14 +46,14 @@ namespace Microsoft.Diagnostics.Runtime.Native
         {
             if (_sos == null)
             {
-                var dac = DacLibrary.DacPrivateInterface;
+                var dac = DacLibrary.InternalDacPrivateInterface;
                 if (!(dac is ISOSNative))
                     throw new ClrDiagnosticsException("This version of mrt100 is too old.", ClrDiagnosticsException.HR.DataRequestError);
 
                 _sos = (ISOSNative)dac;
             }
 
-            _sosNativeSerializedExceptionSupport = DacLibrary.DacPrivateInterface as ISOSNativeSerializedExceptionSupport;
+            _sosNativeSerializedExceptionSupport = DacLibrary.InternalDacPrivateInterface as ISOSNativeSerializedExceptionSupport;
         }
 
         public override ClrHeap Heap => _heap.Value;

--- a/src/Microsoft.Diagnostics.Runtime/RuntimeBase.cs
+++ b/src/Microsoft.Diagnostics.Runtime/RuntimeBase.cs
@@ -34,12 +34,12 @@ namespace Microsoft.Diagnostics.Runtime
         public RuntimeBase(ClrInfo info, DataTargetImpl dataTarget, DacLibrary lib)
         {
             Debug.Assert(lib != null);
-            Debug.Assert(lib.DacPrivateInterface != null);
+            Debug.Assert(lib.InternalDacPrivateInterface != null);
 
             ClrInfo = info;
             _dataTarget = dataTarget;
             DacLibrary = lib;
-            _dacInterface = DacLibrary.DacPrivateInterface;
+            _dacInterface = DacLibrary.InternalDacPrivateInterface;
             InitApi();
 
             _dacInterface.Flush();


### PR DESCRIPTION
Clean up releasing interfaces (and therefore the underlying dac).  This allows the call to DataTarget.Dispose to release all interfaces and unload the dac, if there are no outstanding references to SOSDac.