### PR TITLE
Flush the DataReader when flushing the runtime

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/src/Desktop/DesktopRuntimeBase.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Desktop/DesktopRuntimeBase.cs
@@ -58,6 +58,7 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
 
             Revision++;
             _dacInterface.Flush();
+            _dataTarget.DataReader.Flush();
 
             MemoryReader = null;
             _moduleList = null;


### PR DESCRIPTION
DataReaders are not properly flushed when the runtime is.

Fixes https://github.com/microsoft/clrmd/issues/303.