### PR TITLE
Fix linux live data reader

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/src/Linux/LinuxLiveDataReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Linux/LinuxLiveDataReader.cs
@@ -74,13 +74,13 @@ namespace Microsoft.Diagnostics.Runtime.Linux
                 {
                     continue;
                 }
-                var module = result.FirstOrDefault(m => m.FileName == entry.FileName);
+                var module = result.FirstOrDefault(m => m.FileName == entry.FilePath);
                 if (module == null)
                 {
                     ModuleInfo moduleInfo = new ModuleInfo(this)
                     {
                         ImageBase = entry.BeginAddr,
-                        FileName = entry.FileName
+                        FileName = entry.FilePath
                     };
                     if (File.Exists(entry.FilePath))
                     {


### PR DESCRIPTION
The module file name needs to be the full path for SOS to work and to match the core dump data reader.