### PR TITLE
Update script for building test assets

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime.Tests/TestInstructions.txt
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/TestInstructions.txt
@@ -6,14 +6,14 @@ To do this, first install both the x86 and x64 version of Debugging Tools
 for Windows (windbg, cdb, etc).  Then you will need to set the following
 environment variables:
 
-set CSC=[path_to_csc]
-set Debug32=[path_to_32bit_cdb_folder]
-set Debug64=[path_to_64bit_cdb_folder]
+set csc=[path_to_csc]
+set cdb32=[path_to_32bit_cdb]
+set cdb64=[path_to_64bit_cdb]
 
 Then run build_test_assets.cmd.
 
 For example:
-	set CSC=c:\Windows\Microsoft.NET\Framework64\v4.0.30319\csc.exe
-	set DEBUG32=d:\x86\
-	set DEBUG64=d:\amd64\
+	set csc=c:\Windows\Microsoft.NET\Framework64\v4.0.30319\csc.exe
+	set cdb32=d:\x86\cdb.exe
+	set cdb64=d:\amd64\cdb.exe
 	build_test_assets.cmd


### PR DESCRIPTION
Experimented with tests for a while.
It appeared that `build_test_assets.cmd` sometimes is not that convenient.

With proposed changes the script
- is less dependent on ~dp0, can be placed anywhere, needs just %SourcePath% to be fixed.
- has a bit more verbose error messages
- has predefined placeholders for default `csc` and `cdb` locations right in the script;
changing few lines of code for a single run is usually faster than setting environment variables and making sure they were propagated to the console