### PR TITLE
Fix tests based on the multi-app-domain sample

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/RuntimeTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/RuntimeTests.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             {
                 ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
 
-                HashSet<string> expected = new HashSet<string>(new[] {"mscorlib.dll", "sharedlibrary.dll", "nestedexception.exe", "appdomains.exe"}, StringComparer.OrdinalIgnoreCase);
+                HashSet<string> expected = new HashSet<string>(new[] {"mscorlib.dll", "system.dll", "system.core.dll", "sharedlibrary.dll", "nestedexception.exe", "appdomains.exe"}, StringComparer.OrdinalIgnoreCase);
                 HashSet<ClrModule> modules = new HashSet<ClrModule>();
 
                 foreach (ClrModule module in runtime.Modules)

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/TypeTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/TypeTests.cs
@@ -251,7 +251,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
 
                         Assert.NotEqual(0ul, mt);
                         ulong[] collection = type.EnumerateMethodTables().ToArray();
-                        Assert.Contains(mt, collection);
+                        Assert.Contains(type.MethodTable, collection);
 
                         Assert.Same(type, heap.GetTypeByMethodTable(mt));
                         Assert.Same(type, heap.GetTypeByMethodTable(mt, 0));


### PR DESCRIPTION
It looks like in recent runtimes few more classes and modules are getting loaded during sample app execution.

Some of the tests started to fail:
- `RuntimeTests.ModuleEnumerationTest` wasn't ready for the presence of the `System` and `System.Core` modules
- `TypeTests.GetObjectMethodTableTest` wasn't ready for the presence of types with generic arguments, `System.Collections.Concurrent.ConcurrentDictionary<System.IntPtr,System.Reflection.Metadata.MetadataReaderProvider>` in particular
