### PR TITLE
Implement SuspendAndAttachToProcess on Linux

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/src/DataTargets/DataTarget.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataTargets/DataTarget.cs
@@ -66,6 +66,8 @@ namespace Microsoft.Diagnostics.Runtime
         {
             if (!_disposed)
             {
+                DataReader.Dispose();
+
                 foreach (PEImage img in _pefileCache.Values)
                     img.Stream.Dispose();
 
@@ -231,7 +233,7 @@ namespace Microsoft.Diagnostics.Runtime
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
-                LinuxLiveDataReader reader = new LinuxLiveDataReader((uint)pid);
+                LinuxLiveDataReader reader = new LinuxLiveDataReader(pid, suspend: false);
                 return new DataTarget(reader)
                 {
                     SymbolLocator = new LinuxDefaultSymbolLocator(reader.GetModulesFullPath())
@@ -249,7 +251,13 @@ namespace Microsoft.Diagnostics.Runtime
         public static DataTarget SuspendAndAttachToProcess(int pid)
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-                throw new NotImplementedException("Suspending a process is not yet implemented on Linux");
+            {
+                LinuxLiveDataReader reader = new LinuxLiveDataReader(pid, suspend: true);
+                return new DataTarget(reader)
+                {
+                    SymbolLocator = new LinuxDefaultSymbolLocator(reader.GetModulesFullPath())
+                };
+            }
 
             return new DataTarget(new DbgEngDataReader(pid, invasive: false, 5000));
         }

--- a/src/Microsoft.Diagnostics.Runtime/src/Linux/LinuxLiveDataReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Linux/LinuxLiveDataReader.cs
@@ -1,10 +1,12 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
+
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 namespace Microsoft.Diagnostics.Runtime.Linux
@@ -28,21 +30,61 @@ namespace Microsoft.Diagnostics.Runtime.Linux
         private bool _initializedMemFile;
         private readonly List<uint> _threadIDs = new List<uint>();
 
-        public LinuxLiveDataReader(uint processId)
+        private bool _suspended;
+        private bool _disposed;
+
+        public LinuxLiveDataReader(int processId, bool suspend)
         {
-            this.ProcessId = processId;
+            this.ProcessId = (uint)processId;
             _memoryMapEntries = this.LoadMemoryMap();
+
+            if (suspend)
+            {
+                int status = (int)ptrace(PTRACE_ATTACH, processId, IntPtr.Zero, IntPtr.Zero);
+                if (status < 0)
+                {
+                    int errno = Marshal.GetLastWin32Error();
+                    throw new ClrDiagnosticsException($"Could not attach to pid {processId}, errno: {errno}", ClrDiagnosticsExceptionKind.DebuggerError, errno);
+                }
+
+                _suspended = true;
+            }
         }
+
+        ~LinuxLiveDataReader() => Dispose(false);
 
         public uint ProcessId { get; private set; }
 
-        public bool IsMinidump { get { return false; } }
+        public bool IsMinidump => false;
 
         public void Dispose()
         {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_disposed)
+                return;
+
             _memoryStream?.Dispose();
             _memoryStream = null;
             _initializedMemFile = false;
+
+            if (_suspended)
+            {
+                int status = (int)ptrace(PTRACE_DETACH, (int)ProcessId, IntPtr.Zero, IntPtr.Zero);
+                if (status < 0)
+                {
+                    int errno = Marshal.GetLastWin32Error();
+                    throw new ClrDiagnosticsException($"Could not detach from pid {ProcessId}, errno: {errno}", ClrDiagnosticsExceptionKind.DebuggerError, errno);
+                }
+
+                _suspended = false;
+            }
+
+            _disposed = true;
         }
 
         public void ClearCachedData()
@@ -162,7 +204,7 @@ namespace Microsoft.Diagnostics.Runtime.Linux
 
         public unsafe uint ReadDwordUnsafe(ulong address)
         {
-            Span<byte> buffer = stackalloc byte[4];
+            Span<byte> buffer = stackalloc byte[sizeof(uint)];
             if (!ReadMemory(address, buffer, out int _))
                 return 0;
 
@@ -195,48 +237,19 @@ namespace Microsoft.Diagnostics.Runtime.Linux
             if (!_threadIDs.Contains(threadID) || context.Length != AMD64Context.Size)
                 return false;
 
-            fixed (byte* ctxPtr = context)
-            {
-                AMD64Context* ctx = (AMD64Context*)ctxPtr;
-                ctx->ContextFlags = contextFlags;
-                IntPtr ptr = Marshal.AllocHGlobal(sizeof(RegSetX64));
-                try
-                {
-                    ptrace(PTRACE_GETREGS, (int)threadID, IntPtr.Zero, ptr);
-                    RegSetX64 r = Marshal.PtrToStructure<RegSetX64>(ptr);
-                    CopyContext(ctx, ref r);
-                }
-                finally
-                {
-                    Marshal.FreeHGlobal(ptr);
-                }
-            }
-            return true;
-        }
-
-        public unsafe bool GetThreadContext(uint threadID, uint contextFlags, uint contextSize, byte[] context)
-        {
-            this.LoadThreads();
-            if (!_threadIDs.Contains(threadID) || contextSize != AMD64Context.Size)
-            {
-                return false;
-            }
-            IntPtr ptrContext = Marshal.AllocHGlobal(sizeof(AMD64Context));
-            AMD64Context* ctx = (AMD64Context*)ptrContext;
-            ctx->ContextFlags = contextFlags;
-            IntPtr ptr = Marshal.AllocHGlobal(sizeof(RegSetX64));
+            ref AMD64Context ctx = ref Unsafe.As<byte, AMD64Context>(ref MemoryMarshal.GetReference(context));
+            ctx.ContextFlags = contextFlags;
+            IntPtr registerSet = Marshal.AllocHGlobal(sizeof(RegSetX64));
             try
             {
-                ptrace(PTRACE_GETREGS, (int)threadID, IntPtr.Zero, ptr);
-                RegSetX64 r = Marshal.PtrToStructure<RegSetX64>(ptr);
-                CopyContext(ctx, ref r);
-                Marshal.Copy(ptrContext, context, 0, sizeof(AMD64Context));
+                ptrace(PTRACE_GETREGS, (int)threadID, IntPtr.Zero, registerSet);
+                CopyContext(ref ctx, Unsafe.AsRef<RegSetX64>(registerSet.ToPointer()));
             }
             finally
             {
-                Marshal.FreeHGlobal(ptr);
-                Marshal.FreeHGlobal(ptrContext);
+                Marshal.FreeHGlobal(registerSet);
             }
+
             return true;
         }
 
@@ -245,25 +258,25 @@ namespace Microsoft.Diagnostics.Runtime.Linux
             return _memoryMapEntries.Where(e => !string.IsNullOrEmpty(e.FilePath)).Select(e => e.FilePath).Distinct();
         }
 
-        private static unsafe void CopyContext(AMD64Context* ctx, ref RegSetX64 registerSet)
+        private static void CopyContext(ref AMD64Context context, in RegSetX64 registerSet)
         {
-            ctx->R15 = registerSet.R15;
-            ctx->R14 = registerSet.R14;
-            ctx->R13 = registerSet.R13;
-            ctx->R12 = registerSet.R12;
-            ctx->Rbp = registerSet.Rbp;
-            ctx->Rbx = registerSet.Rbx;
-            ctx->R11 = registerSet.R11;
-            ctx->R10 = registerSet.R10;
-            ctx->R9 = registerSet.R9;
-            ctx->R8 = registerSet.R8;
-            ctx->Rax = registerSet.Rax;
-            ctx->Rcx = registerSet.Rcx;
-            ctx->Rdx = registerSet.Rdx;
-            ctx->Rsi = registerSet.Rsi;
-            ctx->Rdi = registerSet.Rdi;
-            ctx->Rip = registerSet.Rip;
-            ctx->Rsp = registerSet.Rsp;
+            context.R15 = registerSet.R15;
+            context.R14 = registerSet.R14;
+            context.R13 = registerSet.R13;
+            context.R12 = registerSet.R12;
+            context.Rbp = registerSet.Rbp;
+            context.Rbx = registerSet.Rbx;
+            context.R11 = registerSet.R11;
+            context.R10 = registerSet.R10;
+            context.R9 = registerSet.R9;
+            context.R8 = registerSet.R8;
+            context.Rax = registerSet.Rax;
+            context.Rcx = registerSet.Rcx;
+            context.Rdx = registerSet.Rdx;
+            context.Rsi = registerSet.Rsi;
+            context.Rdi = registerSet.Rdi;
+            context.Rip = registerSet.Rip;
+            context.Rsp = registerSet.Rsp;
         }
 
         private void LoadThreads()
@@ -356,45 +369,42 @@ namespace Microsoft.Diagnostics.Runtime.Linux
         {
             List<MemoryMapEntry> result = new List<MemoryMapEntry>();
             string mapsFilePath = $"/proc/{this.ProcessId}/maps";
-            using (FileStream fs = File.OpenRead(mapsFilePath))
-            using (StreamReader sr = new StreamReader(fs))
+            using StreamReader reader = new StreamReader(mapsFilePath);
+            while (true)
             {
-                while (true)
+                string line = reader.ReadLine();
+                if (string.IsNullOrEmpty(line))
                 {
-                    string line = sr.ReadLine();
-                    if (string.IsNullOrEmpty(line))
-                    {
-                        break;
-                    }
-                    string address, permission, path;
-                    string[] parts = line.Split(new char[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
-                    if (parts.Length == 5)
-                    {
-                        path = string.Empty;
-                    }
-                    else if (parts.Length == 6)
-                    {
-                        path = parts[5].StartsWith("[") ? string.Empty : parts[5];
-                    }
-                    else
-                    {
-                        // Unknown data format 
-                        continue;
-                    }
-                    address = parts[0];
-                    permission = parts[1];
-                    string[] addressBeginEnd = address.Split('-');
-                    MemoryMapEntry entry = new MemoryMapEntry()
-                    {
-                        BeginAddr = Convert.ToUInt64(addressBeginEnd[0], 16),
-                        EndAddr = Convert.ToUInt64(addressBeginEnd[1], 16),
-                        FilePath = path,
-                        FileName = string.IsNullOrEmpty(path) ? string.Empty : Path.GetFileName(path),
-                        Permission = ParsePermission(permission)
-                    };
-                    result.Add(entry);
+                    break;
                 }
+                string address, permission, path;
+                string[] parts = line.Split(new char[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+                if (parts.Length == 5)
+                {
+                    path = string.Empty;
+                }
+                else if (parts.Length == 6)
+                {
+                    path = parts[5].StartsWith("[") ? string.Empty : parts[5];
+                }
+                else
+                {
+                    // Unknown data format 
+                    continue;
+                }
+                address = parts[0];
+                permission = parts[1];
+                string[] addressBeginEnd = address.Split('-');
+                MemoryMapEntry entry = new MemoryMapEntry()
+                {
+                    BeginAddr = Convert.ToUInt64(addressBeginEnd[0], 16),
+                    EndAddr = Convert.ToUInt64(addressBeginEnd[1], 16),
+                    FilePath = path,
+                    Permission = ParsePermission(permission)
+                };
+                result.Add(entry);
             }
+
             return result;
         }
 
@@ -413,11 +423,12 @@ namespace Microsoft.Diagnostics.Runtime.Linux
             return r + w + x + p;
         }
 
+        private const string LibC = "libc";
 
-        [DllImport("libc", SetLastError = true)]
-        private static extern ulong ptrace(uint command, int pid, IntPtr addr, IntPtr data);
+        [DllImport(LibC, SetLastError = true)]
+        private static extern IntPtr ptrace(uint request, int pid, IntPtr addr, IntPtr data);
 
-        [DllImport("libc", SetLastError = true)]
+        [DllImport(LibC, SetLastError = true)]
         private static extern unsafe IntPtr process_vm_readv(int pid, iovec* local_iov, UIntPtr liovcnt, iovec* remote_iov, UIntPtr riovcnt, UIntPtr flags);
 
         private unsafe struct iovec
@@ -427,6 +438,8 @@ namespace Microsoft.Diagnostics.Runtime.Linux
         }
 
         private const uint PTRACE_GETREGS = 12;
+        private const uint PTRACE_ATTACH = 16;
+        private const uint PTRACE_DETACH = 17;
     }
 
     internal class MemoryMapEntry
@@ -434,12 +447,11 @@ namespace Microsoft.Diagnostics.Runtime.Linux
         public ulong BeginAddr { get; set; }
         public ulong EndAddr { get; set; }
         public string FilePath { get; set; }
-        public string FileName { get; set; }
         public int Permission { get; set; }
 
         public bool IsReadable()
         {
-            return (this.Permission & 8) > 0;
+            return (this.Permission & 8) != 0;
         }
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/src/Linux/Structs/RegSetX64.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Linux/Structs/RegSetX64.cs
@@ -3,73 +3,72 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 namespace Microsoft.Diagnostics.Runtime.Linux
 {
     [StructLayout(LayoutKind.Sequential, Pack = 1)]
-    internal struct RegSetX64
+    internal readonly struct RegSetX64
     {
-        public ulong R15;
-        public ulong R14;
-        public ulong R13;
-        public ulong R12;
-        public ulong Rbp;
-        public ulong Rbx;
-        public ulong R11;
-        public ulong R10;
-        public ulong R8;
-        public ulong R9;
-        public ulong Rax;
-        public ulong Rcx;
-        public ulong Rdx;
-        public ulong Rsi;
-        public ulong Rdi;
-        public ulong OrigRax;
-        public ulong Rip;
-        public ulong CS;
-        public ulong EFlags;
-        public ulong Rsp;
-        public ulong SS;
-        public ulong FSBase;
-        public ulong GSBase;
-        public ulong DS;
-        public ulong ES;
-        public ulong FS;
-        public ulong GS;
+        public readonly ulong R15;
+        public readonly ulong R14;
+        public readonly ulong R13;
+        public readonly ulong R12;
+        public readonly ulong Rbp;
+        public readonly ulong Rbx;
+        public readonly ulong R11;
+        public readonly ulong R10;
+        public readonly ulong R8;
+        public readonly ulong R9;
+        public readonly ulong Rax;
+        public readonly ulong Rcx;
+        public readonly ulong Rdx;
+        public readonly ulong Rsi;
+        public readonly ulong Rdi;
+        public readonly ulong OrigRax;
+        public readonly ulong Rip;
+        public readonly ulong CS;
+        public readonly ulong EFlags;
+        public readonly ulong Rsp;
+        public readonly ulong SS;
+        public readonly ulong FSBase;
+        public readonly ulong GSBase;
+        public readonly ulong DS;
+        public readonly ulong ES;
+        public readonly ulong FS;
+        public readonly ulong GS;
 
-        public unsafe bool CopyContext(Span<byte> buffer)
+        public bool CopyContext(Span<byte> buffer)
         {
             if (buffer.Length < AMD64Context.Size)
                 return false;
 
-            fixed (byte* context = buffer)
-            {
-                AMD64Context* ctx = (AMD64Context*)context;
-                ctx->ContextFlags = AMD64Context.ContextControl | AMD64Context.ContextInteger | AMD64Context.ContextSegments;
-                ctx->R15 = R15;
-                ctx->R14 = R14;
-                ctx->R13 = R13;
-                ctx->R12 = R12;
-                ctx->Rbp = Rbp;
-                ctx->Rbx = Rbx;
-                ctx->R11 = R11;
-                ctx->R10 = R10;
-                ctx->R9 = R9;
-                ctx->R8 = R8;
-                ctx->Rax = Rax;
-                ctx->Rcx = Rcx;
-                ctx->Rdx = Rdx;
-                ctx->Rsi = Rsi;
-                ctx->Rdi = Rdi;
-                ctx->Rip = Rip;
-                ctx->Rsp = Rsp;
-                ctx->Cs = (ushort)CS;
-                ctx->Ds = (ushort)DS;
-                ctx->Ss = (ushort)SS;
-                ctx->Fs = (ushort)FS;
-                ctx->Gs = (ushort)GS;
-            }
+            ref AMD64Context context = ref Unsafe.As<byte, AMD64Context>(ref MemoryMarshal.GetReference(buffer));
+
+            context.ContextFlags = AMD64Context.ContextControl | AMD64Context.ContextInteger | AMD64Context.ContextSegments;
+            context.R15 = R15;
+            context.R14 = R14;
+            context.R13 = R13;
+            context.R12 = R12;
+            context.Rbp = Rbp;
+            context.Rbx = Rbx;
+            context.R11 = R11;
+            context.R10 = R10;
+            context.R9 = R9;
+            context.R8 = R8;
+            context.Rax = Rax;
+            context.Rcx = Rcx;
+            context.Rdx = Rdx;
+            context.Rsi = Rsi;
+            context.Rdi = Rdi;
+            context.Rip = Rip;
+            context.Rsp = Rsp;
+            context.Cs = (ushort)CS;
+            context.Ds = (ushort)DS;
+            context.Ss = (ushort)SS;
+            context.Fs = (ushort)FS;
+            context.Gs = (ushort)GS;
 
             return true;
         }

--- a/src/Microsoft.Diagnostics.Runtime/src/Utilities/Symbols/DefaultSymbolLocator.Async.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Utilities/Symbols/DefaultSymbolLocator.Async.cs
@@ -291,8 +291,8 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
                     using Stream fromStream = response.GetResponseStream();
                     if (returnContents)
                     {
-                        using StreamReader stream = new StreamReader(fromStream);
-                        return await stream.ReadToEndAsync().ConfigureAwait(false);
+                        using StreamReader reader = new StreamReader(fromStream);
+                        return await reader.ReadToEndAsync().ConfigureAwait(false);
                     }
 
                     Directory.CreateDirectory(Path.GetDirectoryName(fullDestPath));


### PR DESCRIPTION
This test sample is dangerous: if the parent process crashed due to an assertion failure, the child process won't be killed.

```cs
// Licensed to the .NET Foundation under one or more agreements.
// The .NET Foundation licenses this file to you under the MIT license.
// See the LICENSE file in the project root for more information.

using System.Diagnostics;
using System.Linq;
using Xunit;

namespace Microsoft.Diagnostics.Runtime.Tests
{
    public class DataTargetTests
    {
        [Fact]
        public void SuspendAndAttachToProcess()
        {
            using Process process = Process.Start(new ProcessStartInfo
            {
                FileName = "...",
                Arguments = "...",
                RedirectStandardOutput = true,
            });

            _ = process.StandardOutput.ReadLine();

            using (DataTarget dataTarget = DataTarget.SuspendAndAttachToProcess(process.Id))
            {
                ClrRuntime runtime = dataTarget.ClrVersions.Single().CreateRuntime();
                uint mainThreadId = runtime.GetMainThread().OSThreadId;
                ProcessThread mainThread = process.Threads.Cast<ProcessThread>().Single(thread => thread.Id == mainThreadId);

                Assert.Equal(ThreadState.Wait, mainThread.ThreadState);
            }

            process.Kill();
        }
    }
}
```

```cs
using System;

class Program
{
    private static void Main(string[] args)
    {
        if (args.Length == 0)
            throw new Exception();

        Console.WriteLine();
        for (; ; ) { }
    }
}
```