### PR TITLE
COM interop helper cleanup

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/src/DacInterface/ClrDataMethod.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DacInterface/ClrDataMethod.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.Diagnostics.Runtime.Utilities;
 using System;
 using System.Runtime.InteropServices;
 

--- a/src/Microsoft.Diagnostics.Runtime/src/DacInterface/ClrDataProcess.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DacInterface/ClrDataProcess.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.Diagnostics.Runtime.Utilities;
 using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;

--- a/src/Microsoft.Diagnostics.Runtime/src/DacInterface/ClrDataTask.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DacInterface/ClrDataTask.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.Diagnostics.Runtime.Utilities;
 using System;
 using System.Runtime.InteropServices;
 

--- a/src/Microsoft.Diagnostics.Runtime/src/DacInterface/ClrStackWalk.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DacInterface/ClrStackWalk.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.Diagnostics.Runtime.Utilities;
 using System;
 using System.Runtime.InteropServices;
 

--- a/src/Microsoft.Diagnostics.Runtime/src/DacInterface/MetaDataImport.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DacInterface/MetaDataImport.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.Diagnostics.Runtime.Utilities;
 using System;
 using System.Collections.Generic;
 using System.Reflection;

--- a/src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.Diagnostics.Runtime.Utilities;
 using System;
 using System.Runtime.InteropServices;
 using System.Text;

--- a/src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosHandleEnum.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosHandleEnum.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.Diagnostics.Runtime.Utilities;
 using System;
 using System.Runtime.InteropServices;
 

--- a/src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosStackRefEnum.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosStackRefEnum.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.Diagnostics.Runtime.Utilities;
 using System;
 using System.Runtime.InteropServices;
 

--- a/src/Microsoft.Diagnostics.Runtime/src/DataTargets/DacLibrary.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataTargets/DacLibrary.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Runtime.InteropServices;
 using Microsoft.Diagnostics.Runtime.DacInterface;
+using Microsoft.Diagnostics.Runtime.Utilities;
 
 namespace Microsoft.Diagnostics.Runtime
 {

--- a/src/Microsoft.Diagnostics.Runtime/src/Desktop/LegacyRuntime.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Desktop/LegacyRuntime.cs
@@ -9,6 +9,7 @@ using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
 using Microsoft.Diagnostics.Runtime.DacInterface;
+using Microsoft.Diagnostics.Runtime.Utilities;
 
 namespace Microsoft.Diagnostics.Runtime.Desktop
 {

--- a/src/Microsoft.Diagnostics.Runtime/src/Utilities/COMInterop/CallableComWrapper.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Utilities/COMInterop/CallableComWrapper.cs
@@ -6,7 +6,7 @@ using System;
 using System.Linq;
 using System.Runtime.InteropServices;
 
-namespace Microsoft.Diagnostics.Runtime.DacInterface
+namespace Microsoft.Diagnostics.Runtime.Utilities
 {
     public unsafe class CallableCOMWrapper : COMHelper, IDisposable
     {

--- a/src/Microsoft.Diagnostics.Runtime/src/Utilities/COMInterop/ComCallableIUnknown.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Utilities/COMInterop/ComCallableIUnknown.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Threading;
 
-namespace Microsoft.Diagnostics.Runtime.DacInterface
+namespace Microsoft.Diagnostics.Runtime.Utilities
 {
     /// <summary>
     /// A class that allows you to build a custom IUnknown based interface to pass as a COM object.

--- a/src/Microsoft.Diagnostics.Runtime/src/Utilities/COMInterop/ComHelper.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Utilities/COMInterop/ComHelper.cs
@@ -5,7 +5,7 @@
 using System;
 using System.Runtime.InteropServices;
 
-namespace Microsoft.Diagnostics.Runtime.DacInterface
+namespace Microsoft.Diagnostics.Runtime.Utilities
 {
     /// <summary>
     /// Base class for COM related objects in ClrMD.

--- a/src/Microsoft.Diagnostics.Runtime/src/Utilities/COMInterop/UnknownVTable.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Utilities/COMInterop/UnknownVTable.cs
@@ -4,7 +4,7 @@
 
 using System;
 
-namespace Microsoft.Diagnostics.Runtime.DacInterface
+namespace Microsoft.Diagnostics.Runtime.Utilities
 {
 #pragma warning disable CS0169
 #pragma warning disable CS0649

--- a/src/Microsoft.Diagnostics.Runtime/src/Utilities/COMInterop/VTableBuilder.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Utilities/COMInterop/VTableBuilder.cs
@@ -47,9 +47,6 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
                 object[] attrs = func.GetType().GetCustomAttributes(false);
                 if (attrs.Count(c => c is UnmanagedFunctionPointerAttribute) != 1)
                     throw new InvalidOperationException();
-
-                if (func.Method.ReturnType != typeof(int))
-                    throw new InvalidOperationException();
             }
 
             _delegates.Add(func);

--- a/src/Microsoft.Diagnostics.Runtime/src/Utilities/COMInterop/VTableBuilder.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Utilities/COMInterop/VTableBuilder.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
 
-namespace Microsoft.Diagnostics.Runtime.DacInterface
+namespace Microsoft.Diagnostics.Runtime.Utilities
 {
     /// <summary>
     /// Builds an individual VTable for a COM object.


### PR DESCRIPTION
- Move COM interop helpers to Utilities namespace.
- Add manual AddRef/Release to COMCallableIUnknown.
- Ensure COMCallableIUnknown will only free data once.
- Allow different return types in VTableBuilder. Now only validate what would cause a crash.