### PR TITLE
Handle cache* elements in the symbol path.

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/src/Utilities/Symbols/DefaultSymbolLocator.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Utilities/Symbols/DefaultSymbolLocator.cs
@@ -110,6 +110,7 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
 
             // Finally, check the symbol paths.
             string exeIndexPath = null;
+            string activeSymbolCache = SymbolCache;
             foreach (SymPathElement element in SymPathElement.GetElements(SymbolPath))
             {
                 if (element.IsSymServer)
@@ -117,7 +118,7 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
                     if (exeIndexPath == null)
                         exeIndexPath = GetIndexPath(fileName, buildTimeStamp, imageSize);
 
-                    string target = TryGetFileFromServer(element.Target, exeIndexPath, element.Cache ?? SymbolCache);
+                    string target = TryGetFileFromServer(element.Target, exeIndexPath, element.Cache ?? activeSymbolCache);
                     if (target == null)
                     {
                         Trace($"Server '{element.Target}' did not have file '{Path.GetFileName(fileName)}' with timestamp={buildTimeStamp:x} and filesize={imageSize:x}.");
@@ -128,6 +129,13 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
                         SetFileEntry(missingFiles, entry, target);
                         return target;
                     }
+                }
+                else if (element.IsCache)
+                {
+                    if (!string.IsNullOrEmpty(element.Cache))
+                        activeSymbolCache = element.Cache;
+                    else
+                        activeSymbolCache = SymbolCache;
                 }
                 else
                 {

--- a/src/Microsoft.Diagnostics.Runtime/src/Utilities/Symbols/SymPathElement.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Utilities/Symbols/SymPathElement.cs
@@ -37,6 +37,10 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
         /// </summary>
         public bool IsSymServer { get; }
         /// <summary>
+        /// returns true if this element of the symbol server path is a local cache specification
+        /// </summary>
+        public bool IsCache { get; }
+        /// <summary>
         /// returns the local cache for a symbol server specifcation.  returns null if not specified
         /// </summary>
         public string Cache { get; set; }
@@ -174,7 +178,7 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
             m = Regex.Match(strElem, @"^\s*CACHE\*(.*?)\s*$", RegexOptions.IgnoreCase);
             if (m.Success)
             {
-                IsSymServer = true;
+                IsCache = true;
                 Cache = m.Groups[1].Value;
             }
             else


### PR DESCRIPTION
According to https://docs.microsoft.com/en-us/windows-hardware/drivers/debugger/symbol-path#caching-symbols-locally a cache* entry is supposed to change the cache path for everything following it. The current implementation instead adds it as a symsrv entry with a null target, which is then later ignored in TryGetFileFromServer.

The documentation is unclear on whether the cache* entry takes precedence over a cache specification inside a srv element, for now I am assuming that it does not.