### PR TITLE
Define contracts for ClrObject functionality

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime.Tests/Microsoft.Diagnostics.Runtime.Tests.csproj
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/Microsoft.Diagnostics.Runtime.Tests.csproj
@@ -23,4 +23,8 @@
       <Link>data\%(RecursiveDir)%(Filename)%(Extension)</Link>
     </None>
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="AutoFixture" Version="4.6.0" />
+    <PackageReference Include="AutoFixture.Xunit2" Version="4.6.0" />
+  </ItemGroup>
 </Project>

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/ClrObjectTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/ClrObjectTests.cs
@@ -1,0 +1,158 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Microsoft.Diagnostics.Runtime.Tests.Fixtures;
+using Xunit;
+
+namespace Microsoft.Diagnostics.Runtime.Tests
+{
+    public class ClrObjectTests : IClassFixture<ClrObjectConnection>
+    {
+        private readonly ClrObjectConnection _connection;
+
+        private ClrObject _primitiveCarrier => _connection.PrimitiveTypeCarrier;
+
+        public ClrObjectTests(ClrObjectConnection connection)
+            => _connection = connection;
+
+        [Fact]
+        public void GetField_WhenBool_ReturnsExpected()
+        {
+            // Act
+            bool actual = _primitiveCarrier.GetField<bool>("TrueBool");
+
+            // Assert
+            Assert.True(actual);
+        }
+
+        [Fact]
+        public void GetField_WhenLong_ReturnsExpected()
+        {
+            // Arrange
+            long expected = (long)int.MaxValue + 1;
+
+            // Act
+            long actual = _primitiveCarrier.GetField<long>("OneLargerMaxInt");
+
+            // Assert
+            Assert.Equal(actual, expected);
+        }
+
+        [Fact]
+        public void GetField_WhenEnum_ReturnsExpected()
+        {
+            // Act
+            EnumType enumValue = _primitiveCarrier.GetField<EnumType>("SomeEnum");
+
+            // Assert
+            Assert.Equal(EnumType.PickedValue, enumValue);
+        }
+
+        [Fact]
+        public void GetField_WhenDateTime_ThrowsException()
+        {
+            // Act
+            void readDateTime() => _primitiveCarrier.GetField<DateTime>("Birthday");
+
+            // Assert
+            Assert.ThrowsAny<Exception>(readDateTime);
+        }
+
+        [Fact]
+        public void GetField_WhenGuid_ThrowsException()
+        {
+            // Act
+            void readGuid() => _primitiveCarrier.GetField<Guid>("SampleGuid");
+
+            // Assert
+            Assert.ThrowsAny<Exception>(readGuid);
+        }
+
+        [Fact]
+        public void GetField_WhenTargetTypeMismatch_ThrowsException()
+        {
+            // Act
+            void readingPointerAsBool() => _primitiveCarrier.GetField<bool>("SamplePointerType");
+
+            // Assert
+            Assert.ThrowsAny<Exception>(readingPointerAsBool);
+        }
+
+        [Fact]
+        public void GetStringField_WhenStringField_ReturnsPointerToObject()
+        {
+            // Act
+            string text = _primitiveCarrier.GetStringField("HelloWorldString");
+
+            // Assert
+            Assert.Equal("Hello World", text);
+        }
+
+        [Fact]
+        public void GetStringField_WhenTypeMismatch_ThrowsInvalidOperation()
+        {
+            // Act
+            void readDifferentFieldTypeAsString() => _primitiveCarrier.GetStringField("SomeEnum");
+
+            // Assert
+            Assert.Throws<InvalidOperationException>(readDifferentFieldTypeAsString);
+        }
+
+        [Fact]
+        public void GetObjectField_WhenStringField_ReturnsPointerToObject()
+        {
+            // Act
+            ClrObject textPointer = _primitiveCarrier.GetObjectField("HelloWorldString");
+
+            // Assert
+            Assert.Equal("Hello World", (string)textPointer);
+        }
+
+        [Fact]
+        public void GetObjectField_WhenReferenceField_ReturnsPointerToObject()
+        {
+            // Act
+            ClrObject referenceFieldValue = _primitiveCarrier.GetObjectField("SamplePointer");
+
+            // Assert
+            Assert.Equal("SamplePointerType", referenceFieldValue.Type.Name);
+        }
+
+        [Fact]
+        public void GetObjectField_WhenNonExistingField_ThrowsArgumentException()
+        {
+            // Act
+            void readNonExistingField() => _primitiveCarrier.GetObjectField("nonExistingField");
+
+            // Assert
+            Assert.Throws<ArgumentException>(readNonExistingField);
+        }
+
+        [Fact]
+        public void GetValueClassField_WhenDateTime_ThrowsException()
+        {
+            // Act
+            ClrValueClass birthday = _primitiveCarrier.GetValueClassField("Birthday");
+
+            // Assert
+            Assert.Equal(typeof(DateTime).FullName, birthday.Type.Name);
+        }
+
+        [Fact]
+        public void GetValueClassField_WhenGuid_ThrowsException()
+        {
+            // Act
+            ClrValueClass sampleGuid = _primitiveCarrier.GetValueClassField("SampleGuid");
+
+            // Assert
+            Assert.Equal(typeof(Guid).FullName, sampleGuid.Type.Name);
+        }
+
+        /// <summary>
+        /// Must be alligned with enum declared in source ClrObjects testTarget.
+        /// </summary>
+        public enum EnumType { Zero, One, Two, PickedValue }
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/Fixtures/ClrObjectConnection.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/Fixtures/ClrObjectConnection.cs
@@ -1,0 +1,43 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Linq;
+
+namespace Microsoft.Diagnostics.Runtime.Tests.Fixtures
+{
+    /// <summary>
+    /// Provides test data from <see cref="TestTargets.ClrObjects"/> testTarget source.
+    /// </summary>
+    public class ClrObjectConnection : IDisposable
+    {
+        public ClrObjectConnection()
+        {
+            DataTarget = TestTargets.ClrObjects.LoadFullDump();
+            Runtime = DataTarget.ClrVersions.Single().CreateRuntime();
+
+            PrimitiveTypeCarrier = FindFirstInstanceOfType(Runtime.Heap, "PrimitiveTypeCarrier");
+        }
+
+        /// <summary>
+        /// Test object with various field types.
+        /// </summary>
+        public ClrObject PrimitiveTypeCarrier { get; }
+
+        public ClrRuntime Runtime { get; }
+
+        public DataTarget DataTarget { get; }
+
+        private static ClrObject FindFirstInstanceOfType(ClrHeap heap, string typeName)
+        {
+            var type = heap.GetTypeByName(typeName);
+
+            if (type is null) throw new InvalidOperationException($"Could not find {typeName} in {nameof(TestTargets.ClrObjects)} source.");
+
+            return new ClrObject(heap.GetObjectsOfType(typeName).First(), type);
+        }
+
+        void IDisposable.Dispose() => DataTarget?.Dispose();
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/TestTargets.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/TestTargets.cs
@@ -24,6 +24,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
 
     public static class TestTargets
     {
+        private static readonly Lazy<TestTarget> _clrObjects = new Lazy<TestTarget>(() => new TestTarget("ClrObjects.cs"));
         private static readonly Lazy<TestTarget> _gcroot = new Lazy<TestTarget>(() => new TestTarget("GCRoot.cs"));
         private static readonly Lazy<TestTarget> _nestedException = new Lazy<TestTarget>(() => new TestTarget("NestedException.cs"));
         private static readonly Lazy<TestTarget> _gcHandles = new Lazy<TestTarget>(() => new TestTarget("GCHandles.cs"));
@@ -38,6 +39,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         public static TestTarget Types => _types.Value;
         public static TestTarget AppDomains => _appDomains.Value;
         public static TestTarget FinalizationQueue => _finalizationQueue.Value;
+        public static TestTarget ClrObjects => _clrObjects.Value;
     }
 
     public class TestTarget

--- a/src/TestTargets/ClrObjects.cs
+++ b/src/TestTargets/ClrObjects.cs
@@ -1,0 +1,37 @@
+using System;
+
+public class Program
+{
+  public static void Main(string[] args)
+  {
+    var primitiveObj = new PrimitiveTypeCarrier();
+
+    throw new Exception();
+
+    GC.KeepAlive(primitiveObj);
+  }
+}
+
+public class PrimitiveTypeCarrier
+{
+  bool TrueBool = true;
+
+  long OneLargerMaxInt = ((long)int.MaxValue + 1);
+
+  DateTime Birthday = new DateTime(1992, 1, 24);
+
+  SamplePointerType SamplePointer = new SamplePointerType();
+
+  EnumType SomeEnum = EnumType.PickedValue;
+
+  string HelloWorldString = "Hello World";
+
+  Guid SampleGuid = new Guid("{EB06CEC0-5E2D-4DC4-875B-01ADCC577D13}");
+}
+
+
+public class SamplePointerType
+{ }
+
+
+public enum EnumType { Zero, One, Two, PickedValue }


### PR DESCRIPTION
Key takeaway - DateTime and Guid processing is not yet out-of-the-box.

I referenced AutoFixture to make test neater and reuse one DataTarget fixture-wide.