### PR TITLE
Feature/define array processing

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/BasicArrayTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/BasicArrayTests.cs
@@ -1,0 +1,351 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using AutoFixture.Xunit2;
+using Microsoft.Diagnostics.Runtime.Tests.Fixtures;
+using Xunit;
+
+namespace Microsoft.Diagnostics.Runtime.Tests
+{
+    public class BasicArrayTests : IClassFixture<ArrayConnection>
+    {
+        private readonly ArrayConnection _connection;
+
+        /// <summary>
+        /// Snapshot of <see cref="ArraysHolder"/> object.
+        /// </summary>
+        private ClrObject _arrayHolder => _connection.TestDataClrObject;
+
+        private ArrayConnection.ArraysHolder _prototype => _connection.Prototype;
+        private ClrHeap _heap => _arrayHolder.Type.Heap;
+
+        public BasicArrayTests(ArrayConnection connection)
+        {
+            _connection = connection;
+        }
+
+        [Fact]
+        public void Length_WhenPrimitiveValueTypeArray_ReturnsExpected()
+        {
+            // Arrange 
+            ClrObject intArraySnapshot = _arrayHolder
+                .GetObjectField(nameof(ArrayConnection.ArraysHolder.IntArray));
+
+            // Act & Assert
+            Assert.Equal(_prototype.IntArray.Length, intArraySnapshot.Length);
+        }
+
+        [Fact]
+        public void Length_WhenGuidArray_ReturnsExpected()
+        {
+            // Arrange 
+            ClrObject guidArray = _arrayHolder
+                .GetObjectField(nameof(ArrayConnection.ArraysHolder.GuidArray));
+
+            // Act & Assert
+            Assert.Equal(_prototype.GuidArray.Length, guidArray.Length);
+        }
+
+        [Fact]
+        public void Length_WhenDateTimeArray_ReturnsExpected()
+        {
+            // Arrange 
+            ClrObject dateTimeArray = _arrayHolder
+                .GetObjectField(nameof(ArrayConnection.ArraysHolder.DateTimeArray));
+
+            // Act & Assert
+            Assert.Equal(_prototype.DateTimeArray.Length, dateTimeArray.Length);
+        }
+
+        [Fact]
+        public void Length_WhenCustomStructArray_ReturnsExpected()
+        {
+            // Arrange 
+            ClrObject customStructArray = _arrayHolder
+                .GetObjectField(nameof(ArrayConnection.ArraysHolder.StructArray));
+
+            // Act & Assert
+            Assert.Equal(_prototype.StructArray.Length, customStructArray.Length);
+        }
+
+        [Fact]
+        public void Length_WhenStringArray_ReturnsExpected()
+        {
+            // Arrange 
+            ClrObject referenceArraySnapshot = _arrayHolder
+                .GetObjectField(nameof(ArrayConnection.ArraysHolder.StringArray));
+
+            // Act & Assert
+            Assert.Equal(_prototype.StringArray.Length, referenceArraySnapshot.Length);
+        }
+
+        [Fact]
+        public void Length_WhenReferenceArrayWithBlanks_ReturnsExpected()
+        {
+            // Arrange             
+            ClrObject referenceArraySnapshot = _arrayHolder
+                .GetObjectField(nameof(ArrayConnection.ArraysHolder.ReferenceArrayWithBlanks));
+
+            // Act & Assert
+            Assert.Equal(_prototype.ReferenceArrayWithBlanks.Length, referenceArraySnapshot.Length);
+        }
+
+        [Theory, AutoData]
+        public void GetArrayElementValue_WhenIntTypeArray_ReturnsExpectedElement(int seed)
+        {
+            // Arrange
+            var originalArray = _prototype.IntArray;
+            ClrObject intArraySnapshot = _arrayHolder.GetObjectField(nameof(ArrayConnection.ArraysHolder.IntArray));
+
+            var index = seed % originalArray.Length;
+
+            // Act 
+            int actual = (int)intArraySnapshot.Type.GetArrayElementValue(intArraySnapshot, index);
+
+            // Assert
+            Assert.Equal(originalArray[index], actual);
+        }
+
+        [Theory, AutoData]
+        public void GetArrayElementValue_WhenStringArray_ReturnsExpectedElement(int seed)
+        {
+            // Arrange
+            var originalArray = _prototype.StringArray;
+            ClrObject referenceArray = _arrayHolder.GetObjectField(nameof(ArrayConnection.ArraysHolder.StringArray));
+
+            var index = seed % originalArray.Length;
+
+            // Act 
+            string actual = (string)referenceArray.Type.GetArrayElementValue(referenceArray, index);
+
+            // Assert
+            Assert.Equal(originalArray[index], actual);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(2)]
+        public void GetArrayElementValue_WhenReferenceArray_ReturnsExpectedElement(int setElementIndex)
+        {
+            // Arrange
+            var originalArray = _prototype.ReferenceArrayWithBlanks;
+            ClrObject referenceArray = _arrayHolder.GetObjectField(nameof(ArrayConnection.ArraysHolder.ReferenceArrayWithBlanks));
+
+            // Act 
+            ulong actualPointer = (ulong)referenceArray.Type.GetArrayElementValue(referenceArray, setElementIndex);
+
+            ClrType pointerType = _connection.Runtime.Heap.GetObjectType(actualPointer);
+
+            // Assert
+            Assert.Equal(typeof(object).FullName, pointerType.Name);
+        }
+
+        [Theory, InlineData(1)]
+        public void GetArrayElementValue_WhenReferenceArrayHasNullElement_ReturnsEmptyObject(int blankElementIndex)
+        {
+            // Arrange
+            var originalArray = _prototype.ReferenceArrayWithBlanks;
+            ClrObject referenceArray = _arrayHolder.GetObjectField(nameof(ArrayConnection.ArraysHolder.ReferenceArrayWithBlanks));
+
+            // Act 
+            ulong actualPointer = (ulong)referenceArray.Type.GetArrayElementValue(referenceArray, blankElementIndex);
+
+            // Assert
+            Assert.Equal(default, actualPointer);
+        }
+
+        [Theory, AutoData]
+        public void GetArrayElementValue_WhenCustomStructArray_Throws(int seed)
+        {
+            // Arrange
+            var originalArray = _prototype.StructArray;
+            ClrObject structArray = _arrayHolder.GetObjectField(nameof(ArrayConnection.ArraysHolder.StructArray));
+
+            var index = seed % originalArray.Length;
+
+            // Act 
+            Action readingCustomStructArrayElement = () => structArray.Type.GetArrayElementValue(structArray, index);
+
+            // Assert
+            Assert.ThrowsAny<Exception>(readingCustomStructArrayElement);
+        }
+
+        [Theory, AutoData]
+        public void GetArrayElementValue_WhenDateTimeArray_Throws(int seed)
+        {
+            // Arrange
+            var originalArray = _prototype.DateTimeArray;
+            ClrObject structArray = _arrayHolder.GetObjectField(nameof(ArrayConnection.ArraysHolder.DateTimeArray));
+
+            var index = seed % originalArray.Length;
+
+            // Act 
+            Action readingCustomStructArrayElement = () => structArray.Type.GetArrayElementValue(structArray, index);
+
+            // Assert
+            Assert.ThrowsAny<Exception>(readingCustomStructArrayElement);
+        }
+
+        [Theory, AutoData]
+        public void GetArrayElementValue_WhenGuidArray_Throws(int seed)
+        {
+            // Arrange
+            var originalArray = _prototype.GuidArray;
+            ClrObject structArray = _arrayHolder.GetObjectField(nameof(ArrayConnection.ArraysHolder.GuidArray));
+
+            var index = seed % originalArray.Length;
+
+            // Act 
+            Action readingCustomStructArrayElement = () => structArray.Type.GetArrayElementValue(structArray, index);
+
+            // Assert
+            Assert.ThrowsAny<Exception>(readingCustomStructArrayElement);
+        }
+
+        [Theory, AutoData]
+        public void GetArrayElementAddress_WhenGuidArray_Throws(int seed)
+        {
+            // Arrange
+            var originalArray = _prototype.GuidArray;
+            ClrObject structArray = _arrayHolder.GetObjectField(nameof(ArrayConnection.ArraysHolder.GuidArray));
+
+            var index = seed % originalArray.Length;
+
+            // Act 
+            ulong elementAddress = structArray.Type.GetArrayElementAddress(structArray, index);
+
+            // Assert
+            Assert.NotEqual(default, elementAddress);
+        }
+
+        [Theory, AutoData]
+        public void GetArrayElementAddress_WhenStringArray_ReturnsExpectedElement(int seed)
+        {
+            // Arrange
+            var originalArray = _prototype.StringArray;
+            ClrObject referenceArray = _arrayHolder.GetObjectField(nameof(ArrayConnection.ArraysHolder.StringArray));
+
+            var index = seed % originalArray.Length;
+
+            // Act 
+            ulong elementAddress = referenceArray.Type.GetArrayElementAddress(referenceArray, index);
+
+            _heap.ReadPointer(elementAddress, out var actualValue);
+
+            string actual = (string)(new ClrObject(actualValue, _heap.GetObjectType(actualValue)));
+
+            // Assert
+            Assert.Equal(originalArray[index], actual);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(2)]
+        public void GetArrayElementAddress_WhenReferenceArray_ReturnsExpectedElement(int setElementIndex)
+        {
+            // Arrange
+            var originalArray = _prototype.ReferenceArrayWithBlanks;
+            ClrObject referenceArray = _arrayHolder.GetObjectField(nameof(ArrayConnection.ArraysHolder.ReferenceArrayWithBlanks));
+
+            // Act 
+            ulong elementAddress = referenceArray.Type.GetArrayElementAddress(referenceArray, setElementIndex);
+
+            _heap.ReadPointer(elementAddress, out ulong actualPointer);
+
+            ClrType pointerType = _connection.Runtime.Heap.GetObjectType(actualPointer);
+
+            // Assert
+            Assert.Equal(typeof(object).FullName, pointerType.Name);
+        }
+
+        [Theory, InlineData(1)]
+        public void GetArrayElementAddress_WhenReferenceArrayHasNullElement_ReturnsNotEmptyPosition(int blankElementIndex)
+        {
+            // Arrange
+            var originalArray = _prototype.ReferenceArrayWithBlanks;
+            ClrObject referenceArray = _arrayHolder.GetObjectField(nameof(ArrayConnection.ArraysHolder.ReferenceArrayWithBlanks));
+
+            // Act 
+            ulong elementAddress = referenceArray.Type.GetArrayElementAddress(referenceArray, blankElementIndex);
+
+            // Assert
+            Assert.NotEqual(default, elementAddress);
+        }
+
+
+        [Theory, AutoData]
+        public void GetArrayElementAddress_WhenCustomStructArray_GetsStructStartPos(int seed)
+        {
+            // Arrange
+            var originalArray = _prototype.StructArray;
+            ClrObject structArray = _arrayHolder.GetObjectField(nameof(ArrayConnection.ArraysHolder.StructArray));
+
+            var index = seed % originalArray.Length;
+
+            // Act 
+            ulong structStart = structArray.Type.GetArrayElementAddress(structArray, index);
+
+            // Assert
+            Assert.NotEqual(default, structStart);
+        }
+
+        [Theory, AutoData]
+        public void GetArrayElementAddress_WhenCustomStructArray_ReturnsPointerToActualData(int seed)
+        {
+            // Arrange
+            var originalArray = _prototype.StructArray;
+            ClrObject structArray = _arrayHolder.GetObjectField(nameof(ArrayConnection.ArraysHolder.StructArray));
+
+            var index = seed % originalArray.Length;
+            var structType = structArray.Type.ComponentType;
+            var textField = structType.GetFieldByName(nameof(ArrayConnection.SampleStruct.ReferenceLoad));
+
+            // Act 
+            ulong structStart = structArray.Type.GetArrayElementAddress(structArray, index);
+            
+            _heap.ReadPointer(structStart + (ulong)textField.Offset, out var textAddress);
+
+            var text = (string)_heap.GetObjectType(textAddress).GetValue(textAddress);
+
+            // Assert
+            Assert.Equal(originalArray[index].ReferenceLoad, actual: text);
+        }
+
+        [Theory, AutoData]
+        public void GetArrayElementAddress_WhenCustomStructArray_ReadsIntData(int seed)
+        {
+            // Arrange
+            var originalArray = _prototype.StructArray;
+            ClrObject structArray = _arrayHolder.GetObjectField(nameof(ArrayConnection.ArraysHolder.StructArray));
+
+            var index = seed % originalArray.Length;
+            var structType = structArray.Type.ComponentType;
+            var primitiveField = structType.GetFieldByName(nameof(ArrayConnection.SampleStruct.Number));
+
+            // Act 
+            ulong structStart = structArray.Type.GetArrayElementAddress(structArray, index);
+            int number = (int)primitiveField.Type.GetValue(structStart);
+
+            // Assert
+            Assert.Equal(originalArray[index].Number, number);
+        }
+
+        [Theory, AutoData]
+        public void GetArrayElementAddress_WhenDateTimeArray_GetsStructStartPos(int seed)
+        {
+            // Arrange
+            var originalArray = _prototype.DateTimeArray;
+            ClrObject structArray = _arrayHolder.GetObjectField(nameof(ArrayConnection.ArraysHolder.DateTimeArray));
+
+            var index = seed % originalArray.Length;
+
+            // Act 
+            ulong structStart = structArray.Type.GetArrayElementAddress(structArray, index);
+
+            // Assert
+            Assert.NotEqual(default, structStart);
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/ClrObjectTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/ClrObjectTests.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
     {
         private readonly ClrObjectConnection _connection;
 
-        private ClrObject _primitiveCarrier => _connection.PrimitiveTypeCarrier;
+        private ClrObject _primitiveCarrier => _connection.TestDataClrObject;
 
         public ClrObjectTests(ClrObjectConnection connection)
             => _connection = connection;

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/ClrObjectTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/ClrObjectTests.cs
@@ -20,8 +20,11 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         [Fact]
         public void GetField_WhenBool_ReturnsExpected()
         {
+            // Arrange 
+            var prototype = _connection.Prototype;
+            
             // Act
-            bool actual = _primitiveCarrier.GetField<bool>("TrueBool");
+            bool actual = _primitiveCarrier.GetField<bool>(nameof(prototype.TrueBool));
 
             // Assert
             Assert.True(actual);
@@ -31,30 +34,36 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         public void GetField_WhenLong_ReturnsExpected()
         {
             // Arrange
-            long expected = (long)int.MaxValue + 1;
+            var prototype = _connection.Prototype;
 
             // Act
-            long actual = _primitiveCarrier.GetField<long>("OneLargerMaxInt");
+            long actual = _primitiveCarrier.GetField<long>(nameof(prototype.OneLargerMaxInt));
 
             // Assert
-            Assert.Equal(actual, expected);
+            Assert.Equal(prototype.OneLargerMaxInt, actual);
         }
 
         [Fact]
         public void GetField_WhenEnum_ReturnsExpected()
         {
+            // Arrange
+            var prototype = _connection.Prototype;
+
             // Act
-            EnumType enumValue = _primitiveCarrier.GetField<EnumType>("SomeEnum");
+            ClrObjectConnection.EnumType enumValue = _primitiveCarrier.GetField<ClrObjectConnection.EnumType>(nameof(prototype.SomeEnum));
 
             // Assert
-            Assert.Equal(EnumType.PickedValue, enumValue);
+            Assert.Equal(prototype.SomeEnum, enumValue);
         }
 
         [Fact]
         public void GetField_WhenDateTime_ThrowsException()
         {
+            // Arrange
+            var prototype = _connection.Prototype;
+
             // Act
-            void readDateTime() => _primitiveCarrier.GetField<DateTime>("Birthday");
+            void readDateTime() => _primitiveCarrier.GetField<DateTime>(nameof(prototype.Birthday));
 
             // Assert
             Assert.ThrowsAny<Exception>(readDateTime);
@@ -63,8 +72,11 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         [Fact]
         public void GetField_WhenGuid_ThrowsException()
         {
+            // Arrange
+            var prototype = _connection.Prototype;
+
             // Act
-            void readGuid() => _primitiveCarrier.GetField<Guid>("SampleGuid");
+            void readGuid() => _primitiveCarrier.GetField<Guid>(nameof(prototype.SampleGuid));
 
             // Assert
             Assert.ThrowsAny<Exception>(readGuid);
@@ -73,8 +85,11 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         [Fact]
         public void GetField_WhenTargetTypeMismatch_ThrowsException()
         {
+            // Arrange
+            var prototype = _connection.Prototype;
+
             // Act
-            void readingPointerAsBool() => _primitiveCarrier.GetField<bool>("SamplePointerType");
+            void readingPointerAsBool() => _primitiveCarrier.GetField<bool>(nameof(prototype.SamplePointer));
 
             // Assert
             Assert.ThrowsAny<Exception>(readingPointerAsBool);
@@ -83,18 +98,24 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         [Fact]
         public void GetStringField_WhenStringField_ReturnsPointerToObject()
         {
+            // Arrange
+            var prototype = _connection.Prototype;
+
             // Act
-            string text = _primitiveCarrier.GetStringField("HelloWorldString");
+            string text = _primitiveCarrier.GetStringField(nameof(prototype.HelloWorldString));
 
             // Assert
-            Assert.Equal("Hello World", text);
+            Assert.Equal(prototype.HelloWorldString, text);
         }
 
         [Fact]
         public void GetStringField_WhenTypeMismatch_ThrowsInvalidOperation()
         {
+            // Arrange
+            var prototype = _connection.Prototype;
+
             // Act
-            void readDifferentFieldTypeAsString() => _primitiveCarrier.GetStringField("SomeEnum");
+            void readDifferentFieldTypeAsString() => _primitiveCarrier.GetStringField(nameof(prototype.SomeEnum));
 
             // Assert
             Assert.Throws<InvalidOperationException>(readDifferentFieldTypeAsString);
@@ -103,18 +124,24 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         [Fact]
         public void GetObjectField_WhenStringField_ReturnsPointerToObject()
         {
+            // Arrange
+            var prototype = _connection.Prototype;
+
             // Act
-            ClrObject textPointer = _primitiveCarrier.GetObjectField("HelloWorldString");
+            ClrObject textPointer = _primitiveCarrier.GetObjectField(nameof(prototype.HelloWorldString));
 
             // Assert
-            Assert.Equal("Hello World", (string)textPointer);
+            Assert.Equal(prototype.HelloWorldString, (string)textPointer);
         }
 
         [Fact]
         public void GetObjectField_WhenReferenceField_ReturnsPointerToObject()
         {
+            // Arrange
+            var prototype = _connection.Prototype;
+
             // Act
-            ClrObject referenceFieldValue = _primitiveCarrier.GetObjectField("SamplePointer");
+            ClrObject referenceFieldValue = _primitiveCarrier.GetObjectField(nameof(prototype.SamplePointer));
 
             // Assert
             Assert.Equal("SamplePointerType", referenceFieldValue.Type.Name);
@@ -123,6 +150,9 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         [Fact]
         public void GetObjectField_WhenNonExistingField_ThrowsArgumentException()
         {
+            // Arrange
+            var prototype = _connection.Prototype;
+
             // Act
             void readNonExistingField() => _primitiveCarrier.GetObjectField("nonExistingField");
 
@@ -133,8 +163,11 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         [Fact]
         public void GetValueClassField_WhenDateTime_ThrowsException()
         {
+            // Arrange
+            var prototype = _connection.Prototype;
+
             // Act
-            ClrValueClass birthday = _primitiveCarrier.GetValueClassField("Birthday");
+            ClrValueClass birthday = _primitiveCarrier.GetValueClassField(nameof(prototype.Birthday));
 
             // Assert
             Assert.Equal(typeof(DateTime).FullName, birthday.Type.Name);
@@ -143,16 +176,14 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         [Fact]
         public void GetValueClassField_WhenGuid_ThrowsException()
         {
+            // Arrange
+            var prototype = _connection.Prototype;
+
             // Act
-            ClrValueClass sampleGuid = _primitiveCarrier.GetValueClassField("SampleGuid");
+            ClrValueClass sampleGuid = _primitiveCarrier.GetValueClassField(nameof(prototype.SampleGuid));
 
             // Assert
             Assert.Equal(typeof(Guid).FullName, sampleGuid.Type.Name);
         }
-
-        /// <summary>
-        /// Must be alligned with enum declared in source ClrObjects testTarget.
-        /// </summary>
-        public enum EnumType { Zero, One, Two, PickedValue }
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/Fixtures/ArrayConnection.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/Fixtures/ArrayConnection.cs
@@ -1,0 +1,52 @@
+﻿using System;
+
+namespace Microsoft.Diagnostics.Runtime.Tests.Fixtures
+{
+    public class ArrayConnection : ObjectConnection<ArrayConnection.ArraysHolder>
+    {
+        public ArrayConnection() : base(TestTargets.Arrays, typeof(ArraysHolder))
+        {
+        }
+
+        /// <summary>
+        /// Please keep definitions in sync with Array.cs
+        /// </summary>
+        public class ArraysHolder
+        {
+            public readonly int[] IntArray = new int[] { 0, 1, 2, 3, 4, 5 };
+
+            public readonly string[] StringArray = new string[] { "first", "second", "third" };
+
+            public readonly Guid[] GuidArray = new Guid[]
+            {
+            new Guid("{56C15C6D-FD5A-40CA-BB37-64CEEC6A9BD5}"),
+            new Guid("{39C4902E-9960-4469-AEEF-E878E9C8218F}"),
+            new Guid("{FF62DBCC-FEA8-4373-8014-09E97362911B}")
+            };
+
+            public readonly DateTime[] DateTimeArray = new DateTime[]
+
+                {
+                new DateTime(2018,12,24),
+                new DateTime(1992, 1, 24),
+                new DateTime(1991, 8, 31)
+                };
+
+            public readonly object[] ReferenceArrayWithBlanks = new object[] { new object(), null, new object() };
+
+            public readonly SampleStruct[] StructArray = new SampleStruct[] { new SampleStruct(5, "Five"), new SampleStruct(10, "Ten") };
+        }
+
+        public struct SampleStruct
+        {
+            public readonly int Number;
+            public readonly string ReferenceLoad;
+
+            public SampleStruct(int num, string load)
+            {
+                Number = num;
+                ReferenceLoad = load;
+            }
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/Fixtures/ClrObjectConnection.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/Fixtures/ClrObjectConnection.cs
@@ -10,34 +10,34 @@ namespace Microsoft.Diagnostics.Runtime.Tests.Fixtures
     /// <summary>
     /// Provides test data from <see cref="TestTargets.ClrObjects"/> testTarget source.
     /// </summary>
-    public class ClrObjectConnection : IDisposable
+    public class ClrObjectConnection : ObjectConnection<ClrObjectConnection.PrimitiveTypeCarrier>
     {
-        public ClrObjectConnection()
+        public ClrObjectConnection() : base(TestTargets.ClrObjects, typeof(PrimitiveTypeCarrier))
         {
-            DataTarget = TestTargets.ClrObjects.LoadFullDump();
-            Runtime = DataTarget.ClrVersions.Single().CreateRuntime();
-
-            PrimitiveTypeCarrier = FindFirstInstanceOfType(Runtime.Heap, "PrimitiveTypeCarrier");
         }
 
-        /// <summary>
-        /// Test object with various field types.
-        /// </summary>
-        public ClrObject PrimitiveTypeCarrier { get; }
-
-        public ClrRuntime Runtime { get; }
-
-        public DataTarget DataTarget { get; }
-
-        private static ClrObject FindFirstInstanceOfType(ClrHeap heap, string typeName)
+        public class PrimitiveTypeCarrier
         {
-            var type = heap.GetTypeByName(typeName);
+            public bool TrueBool = true;
 
-            if (type is null) throw new InvalidOperationException($"Could not find {typeName} in {nameof(TestTargets.ClrObjects)} source.");
+            public long OneLargerMaxInt = ((long)int.MaxValue + 1);
 
-            return new ClrObject(heap.GetObjectsOfType(typeName).First(), type);
+            public DateTime Birthday = new DateTime(1992, 1, 24);
+
+            public SamplePointerType SamplePointer = new SamplePointerType();
+
+            public EnumType SomeEnum = EnumType.PickedValue;
+
+            public string HelloWorldString = "Hello World";
+
+            public Guid SampleGuid = new Guid("{EB06CEC0-5E2D-4DC4-875B-01ADCC577D13}");
         }
 
-        void IDisposable.Dispose() => DataTarget?.Dispose();
+
+        public class SamplePointerType
+        { }
+
+
+        public enum EnumType { Zero, One, Two, PickedValue }
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/Fixtures/ObjectConnection.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/Fixtures/ObjectConnection.cs
@@ -1,0 +1,54 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Linq;
+
+namespace Microsoft.Diagnostics.Runtime.Tests.Fixtures
+{
+    /// <summary>
+    /// Provides test data from <see cref="Tests.TestTarget"/> source.
+    /// <para><see cref="T"/> is object prototype to compare values from snapshot with live instance - must have matching definition in snapshot and during test execution.</para>
+    /// </summary>
+    public abstract class ObjectConnection<T> : IDisposable
+        where T : new()
+    {
+        protected ObjectConnection(TestTarget testTarget, Type type): this(testTarget, type.Name)
+        {
+        }
+
+        protected ObjectConnection(TestTarget testTarget, string typeName)
+        {
+            DataTarget = testTarget.LoadFullDump();
+            Runtime = DataTarget.ClrVersions.Single().CreateRuntime();
+
+            TestDataClrObject = FindFirstInstanceOfType(Runtime.Heap, typeName);
+            TestTarget = testTarget;
+        }
+
+        /// <summary>
+        /// Test object with various field types.
+        /// </summary>
+        public ClrObject TestDataClrObject { get; }
+
+        public ClrRuntime Runtime { get; }
+
+        public DataTarget DataTarget { get; }
+        public TestTarget TestTarget { get; }
+
+        public T Prototype => new T();
+
+        private ClrObject FindFirstInstanceOfType(ClrHeap heap, string typeName)
+        {
+            var type = heap.GetTypeByName(typeName);
+
+            if (type is null)
+                throw new InvalidOperationException($"Could not find {typeName} in {TestTarget.Source} source.");
+
+            return new ClrObject(heap.GetObjectsOfType(typeName).First(), type);
+        }
+
+        void IDisposable.Dispose() => DataTarget?.Dispose();
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/TestTargets.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/TestTargets.cs
@@ -24,6 +24,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
 
     public static class TestTargets
     {
+        private static readonly Lazy<TestTarget> _arrays = new Lazy<TestTarget>(() => new TestTarget("Arrays.cs"));
         private static readonly Lazy<TestTarget> _clrObjects = new Lazy<TestTarget>(() => new TestTarget("ClrObjects.cs"));
         private static readonly Lazy<TestTarget> _gcroot = new Lazy<TestTarget>(() => new TestTarget("GCRoot.cs"));
         private static readonly Lazy<TestTarget> _nestedException = new Lazy<TestTarget>(() => new TestTarget("NestedException.cs"));
@@ -40,6 +41,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         public static TestTarget AppDomains => _appDomains.Value;
         public static TestTarget FinalizationQueue => _finalizationQueue.Value;
         public static TestTarget ClrObjects => _clrObjects.Value;
+        public static TestTarget Arrays => _arrays.Value;
     }
 
     public class TestTarget

--- a/src/TestTargets/Arrays.cs
+++ b/src/TestTargets/Arrays.cs
@@ -1,0 +1,55 @@
+using System;
+
+public class Program
+{
+  public static void Main(string[] args)
+  {
+    var arrayHolder = new ArraysHolder();
+
+    throw new Exception();
+
+    GC.KeepAlive(arrayHolder);
+  }
+}
+
+/// <summary>
+/// Please keep in sync this content with test class (f.e. ArrayConnection).
+/// </summary>
+public class ArraysHolder
+{
+  public readonly int[] IntArray = new int[] { 0, 1, 2, 3, 4, 5 };
+
+  public readonly string[] StringArray = new string[] { "first", "second", "third" };
+
+  public readonly Guid[] GuidArray = new Guid[]
+  {
+            new Guid("{56C15C6D-FD5A-40CA-BB37-64CEEC6A9BD5}"),
+            new Guid("{39C4902E-9960-4469-AEEF-E878E9C8218F}"),
+            new Guid("{FF62DBCC-FEA8-4373-8014-09E97362911B}")
+  };
+
+  public readonly DateTime[] DateTimeArray = new DateTime[]
+
+      {
+                new DateTime(2018,12,24),
+                new DateTime(1992, 1, 24),
+                new DateTime(1991, 8, 31)
+      };
+
+  public readonly object[] ReferenceArrayWithBlanks = new object[] { new object(), null, new object() };
+
+  public readonly SampleStruct[] StructArray = new SampleStruct[] { new SampleStruct(5, "Five"), new SampleStruct(10, "Ten") };
+}
+
+public struct SampleStruct
+{
+  public readonly int Number;
+  public readonly string ReferenceLoad;
+
+  public SampleStruct(int num, string load)
+  {
+    Number = num;
+    ReferenceLoad = load;
+  }
+}
+

--- a/src/TestTargets/ClrObjects.cs
+++ b/src/TestTargets/ClrObjects.cs
@@ -14,19 +14,19 @@ public class Program
 
 public class PrimitiveTypeCarrier
 {
-  bool TrueBool = true;
+  public bool TrueBool = true;
 
-  long OneLargerMaxInt = ((long)int.MaxValue + 1);
+  public long OneLargerMaxInt = ((long)int.MaxValue + 1);
 
-  DateTime Birthday = new DateTime(1992, 1, 24);
+  public DateTime Birthday = new DateTime(1992, 1, 24);
 
-  SamplePointerType SamplePointer = new SamplePointerType();
+  public SamplePointerType SamplePointer = new SamplePointerType();
 
-  EnumType SomeEnum = EnumType.PickedValue;
+  public EnumType SomeEnum = EnumType.PickedValue;
 
-  string HelloWorldString = "Hello World";
+  public string HelloWorldString = "Hello World";
 
-  Guid SampleGuid = new Guid("{EB06CEC0-5E2D-4DC4-875B-01ADCC577D13}");
+  public Guid SampleGuid = new Guid("{EB06CEC0-5E2D-4DC4-875B-01ADCC577D13}");
 }
 
 


### PR DESCRIPTION
Define how arrays are treated here.

Key aspects - only primitive struct types arrays are read.
Neither DateTime, nor Guid, nor any other hand-written structs must be processed manually.
While the pointer to struct start is located perfectly