### PR TITLE
Fix DAC name on Linux.

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/src/Utilities/Platform/LinuxFunctions.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Utilities/Platform/LinuxFunctions.cs
@@ -47,6 +47,9 @@ namespace Microsoft.Diagnostics.Runtime
         [DllImport("libdl.so")]
         private static extern IntPtr dlsym(IntPtr handle, string symbol);
 
+        [DllImport("libdl.so")]
+        public static extern int symlink(string file, string symlink);
+
         private const int RTLD_NOW = 2;
     }
 }


### PR DESCRIPTION
Symlink the DAC module into a temp file on Linux so it can't load libcoreclrtraceptprovider.so.