### PR TITLE
mark ClrDiagnosticsException serializable

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/src/Common/ClrDiagnosticsException.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/ClrDiagnosticsException.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Runtime.Serialization;
 
 namespace Microsoft.Diagnostics.Runtime
 {
@@ -10,6 +11,7 @@ namespace Microsoft.Diagnostics.Runtime
     /// Exception thrown by Microsoft.Diagnostics.Runtime unless there is a more appropriate
     /// exception subclass.
     /// </summary>
+    [Serializable]
     public class ClrDiagnosticsException : Exception
     {
         /// <summary>
@@ -76,6 +78,11 @@ namespace Microsoft.Diagnostics.Runtime
             : base(message)
         {
             base.HResult = (int)hr;
+        }
+
+        protected ClrDiagnosticsException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
         }
 
         internal static void ThrowRevisionError(int revision, int runtimeRevision)


### PR DESCRIPTION
for the scenarios when exceptions are transferred across process boundaries during multi-process-execution it would be nice to have ClrDiagnosticsException serializable as most of the other default framework exceptions