### PR TITLE
Fix issue with CollectibleTypeTest

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/TypeTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/TypeTests.cs
@@ -348,7 +348,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             RuntimeHelpers.RunClassConstructor(Assembly.GetExecutingAssembly()
                 .GetType(typeof(UncollectibleUnmanagedStruct).FullName).TypeHandle);
 
-            using DataTarget dataTarget = DataTarget.AttachToProcess(Process.GetCurrentProcess().Id, uint.MaxValue, AttachFlag.Passive);
+            using DataTarget dataTarget = DataTarget.CreateSnapshotAndAttach(Process.GetCurrentProcess().Id);
 
             ClrHeap heap = dataTarget.ClrVersions.Single().CreateRuntime().Heap;
 


### PR DESCRIPTION
CollectibleTypeTest will non-determinstically fail.  This is because the test would attach to its own process.  Moving this to CreateSnapshotAndAttach makes the test pass all the time.