### PR TITLE
PEImage - Implement a new (cleaner) PE reader

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/PdbTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/PdbTests.cs
@@ -50,10 +50,12 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             }
 
             // Ensure the PEFile has the same signature/age.
-            using (PEFile peFile = new PEFile(TestTargets.NestedException.Executable))
+            using (Stream stream = File.OpenRead(TestTargets.NestedException.Executable))
             {
-                Assert.Equal(peFile.PdbInfo.Guid, pdbSignature);
-                Assert.Equal(peFile.PdbInfo.Revision, pdbAge);
+                PEImage peimage = new PEImage(stream);
+                Assert.True(peimage.IsValid);
+                Assert.Equal(peimage.DefaultPdb.Guid, pdbSignature);
+                Assert.Equal(peimage.DefaultPdb.Revision, pdbAge);
             }
         }
 

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/SymbolLocatorTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/SymbolLocatorTests.cs
@@ -129,7 +129,11 @@ namespace Microsoft.Diagnostics.Runtime.Tests
 
             Assert.NotNull(dac);
             Assert.True(File.Exists(dac));
-            new PEFile(dac).Dispose(); // This will throw if the image is invalid.
+            using (Stream stream = File.OpenRead(dac))
+            {
+                PEImage peimage = new PEImage(stream);
+                Assert.True(peimage.IsValid);
+            }
 
             // Ensure we got the same answer for everything.
             foreach (Task<string> task in tasks)

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/ReadVirtualStream.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/ReadVirtualStream.cs
@@ -48,7 +48,12 @@ namespace Microsoft.Diagnostics.Runtime
             if (offset == 0)
             {
                 if (_dataReader.ReadMemory((ulong)(_pos + _disp), buffer, count, out int read))
+                {
+                    if (read > 0)
+                        _pos += read;
+
                     return read;
+                }
 
                 return 0;
             }
@@ -60,7 +65,12 @@ namespace Microsoft.Diagnostics.Runtime
                 if (!_dataReader.ReadMemory((ulong)(_pos + _disp), _tmp, count, out int read))
                     return 0;
 
-                Buffer.BlockCopy(_tmp, 0, buffer, offset, read);
+                if (read > 0)
+                {
+                    Buffer.BlockCopy(_tmp, 0, buffer, offset, read);
+                    _pos += read;
+                }
+
                 return read;
             }
         }

--- a/src/Microsoft.Diagnostics.Runtime/src/Debugger/Structs/ImageCor20HeaderEntryPoint.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Debugger/Structs/ImageCor20HeaderEntryPoint.cs
@@ -10,8 +10,8 @@ namespace Microsoft.Diagnostics.Runtime.Interop
     public struct IMAGE_COR20_HEADER_ENTRYPOINT
     {
         [FieldOffset(0)]
-        private readonly uint _token;
+        public readonly uint Token;
         [FieldOffset(0)]
-        private readonly uint _RVA;
+        public readonly uint RVA;
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/src/Desktop/DesktopModule.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Desktop/DesktopModule.cs
@@ -54,9 +54,12 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
                 {
                     try
                     {
-                        using (PEFile pefile = new PEFile(new ReadVirtualStream(_runtime.DataReader, (long)ImageBase, (long)(Size > 0 ? Size : 0x1000)), true))
+
+                        using (ReadVirtualStream stream = new ReadVirtualStream(_runtime.DataReader, (long)ImageBase, (long)(Size > 0 ? Size : 0x1000)))
                         {
-                            _pdb = pefile.PdbInfo ?? s_failurePdb;
+                            PEImage pefile = new PEImage(stream, true);
+                            if (pefile.IsValid)
+                                _pdb = pefile.DefaultPdb ?? s_failurePdb;
                         }
                     }
                     catch

--- a/src/Microsoft.Diagnostics.Runtime/src/Utilities/PEFile/ImageDataDirectory.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Utilities/PEFile/ImageDataDirectory.cs
@@ -2,11 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+
 namespace Microsoft.Diagnostics.Runtime.Utilities
 {
     /// <summary>
     /// Represents a Portable Executable (PE) Data directory.  This is just a well known optional 'Blob' of memory (has a starting point and size)
     /// </summary>
+    [Obsolete]
     public struct IMAGE_DATA_DIRECTORY
     {
         /// <summary>

--- a/src/Microsoft.Diagnostics.Runtime/src/Utilities/PEFile/PEFile.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Utilities/PEFile/PEFile.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
     /// PEFile is a reader for the information in a Portable Exectable (PE) FILE.   This is what EXEs and DLLs are.
     /// It can read both 32 and 64 bit PE files.
     /// </summary>
+    [Obsolete("Use PEImage instead.")]
     public sealed unsafe class PEFile : IDisposable
     {
         /// <summary>
@@ -96,11 +97,11 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
             if (Header.DebugDirectory.VirtualAddress != 0)
             {
                 PEBuffer buff = AllocBuff();
-                IMAGE_DEBUG_DIRECTORY* debugEntries = (IMAGE_DEBUG_DIRECTORY*)FetchRVA(Header.DebugDirectory.VirtualAddress, Header.DebugDirectory.Size, buff);
+                IMAGE_DEBUG_DIRECTORY* debugEntries = (IMAGE_DEBUG_DIRECTORY*)FetchRVA((int)Header.DebugDirectory.VirtualAddress, (int)Header.DebugDirectory.Size, buff);
                 if (Header.DebugDirectory.Size % sizeof(IMAGE_DEBUG_DIRECTORY) != 0)
                     return false;
 
-                int debugCount = Header.DebugDirectory.Size / sizeof(IMAGE_DEBUG_DIRECTORY);
+                int debugCount = (int)Header.DebugDirectory.Size / sizeof(IMAGE_DEBUG_DIRECTORY);
                 for (int i = 0; i < debugCount; i++)
                 {
                     if (debugEntries[i].Type == IMAGE_DEBUG_TYPE.CODEVIEW)

--- a/src/Microsoft.Diagnostics.Runtime/src/Utilities/PEFile/PEHeader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Utilities/PEFile/PEHeader.cs
@@ -471,10 +471,10 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
         /// <summary>
         /// returns the data directory (virtual address an blob, of a data directory with index 'idx'.   14 are currently defined.
         /// </summary>
-        public IMAGE_DATA_DIRECTORY Directory(int idx)
+        public Interop.IMAGE_DATA_DIRECTORY Directory(int idx)
         {
             if (idx >= NumberOfRvaAndSizes)
-                return new IMAGE_DATA_DIRECTORY();
+                return new Interop.IMAGE_DATA_DIRECTORY();
 
             return NTDirectories[idx];
         }
@@ -482,63 +482,63 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
         /// <summary>
         /// Return the data directory for DLL Exports see PE file spec for more
         /// </summary>
-        public IMAGE_DATA_DIRECTORY ExportDirectory => Directory(0);
+        public Interop.IMAGE_DATA_DIRECTORY ExportDirectory => Directory(0);
         /// <summary>
         /// Return the data directory for DLL Imports see PE file spec for more
         /// </summary>
-        public IMAGE_DATA_DIRECTORY ImportDirectory => Directory(1);
+        public Interop.IMAGE_DATA_DIRECTORY ImportDirectory => Directory(1);
         /// <summary>
         /// Return the data directory for DLL Resources see PE file spec for more
         /// </summary>
-        public IMAGE_DATA_DIRECTORY ResourceDirectory => Directory(2);
+        public Interop.IMAGE_DATA_DIRECTORY ResourceDirectory => Directory(2);
         /// <summary>
         /// Return the data directory for DLL Exceptions see PE file spec for more
         /// </summary>
-        public IMAGE_DATA_DIRECTORY ExceptionDirectory => Directory(3);
+        public Interop.IMAGE_DATA_DIRECTORY ExceptionDirectory => Directory(3);
         /// <summary>
         /// Return the data directory for DLL securiy certificates (Authenticode) see PE file spec for more
         /// </summary>
-        public IMAGE_DATA_DIRECTORY CertificatesDirectory => Directory(4);
+        public Interop.IMAGE_DATA_DIRECTORY CertificatesDirectory => Directory(4);
         /// <summary>
         /// Return the data directory Image Base Relocations (RELOCS) see PE file spec for more
         /// </summary>
-        public IMAGE_DATA_DIRECTORY BaseRelocationDirectory => Directory(5);
+        public Interop.IMAGE_DATA_DIRECTORY BaseRelocationDirectory => Directory(5);
         /// <summary>
         /// Return the data directory for Debug information see PE file spec for more
         /// </summary>
-        public IMAGE_DATA_DIRECTORY DebugDirectory => Directory(6);
+        public Interop.IMAGE_DATA_DIRECTORY DebugDirectory => Directory(6);
         /// <summary>
         /// Return the data directory for DLL Exports see PE file spec for more
         /// </summary>
-        public IMAGE_DATA_DIRECTORY ArchitectureDirectory => Directory(7);
+        public Interop.IMAGE_DATA_DIRECTORY ArchitectureDirectory => Directory(7);
         /// <summary>
         /// Return the data directory for GlobalPointer (IA64) see PE file spec for more
         /// </summary>
-        public IMAGE_DATA_DIRECTORY GlobalPointerDirectory => Directory(8);
+        public Interop.IMAGE_DATA_DIRECTORY GlobalPointerDirectory => Directory(8);
         /// <summary>
         /// Return the data directory for THread local storage see PE file spec for more
         /// </summary>
-        public IMAGE_DATA_DIRECTORY ThreadStorageDirectory => Directory(9);
+        public Interop.IMAGE_DATA_DIRECTORY ThreadStorageDirectory => Directory(9);
         /// <summary>
         /// Return the data directory for Load Configuration see PE file spec for more
         /// </summary>
-        public IMAGE_DATA_DIRECTORY LoadConfigurationDirectory => Directory(10);
+        public Interop.IMAGE_DATA_DIRECTORY LoadConfigurationDirectory => Directory(10);
         /// <summary>
         /// Return the data directory for Bound Imports see PE file spec for more
         /// </summary>
-        public IMAGE_DATA_DIRECTORY BoundImportDirectory => Directory(11);
+        public Interop.IMAGE_DATA_DIRECTORY BoundImportDirectory => Directory(11);
         /// <summary>
         /// Return the data directory for the DLL Import Address Table (IAT) see PE file spec for more
         /// </summary>
-        public IMAGE_DATA_DIRECTORY ImportAddressTableDirectory => Directory(12);
+        public Interop.IMAGE_DATA_DIRECTORY ImportAddressTableDirectory => Directory(12);
         /// <summary>
         /// Return the data directory for Delayed Imports see PE file spec for more
         /// </summary>
-        public IMAGE_DATA_DIRECTORY DelayImportDirectory => Directory(13);
+        public Interop.IMAGE_DATA_DIRECTORY DelayImportDirectory => Directory(13);
         /// <summary>
         /// see PE file spec for more .NET Runtime infomration.
         /// </summary>
-        public IMAGE_DATA_DIRECTORY ComDescriptorDirectory => Directory(14);
+        public Interop.IMAGE_DATA_DIRECTORY ComDescriptorDirectory => Directory(14);
 
         internal static DateTime TimeDateStampToDate(int timeDateStampSec)
         {
@@ -560,20 +560,20 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
                 if (ResourceDirectory.VirtualAddress == 0)
                     return 0;
 
-                return RvaToFileOffset(ResourceDirectory.VirtualAddress);
+                return RvaToFileOffset((int)ResourceDirectory.VirtualAddress);
             }
         }
 
         private IMAGE_OPTIONAL_HEADER32* OptionalHeader32 => (IMAGE_OPTIONAL_HEADER32*)((byte*)_ntHeader + sizeof(IMAGE_NT_HEADERS));
         private IMAGE_OPTIONAL_HEADER64* OptionalHeader64 => (IMAGE_OPTIONAL_HEADER64*)((byte*)_ntHeader + sizeof(IMAGE_NT_HEADERS));
-        private IMAGE_DATA_DIRECTORY* NTDirectories
+        private Interop.IMAGE_DATA_DIRECTORY* NTDirectories
         {
             get
             {
                 if (IsPE64)
-                    return (IMAGE_DATA_DIRECTORY*)((byte*)_ntHeader + sizeof(IMAGE_NT_HEADERS) + sizeof(IMAGE_OPTIONAL_HEADER64));
+                    return (Interop.IMAGE_DATA_DIRECTORY*)((byte*)_ntHeader + sizeof(IMAGE_NT_HEADERS) + sizeof(IMAGE_OPTIONAL_HEADER64));
 
-                return (IMAGE_DATA_DIRECTORY*)((byte*)_ntHeader + sizeof(IMAGE_NT_HEADERS) + sizeof(IMAGE_OPTIONAL_HEADER32));
+                return (Interop.IMAGE_DATA_DIRECTORY*)((byte*)_ntHeader + sizeof(IMAGE_NT_HEADERS) + sizeof(IMAGE_OPTIONAL_HEADER32));
             }
         }
 

--- a/src/Microsoft.Diagnostics.Runtime/src/Utilities/PEFile/ResourceNode.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Utilities/PEFile/ResourceNode.cs
@@ -2,11 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 
 namespace Microsoft.Diagnostics.Runtime.Utilities
 {
+    [Obsolete]
     internal sealed unsafe class ResourceNode
     {
         public string Name { get; }

--- a/src/Microsoft.Diagnostics.Runtime/src/Utilities/PEImage/COMIMAGE_FLAGS.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Utilities/PEImage/COMIMAGE_FLAGS.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace Microsoft.Diagnostics.Runtime.Utilities
+{
+    [Flags]
+    public enum COMIMAGE_FLAGS
+    {
+        ILONLY = 0x00000001,
+        _32BITREQUIRED = 0x00000002,
+        IL_LIBRARY = 0x00000004,
+        STRONGNAMESIGNED = 0x00000008,
+        NATIVE_ENTRYPOINT = 0x00000010,
+        TRACKDEBUGDATA = 0x00010000,
+        _32BITPREFERRED = 0x00020000,
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/src/Utilities/PEImage/CorHeader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Utilities/PEImage/CorHeader.cs
@@ -1,0 +1,56 @@
+﻿using Microsoft.Diagnostics.Runtime.Interop;
+using System;
+
+namespace Microsoft.Diagnostics.Runtime.Utilities
+{
+    /// <summary>
+    /// A wrapper for the IMAGE_COR20_HEADER structure.
+    /// </summary>
+    public class CorHeader
+    {
+        private IMAGE_COR20_HEADER _header;
+
+        internal CorHeader(IMAGE_COR20_HEADER header)
+        {
+            _header = header;
+        }
+
+        /// <summary>
+        /// A set of COMIMAGE_FLAGS.
+        /// </summary>
+        public COMIMAGE_FLAGS Flags => (COMIMAGE_FLAGS)_header.Flags;
+        public ushort MajorRuntimeVersion => _header.MajorRuntimeVersion;
+        public ushort MinorRuntimeVersion => _header.MinorRuntimeVersion;
+
+        // Symbol table and startup information
+        public Interop.IMAGE_DATA_DIRECTORY Metadata => _header.MetaData;
+
+        public uint NativeEntryPoint => (Flags & COMIMAGE_FLAGS.NATIVE_ENTRYPOINT) == COMIMAGE_FLAGS.NATIVE_ENTRYPOINT ? _header.EntryPoint.RVA : throw new InvalidOperationException();
+        public uint ManagedEntryPoint => (Flags & COMIMAGE_FLAGS.NATIVE_ENTRYPOINT) != COMIMAGE_FLAGS.NATIVE_ENTRYPOINT ? _header.EntryPoint.Token : throw new InvalidOperationException();
+
+        /// <summary>
+        /// This is the blob of managed resources. Fetched using code:AssemblyNative.GetResource and
+        /// code:PEFile.GetResource and accessible from managed code from
+        /// System.Assembly.GetManifestResourceStream.  The meta data has a table that maps names to offsets into
+        /// this blob, so logically the blob is a set of resources.
+        /// </summary>
+        public Interop.IMAGE_DATA_DIRECTORY Resources => _header.Resources;
+
+        /// <summary>
+        /// IL assemblies can be signed with a public-private key to validate who created it.  The signature goes
+        /// here if this feature is used.
+        /// </summary>
+        public Interop.IMAGE_DATA_DIRECTORY StrongNameSignature => _header.StrongNameSignature;
+
+        /// <summary>
+        /// Used for managed codeethat has unmanaged code inside of it (or exports methods as unmanaged entry points) .
+        /// </summary>
+        public Interop.IMAGE_DATA_DIRECTORY VTableFixups => _header.VTableFixups;
+        public Interop.IMAGE_DATA_DIRECTORY ExportAddressTableJumps => _header.ExportAddressTableJumps;
+
+        /// <summary>
+        /// This is null for ordinary IL images.  NGEN images it points at a CORCOMPILE_HEADER structure.
+        /// </summary>
+        public Interop.IMAGE_DATA_DIRECTORY ManagedNativeHeader => _header.ManagedNativeHeader;
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/src/Utilities/PEImage/IMAGE_FILE.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Utilities/PEImage/IMAGE_FILE.cs
@@ -1,0 +1,21 @@
+﻿using System;
+
+namespace Microsoft.Diagnostics.Runtime.Utilities
+{
+    [Flags]
+    public enum IMAGE_FILE
+    {
+        RELOCS_STRIPPED = 0x0001,
+        EXECUTABLE_IMAGE = 0x0002,
+        LINE_NUMS_STRIPPED = 0x0004,
+        LOCAL_SYMS_STRIPPED = 0x0008,
+        LARGE_ADDRESS_AWARE = 0x0020,
+        _32BIT_MACHINE = 0x0100,
+        DEBUG_STRIPPED = 0x0200,
+        REMOVABLE_RUN_FROM_SWAP = 0x0400,
+        NET_RUN_FROM_SWAP = 0x0800,
+        SYSTEM = 0x1000,
+        DLL = 0x2000,
+        UP_SYSTEM_ONLY = 0x4000
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/src/Utilities/PEImage/IMAGE_OPTIONAL_HEADER_AGNOSTIC.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Utilities/PEImage/IMAGE_OPTIONAL_HEADER_AGNOSTIC.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.Diagnostics.Runtime.Utilities
+{
+    [StructLayout(LayoutKind.Explicit)]
+    internal struct IMAGE_OPTIONAL_HEADER_AGNOSTIC
+    {
+        [FieldOffset(0)]
+        public ushort Magic;
+        [FieldOffset(2)]
+        public byte MajorLinkerVersion;
+        [FieldOffset(3)]
+        public byte MinorLinkerVersion;
+        [FieldOffset(4)]
+        public UInt32 SizeOfCode;
+        [FieldOffset(8)]
+        public UInt32 SizeOfInitializedData;
+        [FieldOffset(12)]
+        public UInt32 SizeOfUninitializedData;
+        [FieldOffset(16)]
+        public UInt32 AddressOfEntryPoint;
+        [FieldOffset(20)]
+        public UInt32 BaseOfCode;
+        [FieldOffset(24)]
+        public UInt64 ImageBase64;
+        [FieldOffset(24)]
+        public UInt32 BaseOfData;
+        [FieldOffset(28)]
+        public UInt32 ImageBase;
+        [FieldOffset(32)]
+        public UInt32 SectionAlignment;
+        [FieldOffset(36)]
+        public UInt32 FileAlignment;
+        [FieldOffset(40)]
+        public ushort MajorOperatingSystemVersion;
+        [FieldOffset(42)]
+        public ushort MinorOperatingSystemVersion;
+        [FieldOffset(44)]
+        public ushort MajorImageVersion;
+        [FieldOffset(46)]
+        public ushort MinorImageVersion;
+        [FieldOffset(48)]
+        public ushort MajorSubsystemVersion;
+        [FieldOffset(50)]
+        public ushort MinorSubsystemVersion;
+        [FieldOffset(52)]
+        public UInt32 Win32VersionValue;
+        [FieldOffset(56)]
+        public UInt32 SizeOfImage;
+        [FieldOffset(60)]
+        public UInt32 SizeOfHeaders;
+        [FieldOffset(64)]
+        public UInt32 CheckSum;
+        [FieldOffset(68)]
+        public ushort Subsystem;
+        [FieldOffset(70)]
+        public ushort DllCharacteristics;
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/src/Utilities/PEImage/IMAGE_OPTIONAL_HEADER_SPECIFIC.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Utilities/PEImage/IMAGE_OPTIONAL_HEADER_SPECIFIC.cs
@@ -1,0 +1,12 @@
+﻿namespace Microsoft.Diagnostics.Runtime.Utilities
+{
+    internal struct IMAGE_OPTIONAL_HEADER_SPECIFIC
+    {
+        public ulong SizeOfStackReserve;
+        public ulong SizeOfStackCommit;
+        public ulong SizeOfHeapReserve;
+        public ulong SizeOfHeapCommit;
+        public uint LoaderFlags;
+        public uint NumberOfRvaAndSizes;
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/src/Utilities/PEImage/IMAGE_SCN.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Utilities/PEImage/IMAGE_SCN.cs
@@ -1,0 +1,170 @@
+﻿using System;
+
+namespace Microsoft.Diagnostics.Runtime.Utilities
+{
+    /// <summary>
+    /// See https://msdn.microsoft.com/en-us/library/windows/desktop/ms680341(v=vs.85).aspx
+    /// </summary>
+    [Flags]
+    public enum IMAGE_SCN : uint
+    {
+        /// <summary>
+        /// The section should not be padded to the next boundary. This flag is obsolete and is replaced by IMAGE_SCN_ALIGN_1BYTES.
+        /// </summary>
+        NO_PAD = 0x00000008,
+
+        /// <summary>
+        /// Section contains executable code.
+        /// </summary>
+        CNT_CODE = 0x00000020,
+
+        /// <summary>
+        /// The section contains initialized data.
+        /// </summary>
+        CNT_INITIALIZED_DATA = 0x00000040,
+
+        /// <summary>
+        /// The section contains uninitialized data.
+        /// </summary>
+        CNT_UNINITIALIZED_DATA = 0x00000080,
+
+        /// <summary>
+        /// The section contains comments or other information. This is valid only for object files.
+        /// </summary>
+        LNK_INFO = 0x00000200,
+
+        /// <summary>
+        /// The section will not become part of the image. This is valid only for object files.
+        /// </summary>
+        LNK_REMOVE = 0x00000800,
+
+        /// <summary>
+        /// The section contains COMDAT data. This is valid only for object files
+        /// </summary>
+        LNK_COMDAT = 0x00001000,
+
+        /// <summary>
+        /// Reset speculative exceptions handling bits in the TLB entries for this section.
+        /// </summary>
+        NO_DEFER_SPEC_EXC = 0x00004000,
+
+        /// <summary>
+        /// The section contains data referenced through the global pointer.
+        /// </summary>
+        GPREL = 0x00008000,
+
+        /// <summary>
+        /// Alignment.  This is valid only for object files.
+        /// </summary>
+        ALIGN_1BYTES = 0x00100000,
+
+        /// <summary>
+        /// Alignment.  This is valid only for object files.
+        /// </summary>
+        ALIGN_2BYTES = 0x00200000,
+
+        /// <summary>
+        /// Alignment.  This is valid only for object files.
+        /// </summary>
+        ALIGN_4BYTES = 0x00300000,
+
+        /// <summary>
+        /// Alignment.  This is valid only for object files.
+        /// </summary>
+        ALIGN_8BYTES = 0x00400000,
+
+        /// <summary>
+        /// Alignment.  This is valid only for object files.
+        /// </summary>
+        ALIGN_16BYTES = 0x00500000,
+
+        /// <summary>
+        /// Alignment.  This is valid only for object files.
+        /// </summary>
+        ALIGN_32BYTES = 0x00600000,
+
+        /// <summary>
+        /// Alignment.  This is valid only for object files.
+        /// </summary>
+        ALIGN_64BYTES = 0x00700000,
+
+        /// <summary>
+        /// Alignment.  This is valid only for object files.
+        /// </summary>
+        ALIGN_128BYTES = 0x00800000,
+
+        /// <summary>
+        /// Alignment.  This is valid only for object files.
+        /// </summary>
+        ALIGN_256BYTES = 0x00900000,
+
+        /// <summary>
+        /// Alignment.  This is valid only for object files.
+        /// </summary>
+        ALIGN_512BYTES = 0x00a00000,
+
+        /// <summary>
+        /// Alignment.  This is valid only for object files.
+        /// </summary>
+        ALIGN_1024BYTES = 0x00b00000,
+
+        /// <summary>
+        /// Alignment.  This is valid only for object files.
+        /// </summary>
+        ALIGN_2048BYTES = 0x00c00000,
+
+        /// <summary>
+        /// Alignment.  This is valid only for object files.
+        /// </summary>
+        ALIGN_4096BYTES = 0x00d00000,
+
+        /// <summary>
+        /// Alignment.  This is valid only for object files.
+        /// </summary>
+        ALIGN_8192BYTES = 0x00e00000,
+
+        /// <summary>
+        /// The section contains extended relocations. The count of relocations for the section
+        /// exceeds the 16 bits that is reserved for it in the section header. If the NumberOfRelocations
+        /// field in the section header is 0xffff, the actual relocation count is stored in the
+        /// VirtualAddress field of the first relocation. It is an error if IMAGE_SCN_LNK_NRELOC_OVFL
+        /// is set and there are fewer than 0xffff relocations in the section.
+        /// </summary>
+        LNK_NRELOC_OVFL = 0x01000000,
+
+        /// <summary>
+        /// The section can be discarded as needed.
+        /// </summary>
+        MEM_DISCARDABLE = 0x02000000,
+
+        /// <summary>
+        /// The section cannot be cached.
+        /// </summary>
+        MEM_NOT_CACHED = 0x04000000,
+
+        /// <summary>
+        /// The section cannot be paged.
+        /// </summary>
+        MEM_NOT_PAGED = 0x08000000,
+
+        /// <summary>
+        /// The section can be shared in memory.
+        /// </summary>
+        MEM_SHARED = 0x10000000,
+
+        /// <summary>
+        /// The section can be executed as code.
+        /// </summary>
+        MEM_EXECUTE = 0x20000000,
+
+        /// <summary>
+        /// The section can be read.
+        /// </summary>
+        MEM_READ = 0x40000000,
+
+        /// <summary>
+        /// The section can be written to.
+        /// </summary>
+        MEM_WRITE = 0x80000000,
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/src/Utilities/PEImage/ImageFileHeader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Utilities/PEImage/ImageFileHeader.cs
@@ -1,0 +1,52 @@
+﻿using Microsoft.Diagnostics.Runtime.Interop;
+
+namespace Microsoft.Diagnostics.Runtime.Utilities
+{
+    /// <summary>
+    /// A wrapper over IMAGE_FILE_HEADER.  See https://msdn.microsoft.com/en-us/library/windows/desktop/ms680313(v=vs.85).aspx.
+    /// </summary>
+    public class ImageFileHeader
+    {
+        private IMAGE_FILE_HEADER _header;
+
+        internal ImageFileHeader(IMAGE_FILE_HEADER header)
+        {
+            _header = header;
+        }
+
+        /// <summary>
+        /// The architecture type of the computer. An image file can only be run on the specified computer or a system that emulates the specified computer. 
+        /// </summary>
+        public IMAGE_FILE_MACHINE Machine => (IMAGE_FILE_MACHINE)_header.Machine;
+
+        /// <summary>
+        /// The number of sections. This indicates the size of the section table, which immediately follows the headers. Note that the Windows loader limits the number of sections to 96.
+        /// </summary>
+        public ushort NumberOfSections => _header.NumberOfSections;
+
+        /// <summary>
+        /// The offset of the symbol table, in bytes, or zero if no COFF symbol table exists.
+        /// </summary>
+        public uint PointerToSymbolTable => _header.PointerToSymbolTable;
+
+        /// <summary>
+        /// The number of symbols in the symbol table.
+        /// </summary>
+        public uint NumberOfSymbols => _header.NumberOfSymbols;
+
+        /// <summary>
+        /// The low 32 bits of the time stamp of the image. This represents the date and time the image was created by the linker. The value is represented in the number of seconds elapsed since midnight (00:00:00), January 1, 1970, Universal Coordinated Time, according to the system clock.
+        /// </summary>
+        public uint TimeDateStamp => _header.TimeDateStamp;
+
+        /// <summary>
+        /// The size of the optional header, in bytes. This value should be 0 for object files.
+        /// </summary>
+        public ushort SizeOfOptionalHeader => _header.SizeOfOptionalHeader;
+
+        /// <summary>
+        /// The characteristics of the image
+        /// </summary>
+        public IMAGE_FILE Characteristics => (IMAGE_FILE)_header.Characteristics;
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/src/Utilities/PEImage/ImageOptionalHeader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Utilities/PEImage/ImageOptionalHeader.cs
@@ -1,0 +1,77 @@
+﻿using System;
+
+namespace Microsoft.Diagnostics.Runtime.Utilities
+{
+    /// <summary>
+    /// A wrapper over IMAGE_OPTIONAL_HEADER.  See https://msdn.microsoft.com/en-us/library/windows/desktop/ms680339(v=vs.85).aspx.
+    /// </summary>
+    public class ImageOptionalHeader
+    {
+        private readonly bool _32bit;
+        private readonly IMAGE_OPTIONAL_HEADER_AGNOSTIC _optional;
+        private readonly Lazy<IMAGE_OPTIONAL_HEADER_SPECIFIC> _specific;
+        private readonly Lazy<Interop.IMAGE_DATA_DIRECTORY[]> _directories;
+
+        private IMAGE_OPTIONAL_HEADER_SPECIFIC OptionalSpecific => _specific.Value;
+
+        internal ImageOptionalHeader(IMAGE_OPTIONAL_HEADER_AGNOSTIC optional, Lazy<IMAGE_OPTIONAL_HEADER_SPECIFIC> specific, Lazy<Interop.IMAGE_DATA_DIRECTORY[]> directories, bool is32bit)
+        {
+            _optional = optional;
+            _specific = specific;
+            _32bit = is32bit;
+            _directories = directories;
+        }
+
+        public ushort Magic => _optional.Magic;
+        public byte MajorLinkerVersion => _optional.MajorLinkerVersion;
+        public byte MinorLinkerVersion => _optional.MinorLinkerVersion;
+        public uint SizeOfCode => _optional.SizeOfCode;
+        public uint SizeOfInitializedData => _optional.SizeOfInitializedData;
+        public uint SizeOfUninitializedData => _optional.SizeOfUninitializedData;
+        public uint AddressOfEntryPoint => _optional.AddressOfEntryPoint;
+        public uint BaseOfCode => _optional.BaseOfCode;
+
+        /// <summary>
+        /// Only valid in 32bit images.
+        /// </summary>
+        public uint BaseOfData => _32bit ? _optional.BaseOfData : throw new InvalidOperationException();
+        public ulong ImageBase => _32bit ? _optional.ImageBase : _optional.ImageBase64;
+        public uint SectionAlignment => _optional.SectionAlignment;
+        public uint FileAlignment => _optional.FileAlignment;
+        public ushort MajorOperatingSystemVersion => _optional.MajorOperatingSystemVersion;
+        public ushort MinorOperatingSystemVersion => _optional.MinorOperatingSystemVersion;
+        public ushort MajorImageVersion => _optional.MajorImageVersion;
+        public ushort MinorImageVersion => _optional.MinorImageVersion;
+        public ushort MajorSubsystemVersion => _optional.MajorSubsystemVersion;
+        public ushort MinorSubsystemVersion => _optional.MinorSubsystemVersion;
+        public uint Win32VersionValue => _optional.Win32VersionValue;
+        public uint SizeOfImage => _optional.SizeOfImage;
+        public uint SizeOfHeaders => _optional.SizeOfHeaders;
+        public uint CheckSum => _optional.CheckSum;
+        public ushort Subsystem => _optional.Subsystem;
+        public ushort DllCharacteristics => _optional.DllCharacteristics;
+
+        public ulong SizeOfStackReserve => OptionalSpecific.SizeOfStackReserve;
+        public ulong SizeOfStackCommit => OptionalSpecific.SizeOfStackCommit;
+        public ulong SizeOfHeapReserve => OptionalSpecific.SizeOfHeapReserve;
+        public ulong SizeOfHeapCommit => OptionalSpecific.SizeOfHeapCommit;
+        public uint LoaderFlags => OptionalSpecific.LoaderFlags;
+        public uint NumberOfRvaAndSizes => OptionalSpecific.NumberOfRvaAndSizes;
+
+        public Interop.IMAGE_DATA_DIRECTORY ExportDirectory => _directories.Value[0];
+        public Interop.IMAGE_DATA_DIRECTORY ImportDirectory => _directories.Value[1];
+        public Interop.IMAGE_DATA_DIRECTORY ResourceDirectory => _directories.Value[2];
+        public Interop.IMAGE_DATA_DIRECTORY ExceptionDirectory => _directories.Value[3];
+        public Interop.IMAGE_DATA_DIRECTORY CertificatesDirectory => _directories.Value[4];
+        public Interop.IMAGE_DATA_DIRECTORY BaseRelocationDirectory => _directories.Value[5];
+        public Interop.IMAGE_DATA_DIRECTORY DebugDirectory => _directories.Value[6];
+        public Interop.IMAGE_DATA_DIRECTORY ArchitectureDirectory => _directories.Value[7];
+        public Interop.IMAGE_DATA_DIRECTORY GlobalPointerDirectory => _directories.Value[8];
+        public Interop.IMAGE_DATA_DIRECTORY ThreadStorageDirectory => _directories.Value[9];
+        public Interop.IMAGE_DATA_DIRECTORY LoadConfigurationDirectory => _directories.Value[10];
+        public Interop.IMAGE_DATA_DIRECTORY BoundImportDirectory => _directories.Value[11];
+        public Interop.IMAGE_DATA_DIRECTORY ImportAddressTableDirectory => _directories.Value[12];
+        public Interop.IMAGE_DATA_DIRECTORY DelayImportDirectory => _directories.Value[13];
+        public Interop.IMAGE_DATA_DIRECTORY ComDescriptorDirectory => _directories.Value[14];
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/src/Utilities/PEImage/PEImage.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Utilities/PEImage/PEImage.cs
@@ -1,0 +1,415 @@
+﻿using Microsoft.Diagnostics.Runtime.Interop;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace Microsoft.Diagnostics.Runtime.Utilities
+{
+    /// <summary>
+    /// A class to read information out of PE images (dll/exe).
+    /// </summary>
+    public unsafe class PEImage
+    {
+        private const ushort ExpectedDosHeaderMagic = 0x5A4D;   // MZ
+        private const int PESignatureOffsetLocation = 0x3C;
+        private const uint ExpectedPESignature = 0x00004550;    // PE00
+        private const int ImageDataDirectoryCount = 15;
+        private const int ComDataDirectory = 14;
+        private const int DebugDataDirectory = 6;
+
+        private readonly bool _virt;
+        private byte[] _buffer = new byte[260];
+        private int _offset = 0;
+        private readonly int _peHeaderOffset;
+
+        private readonly Lazy<ImageFileHeader> _imageFileHeader;
+        private readonly Lazy<ImageOptionalHeader> _imageOptionalHeader;
+        private readonly Lazy<CorHeader> _corHeader;
+        private readonly Lazy<List<SectionHeader>> _sections;
+        private readonly Lazy<List<PdbInfo>> _pdbs;
+        private readonly Lazy<Interop.IMAGE_DATA_DIRECTORY[]> _directories;
+
+        private Interop.IMAGE_DATA_DIRECTORY GetDirectory(int index) => _directories.Value[index];
+        private int HeaderOffset => _peHeaderOffset + sizeof(uint);
+        private int OptionalHeaderOffset => HeaderOffset + sizeof(IMAGE_FILE_HEADER);
+        private int SpecificHeaderOffset => OptionalHeaderOffset + sizeof(IMAGE_OPTIONAL_HEADER_AGNOSTIC);
+        private int DataDirectoryOffset => SpecificHeaderOffset + (IsPE64 ? 5 * 8 : 6 * 4);
+        private int ImageDataDirectoryOffset => DataDirectoryOffset + ImageDataDirectoryCount * sizeof(Interop.IMAGE_DATA_DIRECTORY);
+
+        /// <summary>
+        /// Constructs a PEImage class for a given PE image (dll/exe) on disk.
+        /// </summary>
+        /// <param name="stream">A Stream that contains a PE image at its 0th offset.  This stream must be seekable.</param>
+        public PEImage(Stream stream)
+            : this(stream, false)
+        {
+        }
+
+        /// <summary>
+        /// Constructs a PEImage class for a given PE image (dll/exe) on disk.
+        /// </summary>
+        /// <param name="stream">A Stream that contains a PE image at its 0th offset.  This stream must be seekable.</param>
+        /// <param name="isVirtual">Whether stream points to a PE image mapped into an address space (such as in a live process or crash dump).</param>
+        public PEImage(Stream stream, bool isVirtual)
+        {
+            if (!stream.CanSeek)
+                throw new ArgumentException($"{nameof(stream)} is not seekable.");
+
+            _virt = isVirtual;
+            Stream = stream;
+
+            ushort? dosHeaderMagic = Read<ushort>(0);
+            if (dosHeaderMagic != ExpectedDosHeaderMagic)
+            {
+                IsValid = false;
+            }
+            else
+            {
+                _peHeaderOffset = Read<int>(PESignatureOffsetLocation) ?? 0;
+                uint? peSignature = null;
+
+                if (_peHeaderOffset != 0)
+                    peSignature = Read<uint>(_peHeaderOffset);
+
+                IsValid = peSignature.HasValue && peSignature.Value == ExpectedPESignature;
+            }
+
+            _imageFileHeader = new Lazy<ImageFileHeader>(ReadImageFileHeader);
+            _imageOptionalHeader = new Lazy<ImageOptionalHeader>(ReadImageOptionalHeader);
+            _corHeader = new Lazy<CorHeader>(ReadCorHeader);
+            _directories = new Lazy<Interop.IMAGE_DATA_DIRECTORY[]>(ReadDataDirectories);
+            _sections = new Lazy<List<SectionHeader>>(ReadSections);
+            _pdbs = new Lazy<List<PdbInfo>>(ReadPdbs);
+        }
+
+        /// <summary>
+        /// The underlying stream.
+        /// </summary>
+        public Stream Stream { get; }
+
+        /// <summary>
+        /// Returns true if the given Stream contains a valid DOS header and PE signature.
+        /// </summary>
+        public bool IsValid { get; private set; }
+
+        /// <summary>
+        /// Returns true if this image is for a 64bit processor.
+        /// </summary>
+        public bool IsPE64 => OptionalHeader != null ? OptionalHeader.Magic != 0x010b : false;
+
+        /// <summary>
+        /// Returns true if this image is managed.  (.Net image)
+        /// </summary>
+        public bool IsManaged => GetDirectory(14).VirtualAddress != 0;
+
+        /// <summary>
+        /// Returns the timestamp that this PE image is indexed under.
+        /// </summary>
+        public int IndexTimeStamp => (int)(Header?.TimeDateStamp ?? 0);
+
+        /// <summary>
+        /// Returns the file size that this PE image is indexed under.
+        /// </summary>
+        public int IndexFileSize => (int)(OptionalHeader?.SizeOfImage ?? 0);
+
+        /// <summary>
+        /// Returns the managed header information for this image.  Undefined behavior if IsValid is false.
+        /// </summary>
+        public CorHeader CorHeader => _corHeader.Value;
+
+        /// <summary>
+        /// Returns a wrapper over this PE image's IMAGE_FILE_HEADER structure.  Undefined behavior if IsValid is false.
+        /// </summary>
+        public ImageFileHeader Header => _imageFileHeader.Value;
+
+        /// <summary>
+        /// Returns a wrapper over this PE image's IMAGE_OPTIONAL_HEADER.  Undefined behavior if IsValid is false.
+        /// </summary>
+        public ImageOptionalHeader OptionalHeader => _imageOptionalHeader.Value;
+
+        /// <summary>
+        /// Returns a collection of IMAGE_SECTION_HEADERs in the PE iamge.  Undefined behavior if IsValid is false.
+        /// </summary>
+        public ReadOnlyCollection<SectionHeader> Sections => _sections.Value.AsReadOnly();
+
+        /// <summary>
+        /// Enumerates a list of PDBs associated with this PE image.  PE images can contain multiple PDB entries,
+        /// but by convention it's usually the last entry that is the most up to date.  Unless you need to enumerate
+        /// all PDBs for some reason, you should use DefaultPdb instead.
+        /// Undefined behavior if IsValid is false.
+        /// </summary>
+        public ReadOnlyCollection<PdbInfo> Pdbs => _pdbs.Value.AsReadOnly();
+
+        /// <summary>
+        /// Returns the PDB information for this module.  If this image does not contain PDB info (or that information
+        /// wasn't included in Stream) this returns null.  If multiple PDB streams are present, this method returns the
+        /// last entry.
+        /// </summary>
+        public PdbInfo DefaultPdb => Pdbs.LastOrDefault();
+
+        /// <summary>
+        /// Allows you to convert between a virtual address to a stream offset for this module.
+        /// </summary>
+        /// <param name="virtualAddress">The address to translate.</param>
+        /// <returns>The position in the stream of the data, -1 if the virtual address doesn't map to any location of the PE image.</returns>
+        public int RvaToOffset(int virtualAddress)
+        {
+            if (_virt)
+                return virtualAddress;
+
+            List<SectionHeader> sections = _sections.Value;
+            for (int i = 0; i < sections.Count; i++)
+                if (sections[i].VirtualAddress <= virtualAddress && virtualAddress < sections[i].VirtualAddress + sections[i].VirtualSize)
+                    return (int)sections[i].PointerToRawData + (virtualAddress - (int)sections[i].VirtualAddress);
+
+            return -1;
+        }
+
+        /// <summary>
+        /// Reads data out of PE image into a native buffer.
+        /// </summary>
+        /// <param name="dest">The location to write the data.</param>
+        /// <param name="virtualAddress">The address to read from.</param>
+        /// <param name="bytesRequested">The number of bytes to read.</param>
+        /// <returns>The number of bytes actually read from the image and written to dest.</returns>
+        public int Read(IntPtr dest, int virtualAddress, int bytesRequested)
+        {
+            byte[] buffer = _buffer;
+            EnsureSize(ref buffer, bytesRequested);
+
+            int offset = RvaToOffset(virtualAddress);
+            if (offset == -1)
+                return 0;
+
+            SeekTo(offset);
+            int read = Stream.Read(buffer, 0, bytesRequested);
+            if (read > 0)
+                Marshal.Copy(buffer, 0, dest, read);
+
+            return read;
+        }
+
+        /// <summary>
+        /// Reads data out of PE image into a byte array.
+        /// </summary>
+        /// <param name="dest">The location to write the data.</param>
+        /// <param name="virtualAddress">The address to read from.</param>
+        /// <param name="bytesRequested">The number of bytes to read.</param>
+        /// <returns>The number of bytes actually read from the image and written to dest.</returns>
+        public int Read(byte[] dest, int virtualAddress, int bytesRequested)
+        {
+            int offset = RvaToOffset(virtualAddress);
+            if (offset == -1)
+                return 0;
+
+            SeekTo(offset);
+            int read = Stream.Read(dest, 0, bytesRequested);
+            return read;
+        }
+
+
+        private List<SectionHeader> ReadSections()
+        {
+            List<SectionHeader> sections = new List<SectionHeader>();
+            if (!IsValid)
+                return sections;
+
+            ImageFileHeader header = Header;
+            if (header == null)
+                return sections;
+
+            SeekTo(ImageDataDirectoryOffset);
+
+            // Sanity check, there's a null row at the end of the data directory table
+            ulong? zero = Read<ulong>();
+            if (zero != 0)
+                return sections;
+
+            for (int i = 0; i < header.NumberOfSections; i++)
+            {
+                IMAGE_SECTION_HEADER? sectionHdr = Read<IMAGE_SECTION_HEADER>();
+                if (sectionHdr.HasValue)
+                    sections.Add(new SectionHeader(sectionHdr.Value));
+            }
+
+            return sections;
+        }
+
+        private List<PdbInfo> ReadPdbs()
+        {
+            int offs = _offset;
+            List<PdbInfo> result = new List<PdbInfo>();
+
+            var debugData = GetDirectory(DebugDataDirectory);
+            if (debugData.VirtualAddress != 0 && debugData.Size != 0)
+            {
+                if ((debugData.Size % sizeof(IMAGE_DEBUG_DIRECTORY)) != 0)
+                    return result;
+
+                int offset = RvaToOffset((int)debugData.VirtualAddress);
+                if (offset == -1)
+                    return result;
+
+                int count = (int)debugData.Size / sizeof(IMAGE_DEBUG_DIRECTORY);
+                List<Tuple<int, int>> entries = new List<Tuple<int, int>>(count);
+
+                SeekTo(offset);
+                for (int i = 0; i < count; i++)
+                {
+                    IMAGE_DEBUG_DIRECTORY? entryRead = Read<IMAGE_DEBUG_DIRECTORY>();
+                    if (entryRead.HasValue)
+                    {
+                        IMAGE_DEBUG_DIRECTORY tmp = entryRead.Value;
+                        if (tmp.Type == IMAGE_DEBUG_TYPE.CODEVIEW && tmp.SizeOfData >= sizeof(CV_INFO_PDB70))
+                            entries.Add(Tuple.Create(_virt ? tmp.AddressOfRawData : tmp.PointerToRawData, tmp.SizeOfData));
+                    }
+                }
+
+                foreach (Tuple<int, int> tmp in entries.OrderBy(e => e.Item1))
+                {
+                    int ptr = tmp.Item1;
+                    int size = tmp.Item2;
+
+                    int? cvSig = Read<int>(ptr);
+                    if (cvSig.HasValue && cvSig.Value == CV_INFO_PDB70.PDB70CvSignature)
+                    {
+                        Guid guid = Read<Guid>() ?? default;
+                        int age = Read<int>() ?? -1;
+
+                        // sizeof(sig) + sizeof(guid) + sizeof(age) - [null char] = 0x18 - 1
+                        int nameLen = size - 0x18 - 1;
+                        string filename = ReadString(nameLen);
+
+
+                        PdbInfo pdb = new PdbInfo(filename, guid, age);
+                        result.Add(pdb);
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        private string ReadString(int len)
+        {
+            return ReadString(_offset, len);
+        }
+
+        private string ReadString(int offset, int len)
+        {
+            if (len > 4096)
+                len = 4096;
+
+            SeekTo(offset);
+
+            byte[] buffer = _buffer;
+            EnsureSize(ref buffer, len);
+
+            if (Stream.Read(_buffer, 0, len) != len)
+                return null;
+
+            return Encoding.ASCII.GetString(_buffer, 0, len);
+        }
+
+        private T? Read<T>() where T : struct
+        {
+            return Read<T>(_offset);
+        }
+
+        private T? Read<T>(int offset) where T : struct
+        {
+            int size = Marshal.SizeOf(typeof(T));
+
+            SeekTo(offset);
+            EnsureSize(ref _buffer, size);
+
+            if (Stream.Read(_buffer, 0, size) != size)
+                return null;
+
+            _offset = offset + size;
+            fixed (byte* buffer = _buffer)
+                return (T)Marshal.PtrToStructure(new IntPtr(buffer), typeof(T));
+        }
+
+        private static void EnsureSize(ref byte[] readBuffer, int size)
+        {
+            if (readBuffer == null || readBuffer.Length < size)
+                readBuffer = new byte[size];
+        }
+
+        private void SeekTo(int offset)
+        {
+            if (offset != _offset)
+            {
+                Stream.Seek(offset, SeekOrigin.Begin);
+                _offset = offset;
+            }
+        }
+
+        private ImageFileHeader ReadImageFileHeader()
+        {
+            if (!IsValid)
+                return null;
+
+            IMAGE_FILE_HEADER? header = Read<IMAGE_FILE_HEADER>(HeaderOffset);
+            return header.HasValue ? new ImageFileHeader(header.Value) : null;
+        }
+
+        private Interop.IMAGE_DATA_DIRECTORY[] ReadDataDirectories()
+        {
+            Interop.IMAGE_DATA_DIRECTORY[] directories = new Interop.IMAGE_DATA_DIRECTORY[ImageDataDirectoryCount];
+
+            if (!IsValid)
+                return directories;
+
+            SeekTo(DataDirectoryOffset);
+            for (int i = 0; i < directories.Length; i++)
+                directories[i] = Read<Interop.IMAGE_DATA_DIRECTORY>() ?? default;
+
+            return directories;
+        }
+
+        private ImageOptionalHeader ReadImageOptionalHeader()
+        {
+            if (!IsValid)
+                return null;
+
+            IMAGE_OPTIONAL_HEADER_AGNOSTIC? optional = Read<IMAGE_OPTIONAL_HEADER_AGNOSTIC>(OptionalHeaderOffset);
+            if (!optional.HasValue)
+                return null;
+
+            bool is32Bit = optional.Value.Magic == 0x010b;
+            Lazy<IMAGE_OPTIONAL_HEADER_SPECIFIC> specific = new Lazy<IMAGE_OPTIONAL_HEADER_SPECIFIC>(() =>
+            {
+                SeekTo(SpecificHeaderOffset);
+                return new IMAGE_OPTIONAL_HEADER_SPECIFIC()
+                {
+                    SizeOfStackReserve = (is32Bit ? Read<uint>() : Read<ulong>()) ?? 0,
+                    SizeOfStackCommit = (is32Bit ? Read<uint>() : Read<ulong>()) ?? 0,
+                    SizeOfHeapReserve = (is32Bit ? Read<uint>() : Read<ulong>()) ?? 0,
+                    SizeOfHeapCommit = (is32Bit ? Read<uint>() : Read<ulong>()) ?? 0,
+                    LoaderFlags = (Read<uint>()) ?? 0,
+                    NumberOfRvaAndSizes = (Read<uint>()) ?? 0
+                };
+            });
+
+            return new ImageOptionalHeader(optional.Value, specific, _directories, is32Bit);
+        }
+
+        private CorHeader ReadCorHeader()
+        {
+            var clrDataDirectory = GetDirectory(ComDataDirectory);
+
+            int offset = RvaToOffset((int)clrDataDirectory.VirtualAddress);
+            if (offset == -1)
+                return null;
+
+            IMAGE_COR20_HEADER? corHdr = Read<IMAGE_COR20_HEADER>(offset);
+            return corHdr.HasValue ? new CorHeader(corHdr.Value) : null;
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/src/Utilities/PEImage/PEImage.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Utilities/PEImage/PEImage.cs
@@ -323,10 +323,9 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
         private T? Read<T>(int offset) where T : struct
         {
             int size = Marshal.SizeOf(typeof(T));
-
-            SeekTo(offset);
             EnsureSize(ref _buffer, size);
 
+            SeekTo(offset);
             if (Stream.Read(_buffer, 0, size) != size)
                 return null;
 

--- a/src/Microsoft.Diagnostics.Runtime/src/Utilities/PEImage/SectionHeader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Utilities/PEImage/SectionHeader.cs
@@ -1,0 +1,36 @@
+﻿namespace Microsoft.Diagnostics.Runtime.Utilities
+{
+    /// <summary>
+    /// A wrapper over the IMAGE_SECTION_HEADER structure.
+    /// https://msdn.microsoft.com/en-us/library/windows/desktop/ms680341(v=vs.85).aspx
+    /// </summary>
+    public class SectionHeader
+    {
+        public string Name { get; private set; }
+        public uint VirtualSize { get; private set; }
+        public uint VirtualAddress { get; private set; }
+        public uint SizeOfRawData { get; private set; }
+        public uint PointerToRawData { get; private set; }
+        public uint PointerToRelocations { get; private set; }
+        public uint PointerToLineNumbers { get; private set; }
+        public ushort NumberOfRelocations { get; private set; }
+        public ushort NumberOfLineNumbers { get; private set; }
+        public IMAGE_SCN Characteristics { get; private set; }
+
+        internal SectionHeader(IMAGE_SECTION_HEADER section)
+        {
+            Name = section.Name;
+            VirtualSize = section.VirtualSize;
+            VirtualAddress = section.VirtualAddress;
+            SizeOfRawData = section.SizeOfRawData;
+            PointerToRawData = section.PointerToRawData;
+            PointerToRelocations = section.PointerToRelocations;
+            PointerToLineNumbers = section.PointerToLinenumbers;
+            NumberOfRelocations = section.NumberOfRelocations;
+            NumberOfLineNumbers = section.NumberOfLinenumbers;
+            Characteristics = (IMAGE_SCN)section.Characteristics;
+        }
+
+        public override string ToString() => Name;
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/src/Utilities/Symbols/SymbolLocator.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Utilities/Symbols/SymbolLocator.cs
@@ -281,18 +281,17 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
                             return true;
                         }
 
-                        using (PEFile pefile = PEFile.TryLoad(fs, false))
+                        PEImage peimage = new PEImage(fs, false);
+                        if (peimage.IsValid)
                         {
-                            if (pefile != null)
-                            {
-                                PEHeader header = pefile.Header;
-                                if (!checkProperties || header.TimeDateStampSec == buildTimeStamp && header.SizeOfImage == imageSize)
-                                {
-                                    return true;
-                                }
+                            if (!checkProperties || peimage.IndexTimeStamp == buildTimeStamp && peimage.IndexFileSize == imageSize)
+                                return true;
 
-                                Trace("Rejected file '{0}' because file size and time stamp did not match.", fullPath);
-                            }
+                            Trace($"Rejected file '{fullPath}' because file size and time stamp did not match.");
+                        }
+                        else
+                        {
+                            Trace($"Rejected file '{fullPath}' because it is not a valid PE image.");
                         }
                     }
                 }


### PR DESCRIPTION
The old PEFile class used a lot of unsafe code and was overly complex for what it did.  This change implements a new PE reader (PEImage).  PEImage loads most data on demand and does through via straight forward stream reads from the given stream, and only uses unsafe code in a narrow case to convert a byte[] into a a struct.

Fixes https://github.com/Microsoft/clrmd/issues/159.