### PR TITLE
Distinguish exception kind and HResult

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime.Native/src/Common/NativeRuntime.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Native/src/Common/NativeRuntime.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Diagnostics.Runtime.Native
             _modules = dt.EnumerateModules().ToArray();
 
             if (SOSNative == null)
-                throw new ClrDiagnosticsException("Unsupported dac version.", ClrDiagnosticsException.HR.DacError);
+                throw new ClrDiagnosticsException("Unsupported dac version.", ClrDiagnosticsExceptionKind.DacError);
         }
 
         public IReadOnlyList<NativeThread> Threads

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/ClrDiagnosticsException.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/ClrDiagnosticsException.cs
@@ -14,82 +14,32 @@ namespace Microsoft.Diagnostics.Runtime
     [Serializable]
     public class ClrDiagnosticsException : Exception
     {
-        /// <summary>
-        /// Specific HRESULTS for errors.
-        /// </summary>
-        public enum HR
+        internal ClrDiagnosticsException(string message, ClrDiagnosticsExceptionKind kind = ClrDiagnosticsExceptionKind.Unknown, int hr = 0)
+            : base(message)
         {
-            /// <summary>
-            /// Unknown error occured.
-            /// </summary>
-            UnknownError = unchecked((int)(((ulong)0x3 << 31) | ((ulong)0x125 << 16) | 0x0)),
-
-            /// <summary>
-            /// The dll of the specified runtime (mscorwks.dll or clr.dll) is loaded into the process, but
-            /// has not actually been initialized and thus cannot be debugged.
-            /// </summary>
-            RuntimeUninitialized = UnknownError + 1,
-
-            /// <summary>
-            /// Something unexpected went wrong with the debugger we used to attach to the process or load
-            /// the crash dump.
-            /// </summary>
-            DebuggerError,
-
-            /// <summary>
-            /// Something unexpected went wrong when requesting data from the target process.
-            /// </summary>
-            DataRequestError,
-
-            /// <summary>
-            /// Hit an unexpected (non-recoverable) dac error.
-            /// </summary>
-            DacError,
-
-            /// <summary>
-            /// The caller attempted to re-use an object after calling ClrRuntime.Flush.  See the
-            /// documentation for ClrRuntime.Flush for more details.
-            /// </summary>
-            RevisionError,
-
-            /// <summary>
-            /// An error occurred while processing the given crash dump.
-            /// </summary>
-            CrashDumpError,
-
-            /// <summary>
-            /// There is an issue with the configuration of this application.
-            /// </summary>
-            ApplicationError
+            Kind = kind;
+            HResult = hr;
         }
 
         /// <summary>
-        /// The HRESULT of this exception.
+        /// Exception kind
         /// </summary>
-        public new int HResult => base.HResult;
-
-        internal ClrDiagnosticsException(string message)
-            : base(message)
-        {
-            base.HResult = (int)HR.UnknownError;
-        }
-
-        internal ClrDiagnosticsException(string message, HR hr)
-            : base(message)
-        {
-            base.HResult = (int)hr;
-        }
+        public ClrDiagnosticsExceptionKind Kind { get; }
 
         protected ClrDiagnosticsException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
+            if (info == null) throw new ArgumentNullException(nameof(info));
+
+            Kind = (ClrDiagnosticsExceptionKind)info.GetValue(nameof(Kind), typeof(ClrDiagnosticsExceptionKind));
         }
 
-        internal static void ThrowRevisionError(int revision, int runtimeRevision)
+        public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {
-            throw new ClrDiagnosticsException(
-                $"You must not reuse any object other than ClrRuntime after calling flush!\nClrModule revision ({revision}) != ClrRuntime revision ({runtimeRevision}).",
-                HR.RevisionError);
+            if (info == null) throw new ArgumentNullException(nameof(info));
+
+            info.AddValue(nameof(Kind), Kind, typeof(ClrDiagnosticsExceptionKind));
+            base.GetObjectData(info, context);
         }
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/ClrDiagnosticsException.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/ClrDiagnosticsException.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Diagnostics.Runtime
     [Serializable]
     public class ClrDiagnosticsException : Exception
     {
-        internal ClrDiagnosticsException(string message, ClrDiagnosticsExceptionKind kind = ClrDiagnosticsExceptionKind.Unknown, int hr = 0)
+        internal ClrDiagnosticsException(string message, ClrDiagnosticsExceptionKind kind = ClrDiagnosticsExceptionKind.Unknown, int hr = -2146233088)
             : base(message)
         {
             Kind = kind;

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/ClrDiagnosticsExceptionKind.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/ClrDiagnosticsExceptionKind.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Microsoft.Diagnostics.Runtime
+{
+    /// <summary>
+    /// Exception kind
+    /// </summary>
+    [Serializable]
+    public enum ClrDiagnosticsExceptionKind
+    {
+        Unknown,
+        CorruptedFileOrUnknownFormat,
+        RevisionMismatch,
+        DebuggerError,
+        CrashDumpError,
+        DataRequestError,
+        DacError,
+        RuntimeUninitialized
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/ClrDiagnosticsExceptionKind.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/ClrDiagnosticsExceptionKind.cs
@@ -12,13 +12,46 @@ namespace Microsoft.Diagnostics.Runtime
     [Serializable]
     public enum ClrDiagnosticsExceptionKind
     {
+        /// <summary>
+        /// Unknown error occured.
+        /// </summary>
         Unknown,
+
+        /// <summary>
+        /// Dump file is corrupted or has an unknown format.
+        /// </summary>
         CorruptedFileOrUnknownFormat,
+
+        /// <summary>
+        /// The caller attempted to re-use an object after calling ClrRuntime.Flush.  See the
+        /// documentation for ClrRuntime.Flush for more details.
+        /// </summary>
         RevisionMismatch,
+
+        /// <summary>
+        /// Something unexpected went wrong with the debugger we used to attach to the process or load the crash dump.
+        /// </summary>
         DebuggerError,
+
+        /// <summary>
+        /// An error occurred while processing the given crash dump.
+        /// </summary>
         CrashDumpError,
+
+        /// <summary>
+        /// Something unexpected went wrong when requesting data from the target process.
+        /// </summary>
         DataRequestError,
+
+        /// <summary>
+        /// Hit an unexpected (non-recoverable) dac error.
+        /// </summary>
         DacError,
+
+        /// <summary>
+        /// The dll of the specified runtime (mscorwks.dll or clr.dll) is loaded into the process, but
+        /// has not actually been initialized and thus cannot be debugged.
+        /// </summary>
         RuntimeUninitialized
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/ExceptionExtensions.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/ExceptionExtensions.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Microsoft.Diagnostics.Runtime
+{
+    internal static class ExceptionExtensions
+    {
+        public static Exception AddData(this Exception exception, string name, object value)
+        {
+            if (exception == null) throw new ArgumentNullException(nameof(exception));
+
+            exception.Data[name] = value;
+            return exception;
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/HeapBase.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/HeapBase.cs
@@ -56,8 +56,7 @@ namespace Microsoft.Diagnostics.Runtime
         {
             get
             {
-                if (Revision != GetRuntimeRevision())
-                    ClrDiagnosticsException.ThrowRevisionError(Revision, GetRuntimeRevision());
+                RevisionValidator.Validate(Revision, GetRuntimeRevision());
                 return _segments;
             }
         }
@@ -165,8 +164,7 @@ namespace Microsoft.Diagnostics.Runtime
 
         public override IEnumerable<ClrObject> EnumerateObjects()
         {
-            if (Revision != GetRuntimeRevision())
-                ClrDiagnosticsException.ThrowRevisionError(Revision, GetRuntimeRevision());
+            RevisionValidator.Validate(Revision, GetRuntimeRevision());
 
             for (int i = 0; i < _segments.Length; ++i)
             {
@@ -182,8 +180,7 @@ namespace Microsoft.Diagnostics.Runtime
 
         public override IEnumerable<ulong> EnumerateObjectAddresses()
         {
-            if (Revision != GetRuntimeRevision())
-                ClrDiagnosticsException.ThrowRevisionError(Revision, GetRuntimeRevision());
+            RevisionValidator.Validate(Revision, GetRuntimeRevision());
 
             for (int i = 0; i < _segments.Length; ++i)
             {

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/RevisionValidator.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/RevisionValidator.cs
@@ -1,0 +1,17 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.Diagnostics.Runtime
+{
+    internal static class RevisionValidator
+    {
+        public static void Validate(int revision, int runtimeRevision)
+        {
+            if (revision != runtimeRevision)
+                throw new ClrDiagnosticsException(
+                    $"You must not reuse any object other than ClrRuntime after calling flush!\nClrModule revision ({revision}) != ClrRuntime revision ({runtimeRevision}).",
+                    ClrDiagnosticsExceptionKind.RevisionMismatch);
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/src/DataReaders/DbgEng/DbgEngDataReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataReaders/DbgEng/DbgEngDataReader.cs
@@ -54,7 +54,10 @@ namespace Microsoft.Diagnostics.Runtime
             int hr = client.OpenDumpFile(dumpFile);
 
             if (hr != 0)
-                throw new ClrDiagnosticsException($"Could not load crash dump '{dumpFile}', HRESULT: 0x{hr:x8}", ClrDiagnosticsException.HR.DebuggerError);
+            {
+                var kind = (uint)hr == 0x80004005 ? ClrDiagnosticsExceptionKind.CorruptedFileOrUnknownFormat : ClrDiagnosticsExceptionKind.DebuggerError;
+                throw new ClrDiagnosticsException($"Could not load crash dump, HRESULT: 0x{hr:x8}", kind, hr).AddData("DumpFile", dumpFile);
+            }
 
             CreateClient(client);
 
@@ -101,7 +104,7 @@ namespace Microsoft.Diagnostics.Runtime
                 if ((uint)hr == 0xd00000bb)
                     throw new InvalidOperationException("Mismatched architecture between this process and the target process.");
 
-                throw new ClrDiagnosticsException($"Could not attach to pid {pid:X}, HRESULT: 0x{hr:x8}", ClrDiagnosticsException.HR.DebuggerError);
+                throw new ClrDiagnosticsException($"Could not attach to pid {pid:X}, HRESULT: 0x{hr:x8}", ClrDiagnosticsExceptionKind.DebuggerError, hr);
             }
         }
 
@@ -142,8 +145,8 @@ namespace Microsoft.Diagnostics.Runtime
             SetClientInstance();
 
             int hr = _control.GetExecutingProcessorType(out IMAGE_FILE_MACHINE machineType);
-            if (0 != hr)
-                throw new ClrDiagnosticsException($"Failed to get processor type, HRESULT: {hr:x8}", ClrDiagnosticsException.HR.DebuggerError);
+            if (hr != 0)
+                throw new ClrDiagnosticsException($"Failed to get processor type, HRESULT: {hr:x8}", ClrDiagnosticsExceptionKind.DebuggerError, hr);
 
             switch (machineType)
             {
@@ -192,7 +195,7 @@ namespace Microsoft.Diagnostics.Runtime
             if (hr == 1)
                 return 4;
 
-            throw new ClrDiagnosticsException(string.Format("IsPointer64Bit failed: {0:x8}", hr), ClrDiagnosticsException.HR.DebuggerError);
+            throw new ClrDiagnosticsException($"IsPointer64Bit failed, HRESULT: {hr:x8}", ClrDiagnosticsExceptionKind.DebuggerError, hr);
         }
 
         public void Flush()
@@ -318,7 +321,7 @@ namespace Microsoft.Diagnostics.Runtime
             Interlocked.Increment(ref s_totalInstanceCount);
 
             if (_systemObjects3 == null && s_totalInstanceCount > 1)
-                throw new ClrDiagnosticsException("This version of DbgEng is too old to create multiple instances of DataTarget.", ClrDiagnosticsException.HR.DebuggerError);
+                throw new ClrDiagnosticsException("This version of DbgEng is too old to create multiple instances of DataTarget.", ClrDiagnosticsExceptionKind.DebuggerError);
 
             if (_systemObjects3 != null)
                 _systemObjects3.GetCurrentSystemId(out _instance);

--- a/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Dump/DumpPointer.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Dump/DumpPointer.cs
@@ -183,7 +183,7 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
         private void EnsureSizeRemaining(uint requestedSize)
         {
             if (requestedSize > _size)
-                throw new ClrDiagnosticsException("The given crash dump is in an incorrect format.", ClrDiagnosticsException.HR.CrashDumpError);
+                throw new ClrDiagnosticsException("The given crash dump is in an incorrect format.", ClrDiagnosticsExceptionKind.CrashDumpError);
         }
 
         // The actual raw pointer into the dump file (which is memory mapped into this process space.

--- a/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Dump/DumpReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Dump/DumpReader.cs
@@ -241,7 +241,7 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
                         targetRequestStart.ToString("x"),
                         bytesRead,
                         destinationBufferSizeInBytes),
-                    ClrDiagnosticsException.HR.CrashDumpError);
+                    ClrDiagnosticsExceptionKind.CrashDumpError);
             }
         }
 
@@ -564,7 +564,7 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
         private DumpPointer GetStream(MINIDUMP_STREAM_TYPE type)
         {
             if (!TryGetStream(type, out DumpPointer stream))
-                throw new ClrDiagnosticsException("Dump does not contain a " + type + " stream.", ClrDiagnosticsException.HR.CrashDumpError);
+                throw new ClrDiagnosticsException("Dump does not contain a " + type + " stream.", ClrDiagnosticsExceptionKind.CrashDumpError);
 
             return stream;
         }
@@ -691,7 +691,7 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
         {
             if (loc.IsNull)
             {
-                throw new ClrDiagnosticsException("Context not present", ClrDiagnosticsException.HR.CrashDumpError);
+                throw new ClrDiagnosticsException("Context not present", ClrDiagnosticsExceptionKind.CrashDumpError);
             }
 
             DumpPointer pContext = TranslateDescriptor(loc);
@@ -702,7 +702,7 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
                 // Context size doesn't match
                 throw new ClrDiagnosticsException(
                     "Context size mismatch. Expected = 0x" + sizeBufferBytes.ToString("x") + ", Size in dump = 0x" + sizeContext.ToString("x"),
-                    ClrDiagnosticsException.HR.CrashDumpError);
+                    ClrDiagnosticsExceptionKind.CrashDumpError);
             }
 
             // Now copy from dump into buffer. 

--- a/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Dump/MinidumpArray.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Dump/MinidumpArray.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
                 streamType != MINIDUMP_STREAM_TYPE.ThreadListStream &&
                 streamType != MINIDUMP_STREAM_TYPE.ThreadExListStream)
             {
-                throw new ClrDiagnosticsException("MinidumpArray does not support this stream type.", ClrDiagnosticsException.HR.CrashDumpError);
+                throw new ClrDiagnosticsException("MinidumpArray does not support this stream type.", ClrDiagnosticsExceptionKind.CrashDumpError);
             }
 
             _streamPointer = streamPointer;
@@ -42,7 +42,7 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
             {
                 // Since the callers here are internal, a request out of range means a
                 // corrupted dump file.
-                throw new ClrDiagnosticsException("Dump error: index " + idx + "is out of range.", ClrDiagnosticsException.HR.CrashDumpError);
+                throw new ClrDiagnosticsException("Dump error: index " + idx + "is out of range.", ClrDiagnosticsExceptionKind.CrashDumpError);
             }
 
             // Although the Marshal.SizeOf(...) is not necessarily correct, it is nonetheless

--- a/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Dump/MinidumpExceptionStream.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Dump/MinidumpExceptionStream.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
                     "Crash dump error: Expected to find " + DumpNative.EXCEPTION_MAXIMUM_PARAMETERS +
                     " exception params, but found " +
                     ExceptionRecord.ExceptionInformation.Length + " instead.",
-                    ClrDiagnosticsException.HR.CrashDumpError);
+                    ClrDiagnosticsExceptionKind.CrashDumpError);
             }
 
             for (int i = 0; i < DumpNative.EXCEPTION_MAXIMUM_PARAMETERS; i++)

--- a/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Dump/MinidumpMemoryChunks.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Dump/MinidumpMemoryChunks.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
             if (type != MINIDUMP_STREAM_TYPE.MemoryListStream &&
                 type != MINIDUMP_STREAM_TYPE.Memory64ListStream)
             {
-                throw new ClrDiagnosticsException("Type must be either MemoryListStream or Memory64ListStream", ClrDiagnosticsException.HR.CrashDumpError);
+                throw new ClrDiagnosticsException("Type must be either MemoryListStream or Memory64ListStream", ClrDiagnosticsExceptionKind.CrashDumpError);
             }
 
             _listType = type;
@@ -211,7 +211,7 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
                     throw new ClrDiagnosticsException(
                         "Unexpected inconsistency error in dump memory chunk " + i
                         + " with target base address " + _chunks[i].TargetStartAddress + ".",
-                        ClrDiagnosticsException.HR.CrashDumpError);
+                        ClrDiagnosticsExceptionKind.CrashDumpError);
                 }
 
                 // If there's a next to compare to, and it's a MinidumpWithFullMemory, then we expect
@@ -224,13 +224,13 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
                     throw new ClrDiagnosticsException(
                         "Unexpected relative addresses inconsistency between dump memory chunks "
                         + i + " and " + (i + 1) + ".",
-                        ClrDiagnosticsException.HR.CrashDumpError);
+                        ClrDiagnosticsExceptionKind.CrashDumpError);
                 }
 
                 // Because we sorted and split/merged entries we can expect them to be increasing and non-overlapping
                 if (i < Count - 1 && _chunks[i].TargetEndAddress > _chunks[i + 1].TargetStartAddress)
                 {
-                    throw new ClrDiagnosticsException("Unexpected overlap between memory chunks", ClrDiagnosticsException.HR.CrashDumpError);
+                    throw new ClrDiagnosticsException("Unexpected overlap between memory chunks", ClrDiagnosticsExceptionKind.CrashDumpError);
                 }
             }
         }

--- a/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Dump/MinidumpThreadList.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Dump/MinidumpThreadList.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
         {
             if (streamType != MINIDUMP_STREAM_TYPE.ThreadListStream &&
                 streamType != MINIDUMP_STREAM_TYPE.ThreadExListStream)
-                throw new ClrDiagnosticsException("Only ThreadListStream and ThreadExListStream are supported.", ClrDiagnosticsException.HR.CrashDumpError);
+                throw new ClrDiagnosticsException("Only ThreadListStream and ThreadExListStream are supported.", ClrDiagnosticsExceptionKind.CrashDumpError);
         }
 
         // IMinidumpThreadList

--- a/src/Microsoft.Diagnostics.Runtime/src/DataTargets/DacLibrary.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataTargets/DacLibrary.cs
@@ -102,7 +102,7 @@ namespace Microsoft.Diagnostics.Runtime
             int res = func(ref guid, DacDataTarget.IDacDataTarget, out IntPtr iUnk);
 
             if (res != 0)
-                throw new ClrDiagnosticsException("Failure loading DAC: CreateDacInstance failed 0x" + res.ToString("x"), ClrDiagnosticsException.HR.DacError);
+                throw new ClrDiagnosticsException("Failure loading DAC: CreateDacInstance failed 0x" + res.ToString("x"), ClrDiagnosticsExceptionKind.DacError, res);
 
             InternalDacPrivateInterface = new ClrDataProcess(this, iUnk);
         }

--- a/src/Microsoft.Diagnostics.Runtime/src/Desktop/DesktopGCHeap.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Desktop/DesktopGCHeap.cs
@@ -1250,8 +1250,7 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
 
         public override IEnumerable<ClrObject> EnumerateObjects()
         {
-            if (Revision != GetRuntimeRevision())
-                ClrDiagnosticsException.ThrowRevisionError(Revision, GetRuntimeRevision());
+            RevisionValidator.Validate(Revision, GetRuntimeRevision());
 
             if (IsHeapCached)
                 return _objectMap.Enumerate().Select(item => ClrObject.Create(item.Key, _objects[item.Value].Type));
@@ -1261,8 +1260,7 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
 
         public override IEnumerable<ulong> EnumerateObjectAddresses()
         {
-            if (Revision != GetRuntimeRevision())
-                ClrDiagnosticsException.ThrowRevisionError(Revision, GetRuntimeRevision());
+            RevisionValidator.Validate(Revision, GetRuntimeRevision());
 
             if (IsHeapCached)
                 return _objectMap.Enumerate().Select(item => item.Key);

--- a/src/Microsoft.Diagnostics.Runtime/src/Desktop/DesktopModule.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Desktop/DesktopModule.cs
@@ -178,8 +178,7 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
 
         internal override MetaDataImport GetMetadataImport()
         {
-            if (Revision != _runtime.Revision)
-                ClrDiagnosticsException.ThrowRevisionError(Revision, _runtime.Revision);
+            RevisionValidator.Validate(Revision, _runtime.Revision);
 
             if (_metadata != null)
                 return _metadata;

--- a/src/Microsoft.Diagnostics.Runtime/src/Desktop/DesktopRuntimeBase.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Desktop/DesktopRuntimeBase.cs
@@ -94,7 +94,7 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
             IGCInfo data = GetGCInfoImpl();
             if (data == null)
             {
-                throw new ClrDiagnosticsException("This runtime is not initialized and contains no data.", ClrDiagnosticsException.HR.RuntimeUninitialized);
+                throw new ClrDiagnosticsException("This runtime is not initialized and contains no data.", ClrDiagnosticsExceptionKind.RuntimeUninitialized);
             }
 
             return data;

--- a/src/Microsoft.Diagnostics.Runtime/src/Desktop/LegacyRuntime.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Desktop/LegacyRuntime.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
             _patch = patch;
 
             if (!GetCommonMethodTables(ref _commonMTs))
-                throw new ClrDiagnosticsException("Could not request common MethodTable list.", ClrDiagnosticsException.HR.DacError);
+                throw new ClrDiagnosticsException("Could not request common MethodTable list.", ClrDiagnosticsExceptionKind.DacError);
 
             if (!_commonMTs.Validate())
                 CanWalkHeap = false;
@@ -38,11 +38,11 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
             byte[] tmp = new byte[sizeof(int)];
 
             if (!Request(DacRequests.VERSION, null, tmp))
-                throw new ClrDiagnosticsException("Failed to request dac version.", ClrDiagnosticsException.HR.DacError);
+                throw new ClrDiagnosticsException("Failed to request dac version.", ClrDiagnosticsExceptionKind.DacError);
 
             int v = BitConverter.ToInt32(tmp, 0);
             if (v != 8)
-                throw new ClrDiagnosticsException("Unsupported dac version.", ClrDiagnosticsException.HR.DacError);
+                throw new ClrDiagnosticsException("Unsupported dac version.", ClrDiagnosticsExceptionKind.DacError);
         }
 
         protected override void InitApi()

--- a/src/Microsoft.Diagnostics.Runtime/src/Desktop/V45Runtime.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Desktop/V45Runtime.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
             : base(info, dt, lib)
         {
             if (!GetCommonMethodTables(ref _commonMTs))
-                throw new ClrDiagnosticsException("Could not request common MethodTable list.", ClrDiagnosticsException.HR.DacError);
+                throw new ClrDiagnosticsException("Could not request common MethodTable list.", ClrDiagnosticsExceptionKind.DacError);
 
             if (!_commonMTs.Validate())
                 CanWalkHeap = false;
@@ -30,11 +30,11 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
             byte[] tmp = new byte[sizeof(int)];
 
             if (!Request(DacRequests.VERSION, null, tmp))
-                throw new ClrDiagnosticsException("Failed to request dac version.", ClrDiagnosticsException.HR.DacError);
+                throw new ClrDiagnosticsException("Failed to request dac version.", ClrDiagnosticsExceptionKind.DacError);
 
             int v = BitConverter.ToInt32(tmp, 0);
             if (v != 9)
-                throw new ClrDiagnosticsException("Unsupported dac version.", ClrDiagnosticsException.HR.DacError);
+                throw new ClrDiagnosticsException("Unsupported dac version.", ClrDiagnosticsExceptionKind.DacError);
         }
 
         protected override void InitApi()


### PR DESCRIPTION
(proposed for 1.1)

It would be nice to have an option of getting the original HResult that caused the exception.
This will allow to handle some of the cases more precisely on the client side (e.g. to show different detailed error messages)

PR introduces `ClrDiagnosticsExceptionKind` enum for exception classification (e.g. DacError or DebuggerError).
HResult (where applicable) can be passed via the default `Exception.HResult`.