### PR TITLE
Drop obsolete ModuleInfo.IsRuntime

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/src/Common/ModuleInfo.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/ModuleInfo.cs
@@ -34,11 +34,6 @@ namespace Microsoft.Diagnostics.Runtime
         public virtual string FileName { get; set; }
 
         /// <summary>
-        /// Returns true if this module is a native (non-managed) .Net runtime module.
-        /// </summary>
-        public bool IsRuntime { get; internal set; }
-
-        /// <summary>
         /// Returns a PEFile from a stream constructed using instance fields of this object.
         /// If the PEFile cannot be constructed correctly, null is returned
         /// </summary>

--- a/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Core/CoreDumpReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Core/CoreDumpReader.cs
@@ -70,14 +70,11 @@ namespace Microsoft.Diagnostics.Runtime
 
         private ModuleInfo CreateModuleInfo(ElfLoadedImage img)
         {
-            string filename = Path.GetFileName(img.Path);
-
             return new ModuleInfo
             {
                 FileName = img.Path,
                 FileSize = (uint)img.Size,
                 ImageBase = (ulong)img.BaseAddress,
-                IsRuntime = filename.Equals("libcoreclr.so", StringComparison.OrdinalIgnoreCase),
                 BuildId = img.Open()?.BuildId
             };
         }

--- a/src/Microsoft.Diagnostics.Runtime/src/DataTargets/DataTargetImpl.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataTargets/DataTargetImpl.cs
@@ -190,8 +190,6 @@ namespace Microsoft.Diagnostics.Runtime
                     Version = module.Version
                 };
 
-                module.IsRuntime = true; //strange logic here (originally from the ClrInfo constructor)
-
                 versions.Add(new ClrInfo(this, flavor, module, dacInfo, dacLocation));
             }
 


### PR DESCRIPTION
(proposed for 1.1)

Looks like `IsRuntime` flag is not required anymore.
However there's still some controversial logic around its initialization that would be good to get rid of.