### PR TITLE
fix dac request file name

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/src/DataTargets/DataTargetImpl.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataTargets/DataTargetImpl.cs
@@ -136,13 +136,12 @@ namespace Microsoft.Diagnostics.Runtime
 
                 VersionInfo version = module.Version;
                 string dacAgnosticName = DacInfo.GetDacRequestFileName(flavor, Architecture, Architecture, version);
-                string dacFileName = DacInfo.GetDacRequestFileName(flavor, IntPtr.Size == 4 ? Architecture.X86 : Architecture.Amd64, Architecture, version);
 
                 DacInfo dacInfo = new DacInfo(_dataReader, dacAgnosticName, Architecture)
                 {
                     FileSize = module.FileSize,
                     TimeStamp = module.TimeStamp,
-                    FileName = dacFileName,
+                    FileName = dacAgnosticName,
                     Version = module.Version
                 };
 


### PR DESCRIPTION
Throughout ClrMD there are multiple checks which allow dump processing only when current process architecture is equal to the dump architecture.
Dac info construction logic however uses current architecture to create dac request file name.

This may lead to the undesired effects.
E.g. you may want to try creating a DataTarget for a x86 dump in a x64 process.
Just to get general info and check if suitable dac can be found, without actual `ClrRuntime` creation (which will be done afterwards in a separate process with matching architecture)
But this will not work properly because of the incorrect file name in the dac info.

Seems to be a valid usecase. Or am I missing something?