### PR TITLE
Span!

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/src/Common/RuntimeBase.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/RuntimeBase.cs
@@ -5,9 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Text;
 using Microsoft.Diagnostics.Runtime.DacInterface;
 using Microsoft.Diagnostics.Runtime.Desktop;
 
@@ -222,8 +220,7 @@ namespace Microsoft.Diagnostics.Runtime
             Span<byte> buffer = stackalloc byte[sizeof(T)];
             if (ReadMemory(addr, buffer, out int read) && read == buffer.Length)
             {
-                fixed (byte* ptr = buffer)
-                    value = Unsafe.ReadUnaligned<T>(ptr);
+                value = MemoryMarshal.Read<T>(buffer);
 
                 return true;
             }

--- a/src/Microsoft.Diagnostics.Runtime/src/DacInterface/ClrDataProcess.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DacInterface/ClrDataProcess.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             _flush(Self);
         }
 
-        public int Request(uint reqCode, Span<byte> input, Span<byte> output)
+        public int Request(uint reqCode, ReadOnlySpan<byte> input, Span<byte> output)
         {
             InitDelegate(ref _request, VTable->Request);
 

--- a/src/Microsoft.Diagnostics.Runtime/src/DataTargets/DataTarget.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataTargets/DataTarget.cs
@@ -288,12 +288,9 @@ namespace Microsoft.Diagnostics.Runtime
             byte[] buffer = ArrayPool<byte>.Shared.Rent(sizeof(V2HeapDetails));
             try
             {
-                fixed (byte* pBuffer = buffer)
-                {
-                    int val = lib.InternalDacPrivateInterface.Request(DacRequests.GCHEAPDETAILS_STATIC_DATA, Span<byte>.Empty, new Span<byte>(pBuffer, buffer.Length));
-                    if ((uint)val == 0x80070057)
-                        return new LegacyRuntime(clrInfo, this, lib, DesktopVersion.v4, 10000);
-                }
+                int val = lib.InternalDacPrivateInterface.Request(DacRequests.GCHEAPDETAILS_STATIC_DATA, ReadOnlySpan<byte>.Empty, buffer);
+                if ((uint)val == 0x80070057)
+                    return new LegacyRuntime(clrInfo, this, lib, DesktopVersion.v4, 10000);
 
                 return new LegacyRuntime(clrInfo, this, lib, DesktopVersion.v2, 3054);
             }

--- a/src/Microsoft.Diagnostics.Runtime/src/Desktop/BaseDesktopHeapType.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Desktop/BaseDesktopHeapType.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
 
             int slots = 1 + entries * 2;
             byte[] buffer = new byte[slots * IntPtr.Size];
-            if (!runtime.ReadMemory(_constructedMT - (ulong)(slots * IntPtr.Size), new Span<byte>(buffer, 0, buffer.Length), out int read) || read != buffer.Length)
+            if (!runtime.ReadMemory(_constructedMT - (ulong)(slots * IntPtr.Size), buffer, out int read) || read != buffer.Length)
                 return null;
 
             // Construct the gc desc

--- a/src/Microsoft.Diagnostics.Runtime/src/Desktop/DesktopGCHeap.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Desktop/DesktopGCHeap.cs
@@ -607,7 +607,7 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
             byte[] buffer = ArrayPool<byte>.Shared.Rent(length * 2);
             try
             {
-                if (!DesktopRuntime.ReadMemory(data, new Span<byte>(buffer, 0, length * 2), out int count))
+                if (!DesktopRuntime.ReadMemory(data, buffer, out int count))
                     return null;
 
                 return Encoding.Unicode.GetString(buffer, 0, count);

--- a/src/Microsoft.Diagnostics.Runtime/src/Desktop/V45Runtime.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Desktop/V45Runtime.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
             // Ensure the version of the dac API matches the one we expect.  (Same for both
             // v2 and v4 rtm.)
             int version = 0;
-            if (lib.DacPrivateInterface.Request(DacRequests.VERSION, Span<byte>.Empty, new Span<byte>((byte*)&version, sizeof(int))) != 0)
+            if (lib.DacPrivateInterface.Request(DacRequests.VERSION, ReadOnlySpan<byte>.Empty, new Span<byte>(&version, sizeof(int))) != 0)
                 throw new ClrDiagnosticsException("Failed to request dac version.", ClrDiagnosticsExceptionKind.DacError);
 
             if (version != 9)

--- a/src/Microsoft.Diagnostics.Runtime/src/Helpers/ExtensionMethods.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Helpers/ExtensionMethods.cs
@@ -1,12 +1,8 @@
 ﻿using System;
 using System.Buffers;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
-using System.Runtime.CompilerServices;
-using System.Text;
-using System.Threading.Tasks;
+using System.Runtime.InteropServices;
 
 namespace Microsoft.Diagnostics.Runtime
 {
@@ -18,7 +14,7 @@ namespace Microsoft.Diagnostics.Runtime
             try
             {
                 int numRead = stream.Read(buffer, 0, span.Length);
-                new Span<byte>(buffer, 0, numRead).CopyTo(span);
+                new ReadOnlySpan<byte>(buffer, 0, numRead).CopyTo(span);
                 return numRead;
             }
             finally
@@ -27,34 +23,33 @@ namespace Microsoft.Diagnostics.Runtime
             }
         }
 
-        public unsafe static ulong AsPointer(this Span<byte> span, int index = 0)
+        public static ulong AsPointer(this Span<byte> span, int index = 0)
         {
             if (index != 0)
                 span = span.Slice(index * IntPtr.Size, IntPtr.Size);
 
             Debug.Assert(span.Length >= IntPtr.Size);
-            fixed (byte* ptr = span)
-            {
-                if (IntPtr.Size == 4)
-                    return Unsafe.ReadUnaligned<uint>(ptr);
-
-                return Unsafe.ReadUnaligned<ulong>(ptr);
-            }
+            return IntPtr.Size == 4
+                ? MemoryMarshal.Read<uint>(span)
+                : MemoryMarshal.Read<ulong>(span);
         }
 
-
-        public unsafe static uint AsUInt32(this Span<byte> span)
+        public static int AsInt32(this Span<byte> span)
         {
-            Debug.Assert(span.Length >= 4);
-            fixed (byte* ptr = span)
-                return Unsafe.ReadUnaligned<uint>(ptr);
+            Debug.Assert(span.Length >= sizeof(int));
+            return MemoryMarshal.Read<int>(span);
         }
 
-        public unsafe static int AsInt32(this Span<byte> span)
+        public static uint AsUInt32(this Span<byte> span)
         {
-            Debug.Assert(span.Length >= 4);
-            fixed (byte* ptr = span)
-                return Unsafe.ReadUnaligned<int>(ptr);
+            Debug.Assert(span.Length >= sizeof(uint));
+            return MemoryMarshal.Read<uint>(span);
+        }
+
+        public static ulong AsUInt64(this Span<byte> span)
+        {
+            Debug.Assert(span.Length >= sizeof(ulong));
+            return MemoryMarshal.Read<ulong>(span);
         }
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/src/Linux/ElfCoreFile.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Linux/ElfCoreFile.cs
@@ -155,7 +155,7 @@ namespace Microsoft.Diagnostics.Runtime.Linux
             byte[] bytes = ArrayPool<byte>.Shared.Rent(size);
             try
             {
-                int read = fileNote.ReadContents(position, new Span<byte>(bytes, 0, size));
+                int read = fileNote.ReadContents(position, bytes);
                 int start = 0;
                 for (int i = 0; i < fileTable.Length; i++)
                 {

--- a/src/Microsoft.Diagnostics.Runtime/src/Linux/ElfFile.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Linux/ElfFile.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Diagnostics.Runtime.Linux
                             if (note.Type == ElfNoteType.PrpsInfo && note.Name.Equals("GNU"))
                             {
                                 _buildId = new byte[note.Header.ContentSize];
-                                note.ReadContents(0, new Span<byte>(_buildId, 0, _buildId.Length));
+                                note.ReadContents(0, _buildId);
                                 return _buildId;
                             }
                         }

--- a/src/Microsoft.Diagnostics.Runtime/src/Linux/ElfReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Linux/ElfReader.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Diagnostics.Runtime.Linux
             byte[] buffer = ArrayPool<byte>.Shared.Rent(len);
             try
             {
-                int read = DataSource.Read(position, new Span<byte>(buffer, 0, len));
+                int read = DataSource.Read(position, buffer);
                 if (read == 0)
                     return string.Empty;
 

--- a/src/Microsoft.Diagnostics.Runtime/src/Utilities/PEImage/PEImage.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Utilities/PEImage/PEImage.cs
@@ -320,15 +320,15 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
 #if !NET45
             if (size < Configuration.MaxStackAlloc)
             {
-                byte* ptr = stackalloc byte[size];
+                Span<byte> span = stackalloc byte[size];
                 SeekTo(offset);
 
-                int read = Stream.Read(new Span<byte>(ptr, size));
+                int read = Stream.Read(span);
                 _offset = offset + read;
                 if (read != size)
                     return false;
 
-                Unsafe.Copy(ref t, ptr);
+                t = Unsafe.As<byte, T>(ref span[0]);
                 return true;
             }
 #endif
@@ -343,8 +343,7 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
                 if (read != size)
                     return false;
 
-                fixed (byte* ptr = buffer)
-                    Unsafe.Copy(ref t, ptr);
+                t = Unsafe.As<byte, T>(ref buffer[0]);
 
                 return true;
             }


### PR DESCRIPTION
Not only spans.

In this PR:

Whenever possible:

- Using `ReadOnlySpan`
- Using `sizeof`
- Avoid `fixed`
- Implicitly converting from array to `Span`

---

Note that any Read method other than `Unsafe.As` is unaligned.