### PR TITLE
Expose context of stack frames

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/src/Common/ClrStackFrame.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/ClrStackFrame.cs
@@ -35,6 +35,11 @@ namespace Microsoft.Diagnostics.Runtime
     public abstract class ClrStackFrame
     {
         /// <summary>
+        /// Gets this stack frame context.
+        /// </summary>
+        public abstract byte[] Context { get; }
+
+        /// <summary>
         /// Returns the thread this stack frame came from.
         /// </summary>
         public abstract ClrThread Thread { get; }

--- a/src/Microsoft.Diagnostics.Runtime/src/Desktop/DesktopRuntimeBase.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Desktop/DesktopRuntimeBase.cs
@@ -746,7 +746,10 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
                         ReadPointer(sp, out frameVtbl);
                     }
 
-                    DesktopStackFrame frame = GetStackFrame(thread, ip, sp, frameVtbl);
+                    byte[] contextCopy = new byte[context.Length];
+                    Buffer.BlockCopy(context, 0, contextCopy, 0, context.Length);
+
+                    DesktopStackFrame frame = GetStackFrame(thread, contextCopy, ip, sp, frameVtbl);
                     yield return frame;
                 } while (stackwalk.Next());
             }
@@ -818,7 +821,7 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
         internal abstract string GetNameForMD(ulong md);
         internal abstract IMethodDescData GetMethodDescData(ulong md);
         internal abstract uint GetMetadataToken(ulong mt);
-        protected abstract DesktopStackFrame GetStackFrame(DesktopThread thread, ulong ip, ulong sp, ulong frameVtbl);
+        protected abstract DesktopStackFrame GetStackFrame(DesktopThread thread, byte[] context, ulong ip, ulong sp, ulong frameVtbl);
         internal abstract IList<ClrStackFrame> GetExceptionStackTrace(ulong obj, ClrType type);
         internal abstract string GetAssemblyName(ulong assembly);
         internal abstract string GetAppBase(ulong appDomain);

--- a/src/Microsoft.Diagnostics.Runtime/src/Desktop/DesktopStackFrame.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Desktop/DesktopStackFrame.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
 {
     internal class DesktopStackFrame : ClrStackFrame
     {
+        public override byte[] Context => _context;
         public override ClrThread Thread => _thread;
         public override ulong StackPointer { get; }
         public override ulong InstructionPointer => _ip;
@@ -66,10 +67,11 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
             return sb.ToString();
         }
 
-        public DesktopStackFrame(DesktopRuntimeBase runtime, DesktopThread thread, ulong ip, ulong sp, ulong md)
+        public DesktopStackFrame(DesktopRuntimeBase runtime, DesktopThread thread, byte[] context, ulong ip, ulong sp, ulong md)
         {
             _runtime = runtime;
             _thread = thread;
+            _context = context;
             _ip = ip;
             StackPointer = sp;
             _frameName = _runtime.GetNameForMD(md) ?? "Unknown";
@@ -78,10 +80,11 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
             InitMethod(md);
         }
 
-        public DesktopStackFrame(DesktopRuntimeBase runtime, DesktopThread thread, ulong sp, ulong md)
+        public DesktopStackFrame(DesktopRuntimeBase runtime, DesktopThread thread, byte[] context, ulong sp, ulong md)
         {
             _runtime = runtime;
             _thread = thread;
+            _context = context;
             StackPointer = sp;
             _frameName = _runtime.GetNameForMD(md) ?? "Unknown";
             _type = ClrStackFrameType.Runtime;
@@ -89,10 +92,11 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
             InitMethod(md);
         }
 
-        public DesktopStackFrame(DesktopRuntimeBase runtime, DesktopThread thread, ulong sp, string method, ClrMethod innerMethod)
+        public DesktopStackFrame(DesktopRuntimeBase runtime, DesktopThread thread, byte[] context, ulong sp, string method, ClrMethod innerMethod)
         {
             _runtime = runtime;
             _thread = thread;
+            _context = context;
             StackPointer = sp;
             _frameName = method ?? "Unknown";
             _type = ClrStackFrameType.Runtime;
@@ -121,5 +125,6 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
         private ClrMethod _method;
         private readonly DesktopRuntimeBase _runtime;
         private readonly DesktopThread _thread;
+        private readonly byte[] _context;
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/src/Desktop/LegacyRuntime.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Desktop/LegacyRuntime.cs
@@ -546,7 +546,7 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
             return token;
         }
 
-        protected override DesktopStackFrame GetStackFrame(DesktopThread thread, ulong ip, ulong sp, ulong frameVtbl)
+        protected override DesktopStackFrame GetStackFrame(DesktopThread thread, byte[] context, ulong ip, ulong sp, ulong frameVtbl)
         {
             DesktopStackFrame frame;
             ClearBuffer();
@@ -562,12 +562,12 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
                 if (mdData != null)
                     method = DesktopMethod.Create(this, mdData);
 
-                frame = new DesktopStackFrame(this, thread, sp, frameName, method);
+                frame = new DesktopStackFrame(this, thread, context, sp, frameName, method);
             }
             else
             {
                 ulong md = GetMethodDescFromIp(ip);
-                frame = new DesktopStackFrame(this, thread, ip, sp, md);
+                frame = new DesktopStackFrame(this, thread, context, ip, sp, md);
             }
 
             return frame;
@@ -635,7 +635,7 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
                 if (i == 0)
                     thread = (DesktopThread)GetThreadByStackAddress(sp);
 
-                result.Add(new DesktopStackFrame(this, thread, ip, sp, md));
+                result.Add(new DesktopStackFrame(this, thread, null, ip, sp, md));
 
                 dataPtr += (ulong)elementSize;
             }

--- a/src/Microsoft.Diagnostics.Runtime/src/Desktop/V45Runtime.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Desktop/V45Runtime.cs
@@ -477,7 +477,7 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
             return data.Token;
         }
 
-        protected override DesktopStackFrame GetStackFrame(DesktopThread thread, ulong ip, ulong framePtr, ulong frameVtbl)
+        protected override DesktopStackFrame GetStackFrame(DesktopThread thread, byte[] context, ulong ip, ulong framePtr, ulong frameVtbl)
         {
             DesktopStackFrame frame;
             if (frameVtbl != 0)
@@ -493,11 +493,11 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
                         innerMethod = DesktopMethod.Create(this, mdData);
                 }
 
-                frame = new DesktopStackFrame(this, thread, framePtr, frameName, innerMethod);
+                frame = new DesktopStackFrame(this, thread, context, framePtr, frameName, innerMethod);
             }
             else
             {
-                frame = new DesktopStackFrame(this, thread, ip, framePtr, _sos.GetMethodDescPtrFromIP(ip));
+                frame = new DesktopStackFrame(this, thread, context, ip, framePtr, _sos.GetMethodDescPtrFromIP(ip));
             }
 
             return frame;
@@ -568,7 +568,7 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
                 if (i == 1 && thread == null && sp != 0)
                     thread = (DesktopThread)GetThreadByStackAddress(sp);
 
-                result.Add(new DesktopStackFrame(this, thread, ip, sp, md));
+                result.Add(new DesktopStackFrame(this, thread, null, ip, sp, md));
 
                 dataPtr += (ulong)elementSize;
             }


### PR DESCRIPTION
This change is to expose the context of stack frames. This change is not applicable to stack frames extracted from an exception where this new field is set to null.