### PR TITLE
Fix issue where we over-release MetaDataImport in legacy runtimes

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/src/Common/RuntimeBase.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/RuntimeBase.cs
@@ -58,13 +58,7 @@ namespace Microsoft.Diagnostics.Runtime
         }
 
         public override DataTarget DataTarget => _dataTarget;
-
-        public void RegisterForRelease(IModuleData module)
-        {
-            if (module != null)
-                COMHelper.Release(module.LegacyMetaDataImport);
-        }
-
+        
         public IDataReader DataReader => _dataReader;
 
         protected abstract void InitApi();

--- a/src/Microsoft.Diagnostics.Runtime/src/DacInterface/Structs/ModuleData.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DacInterface/Structs/ModuleData.cs
@@ -37,7 +37,6 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
         ulong IModuleData.PEFile => IsPEFile == 0 ? ILBase : PEFile;
         ulong IModuleData.LookupTableHeap => LookupTableHeap;
         ulong IModuleData.ThunkHeap => ThunkHeap;
-        IntPtr IModuleData.LegacyMetaDataImport => IntPtr.Zero;
         ulong IModuleData.ModuleId => ModuleID;
         ulong IModuleData.ModuleIndex => ModuleIndex;
         bool IModuleData.IsReflection => IsReflection != 0;

--- a/src/Microsoft.Diagnostics.Runtime/src/Desktop/DesktopModule.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Desktop/DesktopModule.cs
@@ -42,11 +42,6 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
             MetadataLength = data.MetadataLength;
             AssemblyId = data.Assembly;
             _size = new Lazy<ulong>(() => runtime.GetModuleSize(address));
-
-            // This is very expensive in the minidump case, as we may be heading out to the symbol server or
-            // reading multiple files from disk. Only optimistically fetch this data if we have full memory.
-            if (!runtime.DataReader.IsMinidump && data.LegacyMetaDataImport != IntPtr.Zero)
-                _metadata = new MetaDataImport(runtime.DacLibrary, data.LegacyMetaDataImport);
         }
 
         public override ulong Address => _address;

--- a/src/Microsoft.Diagnostics.Runtime/src/Desktop/IModuleData.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Desktop/IModuleData.cs
@@ -12,7 +12,6 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
         ulong PEFile { get; }
         ulong LookupTableHeap { get; }
         ulong ThunkHeap { get; }
-        IntPtr LegacyMetaDataImport { get; }
         ulong ModuleId { get; }
         ulong ModuleIndex { get; }
         ulong Assembly { get; }

--- a/src/Microsoft.Diagnostics.Runtime/src/Desktop/LegacyRuntime.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Desktop/LegacyRuntime.cs
@@ -284,14 +284,26 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
             if (addr == 0)
                 return null;
 
-            IModuleData result = null;
+            IModuleData result;
             if (CLRVersion == DesktopVersion.v2)
-                result = Request<IModuleData, V2ModuleData>(DacRequests.MODULE_DATA, addr);
+            {
+                V2ModuleData data = new V2ModuleData();
+                if (!RequestStruct(DacRequests.MODULE_DATA, addr, ref data))
+                    return null;
+                
+                COMHelper.Release(data.MetaDataImport);
+                result = data;
+            }
             else
-                result = Request<IModuleData, V4ModuleData>(DacRequests.MODULE_DATA, addr);
+            {
+                V4ModuleData data = new V4ModuleData();
+                if (!RequestStruct(DacRequests.MODULE_DATA, addr, ref data))
+                    return null;
 
-            // Only needed in legacy runtime since v4.5 and on do not return this interface.
-            RegisterForRelease(result);
+                COMHelper.Release(data.MetaDataImport);
+                result = data;
+            }
+
             return result;
         }
 
@@ -407,13 +419,25 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
 
         internal override MetaDataImport GetMetadataImport(ulong module)
         {
-            IModuleData data = GetModuleData(module);
-            RegisterForRelease(data);
+            IntPtr import;
+            if (CLRVersion == DesktopVersion.v2)
+            {
+                V2ModuleData data = new V2ModuleData();
+                if (!RequestStruct(DacRequests.MODULE_DATA, module, ref data))
+                    return null;
 
-            if (data != null && data.LegacyMetaDataImport != IntPtr.Zero)
-                return new MetaDataImport(DacLibrary, data.LegacyMetaDataImport);
+                import = data.MetaDataImport;
+            }
+            else
+            {
+                V4ModuleData data = new V4ModuleData();
+                if (!RequestStruct(DacRequests.MODULE_DATA, module, ref data))
+                    return null;
 
-            return null;
+                import = data.MetaDataImport;
+            }
+
+            return import != IntPtr.Zero ? new MetaDataImport(DacLibrary, import) : null;
         }
 
         internal override ICCWData GetCCWData(ulong ccw)

--- a/src/Microsoft.Diagnostics.Runtime/src/Desktop/V2ModuleData.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Desktop/V2ModuleData.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
         public readonly uint IsReflection;
         public readonly uint IsPEFile;
         public readonly IntPtr BaseClassIndex;
-        public readonly IntPtr ModuleDefinition;
+        public readonly IntPtr MetaDataImport;
         public readonly IntPtr DomainNeutralIndex;
 
         public readonly uint TransientFlags;
@@ -37,7 +37,6 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
         ulong IModuleData.PEFile => PEFile;
         ulong IModuleData.LookupTableHeap => LookupTableHeap;
         ulong IModuleData.ThunkHeap => ThunkHeap;
-        IntPtr IModuleData.LegacyMetaDataImport => ModuleDefinition;
         ulong IModuleData.ModuleId => (ulong)DomainNeutralIndex.ToInt64();
         ulong IModuleData.ModuleIndex => 0;
         bool IModuleData.IsReflection => IsReflection != 0;

--- a/src/Microsoft.Diagnostics.Runtime/src/Desktop/V4ModuleData.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Desktop/V4ModuleData.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
         public readonly uint IsReflection;
         public readonly uint IsPEFile;
         public readonly IntPtr BaseClassIndex;
-        public readonly IntPtr ModuleDefinition;
+        public readonly IntPtr MetaDataImport;
         public readonly IntPtr ModuleID;
 
         public readonly uint TransientFlags;
@@ -38,7 +38,6 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
         ulong IModuleData.ImageBase => ILBase;
         ulong IModuleData.LookupTableHeap => LookupTableHeap;
         ulong IModuleData.ThunkHeap => ThunkHeap;
-        IntPtr IModuleData.LegacyMetaDataImport => ModuleDefinition;
         ulong IModuleData.ModuleId => (ulong)ModuleID.ToInt64();
         ulong IModuleData.ModuleIndex => (ulong)ModuleIndex.ToInt64();
         bool IModuleData.IsReflection => IsReflection != 0;


### PR DESCRIPTION
Fixed an issue where we would over-release IMetaDataImport:
- Removed IModuleData.LegacyMetaDataImport entirely.
- Always release metadata pointer when requesting ModuleData for legacy runtimes.
- Specifically re-request the ModuleData struct to get IMetaDataImport for legacy runtimes.