### PR TITLE
Set FileSize/TimeStamp on coredumps

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/src/Linux/ElfLoadedImage.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Linux/ElfLoadedImage.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.Diagnostics.Runtime.Utilities;
 using System.Collections.Generic;
+using System.IO;
 
 namespace Microsoft.Diagnostics.Runtime.Linux
 {
@@ -37,6 +39,12 @@ namespace Microsoft.Diagnostics.Runtime.Linux
                 return null;
 
             return new ElfFile(header, _vaReader, BaseAddress, true);
+        }
+
+        public PEImage OpenAsPEImage()
+        {
+            Stream stream = new ReaderStream(BaseAddress, _vaReader);
+            return new PEImage(stream, isVirtual: true);
         }
 
         internal void AddTableEntryPointers(ElfFileTableEntryPointers64 pointers)

--- a/src/Microsoft.Diagnostics.Runtime/src/Linux/ElfReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Linux/ElfReader.cs
@@ -71,6 +71,8 @@ namespace Microsoft.Diagnostics.Runtime.Linux
             return result;
         }
 
+        public int ReadBytes(byte[] buffer, long offset, int size) => DataSource.Read(offset, buffer, 0, size);
+
         public byte[] ReadBytes(long offset, int size)
         {
             byte[] buffer = new byte[size];

--- a/src/Microsoft.Diagnostics.Runtime/src/Linux/ReaderStream.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Linux/ReaderStream.cs
@@ -1,0 +1,70 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics;
+using System.IO;
+
+namespace Microsoft.Diagnostics.Runtime.Linux
+{
+    class ReaderStream : Stream
+    {
+        private readonly Reader _reader;
+        private readonly long _baseAddress;
+        private long _position;
+
+        public ReaderStream(long baseAddress, Reader reader)
+        {
+            _reader = reader;
+            _baseAddress = baseAddress;
+        }
+
+        public override bool CanRead => true;
+
+        public override bool CanSeek => true;
+
+        public override bool CanWrite => false;
+
+        public override long Length => 2048;
+
+        public override long Position { get => _position; set => _position = value; }
+
+        public override void Flush()
+        {
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            if (offset != 0)
+                throw new NotImplementedException();
+
+            int read = _reader.ReadBytes(buffer, _baseAddress + _position, count);
+            Debug.Assert(read >= 0);
+            _position += read;
+
+            return read;
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            if (origin == SeekOrigin.Begin)
+                _position = offset;
+            else if (origin == SeekOrigin.Current)
+                _position += offset;
+            else 
+                throw new InvalidOperationException();
+
+            return _position;
+        }
+
+        public override void SetLength(long value)
+        {
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            throw new InvalidOperationException();
+        }
+    }
+}


### PR DESCRIPTION
Managed binaries did not have a correct filesize and timestamp set when debugging Linux coredumps.

This caused some issues when inspecting Linux coredumps when other code relied on those properties such as ReadVirtual trying to read from module contents.