### PR TITLE
Update the assembly and package version generation

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,10 +2,8 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <!-- This repo version -->
-    <VersionPrefix>1.0.0</VersionPrefix>
+    <VersionPrefix>1.1.0</VersionPrefix>
     <PreReleaseVersionLabel></PreReleaseVersionLabel>
-    <!-- Use SemVer1 (for broader NuGet compatibility) -->
-    <!-- REVIEW: We can disable this, but it means NuGet 3.0 or higher is needed to restore the package -->
-    <SemanticVersioningV1>true</SemanticVersioningV1>
+    <AutoGenerateAssemblyVersion>true</AutoGenerateAssemblyVersion>
   </PropertyGroup>
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <!-- This repo version -->
     <VersionPrefix>1.0.0</VersionPrefix>
-    <PreReleaseVersionLabel>preview1</PreReleaseVersionLabel>
+    <PreReleaseVersionLabel></PreReleaseVersionLabel>
     <!-- Use SemVer1 (for broader NuGet compatibility) -->
     <!-- REVIEW: We can disable this, but it means NuGet 3.0 or higher is needed to restore the package -->
     <SemanticVersioningV1>true</SemanticVersioningV1>

--- a/src/Microsoft.Diagnostics.Runtime/Microsoft.Diagnostics.Runtime.csproj
+++ b/src/Microsoft.Diagnostics.Runtime/Microsoft.Diagnostics.Runtime.csproj
@@ -13,9 +13,6 @@
     <CheckForOverflowUnderflow>false</CheckForOverflowUnderflow>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)\..\..\eng\Microsoft.Diagnostics.Runtime.snk</AssemblyOriginatorKeyFile>
     <RepositoryUrl>https://github.com/Microsoft/clrmd</RepositoryUrl>
-    <AssemblyVersion>1.0.5.0</AssemblyVersion>
-    <FileVersion>1.0.5.0</FileVersion>
-    <Version>1.0.5</Version>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net45|AnyCPU'">
     <DefineConstants>TRACE;DEBUG;NET45</DefineConstants>


### PR DESCRIPTION
This will generate assembly, file and package versions based on the build id instead of hard coding it in the project file (to current 1.0.5).  

The package version will look something like this: Microsoft.Diagnostics.Runtime.1.0.35103.nupkg.  The file and assembly versions will have something similar.  

Removed the preview label to generate stable versioning.