### PR TITLE
Fix issue where we over-fed string reads

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/src/Desktop/DesktopGCHeap.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Desktop/DesktopGCHeap.cs
@@ -607,7 +607,7 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
             byte[] buffer = ArrayPool<byte>.Shared.Rent(length * 2);
             try
             {
-                if (!DesktopRuntime.ReadMemory(data, buffer, out int count))
+                if (!DesktopRuntime.ReadMemory(data, new Span<byte>(buffer, 0, length * 2), out int count))
                     return null;
 
                 return Encoding.Unicode.GetString(buffer, 0, count);


### PR DESCRIPTION
ArrayPool.Rent was returning a larger string than we actually needed, and the code pattern in question would cause stray \0's to end up in the generated string.