### PR TITLE
Enable object reference enumeration with field offset

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/src/Common/ClrHeap.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/ClrHeap.cs
@@ -346,6 +346,9 @@ namespace Microsoft.Diagnostics.Runtime
         public abstract bool ReadPointer(ulong addr, out ulong value);
 
         protected internal abstract IEnumerable<ClrObject> EnumerateObjectReferences(ulong obj, ClrType type, bool carefully);
+        
+        protected internal abstract IEnumerable<ClrObjectReference> EnumerateObjectReferencesWithFields(ulong obj, ClrType type, bool carefully);
+        
         protected internal abstract void EnumerateObjectReferences(ulong obj, ClrType type, bool carefully, Action<ulong, int> callback);
 
         /// <summary>
@@ -355,6 +358,22 @@ namespace Microsoft.Diagnostics.Runtime
         /// until I am convinced there's a good way to surface this.
         /// </summary>
         protected internal virtual long TotalObjects => -1;
+    }
+
+    public readonly struct ClrObjectReference
+    {
+        public int FieldOffset { get; }
+        public ulong Address { get; }
+        public ClrType TargetType { get; }
+
+        public ClrObjectReference(int fieldOffset, ulong address, ClrType targetType)
+        {
+            FieldOffset = fieldOffset;
+            Address = address;
+            TargetType = targetType;
+        }
+
+        public ClrObject Object => new ClrObject(Address, TargetType);
     }
 
     /// <summary>

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/ClrType.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/ClrType.cs
@@ -79,6 +79,12 @@ namespace Microsoft.Diagnostics.Runtime
             return Heap.EnumerateObjectReferences(obj, this, carefully);
         }
 
+        public virtual IEnumerable<ClrObjectReference> EnumerateObjectReferencesWithFields(ulong obj, bool carefully = false)
+        {
+            Debug.Assert(Heap.GetObjectType(obj) == this);
+            return Heap.EnumerateObjectReferencesWithFields(obj, this, carefully);
+        }
+
         /// <summary>
         /// Returns true if the type CAN contain references to other objects.  This is used in optimizations
         /// and 'true' can always be returned safely.

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/HeapBase.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/HeapBase.cs
@@ -12,6 +12,8 @@ namespace Microsoft.Diagnostics.Runtime
     internal abstract class HeapBase : ClrHeap
     {
         protected static readonly ClrObject[] s_emptyObjectSet = new ClrObject[0];
+        protected static readonly ClrObjectReference[] s_emptyObjectReferenceSet = new ClrObjectReference[0];
+
         private ulong _minAddr; // Smallest and largest segment in the GC heap.  Used to make SegmentForObject faster.  
         private ulong _maxAddr;
         private ClrSegment[] _segments;
@@ -254,6 +256,34 @@ namespace Microsoft.Diagnostics.Runtime
             List<ClrObject> result = new List<ClrObject>();
             MemoryReader reader = GetMemoryReaderForAddress(obj);
             gcdesc.WalkObject(obj, size, ptr => ReadPointer(reader, ptr), (reference, offset) => result.Add(new ClrObject(reference, GetObjectType(reference))));
+            return result;
+        }
+
+        protected internal override IEnumerable<ClrObjectReference> EnumerateObjectReferencesWithFields(ulong obj, ClrType type, bool carefully)
+        {
+            if (type == null)
+                type = GetObjectType(obj);
+            else
+                Debug.Assert(type == GetObjectType(obj));
+
+            if (!type.ContainsPointers)
+                return s_emptyObjectReferenceSet;
+
+            GCDesc gcdesc = type.GCDesc;
+            if (gcdesc == null)
+                return s_emptyObjectReferenceSet;
+
+            ulong size = type.GetSize(obj);
+            if (carefully)
+            {
+                ClrSegment seg = GetSegmentByAddress(obj);
+                if (seg == null || obj + size > seg.End || !seg.IsLarge && size > 85000)
+                    return s_emptyObjectReferenceSet;
+            }
+
+            List<ClrObjectReference> result = new List<ClrObjectReference>();
+            MemoryReader reader = GetMemoryReaderForAddress(obj);
+            gcdesc.WalkObject(obj, size, ptr => ReadPointer(reader, ptr), (reference, offset) => result.Add(new ClrObjectReference(offset, reference, GetObjectType(reference))));
             return result;
         }
 

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/HeapBase.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/HeapBase.cs
@@ -238,7 +238,7 @@ namespace Microsoft.Diagnostics.Runtime
             else
                 Debug.Assert(type == GetObjectType(obj));
 
-            if (!type.ContainsPointers)
+            if (type == null || !type.ContainsPointers)
                 return s_emptyObjectSet;
 
             GCDesc gcdesc = type.GCDesc;
@@ -266,7 +266,7 @@ namespace Microsoft.Diagnostics.Runtime
             else
                 Debug.Assert(type == GetObjectType(obj));
 
-            if (!type.ContainsPointers)
+            if (type == null || !type.ContainsPointers)
                 return s_emptyObjectReferenceSet;
 
             GCDesc gcdesc = type.GCDesc;

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/HeapBase.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/HeapBase.cs
@@ -249,7 +249,7 @@ namespace Microsoft.Diagnostics.Runtime
             if (carefully)
             {
                 ClrSegment seg = GetSegmentByAddress(obj);
-                if (seg == null || obj + size > seg.End || !seg.IsLarge && size > 85000)
+                if (seg == null || obj + size > seg.End || (!seg.IsLarge && size > 85000))
                     return s_emptyObjectSet;
             }
 
@@ -277,7 +277,7 @@ namespace Microsoft.Diagnostics.Runtime
             if (carefully)
             {
                 ClrSegment seg = GetSegmentByAddress(obj);
-                if (seg == null || obj + size > seg.End || !seg.IsLarge && size > 85000)
+                if (seg == null || obj + size > seg.End || (!seg.IsLarge && size > 85000))
                     return s_emptyObjectReferenceSet;
             }
 


### PR DESCRIPTION
I wanted the ability to access field offsets during enumeration of object references and couldn't find a way to do that without doing an inner scan. It seems the information is available during the outer scan, and this adds API to expose that.

Part of drewnoakes/string-theory#7