### PR TITLE
Enable strict feature

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,6 +6,7 @@
 
   <PropertyGroup>
     <LangVersion>Latest</LangVersion>
+    <Features>strict</Features>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">


### PR DESCRIPTION
The compiler enables more warnings if this feature is enabled, eg. comparing IntPtr with null.