### PR TITLE
Fix crash getting build id on Linux.

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/src/Linux/ElfFile.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Linux/ElfFile.cs
@@ -100,24 +100,22 @@ namespace Microsoft.Diagnostics.Runtime.Linux
                 return;
 
             LoadProgramHeaders();
-            ElfProgramHeader noteHeader = _programHeaders.SingleOrDefault(ph => ph.Header.Type == ElfProgramHeaderType.Note);
-
-            if (noteHeader == null)
-            {
-                _notes = new ElfNote[0];
-                return;
-            }
 
             List<ElfNote> notes = new List<ElfNote>();
-
-            Reader reader = new Reader(noteHeader.AddressSpace);
-            long position = 0;
-            while (position < reader.DataSource.Length)
+            foreach (ElfProgramHeader programHeader in _programHeaders)
             {
-                ElfNote note = new ElfNote(reader, position);
-                notes.Add(note);
+                if (programHeader.Header.Type == ElfProgramHeaderType.Note)
+                {
+                    Reader reader = new Reader(programHeader.AddressSpace);
+                    long position = 0;
+                    while (position < reader.DataSource.Length)
+                    {
+                        ElfNote note = new ElfNote(reader, position);
+                        notes.Add(note);
 
-                position += note.TotalSize;
+                        position += note.TotalSize;
+                    }
+                }
             }
 
             _notes = notes.ToArray();


### PR DESCRIPTION
There are modules like libicui18n.so.60.2 on Fedora version 28 that have more than one NOTE program header. Changed the code to handle it.