### PR TITLE
Throw better exception when failing to attach on Linux

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/src/DataTargets/DataTarget.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataTargets/DataTarget.cs
@@ -151,6 +151,13 @@ namespace Microsoft.Diagnostics.Runtime
             }
             else
             {
+#if !NET45
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                    throw new PlatformNotSupportedException("Currently only AttachFlag.Passive is supported for AttachToProcess");
+                }
+#endif
+
                 DbgEngDataReader dbgeng = new DbgEngDataReader(pid, attachFlag, msecTimeout);
                 reader = dbgeng;
                 client = dbgeng.DebuggerInterface;


### PR DESCRIPTION
As mentioned in https://github.com/dotnet/corefx/issues/42621, we need to report a better exception when the user specifies an unsupported attach flag on Linux.