### PR TITLE
Support downloading symbols from https

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/src/Utilities/Symbols/DefaultSymbolLocator.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Utilities/Symbols/DefaultSymbolLocator.cs
@@ -225,7 +225,7 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
             if (File.Exists(fullDestPath))
                 return fullDestPath;
 
-            if (serverPath.StartsWith("http:"))
+            if (serverPath.StartsWith("http:") || serverPath.StartsWith("https:"))
             {
                 string fullUri = serverPath + "/" + pdbIndexPath.Replace('\\', '/');
                 try


### PR DESCRIPTION
As far as I can tell the only reason it doesn't work is because of the explicit check of the schema, and this seems to work.