### PR TITLE
Add DataTarget.ProcessId and ModuleInfo.BuildId

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/src/Common/ModuleInfo.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/ModuleInfo.cs
@@ -50,6 +50,11 @@ namespace Microsoft.Diagnostics.Runtime
         }
 
         /// <summary>
+        /// The Linux BuildId of this module.  This will be null if the module does not have a BuildId.
+        /// </summary>
+        public byte[] BuildId { get; internal set; }
+
+        /// <summary>
         /// Whether the module is managed or not.
         /// </summary>
         public virtual bool IsManaged

--- a/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Core/CoreDumpReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Core/CoreDumpReader.cs
@@ -77,7 +77,8 @@ namespace Microsoft.Diagnostics.Runtime
                 FileName = img.Path,
                 FileSize = (uint)img.Size,
                 ImageBase = (ulong)img.BaseAddress,
-                IsRuntime = filename.Equals("libcoreclr.so", StringComparison.OrdinalIgnoreCase)
+                IsRuntime = filename.Equals("libcoreclr.so", StringComparison.OrdinalIgnoreCase),
+                BuildId = img.Open()?.BuildId
             };
         }
 

--- a/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Core/CoreDumpReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Core/CoreDumpReader.cs
@@ -12,7 +12,7 @@ using Microsoft.Diagnostics.Runtime.Linux;
 
 namespace Microsoft.Diagnostics.Runtime
 {
-    internal class CoreDumpReader : IDataReader
+    internal class CoreDumpReader : IDataReader2
     {
         private readonly string _source;
         private readonly Stream _stream;
@@ -44,6 +44,17 @@ namespace Microsoft.Diagnostics.Runtime
 
         public void Close()
         {
+        }
+
+        public uint ProcessId
+        {
+            get
+            {
+                foreach (ElfPRStatus status in _core.EnumeratePRStatus())
+                    return status.PGrp;
+
+                return uint.MaxValue;
+            }
         }
 
         public IEnumerable<uint> EnumerateAllThreads()

--- a/src/Microsoft.Diagnostics.Runtime/src/DataReaders/DbgEng/DbgEngDataReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataReaders/DbgEng/DbgEngDataReader.cs
@@ -12,7 +12,7 @@ using Microsoft.Diagnostics.Runtime.Interop;
 
 namespace Microsoft.Diagnostics.Runtime
 {
-    internal unsafe class DbgEngDataReader : IDisposable, IDataReader
+    internal unsafe class DbgEngDataReader : IDisposable, IDataReader2
     {
         private static int s_totalInstanceCount;
         private static bool s_needRelease = true;
@@ -102,6 +102,15 @@ namespace Microsoft.Diagnostics.Runtime
                     throw new InvalidOperationException("Mismatched architecture between this process and the target process.");
 
                 throw new ClrDiagnosticsException($"Could not attach to pid {pid:X}, HRESULT: 0x{hr:x8}", ClrDiagnosticsException.HR.DebuggerError);
+            }
+        }
+
+        public uint ProcessId
+        {
+            get
+            {
+                int hr = _systemObjects.GetCurrentProcessSystemId(out uint id);
+                return hr == 0 ? id : uint.MaxValue;
             }
         }
 

--- a/src/Microsoft.Diagnostics.Runtime/src/DataReaders/IDataReader2.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataReaders/IDataReader2.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.Diagnostics.Runtime
+{
+    /// <summary>
+    /// A data reader interface that provides the ProcessId of the DataTarget.
+    /// </summary>
+    public interface IDataReader2 : IDataReader
+    {
+        /// <summary>
+        /// The ProcessId of the DataTarget.
+        /// </summary>
+        uint ProcessId { get; }
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Live/LiveDataReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Live/LiveDataReader.cs
@@ -11,7 +11,7 @@ using System.Text;
 
 namespace Microsoft.Diagnostics.Runtime
 {
-    internal unsafe class LiveDataReader : IDataReader
+    internal unsafe class LiveDataReader : IDataReader2
     {
         private readonly int _originalPid;
         private readonly IntPtr _snapshotHandle;
@@ -60,6 +60,8 @@ namespace Microsoft.Diagnostics.Runtime
                     throw new ClrDiagnosticsException("Dac architecture mismatch!");
                 }
         }
+
+        public uint ProcessId => (uint)_pid;
 
         public bool IsMinidump => false;
 

--- a/src/Microsoft.Diagnostics.Runtime/src/DataTargets/DataTarget.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataTargets/DataTarget.cs
@@ -158,6 +158,12 @@ namespace Microsoft.Diagnostics.Runtime
         }
 
         /// <summary>
+        /// Returns the ProcessId of the DataTarget.  May return uint.MaxValue if the underlying IDataReader does
+        /// not implement this functionality.
+        /// </summary>
+        public abstract uint ProcessId { get; }
+
+        /// <summary>
         /// The data reader for this instance.
         /// </summary>
         public abstract IDataReader DataReader { get; }

--- a/src/Microsoft.Diagnostics.Runtime/src/DataTargets/DataTargetImpl.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataTargets/DataTargetImpl.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Diagnostics.Runtime
     internal class DataTargetImpl : DataTarget
     {
         private readonly IDataReader _dataReader;
+        private uint? _pid;
         private ClrInfo[] _versions;
         private ModuleInfo _native;
 
@@ -39,6 +40,23 @@ namespace Microsoft.Diagnostics.Runtime
                 return _native;
             }
         }
+
+        public override uint ProcessId
+        {
+            get
+            {
+                if (!_pid.HasValue)
+                {
+                    if (_dataReader is IDataReader2 reader2)
+                        _pid = reader2.ProcessId;
+                    else
+                        _pid = uint.MaxValue;
+                }
+
+                return _pid.Value;
+            }
+        }
+
 
         public override IDataReader DataReader => _dataReader;
 

--- a/src/Microsoft.Diagnostics.Runtime/src/Linux/ElfCoreFile.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Linux/ElfCoreFile.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Diagnostics.Runtime.Linux
                 start = end + 1;
 
                 if (!lookup.TryGetValue(path, out ElfLoadedImage image))
-                    image = lookup[path] = new ElfLoadedImage(path);
+                    image = lookup[path] = new ElfLoadedImage(ElfFile.VirtualAddressReader, path);
 
                 image.AddTableEntryPointers(fileTable[i]);
             }

--- a/src/Microsoft.Diagnostics.Runtime/src/Linux/ElfReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Linux/ElfReader.cs
@@ -27,6 +27,20 @@ namespace Microsoft.Diagnostics.Runtime.Linux
             _handle = GCHandle.Alloc(_buffer, GCHandleType.Pinned);
         }
 
+        public T? TryRead<T>(long position)
+            where T : struct
+        {
+            int size = Marshal.SizeOf(typeof(T));
+            EnsureSize(size);
+
+            int read = DataSource.Read(position, _buffer, 0, size);
+            if (read != size)
+                return null;
+
+            T result = (T)Marshal.PtrToStructure(_handle.AddrOfPinnedObject(), typeof(T));
+            return result;
+        }
+
         public T Read<T>(long position)
             where T : struct
         {

--- a/src/Microsoft.Diagnostics.Runtime/src/Linux/Structs/ElfHeader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Linux/Structs/ElfHeader.cs
@@ -40,21 +40,33 @@ namespace Microsoft.Diagnostics.Runtime.Linux
 
         public ElfData Data => (ElfData)Ident[5];
 
+        public bool IsValid
+        {
+            get
+            {
+                if (Ident[0] != Magic0 ||
+                    Ident[1] != Magic1 ||
+                    Ident[2] != Magic2 ||
+                    Ident[3] != Magic3)
+                    return false;
+
+                return Data == ElfData.LittleEndian;
+            }
+        }
+
+
         public void Validate(string filename)
         {
-            if (string.IsNullOrWhiteSpace(filename))
-                filename = "This coredump";
-            else
-                filename = $"'{filename}'";
-
             if (Ident[0] != Magic0 ||
                 Ident[1] != Magic1 ||
                 Ident[2] != Magic2 ||
                 Ident[3] != Magic3)
-                throw new InvalidDataException($"{filename} does not contain a valid ELF header.");
+                throw new InvalidDataException($"{MakeFileName(filename)} does not contain a valid ELF header.");
 
             if (Data != ElfData.LittleEndian)
-                throw new InvalidDataException($"{filename} is BigEndian, which is unsupported");
+                throw new InvalidDataException($"{MakeFileName(filename)} is BigEndian, which is unsupported");
         }
+
+        private static string MakeFileName(string filename) => string.IsNullOrWhiteSpace(filename) ? "This coredump" : $"'{filename}'";
     }
 }


### PR DESCRIPTION
Add a way to get the PID on all platforms, and the BuildId for Linux modules.