### PR TITLE
Fix null ptr check

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/src/DacInterface/DacDataTargetWrapper.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DacInterface/DacDataTargetWrapper.cs
@@ -270,7 +270,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             IntPtr buffer,
             int* pDataSize)
         {
-            if (buffer == null)
+            if (buffer == IntPtr.Zero)
                 return E_INVALIDARG;
 
             string filePath = _dataTarget.SymbolLocator.FindBinary(filename, imageTimestamp, imageSize, true);


### PR DESCRIPTION
The compiler doesn't warn about comparing a struct with null unless `strict` is enabled so it's easy to miss it.