### PR TITLE
Add logic contracts for ClrObject APIs

### DIFF
--- a/Microsoft.Diagnostics.Runtime.sln
+++ b/Microsoft.Diagnostics.Runtime.sln
@@ -7,6 +7,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Diagnostics.Runti
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Diagnostics.Runtime.Tests", "src\Microsoft.Diagnostics.Runtime.Tests\Microsoft.Diagnostics.Runtime.Tests.csproj", "{C443A5AF-066E-4B08-B286-2BF1BD1443DC}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Diagnostics.Runtime.UnitTests", "src\Microsoft.Diagnostics.Runtime.UnitTests\Microsoft.Diagnostics.Runtime.UnitTests.csproj", "{214A7EC8-4D32-4202-8D8B-1761743EE527}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -57,26 +59,26 @@ Global
 		{C443A5AF-066E-4B08-B286-2BF1BD1443DC}.Release|x64.Build.0 = Release|Any CPU
 		{C443A5AF-066E-4B08-B286-2BF1BD1443DC}.Release|x86.ActiveCfg = Release|Any CPU
 		{C443A5AF-066E-4B08-B286-2BF1BD1443DC}.Release|x86.Build.0 = Release|Any CPU
-		{C255AA0C-B088-4D1C-9A79-9DE7D76DC4E4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{C255AA0C-B088-4D1C-9A79-9DE7D76DC4E4}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{C255AA0C-B088-4D1C-9A79-9DE7D76DC4E4}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{C255AA0C-B088-4D1C-9A79-9DE7D76DC4E4}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
-		{C255AA0C-B088-4D1C-9A79-9DE7D76DC4E4}.Debug|Win32.ActiveCfg = Debug|Any CPU
-		{C255AA0C-B088-4D1C-9A79-9DE7D76DC4E4}.Debug|Win32.Build.0 = Debug|Any CPU
-		{C255AA0C-B088-4D1C-9A79-9DE7D76DC4E4}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{C255AA0C-B088-4D1C-9A79-9DE7D76DC4E4}.Debug|x64.Build.0 = Debug|Any CPU
-		{C255AA0C-B088-4D1C-9A79-9DE7D76DC4E4}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{C255AA0C-B088-4D1C-9A79-9DE7D76DC4E4}.Debug|x86.Build.0 = Debug|Any CPU
-		{C255AA0C-B088-4D1C-9A79-9DE7D76DC4E4}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{C255AA0C-B088-4D1C-9A79-9DE7D76DC4E4}.Release|Any CPU.Build.0 = Release|Any CPU
-		{C255AA0C-B088-4D1C-9A79-9DE7D76DC4E4}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
-		{C255AA0C-B088-4D1C-9A79-9DE7D76DC4E4}.Release|Mixed Platforms.Build.0 = Release|Any CPU
-		{C255AA0C-B088-4D1C-9A79-9DE7D76DC4E4}.Release|Win32.ActiveCfg = Release|Any CPU
-		{C255AA0C-B088-4D1C-9A79-9DE7D76DC4E4}.Release|Win32.Build.0 = Release|Any CPU
-		{C255AA0C-B088-4D1C-9A79-9DE7D76DC4E4}.Release|x64.ActiveCfg = Release|Any CPU
-		{C255AA0C-B088-4D1C-9A79-9DE7D76DC4E4}.Release|x64.Build.0 = Release|Any CPU
-		{C255AA0C-B088-4D1C-9A79-9DE7D76DC4E4}.Release|x86.ActiveCfg = Release|Any CPU
-		{C255AA0C-B088-4D1C-9A79-9DE7D76DC4E4}.Release|x86.Build.0 = Release|Any CPU
+		{214A7EC8-4D32-4202-8D8B-1761743EE527}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{214A7EC8-4D32-4202-8D8B-1761743EE527}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{214A7EC8-4D32-4202-8D8B-1761743EE527}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{214A7EC8-4D32-4202-8D8B-1761743EE527}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{214A7EC8-4D32-4202-8D8B-1761743EE527}.Debug|Win32.ActiveCfg = Debug|Any CPU
+		{214A7EC8-4D32-4202-8D8B-1761743EE527}.Debug|Win32.Build.0 = Debug|Any CPU
+		{214A7EC8-4D32-4202-8D8B-1761743EE527}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{214A7EC8-4D32-4202-8D8B-1761743EE527}.Debug|x64.Build.0 = Debug|Any CPU
+		{214A7EC8-4D32-4202-8D8B-1761743EE527}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{214A7EC8-4D32-4202-8D8B-1761743EE527}.Debug|x86.Build.0 = Debug|Any CPU
+		{214A7EC8-4D32-4202-8D8B-1761743EE527}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{214A7EC8-4D32-4202-8D8B-1761743EE527}.Release|Any CPU.Build.0 = Release|Any CPU
+		{214A7EC8-4D32-4202-8D8B-1761743EE527}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{214A7EC8-4D32-4202-8D8B-1761743EE527}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{214A7EC8-4D32-4202-8D8B-1761743EE527}.Release|Win32.ActiveCfg = Release|Any CPU
+		{214A7EC8-4D32-4202-8D8B-1761743EE527}.Release|Win32.Build.0 = Release|Any CPU
+		{214A7EC8-4D32-4202-8D8B-1761743EE527}.Release|x64.ActiveCfg = Release|Any CPU
+		{214A7EC8-4D32-4202-8D8B-1761743EE527}.Release|x64.Build.0 = Release|Any CPU
+		{214A7EC8-4D32-4202-8D8B-1761743EE527}.Release|x86.ActiveCfg = Release|Any CPU
+		{214A7EC8-4D32-4202-8D8B-1761743EE527}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Microsoft.Diagnostics.Runtime.UnitTests/AutoFixture/AutoNSubstituteDataAttribute.cs
+++ b/src/Microsoft.Diagnostics.Runtime.UnitTests/AutoFixture/AutoNSubstituteDataAttribute.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using AutoFixture;
+using AutoFixture.AutoNSubstitute;
+using AutoFixture.Xunit2;
+
+namespace Microsoft.Diagnostics.Runtime.UnitTests
+{
+  public class AutoNSubstituteDataAttribute : AutoDataAttribute
+  {
+    public AutoNSubstituteDataAttribute() :
+      base(() => new Fixture().Customize(new AutoNSubstituteCustomization()))
+    {
+    }
+
+  }
+}

--- a/src/Microsoft.Diagnostics.Runtime.UnitTests/ClrObjectTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.UnitTests/ClrObjectTests.cs
@@ -1,0 +1,193 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using AutoFixture.Xunit2;
+using FluentAssertions;
+using NSubstitute;
+using Xunit;
+
+namespace Microsoft.Diagnostics.Runtime.UnitTests
+{
+    public class ClrObjectTests
+    {
+        [Theory, AutoNSubstituteData]
+        public void Equals_WhenSameAddress_ReturnsTrue(ClrHeap heap, ClrType type, ulong address)
+        {
+            // Arrange
+            heap.GetObjectType(address).Returns(type);
+            type.Heap.Returns(heap);
+
+            var uno = new ClrObject(address, type);
+            var dos = new ClrObject(address, type);
+
+            // Act
+            var areSame = uno == dos;
+
+            // Assert
+            areSame.Should().BeTrue();
+        }
+
+        [Theory, AutoNSubstituteData]
+        public void Equals_WhenDifferentAddress_ReturnsFalse(ClrHeap heap, ClrType type, ulong firstAddress, ulong secondAddress)
+        {
+            // Arrange
+            heap.GetObjectType(firstAddress).Returns(type);
+            heap.GetObjectType(secondAddress).Returns(type);
+            type.Heap.Returns(heap);
+
+            var first = new ClrObject(firstAddress, type);
+            var second = new ClrObject(secondAddress, type);
+
+            // Act
+            var areSame = first == second;
+
+            // Assert
+            areSame.Should().BeFalse();
+        }
+
+        [Fact]
+        public void IsNull_WhenNoAddress_ReturnsTrue()
+        {
+            // Arrange
+            var clrObj = new ClrObject(0, type: null);
+
+            // Act
+            var isNull = clrObj.IsNull;
+
+            // Assert
+            isNull.Should().BeTrue();
+        }
+
+        [Theory, AutoNSubstituteData]
+        public void IsNull_WhenHasAddress_ReturnsFalse(ClrHeap heap, ClrType type, ulong address)
+        {
+            // Arrange
+            heap.GetObjectType(address).Returns(type);
+            type.Heap.Returns(heap);
+
+            var clrObject = new ClrObject(address, type);
+
+            // Act
+            var isNull = clrObject.IsNull;
+
+            // Assert
+            isNull.Should().BeFalse();
+        }
+
+        [Theory, AutoNSubstituteData]
+        public void ulongImplicitCast_WhenCalled_ReturnsAddress(ClrHeap heap, ClrType type, ulong objectAddress)
+        {
+            // Arrange
+            heap.GetObjectType(objectAddress).Returns(type);
+            type.Heap.Returns(heap);
+
+            var clrObject = new ClrObject(objectAddress, type);
+
+            // Act
+            ulong ulongImplicitClrObject = clrObject;
+
+            // Assert
+            ulongImplicitClrObject.Should().Be(objectAddress);
+        }
+
+
+        [Theory, AutoNSubstituteData]
+        public void GetObjectField_WhenTypeHasFieldWithName_FindsField(ClrHeap heap, ClrType objectType, ClrInstanceField clrField, ulong clrObj, ulong fieldAddress, ulong fieldValue, string fieldName)
+        {
+            // Arrange
+            heap.GetObjectType(Arg.Is<ulong>(address => address == clrObj || address == fieldValue)).Returns(objectType);
+
+            objectType.GetFieldByName(fieldName).Returns(clrField);
+            clrField.IsObjectReference.Returns(true);
+            objectType.Heap.Returns(heap);
+
+            clrField.GetAddress(clrObj).Returns(fieldAddress);
+
+            heap.ReadPointer(fieldAddress, out var whatever)
+                .Returns
+            (call =>
+            {
+                call[1] = fieldValue;
+                return true;
+            });
+
+            // Act
+            var fieldFoundByName = new ClrObject(clrObj, objectType).GetObjectField(fieldName);
+
+            // Assert
+            fieldFoundByName.Address.Should().Be(fieldValue);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public void GetObjectField_WhenNullObject_ThrowsNullReference(string fieldName)
+        {
+            // Arrange
+            var nullObject = new ClrObject(0, type: null);
+
+            // Act
+            Action locateFieldFromNullObject = () => nullObject.GetObjectField(fieldName);
+
+            // Assert
+            locateFieldFromNullObject.Should().Throw<NullReferenceException>();
+        }
+
+        [Theory, AutoNSubstituteData]
+        public void GetObjectField_WhenFieldDoesNotExistInType_ThrowsArgumentException(ClrHeap heap, ClrType type, ulong address, string unexistingField)
+        {
+            // Arrange
+            heap.GetObjectType(address).Returns(type);
+            type.Heap.Returns(heap);
+
+            var clrObject = new ClrObject(address, type);
+
+            // Act
+            Action locateUnexistingField = () => clrObject.GetObjectField(unexistingField);
+
+            // Assert
+            locateUnexistingField.Should().Throw<ArgumentException>();
+        }
+
+        [Theory, AutoNSubstituteData]
+        public void GetObjectField_WhenTypeHasValueTypeField_ThrowsArgumentException(ClrHeap heap, ClrType objectType, ClrInstanceField valueField, ulong clrObj, string valueFieldName)
+        {
+            // Arrange
+            heap.GetObjectType(clrObj).Returns(objectType);
+
+            objectType.GetFieldByName(valueFieldName).Returns(valueField);
+            valueField.IsObjectReference.Returns(false);
+            objectType.Heap.Returns(heap);
+
+            var clrObject = new ClrObject(clrObj, objectType);
+
+            // Act
+            Action locateObjectFromValueTypeField = () => clrObject.GetObjectField(valueFieldName);
+
+            // Assert
+            locateObjectFromValueTypeField.Should().Throw<ArgumentException>();
+        }
+
+
+        [Theory, AutoNSubstituteData]
+        public void GetObjectField_WhenHeapWasUnableToReadPointer_ThrowsMemoryReadException(ClrHeap heap, ClrType objectType, ClrInstanceField clrField, ulong clrObj, ulong corruptedFieldPointer, string fieldName)
+        {
+            // Arrange
+            heap.GetObjectType(clrObj).Returns(objectType);
+
+            objectType.GetFieldByName(fieldName).Returns(clrField);
+            clrField.IsObjectReference.Returns(true);
+            objectType.Heap.Returns(heap);
+
+            clrField.GetAddress(clrObj).Returns(corruptedFieldPointer);
+
+            heap.ReadPointer(corruptedFieldPointer, out var whatever).Returns(false);
+  
+            // Act
+            Action locateObjectFromValueTypeField = () => new ClrObject(clrObj, objectType).GetObjectField(fieldName);
+           
+            // Assert
+            locateObjectFromValueTypeField.Should().Throw<MemoryReadException>();
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime.UnitTests/Microsoft.Diagnostics.Runtime.UnitTests.csproj
+++ b/src/Microsoft.Diagnostics.Runtime.UnitTests/Microsoft.Diagnostics.Runtime.UnitTests.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="AutoFixture.AutoNSubstitute" Version="4.6.0" />
+    <PackageReference Include="AutoFixture.Xunit2" Version="4.6.0" />
+    <PackageReference Include="FluentAssertions" Version="5.5.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+     <ProjectReference Include="..\Microsoft.Diagnostics.Runtime\Microsoft.Diagnostics.Runtime.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Microsoft.Diagnostics.Runtime.UnitTests/Microsoft.Diagnostics.Runtime.UnitTests.csproj
+++ b/src/Microsoft.Diagnostics.Runtime.UnitTests/Microsoft.Diagnostics.Runtime.UnitTests.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="AutoFixture.AutoNSubstitute" Version="4.6.0" />
     <PackageReference Include="AutoFixture.Xunit2" Version="4.6.0" />
+    <PackageReference Include="Castle.Core" Version="4.3.1" />
     <PackageReference Include="FluentAssertions" Version="5.5.3" />
   </ItemGroup>
 


### PR DESCRIPTION
@leculver Produce sample unit tests for ClrObject APIs.

The outcome is not only to have test harness for safety, but also to have code-by-example documentation (how would the API behave in that scenario).

Should I want to use the API, I have to test it on my own now with runtime values ( f.e. attach to simple console app & inspect values in debugger).

Once we have a solid coverage, one may use tests as example to speed up clrMD-based development.

I recall my last PR affected your build server - please be carefull (might need to inject specific project props).

Thanks :)