### PR TITLE
WIP: Cross-platform support for Passive attached DataTarget

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime.Tests/Microsoft.Diagnostics.Runtime.Tests.csproj
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/Microsoft.Diagnostics.Runtime.Tests.csproj
@@ -22,5 +22,15 @@
     <None Include="..\TestTargets\**\*.*">
       <Link>data\%(RecursiveDir)%(Filename)%(Extension)</Link>
     </None>
+    <None Remove="obj\**" />
+    <None Remove="bin\**" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Remove="obj\**" />
+    <Compile Remove="bin\**" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Remove="obj\**" />
+    <EmbeddedResource Remove="bin\**" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.Diagnostics.Runtime/Microsoft.Diagnostics.Runtime.csproj
+++ b/src/Microsoft.Diagnostics.Runtime/Microsoft.Diagnostics.Runtime.csproj
@@ -34,4 +34,23 @@
       <PackagePath></PackagePath>
     </Content>
   </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="bin\**" />
+    <Compile Remove="obj\**" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Remove="bin\**" />
+    <EmbeddedResource Remove="obj\**" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Remove="bin\**" />
+    <None Remove="obj\**" />
+  </ItemGroup>
 </Project>

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/RuntimeBase.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/RuntimeBase.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Diagnostics.Runtime
         protected ClrDataProcess _dacInterface;
         private MemoryReader _cache;
         protected IDataReader _dataReader;
-        protected DataTargetImpl _dataTarget;
+        protected DataTarget _dataTarget;
 
         protected ICorDebugProcess _corDebugProcess;
         internal ICorDebugProcess CorDebugProcess
@@ -33,7 +33,7 @@ namespace Microsoft.Diagnostics.Runtime
             }
         }
 
-        public RuntimeBase(ClrInfo info, DataTargetImpl dataTarget, DacLibrary lib)
+        public RuntimeBase(ClrInfo info, DataTarget dataTarget, DacLibrary lib)
         {
             Debug.Assert(lib != null);
             Debug.Assert(lib.InternalDacPrivateInterface != null);

--- a/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Live/LiveDataReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Live/LiveDataReader.cs
@@ -327,10 +327,10 @@ namespace Microsoft.Diagnostics.Runtime
         internal static extern int VirtualQueryEx(IntPtr hProcess, IntPtr lpAddress, ref MEMORY_BASIC_INFORMATION lpBuffer, IntPtr dwLength);
 
         [DllImport("kernel32.dll")]
-        private static extern bool GetThreadContext(IntPtr hThread, IntPtr lpContext);
+        internal static extern bool GetThreadContext(IntPtr hThread, IntPtr lpContext);
 
         [DllImport("kernel32.dll", SetLastError = true)]
-        private static extern SafeWin32Handle OpenThread(ThreadAccess dwDesiredAccess, [MarshalAs(UnmanagedType.Bool)] bool bInheritHandle, uint dwThreadId);
+        internal static extern SafeWin32Handle OpenThread(ThreadAccess dwDesiredAccess, [MarshalAs(UnmanagedType.Bool)] bool bInheritHandle, uint dwThreadId);
 
         [DllImport("kernel32")]
         private static extern int PssCaptureSnapshot(IntPtr ProcessHandle, PSS_CAPTURE_FLAGS CaptureFlags, int ThreadContextFlags, out IntPtr SnapshotHandle);

--- a/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Live/ProcMap.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Live/ProcMap.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace Microsoft.Diagnostics.Runtime {
+    public static class ProcMap
+    {
+        
+        public static IEnumerable<ProcMapEntry> GetEntries(int pid)
+        {
+
+            using (var sr = new StreamReader($"/proc/{pid}/maps", Encoding.UTF8, false, 81908))
+            {
+                do
+                {
+                    yield return new ProcMapEntry(sr.ReadLine());
+                } while (!sr.EndOfStream);
+            }
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Live/ProcMapEntry.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Live/ProcMapEntry.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace Microsoft.Diagnostics.Runtime {
+    public class ProcMapEntry
+    {
+        private static readonly Regex s_rxProcMaps = new Regex(
+            @"^([0-9a-fA-F]+)-([0-9a-fA-F]+) ([a-zA-Z0-9_\-]{4,}) ([0-9a-fA-F]+) ([0-9a-fA-F]{2,}:[0-9a-fA-F]{2,}) (\d+)(?:[ \t]+([^\s].*?))?\s*$",
+            RegexOptions.Compiled | RegexOptions.Multiline | RegexOptions.CultureInvariant);
+
+        public string Line { get; }
+        public UIntPtr Start { get; }
+        public UIntPtr End { get; }
+        public UIntPtr Size => (UIntPtr)( End.ToUInt64() - Start.ToUInt64() );
+        public string Perms { get; }
+        public string Offset { get; }
+        public string Device { get; }
+        public string INode { get; }
+        public string Path { get; }
+
+        public ProcMapEntry(string line)
+        {
+            Line = line;
+            
+            var match = s_rxProcMaps.Match(line);
+            if (!match.Success)
+                throw new NotImplementedException("don't understand /proc/pid/map");
+
+            Start = new UIntPtr(ulong.Parse(match.Groups[1].Value, NumberStyles.HexNumber));
+            End = new UIntPtr(ulong.Parse(match.Groups[2].Value, NumberStyles.HexNumber));
+            Perms = match.Groups[3].Value;
+            Offset = match.Groups[4].Value;
+            Device = match.Groups[5].Value;
+            INode = match.Groups[6].Value;
+            Path = match.Groups.Count == 8 ? match.Groups[7].Value : "";
+        }
+
+        public bool InRange(UIntPtr addr) =>
+            InRange(addr.ToUInt64());
+        
+        public bool InRange(ulong addr) =>
+            Start.ToUInt64() <= addr && End.ToUInt64() >= addr;
+
+        public override string ToString() =>
+            Line;
+
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Live/ThreadAccess.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Live/ThreadAccess.cs
@@ -2,10 +2,28 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+
 namespace Microsoft.Diagnostics.Runtime
 {
+    [Flags]
     internal enum ThreadAccess
     {
+        SYNCHRONIZE = 0x00100000,
+        
+        THREAD_TERMINATE = 0x0001,
+        THREAD_SUSPEND_RESUME = 0x0002,
+        
+        THREAD_GET_CONTEXT = 0x0008,
+        THREAD_SET_CONTEXT = 0x0010,
+        THREAD_SET_INFORMATION = 0x0020,
+        THREAD_QUERY_INFORMATION = 0x0040,
+        THREAD_SET_THREAD_TOKEN = 0x0080,
+        
+        THREAD_DIRECT_IMPERSONATION = 0x0200,
+        THREAD_SET_LIMITED_INFORMATION = 0x0400,
+        THREAD_QUERY_LIMITED_INFORMATION = 0x0800,
+        
         THREAD_ALL_ACCESS = 0x1F03FF
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/src/DataTargets/ClrInfo.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataTargets/ClrInfo.cs
@@ -152,7 +152,7 @@ namespace Microsoft.Diagnostics.Runtime
             return Version.ToString();
         }
 
-        internal ClrInfo(DataTargetImpl dt, ClrFlavor flavor, ModuleInfo module, DacInfo dacInfo, string dacLocation)
+        internal ClrInfo(DataTarget dt, ClrFlavor flavor, ModuleInfo module, DacInfo dacInfo, string dacLocation)
         {
             Debug.Assert(dacInfo != null);
 
@@ -168,7 +168,7 @@ namespace Microsoft.Diagnostics.Runtime
         {
         }
 
-        private readonly DataTargetImpl _dataTarget;
+        private readonly DataTarget _dataTarget;
 
         /// <summary>
         /// IComparable.  Sorts the object by version.

--- a/src/Microsoft.Diagnostics.Runtime/src/DataTargets/DacInfo.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataTargets/DacInfo.cs
@@ -19,21 +19,34 @@ namespace Microsoft.Diagnostics.Runtime
         /// </summary>
         public static string GetDacRequestFileName(ClrFlavor flavor, Architecture currentArchitecture, Architecture targetArchitecture, VersionInfo clrVersion)
         {
+            var isWin = Environment.OSVersion.Platform == PlatformID.Win32NT;
+            var prefix = isWin ? "" : "lib";
+            var ext = isWin ? "dll" : "so";
             string dacName = flavor == ClrFlavor.Core ? "mscordaccore" : "mscordacwks";
+            // ReSharper disable once UseStringInterpolation
             return string.Format(
-                "{0}_{1}_{2}_{3}.{4}.{5}.{6:D2}.dll",
+                "{0}{1}_{2}_{3}_{4}.{5}.{6}.{7:D2}.{8}",
+                prefix,
                 dacName,
                 currentArchitecture,
                 targetArchitecture,
                 clrVersion.Major,
                 clrVersion.Minor,
                 clrVersion.Revision,
-                clrVersion.Patch);
+                clrVersion.Patch,
+                ext);
         }
 
         internal static string GetDacFileName(ClrFlavor flavor, Architecture targetArchitecture)
         {
-            return flavor == ClrFlavor.Core ? "mscordaccore.dll" : "mscordacwks.dll";
+            if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+            {
+                return flavor == ClrFlavor.Core ? "mscordaccore.dll" : "mscordacwks.dll";
+            }
+            else
+            {
+                return flavor == ClrFlavor.Core ? "libmscordaccore.so" : "libmscordacwks.so";
+            }
         }
 
         /// <summary>

--- a/src/Microsoft.Diagnostics.Runtime/src/DataTargets/DacLibrary.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataTargets/DacLibrary.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Diagnostics.Runtime
             return pUnk;
         }
 
-        internal DacLibrary(DataTargetImpl dataTarget, IntPtr pUnk)
+        internal DacLibrary(DataTarget dataTarget, IntPtr pUnk)
         {
             InternalDacPrivateInterface = new ClrDataProcess(this, pUnk);
         }

--- a/src/Microsoft.Diagnostics.Runtime/src/DataTargets/DataTargetImpl.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataTargets/DataTargetImpl.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Diagnostics.Runtime
             return _dataReader.ReadMemory(address, buffer, bytesRequested, out bytesRead);
         }
 
-        public override IDebugClient DebuggerInterface { get; }
+        public override object DebuggerInterface { get; }
 
         public override IEnumerable<ModuleInfo> EnumerateModules()
         {

--- a/src/Microsoft.Diagnostics.Runtime/src/DataTargets/XPlatLiveDataTarget.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataTargets/XPlatLiveDataTarget.cs
@@ -1,0 +1,410 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace Microsoft.Diagnostics.Runtime
+{
+    internal unsafe class XPlatLiveDataTarget : DataTarget, IDataReader
+    {
+        private readonly uint _timeout;
+        private readonly AttachFlag _flags;
+        private readonly int _pid;
+
+        private readonly List<DacLibrary> _dacLibraries = new List<DacLibrary>(2);
+
+        public override IDataReader DataReader => this;
+
+        public override bool IsMinidump => false;
+
+        public override Architecture Architecture => GetArchitecture();
+
+        private Lazy<IList<ClrInfo>> _clrVersionsLazy;
+
+        public XPlatLiveDataTarget(int pid, uint timeout, AttachFlag flags)
+        {
+            _pid = pid;
+            _timeout = timeout;
+            _flags = flags;
+
+            _clrVersionsLazy = new Lazy<IList<ClrInfo>>(InitClrVersions);
+
+            // TODO: check dac arch
+        }
+
+        public override IList<ClrInfo> ClrVersions => _clrVersionsLazy.Value;
+
+        public override uint PointerSize => unchecked((uint)IntPtr.Size);
+        //Architecture == Architecture.Amd64 ? 8u
+        //: Architecture == Architecture.X86 ? 4u
+        //: throw new NotImplementedException();
+
+        private IList<ClrInfo> InitClrVersions()
+        {
+            var versions = new List<ClrInfo>();
+            //Console.Error.WriteLine($"Checking modules in {_pid}");
+            foreach (ModuleInfo module in EnumerateModules())
+            {
+                string clrName = Path.GetFileNameWithoutExtension(module.FileName);
+                //Console.Error.WriteLine($"Checking {clrName}");
+                string clrNameLower = clrName?.ToLower();
+
+                if (clrNameLower == null
+                    || clrNameLower != "clr"
+                    && clrNameLower != "mscorwks"
+                    && clrNameLower != "coreclr"
+                    && clrNameLower != "mrt100_app"
+                    && clrNameLower != "libcoreclr")
+                    continue;
+
+                ClrFlavor flavor;
+                switch (clrNameLower)
+                {
+                    case "mrt100_app":
+                        //_native = module;
+                        throw new NotImplementedException("mrt100_app");
+                    //continue;
+
+                    case "libcoreclr":
+                    case "coreclr":
+                        flavor = ClrFlavor.Core;
+                        break;
+
+                    default:
+                        flavor = ClrFlavor.Desktop;
+                        break;
+                }
+
+                string directoryName = Path.GetDirectoryName(module.FileName);
+                string dacLocation = Path.Combine(directoryName, DacInfo.GetDacFileName(flavor, Architecture));
+
+                bool isLinux = clrName == "libcoreclr";
+
+                if (isLinux)
+                {
+                    dacLocation = Path.ChangeExtension(dacLocation, ".so");
+                    if (!File.Exists(dacLocation))
+                        dacLocation = Path.GetFileName(dacLocation);
+                    //Console.Error.WriteLine($"Adding {dacLocation}");
+                }
+                else if (!File.Exists(dacLocation) || !PlatformFunctions.IsEqualFileVersion(dacLocation, module.Version))
+                {
+                    dacLocation = null;
+                }
+
+                VersionInfo version = module.Version;
+                string dacAgnosticName = DacInfo.GetDacRequestFileName(flavor, Architecture, Architecture, version);
+                string dacFileName = DacInfo.GetDacRequestFileName(flavor, IntPtr.Size == 4 ? Architecture.X86 : Architecture.Amd64, Architecture, version);
+
+                var dacInfo = new DacInfo(this, dacAgnosticName, Architecture)
+                {
+                    FileSize = module.FileSize,
+                    TimeStamp = module.TimeStamp,
+                    FileName = dacFileName,
+                    Version = module.Version
+                };
+
+                versions.Add(new ClrInfo(this, flavor, module, dacInfo, dacLocation));
+                //Console.Error.WriteLine($"Added {dacInfo.FileName} {dacInfo.FileSize}");
+            }
+
+            //if (versions.Count < 1)
+            //{
+            //    Console.Error.WriteLine("Crap! Couldn't find DAC module!");
+            //    foreach (var mod in EnumerateModules())
+            //        Console.Error.WriteLine($"0x{mod.ImageBase:x16} {mod.FileSize,11}b {mod.FileName}");
+            //}
+
+            ClrInfo[] result = versions.ToArray();
+            Array.Sort(result);
+            return result;
+        }
+
+        public override bool ReadProcessMemory(ulong address, byte[] buffer, int bytesRequested, out int bytesRead) =>
+            ReadMemory(address, buffer, bytesRequested, out bytesRead);
+
+        public override object DebuggerInterface { get; } = null;
+
+        public void Close()
+        {
+            Dispose();
+        }
+
+        public void Flush()
+        {
+        }
+
+        public Architecture GetArchitecture() =>
+            IntPtr.Size == 4 ? Architecture.X86 : Architecture.Amd64;
+
+        public uint GetPointerSize() =>
+            (uint)IntPtr.Size;
+
+        public override IEnumerable<ModuleInfo> EnumerateModules() =>
+            ((IDataReader)this).EnumerateModules();
+
+        IList<ModuleInfo> IDataReader.EnumerateModules()
+        {
+            using (Process proc = Process.GetProcessById(_pid))
+            {
+                return proc.Modules
+                    .Cast<ProcessModule>()
+                    .Select(
+                        module => new ModuleInfo(this)
+                        {
+                            ImageBase = unchecked((ulong)module.BaseAddress.ToInt64()),
+                            FileName = module.FileName,
+                            FileSize = unchecked((uint)module.ModuleMemorySize),
+                            TimeStamp = 0 // really?
+                        })
+                    .ToArray();
+            }
+        }
+
+        public override void Dispose()
+        {
+            foreach (DacLibrary lib in _dacLibraries)
+                lib.Dispose();
+            _dacLibraries.Clear();
+            GC.SuppressFinalize(this);
+        }
+
+        internal override void AddDacLibrary(DacLibrary dacLibrary)
+        {
+            _dacLibraries.Add(dacLibrary);
+        }
+
+        public void GetVersionInfo(ulong addr, out VersionInfo version)
+        {
+            string filename;
+            if (IsWindows)
+            {
+                var sbFilename = new StringBuilder(1024);
+                using (Process p = Process.GetProcessById(_pid))
+                    LiveDataReader.GetModuleFileNameExA(p.Handle, new IntPtr((long)addr), sbFilename, sbFilename.Capacity);
+                filename = sbFilename.ToString();
+            }
+            else
+                filename = GetModuleFileNameXPlat(addr);
+
+            version = PlatformFunctions.GetFileVersion(filename, out int major, out int minor, out int revision, out int patch)
+                ? new VersionInfo(major, minor, revision, patch)
+                : new VersionInfo();
+        }
+
+        public bool ReadMemory(ulong address, byte[] buffer, int bytesRequested, out int bytesRead)
+        {
+            fixed (byte* pByte = &buffer[0])
+            {
+                return ReadMemory(address, (IntPtr)pByte, bytesRequested, out bytesRead);
+            }
+        }
+
+        public bool ReadMemory(ulong address, IntPtr buffer, int bytesRequested, out int bytesRead)
+        {
+            //Console.Error.WriteLine($"Attempting to read {bytesRequested} bytes from 0x{address:X8} into 0x{(ulong)buffer.ToInt64():X8}.");
+            if (IsWindows)
+            {
+                try
+                {
+                    using (Process p = Process.GetProcessById(_pid))
+                    {
+                        return LiveDataReader.ReadProcessMemory(p.Handle, new IntPtr((long)address), buffer, bytesRequested, out bytesRead) != 0;
+                    }
+                }
+                catch
+                {
+                    bytesRead = 0;
+                    //Console.Error.WriteLine("Windows ReadMemory failed!");
+                    return false;
+                }
+            }
+
+            ulong requested = unchecked((ulong)bytesRequested);
+            ulong offset = 0;
+            do
+            {
+                ulong len = Math.Min(requested - offset, 1024);
+
+                var local = new[]
+                {
+                    new iovec
+                    {
+                        iov_base = (IntPtr)(unchecked((ulong)buffer.ToInt64()) + offset),
+                        iov_len = (UIntPtr)len
+                    }
+                };
+
+                var remote = new[]
+                {
+                    new iovec
+                    {
+                        iov_base = (IntPtr)(address + offset),
+                        iov_len = (UIntPtr)len
+                    }
+                };
+
+                long read = LinuxFunctions.ProcessVmReadV(
+                        _pid,
+                        local,
+                        1,
+                        remote,
+                        1
+                    )
+                    .ToInt64();
+
+                if (read < 0)
+                {
+                    int errno = Marshal.GetLastWin32Error();
+                    //Console.Error.WriteLine($"Non-Win ReadMemory failed! Error Number: {errno:X}");
+                    bytesRead = (int)offset;
+                    return false;
+                }
+
+                var unsignedRead = unchecked((ulong)read);
+
+                offset += unsignedRead;
+
+                if (unsignedRead == len)
+                    continue;
+
+                // incomplete read, assume error? do we return false?
+                bytesRead = (int)offset;
+                //Console.Error.WriteLine($"Non-Win ReadMemory failed! Read {unsignedRead} in last stride, total {bytesRead} versus {requested}.");
+                return false;
+            } while (offset < requested);
+
+            bytesRead = (int)offset;
+
+            return true;
+        }
+
+        public TValue Read<TValue>(ulong addr)
+        {
+            var buf = new byte[Unsafe.SizeOf<TValue>()];
+
+            if (!ReadMemory(addr, buf, buf.Length, out int bytesRead))
+            {
+                //Console.Error.WriteLine("Read Failed!");
+                throw new NotImplementedException("Incomplete read");
+            }
+
+            if (bytesRead != buf.Length)
+            {
+                //Console.Error.WriteLine("Read Wrong Length!");
+                throw new NotImplementedException("Incomplete read");
+            }
+
+            return Unsafe.ReadUnaligned<TValue>(ref buf[0]);
+        }
+
+        public ulong ReadPointerUnsafe(ulong addr)
+        {
+            return Read<UIntPtr>(addr).ToUInt64();
+        }
+
+        public uint ReadDwordUnsafe(ulong addr)
+        {
+            return Read<uint>(addr);
+        }
+
+        public ulong GetThreadTeb(uint thread)
+        {
+            //Console.Error.WriteLine("GetThreadTeb!");
+            throw new NotImplementedException();
+        }
+
+        public IEnumerable<uint> EnumerateAllThreads()
+        {
+            using (Process p = Process.GetProcessById(_pid))
+            {
+                foreach (ProcessThread thread in p.Threads)
+                    yield return (uint)thread.Id;
+            }
+        }
+
+        public bool VirtualQuery(ulong addr, out VirtualQueryData vq)
+        {
+            if (IsWindows)
+            {
+                vq = new VirtualQueryData();
+
+                var mem = new MEMORY_BASIC_INFORMATION();
+                var ptr = new IntPtr((long)addr);
+
+                using (Process p = Process.GetProcessById(_pid))
+                {
+                    if (LiveDataReader.VirtualQueryEx(p.Handle, ptr, ref mem, new IntPtr(Marshal.SizeOf(mem))) == 0)
+                        return false;
+                }
+
+                vq.BaseAddress = mem.BaseAddress;
+                vq.Size = mem.Size;
+                return true;
+            }
+            
+            // non-windows
+
+            ProcMapEntry entry = ProcMap.GetEntries(_pid)
+                .FirstOrDefault(e => e.InRange(addr));
+
+            if (entry != null)
+            {
+                vq = new VirtualQueryData(
+                    entry.Start.ToUInt64(),
+                    entry.Size.ToUInt64());
+                return true;
+            }
+
+            vq = default;
+            return false;
+        }
+
+        private string GetModuleFileNameXPlat(ulong addr)
+        {
+            return ProcMap.GetEntries(_pid)
+                .FirstOrDefault(entry => entry.InRange(addr))
+                ?.Path;
+        }
+
+        public bool GetThreadContext(uint threadId, uint contextFlags, uint contextSize, IntPtr context)
+        {
+            if (IsWindows)
+            {
+                using (SafeWin32Handle hThread = LiveDataReader.OpenThread(ThreadAccess.THREAD_GET_CONTEXT | ThreadAccess.THREAD_QUERY_INFORMATION, false, threadId))
+                {
+                    return LiveDataReader.GetThreadContext(hThread.DangerousGetHandle(), context);
+                }
+            }
+
+            //Console.Error.WriteLine("GetThreadContext 1!");
+            // maybe implement similar to: https://github.com/dotnet/coreclr/blob/master/src/ToolBox/SOS/lldbplugin/services.cpp
+            //throw new NotImplementedException();
+            return false;
+        }
+
+        public bool GetThreadContext(uint threadId, uint contextFlags, uint contextSize, byte[] context)
+        {
+            if (IsWindows)
+            {
+                fixed (byte* p = &context[0])
+                {
+                    return GetThreadContext(threadId, contextFlags, contextSize, (IntPtr)p);
+                }
+            }
+
+            //Console.Error.WriteLine("GetThreadContext 2!");
+            // maybe implement similar to: https://github.com/dotnet/coreclr/blob/master/src/ToolBox/SOS/lldbplugin/services.cpp
+            //throw new NotImplementedException();
+            return false;
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/src/Desktop/DesktopRuntimeBase.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Desktop/DesktopRuntimeBase.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
         private Dictionary<string, DesktopModule> _moduleFiles = new Dictionary<string, DesktopModule>();
         private Lazy<ClrModule> _mscorlib;
 
-        internal DesktopRuntimeBase(ClrInfo info, DataTargetImpl dt, DacLibrary lib)
+        internal DesktopRuntimeBase(ClrInfo info, DataTarget dt, DacLibrary lib)
             : base(info, dt, lib)
         {
             _heap = new Lazy<DesktopGCHeap>(CreateHeap);

--- a/src/Microsoft.Diagnostics.Runtime/src/Desktop/LegacyRuntime.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Desktop/LegacyRuntime.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
         private readonly DesktopVersion _version;
         private readonly int _patch;
 
-        public LegacyRuntime(ClrInfo info, DataTargetImpl dt, DacLibrary lib, DesktopVersion version, int patch)
+        public LegacyRuntime(ClrInfo info, DataTarget dt, DacLibrary lib, DesktopVersion version, int patch)
             : base(info, dt, lib)
         {
             _version = version;

--- a/src/Microsoft.Diagnostics.Runtime/src/Desktop/V45Runtime.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Desktop/V45Runtime.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
         private List<ClrHandle> _handles;
         private SOSDac _sos;
 
-        public V45Runtime(ClrInfo info, DataTargetImpl dt, DacLibrary lib)
+        public V45Runtime(ClrInfo info, DataTarget dt, DacLibrary lib)
             : base(info, dt, lib)
         {
             if (!GetCommonMethodTables(ref _commonMTs))

--- a/src/Microsoft.Diagnostics.Runtime/src/Utilities/Platform/LinuxFunctions.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Utilities/Platform/LinuxFunctions.cs
@@ -1,8 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
-
-using System;
+﻿using System;
+using System.IO;
 using System.Runtime.InteropServices;
 
 namespace Microsoft.Diagnostics.Runtime
@@ -25,28 +22,125 @@ namespace Microsoft.Diagnostics.Runtime
 
         public override IntPtr LoadLibrary(string filename)
         {
-            return dlopen(filename, RTLD_NOW);
+            IntPtr h;
+
+            try
+            {
+                h = DlV2.dlopen(filename, RTLD_NOW);
+            }
+            catch (DllNotFoundException)
+            {
+                h = DlV1.dlopen(filename, RTLD_NOW);
+            }
+
+            if (h != default)
+                return h;
+
+            string m;
+            try
+            {
+                var p = DlV2.dlerror();
+                m = p == default ? "Unknown error." : Marshal.PtrToStringAnsi(p);
+            }
+            catch (DllNotFoundException)
+            {
+                var p = DlV1.dlerror();
+                m = p == default ? "Unknown error." : Marshal.PtrToStringAnsi(p);
+            }
+
+            throw new InvalidOperationException($"Error loading library {filename}", new Exception(m));
         }
 
         public override bool FreeLibrary(IntPtr module)
         {
-            return dlclose(module) == 0;
+            try
+            {
+                return DlV2.dlclose(module) == 0;
+            }
+            catch (DllNotFoundException)
+            {
+                return DlV1.dlclose(module) == 0;
+            }
         }
 
         public override IntPtr GetProcAddress(IntPtr module, string method)
         {
-            return dlsym(module, method);
+            try
+            {
+                return DlV2.dlsym(module, method);
+            }
+            catch (DllNotFoundException)
+            {
+                return DlV1.dlsym(module, method);
+            }
         }
 
-        [DllImport("libdl.so")]
-        private static extern IntPtr dlopen(string filename, int flags);
+        //const int RTLD_LOCAL  = 0x000;
+        //const int RTLD_LAZY   = 0x001;
+        const int RTLD_NOW = 0x002;
+        //const int RTLD_GLOBAL = 0x100;
 
-        [DllImport("libdl.so")]
-        private static extern int dlclose(IntPtr module);
+        internal static class DlV1
+        {
+            [DllImport("dl")]
+            internal static extern IntPtr dlopen(string filename, int flags);
 
-        [DllImport("libdl.so")]
-        private static extern IntPtr dlsym(IntPtr handle, string symbol);
+            [DllImport("dl")]
+            internal static extern int dlclose(IntPtr module);
 
-        private const int RTLD_NOW = 2;
+            [DllImport("dl")]
+            internal static extern IntPtr dlsym(IntPtr handle, string symbol);
+
+            [DllImport("dl")]
+            internal static extern IntPtr dlerror();
+        }
+
+        internal static class DlV2
+        {
+            [DllImport("libdl.so.2")]
+            internal static extern IntPtr dlopen(string filename, int flags);
+
+            [DllImport("libdl.so.2")]
+            internal static extern int dlclose(IntPtr module);
+
+            [DllImport("libdl.so.2")]
+            internal static extern IntPtr dlsym(IntPtr handle, string symbol);
+
+            [DllImport("libdl.so.2")]
+            internal static extern IntPtr dlerror();
+        }
+
+        // NOTE: IOV_MAX is 1024 or something
+        // libc.so.6
+
+        [DllImport("c", EntryPoint = "process_vm_readv", SetLastError=true)]
+        internal static extern IntPtr ProcessVmReadV(
+            int pid,
+            [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2)]
+            iovec[] localIoVec,
+            ulong localIovCount,
+            [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 4)]
+            iovec[] remoteIoVec,
+            ulong remoteIoVecCount,
+            ulong flags = 0);
+
+        [DllImport("c", EntryPoint = "process_vm_writev", SetLastError=true)]
+        internal static extern IntPtr ProcessVmWriteV(
+            int pid,
+            [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2)]
+            iovec localIoVec,
+            ulong localIoVecCount,
+            [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 4)]
+            iovec remoteIoVec,
+            ulong remoteIoVecCount,
+            ulong flags = 0);
+
+        [DllImport("c", EntryPoint = "ptrace")]
+        internal static extern long PTrace(
+            PTraceRequest request,
+            int pid,
+            IntPtr address,
+            IntPtr data = default
+        );
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/src/Utilities/Platform/PTraceRequest.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Utilities/Platform/PTraceRequest.cs
@@ -1,0 +1,38 @@
+﻿namespace Microsoft.Diagnostics.Runtime {
+    public enum PTraceRequest
+    {
+        TraceMe = 0,
+        PeekText,
+        PeekData,
+        PeekUser,
+        PokeText,
+        PokeData,
+        PokeUser,
+        Cont,
+        Kill,
+        SingleStep,
+        GetRegs = 12,
+        SetRegs,
+        GetFpReg,
+        SetFpRegs,
+        Attach = 16,
+        Detach,
+        GetFpXRegs,
+        SetFpXRegs,
+        Syscall = 24,
+        SetOptions = 0x4200,
+        GetEventMsg,
+        GetSigInfo,
+        SetSigInfo,
+        GetRegSet,
+        SetRegSet,
+        Seize,
+        Interrupt,
+        Listen,
+        PeekSigInfo,
+        GetSigMask,
+        SetSigMask,
+        SecCompGetFilter,
+        
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/src/Utilities/Platform/iovec.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Utilities/Platform/iovec.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Microsoft.Diagnostics.Runtime {
+    public struct iovec
+    {
+        public IntPtr iov_base; /* Starting address */
+        public UIntPtr iov_len; /* Number of bytes to transfer */
+    }
+}


### PR DESCRIPTION
***WIP*** Do not merge yet, thanks.

Extracted & ported XPlatLiveDataTarget from feature/public-xplat-netstd-appveyor.

Incomplete port from feature/public-xplat-netstd-appveyor.

See issue #143.

I got it to build and ran the existing tests.

I have attach tests for Linux ([results here](https://github.com/TylerAP/clrmd/issues/1)), I am going to try to port those to this minimal change set too.

Going to likely need help.

***TODO:*** Reference libmscordac.so when not on Windows.

***TODO:*** Maybe `DllNotFoundException`s, but if it does, will just move the Windows `DllImport` methods away from the Linux/Cross-Platform ones.

***TODO:*** Some `DllImport`s might need to target `"dbgshim"` to be fully cross-compatible.

