### PR TITLE
Implement GetFileVersion/GetVersionInfo on Linux

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/src/Common/ModuleInfo.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/ModuleInfo.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Diagnostics.Runtime
         public ulong ImageBase { get; }
 
         /// <summary>
-        /// The filesize of the image.
+        /// The file size of the image.
         /// </summary>
         public uint FileSize { get; }
 

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/VersionInfo.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/VersionInfo.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Diagnostics.Runtime
     /// <summary>
     /// Represents the version of a DLL.
     /// </summary>
-    public struct VersionInfo : IEquatable<VersionInfo>, IComparable<VersionInfo>
+    public readonly struct VersionInfo : IEquatable<VersionInfo>, IComparable<VersionInfo>
     {
         /// <summary>
         /// In a version 'A.B.C.D', this field represents 'A'.

--- a/src/Microsoft.Diagnostics.Runtime/src/DataReaders/DbgEng/DbgEngDataReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataReaders/DbgEng/DbgEngDataReader.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Diagnostics.Runtime
                 if ((uint)hr == 0xd00000bb)
                     throw new InvalidOperationException("Mismatched architecture between this process and the target process.");
 
-                throw new ClrDiagnosticsException($"Could not attach to pid {pid:X}, HRESULT: 0x{hr:x8}", ClrDiagnosticsExceptionKind.DebuggerError, hr);
+                throw new ClrDiagnosticsException($"Could not attach to process {pid:X}, HRESULT: 0x{hr:x8}", ClrDiagnosticsExceptionKind.DebuggerError, hr);
             }
         }
 
@@ -306,14 +306,14 @@ namespace Microsoft.Diagnostics.Runtime
             return false;
         }
 
-        public void GetVersionInfo(ulong baseAddr, out VersionInfo version)
+        public void GetVersionInfo(ulong baseAddress, out VersionInfo version)
         {
             version = default;
 
-            if (!FindModuleIndex(baseAddr, out int index))
+            if (!FindModuleIndex(baseAddress, out int index))
                 return;
 
-            version = _symbols.GetModuleVersionInformation(index, baseAddr);
+            version = _symbols.GetModuleVersionInformation(index, baseAddress);
         }
 
         private bool FindModuleIndex(ulong baseAddr, out int index)

--- a/src/Microsoft.Diagnostics.Runtime/src/DataTargets/DataTarget.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataTargets/DataTarget.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Diagnostics.Runtime
             if (_pefileCache.TryGetValue(fileName, out PEImage result))
                 return result;
 
-            Stream stream = File.Open(fileName, FileMode.Open, FileAccess.Read, FileShare.Read);
+            Stream stream = File.OpenRead(fileName);
             result = new PEImage(stream);
 
             if (!result.IsValid)

--- a/src/Microsoft.Diagnostics.Runtime/src/Linux/ElfCoreFile.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Linux/ElfCoreFile.cs
@@ -134,7 +134,6 @@ namespace Microsoft.Diagnostics.Runtime.Linux
             }
 
             ElfFileTableEntryPointers64[] fileTable = new ElfFileTableEntryPointers64[entryCount];
-            List<ElfLoadedImage> images = new List<ElfLoadedImage>(fileTable.Length);
             Dictionary<string, ElfLoadedImage> lookup = new Dictionary<string, ElfLoadedImage>(fileTable.Length);
 
             for (int i = 0; i < fileTable.Length; i++)

--- a/src/Microsoft.Diagnostics.Runtime/src/Linux/ElfFile.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Linux/ElfFile.cs
@@ -75,13 +75,13 @@ namespace Microsoft.Diagnostics.Runtime.Linux
             }
         }
 
-        public ElfFile(Reader reader, long position = 0, bool virt = false)
+        public ElfFile(Reader reader, long position = 0, bool isVirtual = false)
         {
             _reader = reader;
             _position = position;
-            _virtual = virt;
+            _virtual = isVirtual;
 
-            if (virt)
+            if (isVirtual)
                 _virtualAddressReader = reader;
 
             ElfHeaderCommon common = reader.Read<ElfHeaderCommon>(position);
@@ -90,13 +90,13 @@ namespace Microsoft.Diagnostics.Runtime.Linux
                 throw new InvalidDataException($"{reader.DataSource.Name ?? "This coredump"} does not contain a valid ELF header.");
         }
 
-        internal ElfFile(IElfHeader header, Reader reader, long position = 0, bool virt = false)
+        internal ElfFile(IElfHeader header, Reader reader, long position = 0, bool isVirtual = false)
         {
             _reader = reader;
             _position = position;
-            _virtual = virt;
+            _virtual = isVirtual;
 
-            if (virt)
+            if (isVirtual)
                 _virtualAddressReader = reader;
 
             Header = header;

--- a/src/Microsoft.Diagnostics.Runtime/src/Linux/ElfVirtualAddressSpace.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Linux/ElfVirtualAddressSpace.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Diagnostics.Runtime.Linux
             }
 
         done:
-            buffer.Slice(bytesRead, bytesRead - buffer.Length).Clear();
+            buffer.Slice(bytesRead).Clear();
             return bytesRead;
         }
     }

--- a/src/Microsoft.Diagnostics.Runtime/src/Linux/MemoryVirtualAddressSpace.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Linux/MemoryVirtualAddressSpace.cs
@@ -1,0 +1,28 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Microsoft.Diagnostics.Runtime.Linux
+{
+    internal class MemoryVirtualAddressSpace : IAddressSpace
+    {
+        private readonly LinuxLiveDataReader _dataReader;
+
+        public MemoryVirtualAddressSpace(LinuxLiveDataReader dataReader)
+        {
+            _dataReader = dataReader;
+        }
+
+        public long Length => throw new NotImplementedException();
+
+        public string Name => throw new NotImplementedException();
+
+        public int Read(long position, Span<byte> buffer)
+        {
+            _ = _dataReader.ReadMemory((ulong)position, buffer, out int read);
+            return read;
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/src/Linux/Structs/ElfProgramHeaderAttributes.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Linux/Structs/ElfProgramHeaderAttributes.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Microsoft.Diagnostics.Runtime.Linux
+{
+    [Flags]
+    internal enum ElfProgramHeaderAttributes : uint
+    {
+        Executable = 1,             // PF_X
+        Writable = 2,               // PF_W
+        Readable = 4,               // PF_R
+        OSMask = 0x0FF00000,        // PF_MASKOS
+        ProcessorMask = 0xF0000000, // PF_MASKPROC
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/src/Utilities/Platform/LinuxFunctions.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Utilities/Platform/LinuxFunctions.cs
@@ -3,7 +3,11 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Diagnostics;
+using System.IO;
 using System.Runtime.InteropServices;
+using System.Text;
+using Microsoft.Diagnostics.Runtime.Linux;
 
 namespace Microsoft.Diagnostics.Runtime
 {
@@ -11,6 +15,9 @@ namespace Microsoft.Diagnostics.Runtime
     {
         private const string LibDlGlibc = "libdl.so.2";
         private const string LibDl = "libdl.so";
+
+        private static readonly byte[] s_versionString = Encoding.ASCII.GetBytes("@(#)Version ");
+        private static readonly int s_versionLength = s_versionString.Length;
 
         private readonly Func<string, IntPtr> _loadLibrary;
         private readonly Func<IntPtr, bool> _freeLibrary;
@@ -80,12 +87,194 @@ namespace Microsoft.Diagnostics.Runtime
             }
         }
 
-        internal override bool GetFileVersion(string dll, out int major, out int minor, out int revision, out int patch)
+        internal static void GetVersionInfo(IDataReader dataReader, ulong baseAddress, ElfFile loadedFile, out VersionInfo version)
         {
-            //TODO
+            foreach (ElfProgramHeader programHeader in loadedFile.ProgramHeaders)
+            {
+                if (programHeader.Type == ElfProgramHeaderType.Load && programHeader.IsWritable)
+                {
+                    long loadAddress = programHeader.VirtualAddress;
+                    long loadSize = programHeader.VirtualSize;
+                    GetVersionInfo(dataReader, baseAddress + (ulong)loadAddress, (ulong)loadSize, out version);
+                    return;
+                }
+            }
+
+            version = default;
+        }
+
+        internal static unsafe void GetVersionInfo(IDataReader dataReader, ulong address, ulong size, out VersionInfo version)
+        {
+            Span<byte> buffer = stackalloc byte[s_versionLength];
+            ulong endAddress = address + size;
+
+            while (address < endAddress)
+            {
+                bool result = dataReader.ReadMemory(address, buffer, out int read);
+                if (!result || read < s_versionLength)
+                {
+                    address += (uint)s_versionLength;
+                    continue;
+                }
+
+                if (!buffer.SequenceEqual(s_versionString))
+                {
+                    address++;
+                    continue;
+                }
+
+                address += (uint)s_versionLength;
+
+                StringBuilder builder = new StringBuilder();
+                while (address < endAddress)
+                {
+                    Span<byte> bytes = stackalloc byte[1];
+                    result = dataReader.ReadMemory(address, bytes, out read);
+                    if (!result || read < bytes.Length)
+                    {
+                        break;
+                    }
+
+                    if (bytes[0] == '\0')
+                    {
+                        break;
+                    }
+
+                    if (bytes[0] == ' ')
+                    {
+                        try
+                        {
+                            Version v = Version.Parse(builder.ToString());
+                            version = new VersionInfo(v.Major, v.Minor, v.Build, v.Revision);
+                            return;
+                        }
+                        catch (FormatException)
+                        {
+                            break;
+                        }
+                    }
+
+                    Span<char> chars = stackalloc char[1];
+                    fixed (byte* bytesPtr = &MemoryMarshal.GetReference(bytes))
+                    fixed (char* charsPtr = &MemoryMarshal.GetReference(chars))
+                    {
+                        _ = Encoding.ASCII.GetChars(bytesPtr, bytes.Length, charsPtr, chars.Length);
+                    }
+
+                    _ = builder.Append(chars[0]);
+                    address++;
+                }
+
+                break;
+            }
+
+            version = default;
+        }
+
+        internal override unsafe bool GetFileVersion(string dll, out int major, out int minor, out int revision, out int patch)
+        {
+            using FileStream stream = File.OpenRead(dll);
+            StreamAddressSpace streamAddressSpace = new StreamAddressSpace(stream);
+            Reader streamReader = new Reader(streamAddressSpace);
+            ElfFile file = new ElfFile(streamReader);
+            IElfHeader header = file.Header;
+
+            ElfSectionHeader headerStringHeader = new ElfSectionHeader(streamReader, header.Is64Bit, header.SectionHeaderOffset + header.SectionHeaderStringIndex * header.SectionHeaderEntrySize);
+            long headerStringOffset = (long)headerStringHeader.FileOffset;
+
+            long dataOffset = 0;
+            long dataSize = 0;
+            for (int i = 0; i < header.SectionHeaderCount; i++)
+            {
+                if (i == header.SectionHeaderStringIndex)
+                {
+                    continue;
+                }
+
+                ElfSectionHeader sectionHeader = new ElfSectionHeader(streamReader, header.Is64Bit, header.SectionHeaderOffset + i * header.SectionHeaderEntrySize);
+                if (sectionHeader.Type == ElfSectionHeaderType.ProgBits)
+                {
+                    string sectionName = streamReader.ReadNullTerminatedAscii(headerStringOffset + sectionHeader.NameIndex * sizeof(byte));
+                    if (sectionName == ".data")
+                    {
+                        dataOffset = (long)sectionHeader.FileOffset;
+                        dataSize = (long)sectionHeader.FileSize;
+                        break;
+                    }
+                }
+            }
+
+            Debug.Assert(dataOffset != 0);
+            Debug.Assert(dataSize != 0);
+
+            Span<byte> buffer = stackalloc byte[s_versionLength];
+            long address = dataOffset;
+            long endAddress = address + dataSize;
+
+            while (address < endAddress)
+            {
+                int read = streamAddressSpace.Read(address, buffer);
+                if (read < s_versionLength)
+                {
+                    break;
+                }
+
+                if (!buffer.SequenceEqual(s_versionString))
+                {
+                    address++;
+                    continue;
+                }
+
+                address += s_versionLength;
+
+                StringBuilder builder = new StringBuilder();
+                while (address < endAddress)
+                {
+                    Span<byte> bytes = stackalloc byte[1];
+                    read = streamAddressSpace.Read(address, bytes);
+                    if (read < bytes.Length)
+                    {
+                        break;
+                    }
+
+                    if (bytes[0] == '\0')
+                    {
+                        break;
+                    }
+
+                    if (bytes[0] == ' ')
+                    {
+                        try
+                        {
+                            Version v = Version.Parse(builder.ToString());
+                            major = v.Major;
+                            minor = v.Minor;
+                            revision = v.Build;
+                            patch = v.Revision;
+                            return true;
+                        }
+                        catch (FormatException)
+                        {
+                            break;
+                        }
+                    }
+
+                    Span<char> chars = stackalloc char[1];
+                    fixed (byte* bytesPtr = &MemoryMarshal.GetReference(bytes))
+                    fixed (char* charsPtr = &MemoryMarshal.GetReference(chars))
+                    {
+                        _ = Encoding.ASCII.GetChars(bytesPtr, bytes.Length, charsPtr, chars.Length);
+                    }
+
+                    _ = builder.Append(chars[0]);
+                    address++;
+                }
+
+                break;
+            }
 
             major = minor = revision = patch = 0;
-            return true;
+            return false;
         }
 
         public override bool TryGetWow64(IntPtr proc, out bool result)

--- a/src/Microsoft.Diagnostics.Runtime/src/Utilities/Symbols/FileLoader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Utilities/Symbols/FileLoader.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
             if (_pefileCache.TryGetValue(fileName, out PEImage result))
                 return result;
 
-            Stream stream = File.Open(fileName, FileMode.Open, FileAccess.Read, FileShare.Read);
+            Stream stream = File.OpenRead(fileName);
             result = new PEImage(stream);
 
             if (!result.IsValid)


### PR DESCRIPTION
Fixes #148 
Fixes #306 

`GetFileVersion` works for any *.so* file.

## `CoreDumpReader.GetVersionInfo` in mini dump

```
/usr/share/dotnet/shared/Microsoft.NETCore.App/3.0.0/System.Native.so
v0.0.0.00
/usr/share/dotnet/shared/Microsoft.NETCore.App/3.0.0/libclrjit.so
v0.0.0.00
/usr/share/dotnet/shared/Microsoft.NETCore.App/3.0.0/libcoreclr.so
v4.700.19.46205
/usr/share/dotnet/shared/Microsoft.NETCore.App/3.0.0/libhostpolicy.so
v3.0.19.46706
/usr/share/dotnet/host/fxr/3.0.0/libhostfxr.so
v3.0.19.46706
```

## `LinuxLiveDataReader.GetVersionInfo`

```
/usr/share/dotnet/shared/Microsoft.NETCore.App/3.0.0/System.Native.so
v4.700.19.46214
/usr/share/dotnet/shared/Microsoft.NETCore.App/3.0.0/libclrjit.so
v4.700.19.46205
/usr/share/dotnet/shared/Microsoft.NETCore.App/3.0.0/libcoreclr.so
v4.700.19.46205
/usr/share/dotnet/shared/Microsoft.NETCore.App/3.0.0/libhostpolicy.so
v3.0.19.46706
/usr/share/dotnet/host/fxr/3.0.0/libhostfxr.so
v3.0.19.46706
```