### PR TITLE
Don't read from /proc/<pid>/mem

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/src/Linux/LinuxLiveDataReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Linux/LinuxLiveDataReader.cs
@@ -159,10 +159,12 @@ namespace Microsoft.Diagnostics.Runtime.Linux
                 if (read < 0)
                 {
                     bytesRead = 0;
-                    if (Marshal.GetLastWin32Error() == EPERM)
-                        throw new UnauthorizedAccessException();
-
-                    return false;
+                    return (Marshal.GetLastWin32Error()) switch
+                    {
+                        EPERM => throw new UnauthorizedAccessException(),
+                        ESRCH => throw new InvalidOperationException("The process has exited"),
+                        _ => false
+                    };
                 }
 
                 bytesRead = read;
@@ -386,6 +388,7 @@ namespace Microsoft.Diagnostics.Runtime.Linux
         }
 
         private const int EPERM = 1;
+        private const int ESRCH = 3;
 
         private const string LibC = "libc";
 

--- a/src/Microsoft.Diagnostics.Runtime/src/Linux/LinuxLiveDataReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Linux/LinuxLiveDataReader.cs
@@ -155,12 +155,19 @@ namespace Microsoft.Diagnostics.Runtime.Linux
                     iov_base = (void*)address,
                     iov_len = (IntPtr)readableBytesCount
                 };
-                bytesRead = (int)process_vm_readv((int)ProcessId, &local, (UIntPtr)1, &remote, (UIntPtr)1, UIntPtr.Zero).ToInt64();
-                if (bytesRead < 0 && Marshal.GetLastWin32Error() == EPERM)
-                    throw new UnauthorizedAccessException();
-            }
+                int read = (int)process_vm_readv((int)ProcessId, &local, (UIntPtr)1, &remote, (UIntPtr)1, UIntPtr.Zero).ToInt64();
+                if (read < 0)
+                {
+                    bytesRead = 0;
+                    if (Marshal.GetLastWin32Error() == EPERM)
+                        throw new UnauthorizedAccessException();
 
-            return bytesRead > 0;
+                    return false;
+                }
+
+                bytesRead = read;
+                return true;
+            }
         }
 
         public unsafe ulong ReadPointerUnsafe(ulong address)

--- a/src/Microsoft.Diagnostics.Runtime/src/Linux/LinuxLiveDataReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Linux/LinuxLiveDataReader.cs
@@ -156,6 +156,8 @@ namespace Microsoft.Diagnostics.Runtime.Linux
                     iov_len = (IntPtr)readableBytesCount
                 };
                 bytesRead = (int)process_vm_readv((int)ProcessId, &local, (UIntPtr)1, &remote, (UIntPtr)1, UIntPtr.Zero).ToInt64();
+                if (bytesRead < 0 && Marshal.GetLastWin32Error() == EPERM)
+                    throw new UnauthorizedAccessException();
             }
 
             return bytesRead > 0;
@@ -375,6 +377,8 @@ namespace Microsoft.Diagnostics.Runtime.Linux
             int p = permission[3] != '-' ? 1 : 0;   // 1: private
             return r | w | x | p;
         }
+
+        private const int EPERM = 1;
 
         private const string LibC = "libc";
 


### PR DESCRIPTION
Closes #264 

`process_vm_readv` is faster and doesn't raise exceptions or signals.

Benchmark results

|  Method |      Mean |     Error |    StdDev |
|-------- |----------:|----------:|----------:|
| ProcMem | 13.869 ms | 0.3094 ms | 0.9122 ms |
|   Readv |  6.353 ms | 0.1366 ms | 0.4029 ms |

Benchmark sample

```cs
using System;
using System.Buffers;
using System.Collections.Generic;
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;
using Microsoft.Diagnostics.Runtime;

public class Program
{
    static void Main() => _ = BenchmarkRunner.Run<Program>();

    static readonly DataTarget dataTarget = DataTarget.PassiveAttachToProcess(1);
    static readonly IEnumerable<ModuleInfo> modules = dataTarget.EnumerateModules();

    [Benchmark]
    public void ReadMemory()
    {
        foreach (ModuleInfo module in modules)
        {
            byte[] buffer = ArrayPool<byte>.Shared.Rent((int)module.FileSize);
            _ = dataTarget.DataReader.ReadMemory(module.ImageBase, buffer.AsSpan(0, (int)module.FileSize), out int _);
            ArrayPool<byte>.Shared.Return(buffer);
        }
    }
}
```