### PR TITLE
Handle app domains nullability and absence of shared app domain in the latest CoreCLR

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/src/Common/ClrRuntime.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/ClrRuntime.cs
@@ -55,10 +55,9 @@ namespace Microsoft.Diagnostics.Runtime
         public abstract int PointerSize { get; }
 
         /// <summary>
-        /// Enumerates the list of appdomains in the process.  Note the System appdomain and Shared
-        /// AppDomain are omitted.
+        /// Enumerates the list of appdomains in the process.
         /// </summary>
-        public abstract IList<ClrAppDomain> AppDomains { get; }
+        public abstract IReadOnlyList<ClrAppDomain> AppDomains { get; }
 
         /// <summary>
         /// Give access to the System AppDomain

--- a/src/Microsoft.Diagnostics.Runtime/src/Desktop/DesktopGCHeap.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Desktop/DesktopGCHeap.cs
@@ -667,11 +667,13 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
             // Walking a module is sloooow.  Ensure we only walk each module once.
             HashSet<ulong> modules = new HashSet<ulong>();
 
-            foreach (ulong module in DesktopRuntime.EnumerateModules(DesktopRuntime.GetAppDomainData(DesktopRuntime.SystemDomainAddress)))
-                modules.Add(module);
+            if (DesktopRuntime.SystemDomain != null)
+                foreach (ulong module in DesktopRuntime.EnumerateModules(DesktopRuntime.GetAppDomainData(DesktopRuntime.SystemDomain.Address)))
+                    modules.Add(module);
 
-            foreach (ulong module in DesktopRuntime.EnumerateModules(DesktopRuntime.GetAppDomainData(DesktopRuntime.SharedDomainAddress)))
-                modules.Add(module);
+            if (DesktopRuntime.SharedDomain != null)
+                foreach (ulong module in DesktopRuntime.EnumerateModules(DesktopRuntime.GetAppDomainData(DesktopRuntime.SharedDomain.Address)))
+                    modules.Add(module);
 
             IAppDomainStoreData ads = DesktopRuntime.GetAppDomainStoreData();
             if (ads == null)

--- a/src/Microsoft.Diagnostics.Runtime/src/Desktop/DesktopModule.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Desktop/DesktopModule.cs
@@ -161,7 +161,7 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
 
         internal override ulong GetDomainModule(ClrAppDomain domain)
         {
-            IList<ClrAppDomain> domains = _runtime.AppDomains;
+            IReadOnlyList<ClrAppDomain> domains = _runtime.AppDomains;
             if (domain == null)
             {
                 foreach (ulong addr in _mapping.Values)

--- a/src/Microsoft.Diagnostics.Runtime/src/Desktop/DesktopRuntimeBase.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Desktop/DesktopRuntimeBase.cs
@@ -172,7 +172,6 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
             return result;
         }
 
-        public override IList<ClrAppDomain> AppDomains => _appDomains.Value.Domains;
         public override IList<ClrThread> Threads => _threads.Value;
 
         private List<ClrThread> CreateThreadList()
@@ -227,10 +226,9 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
         }
 
         public override ClrThreadPool ThreadPool => _threadpool.Value;
-        public ulong SystemDomainAddress => _appDomains.Value.System.Address;
-        public ulong SharedDomainAddress => _appDomains.Value.Shared.Address;
         public override ClrAppDomain SystemDomain => _appDomains.Value.System;
         public override ClrAppDomain SharedDomain => _appDomains.Value.Shared;
+        public override IReadOnlyList<ClrAppDomain> AppDomains => _appDomains.Value.Domains;
         public bool IsSingleDomain => _appDomains.Value.Domains.Count == 1;
 
         public override ClrMethod GetMethodByHandle(ulong methodHandle)
@@ -355,21 +353,27 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
 
             // Enumerate each AppDomain and Module specific heap.
             AppDomainHeapWalker adhw = new AppDomainHeapWalker(this);
-            IAppDomainData ad = GetAppDomainData(SystemDomainAddress);
-            foreach (MemoryRegion region in adhw.EnumerateHeaps(ad))
-                yield return region;
-
-            foreach (ulong module in EnumerateModules(ad))
-                foreach (MemoryRegion region in adhw.EnumerateModuleHeaps(ad, module))
+            if (SystemDomain != null)
+            {
+                IAppDomainData ad = GetAppDomainData(SystemDomain.Address);
+                foreach (MemoryRegion region in adhw.EnumerateHeaps(ad))
                     yield return region;
 
-            ad = GetAppDomainData(SharedDomainAddress);
-            foreach (MemoryRegion region in adhw.EnumerateHeaps(ad))
-                yield return region;
+                foreach (ulong module in EnumerateModules(ad))
+                    foreach (MemoryRegion region in adhw.EnumerateModuleHeaps(ad, module))
+                        yield return region;
+            }
 
-            foreach (ulong module in EnumerateModules(ad))
-                foreach (MemoryRegion region in adhw.EnumerateModuleHeaps(ad, module))
+            if (SharedDomain != null)
+            {
+                IAppDomainData ad = GetAppDomainData(SharedDomain.Address);
+                foreach (MemoryRegion region in adhw.EnumerateHeaps(ad))
                     yield return region;
+
+                foreach (ulong module in EnumerateModules(ad))
+                    foreach (MemoryRegion region in adhw.EnumerateModuleHeaps(ad, module))
+                        yield return region;
+            }
 
             IAppDomainStoreData ads = GetAppDomainStoreData();
             if (ads != null)
@@ -379,7 +383,7 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
                 {
                     foreach (ulong addr in appDomains)
                     {
-                        ad = GetAppDomainData(addr);
+                        IAppDomainData ad = GetAppDomainData(addr);
                         foreach (MemoryRegion region in adhw.EnumerateHeaps(ad))
                             yield return region;
 
@@ -609,23 +613,20 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
         {
             IAppDomainStoreData ads = GetAppDomainStoreData();
             if (ads == null)
-                return new DomainContainer();
+                return DomainContainer.Empty;
 
             ulong[] domains = GetAppDomainList(ads.Count);
             if (domains == null)
-                return new DomainContainer();
+                return DomainContainer.Empty;
 
-            return new DomainContainer
-            {
-                Domains = domains.Select(ad => (ClrAppDomain)InitDomain(ad)).Where(ad => ad != null).ToList(),
-                Shared = InitDomain(ads.SharedDomain, "Shared Domain"),
-                System = InitDomain(ads.SystemDomain, "System Domain")
-            };
+            return new DomainContainer(
+                InitDomain(ads.SystemDomain, "System Domain"),
+                InitDomain(ads.SharedDomain, "Shared Domain"),
+                domains.Select(ad => (ClrAppDomain)InitDomain(ad)).Where(ad => ad != null).ToArray());
         }
 
         private DesktopAppDomain InitDomain(ulong domain, string name = null)
         {
-            ulong[] bases = new ulong[1];
             IAppDomainData domainData = GetAppDomainData(domain);
             if (domainData == null)
                 return null;
@@ -719,7 +720,6 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
                 if (stackwalk == null)
                     yield break;
 
-                byte[] ulongBuffer = new byte[8];
                 byte[] context = ContextHelper.Context;
                 do
                 {
@@ -836,11 +836,20 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
         internal abstract uint GetStringLengthOffset();
         internal abstract ulong GetILForModule(ClrModule module, uint rva);
 
-        private struct DomainContainer
+        private class DomainContainer
         {
-            public List<ClrAppDomain> Domains;
-            public DesktopAppDomain System;
-            public DesktopAppDomain Shared;
+            public readonly DesktopAppDomain System;
+            public readonly DesktopAppDomain Shared;
+            public readonly IReadOnlyList<ClrAppDomain> Domains;
+            
+            public static readonly DomainContainer Empty = new DomainContainer(null, null, new ClrAppDomain[0]);
+
+            public DomainContainer(DesktopAppDomain system, DesktopAppDomain shared, IReadOnlyList<ClrAppDomain> domains)
+            {
+                System = system;
+                Shared = shared;
+                Domains = domains ?? throw new ArgumentNullException(nameof(domains));
+            }
         }
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/src/Desktop/DesktopStaticField.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Desktop/DesktopStaticField.cs
@@ -139,7 +139,7 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
         private ClrType TryBuildType(ClrHeap heap)
         {
             ClrRuntime runtime = heap.Runtime;
-            IList<ClrAppDomain> domains = runtime.AppDomains;
+            IReadOnlyList<ClrAppDomain> domains = runtime.AppDomains;
             ClrType[] types = new ClrType[domains.Count];
 
             ClrElementType elType = ElementType;

--- a/src/Microsoft.Diagnostics.Runtime/src/Desktop/MemoryRegion.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Desktop/MemoryRegion.cs
@@ -152,11 +152,11 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
             {
                 if (HasAppDomainData)
                 {
-                    if (_domainModuleHeap == _runtime.SharedDomainAddress)
+                    if (_runtime.SharedDomain != null && _domainModuleHeap == _runtime.SharedDomain.Address)
                     {
                         value = $"{value} for Shared AppDomain";
                     }
-                    else if (_domainModuleHeap == _runtime.SystemDomainAddress)
+                    else if (_runtime.SystemDomain != null && _domainModuleHeap == _runtime.SystemDomain.Address)
                     {
                         value = $"{value} for System AppDomain";
                     }


### PR DESCRIPTION
According to https://github.com/dotnet/coreclr/pull/21031 
there's no shared app domain in the latest CoreCLR.

ClrMd fails with nullref in attempt to get SharedDomainAddress in DesktopGCHeap.LoadAllTypes() on such dumps.