### PR TITLE
Fix GCRoot

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/TestTargets.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/TestTargets.cs
@@ -27,6 +27,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         private static readonly Lazy<TestTarget> _arrays = new Lazy<TestTarget>(() => new TestTarget("Arrays.cs"));
         private static readonly Lazy<TestTarget> _clrObjects = new Lazy<TestTarget>(() => new TestTarget("ClrObjects.cs"));
         private static readonly Lazy<TestTarget> _gcroot = new Lazy<TestTarget>(() => new TestTarget("GCRoot.cs"));
+        private static readonly Lazy<TestTarget> _gcroot2 = new Lazy<TestTarget>(() => new TestTarget("GCRoot2.cs"));
         private static readonly Lazy<TestTarget> _nestedException = new Lazy<TestTarget>(() => new TestTarget("NestedException.cs"));
         private static readonly Lazy<TestTarget> _gcHandles = new Lazy<TestTarget>(() => new TestTarget("GCHandles.cs"));
         private static readonly Lazy<TestTarget> _types = new Lazy<TestTarget>(() => new TestTarget("Types.cs"));
@@ -34,6 +35,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         private static readonly Lazy<TestTarget> _finalizationQueue = new Lazy<TestTarget>(() => new TestTarget("FinalizationQueue.cs"));
 
         public static TestTarget GCRoot => _gcroot.Value;
+        public static TestTarget GCRoot2 => _gcroot2.Value;
         public static TestTarget NestedException => _nestedException.Value;
         public static ExceptionTestData NestedExceptionData => new ExceptionTestData();
         public static TestTarget GCHandles => _gcHandles.Value;

--- a/src/TestTargets/GCRoot.cs
+++ b/src/TestTargets/GCRoot.cs
@@ -1,7 +1,11 @@
 ﻿using System;
-using System.Runtime.InteropServices;
 using System.Runtime.CompilerServices;
 
+//                                              object
+//                                            /
+// SingleRef -- object[] -- DoubleRef -- TripleRef -- SingleRef -- TargetType
+//                              \           / \           /
+//                                SingleRef     SingleRef 
 class GCRootTarget
 {
     static object TheRoot;
@@ -11,18 +15,14 @@ class GCRootTarget
     {
         TargetType target = new TargetType();
         SingleRef s = new SingleRef();
-        DoubleRef d;
-        TripleRef t;
+        DoubleRef d = new DoubleRef();
+        TripleRef t = new TripleRef();
 
         TheRoot = s;
 
         object[] arr = new object[42];
         s.Item1 = arr;
-        d = new DoubleRef();
         arr[27] = d;
-
-
-        t = new TripleRef();
 
         // parallel path.
         d.Item1 = new SingleRef() { Item1 = t };

--- a/src/TestTargets/GCRoot2.cs
+++ b/src/TestTargets/GCRoot2.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// GCHandle \
+//            DirectTarget -- IndirectTarget
+// GCHandle /
+class GCRootTarget
+{
+    private static void Main()
+    {
+        Alloc();
+        throw new Exception();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void Alloc()
+    {
+        DirectTarget source = new DirectTarget
+        {
+            Item = new IndirectTarget()
+        };
+
+        GCHandle.Alloc(source);
+        GCHandle.Alloc(source);
+    }
+}
+
+class DirectTarget
+{
+    public object Item;
+}
+
+class IndirectTarget
+{
+}


### PR DESCRIPTION
This PR makes `GCRoot` get the same results as SOS's for the test target *GCRoot2.cs*.

Test results for *GCRoot2.cs*:

## SOS `DirectTarget` unique/all

```
> !GCRoot 00000266d568c1d0
HandleTable:
    00000266D5321388 (strong handle)
    -> 00000266D568C1D0 DirectTarget

    00000266D5321390 (strong handle)
    -> 00000266D568C1D0 DirectTarget
```

## SOS `IndirectTarget` unique

```
> !GCRoot 00000266D568C1E8
HandleTable:
    00000266D5321388 (strong handle)
    -> 00000266D568C1D0 DirectTarget
    -> 00000266D568C1E8 IndirectTarget

Found 1 unique roots (run '!gcroot -all' to see all roots).
```

## SOS `IndirectTarget` all

```
> !GCRoot -all 00000266D568C1E8
HandleTable:
    00000266D5321388 (strong handle)
    -> 00000266D568C1D0 DirectTarget
    -> 00000266D568C1E8 IndirectTarget

    00000266D5321390 (strong handle)
    -> 00000266D568C1D0 DirectTarget
    -> 00000266D568C1E8 IndirectTarget

Found 2 roots.
```

## ClrMD after `DirectTarget` unique/all

```
GCRoot 266D5321388->266D568C1D0 Strong handle
-> DirectTarget 266d568c1d0

GCRoot 266D5321390->266D568C1D0 Strong handle
-> DirectTarget 266d568c1d0
```

## ClrMD after `IndirectTarget` unique

```
GCRoot 266D5321388->266D568C1D0 Strong handle
-> DirectTarget 266d568c1d0
-> IndirectTarget 266d568c1e8
```

## ClrMD after `IndirectTarget` all

```
GCRoot 266D5321388->266D568C1D0 Strong handle
-> DirectTarget 266d568c1d0
-> IndirectTarget 266d568c1e8

GCRoot 266D5321390->266D568C1D0 Strong handle
-> DirectTarget 266d568c1d0
-> IndirectTarget 266d568c1e8
```

## ClrMD before `DirectTarget` unique/all

```
GCRoot 2BD87501388->2BD8928C1D0 Strong handle
-> DirectTarget 2bd8928c1d0
```

## ClrMD before `IndirectTarget` unique/all

```
GCRoot 2BD87501388->2BD8928C1D0 Strong handle
-> DirectTarget 2bd8928c1d0
-> IndirectTarget 2bd8928c1e8
```