### PR TITLE
Avoid crashing on Linux when getting the threads callstack

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/src/Linux/LinuxLiveDataReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Linux/LinuxLiveDataReader.cs
@@ -309,22 +309,6 @@ namespace Microsoft.Diagnostics.Runtime.Linux
                         _threadIDs.Add(taskId);
                     }
                 }
-                foreach (var tid in _threadIDs)
-                {
-                    if (tid != this.ProcessId)
-                    {
-                        ulong ret = ptrace(PTRACE_ATTACH, (int)tid, IntPtr.Zero, IntPtr.Zero);
-                        if (ret != 0)
-                        {
-                            throw new InvalidOperationException($"ptrace attach failed with 0x{ret:x}. Please ensure SYS_PTRACE capability is enabled. When running inside a Docker container, add 'SYS_PTRACE' to securityContext.capabilities.");
-                        }
-                        int ret2 = wait(IntPtr.Zero);
-                        if (ret2 != tid)
-                        {
-                            throw new InvalidOperationException($"wait failed with {ret2}. is thread {tid} still running?");
-                        }
-                    }
-                }
             }
         }
 


### PR DESCRIPTION
While improving parallel stack to attach to process (both on Windows and Linux - https://github.com/chrisnas/DebuggingExtensions/blob/master/src/ParallelStacks.Runtime/ParallelStack.cs#L86), I've faced exceptions on linux.
After debugging and trying to figure out how to use ptrace, I've ended up to this fix: it is not needed to call ptrace on each thread (especially with this type of code/error handling)