### PR TITLE
Fields and segments

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/src/Implementation/HeapBuilder.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Implementation/HeapBuilder.cs
@@ -171,7 +171,7 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
             IsLargeObjectSegment = true;
             AddSegments(clrHeap, segments, _heap.GenerationTable[3].StartSegment);
             IsLargeObjectSegment = false;
-            AddSegments(clrHeap, segments, _heap.EphemeralHeapSegment);
+            AddSegments(clrHeap, segments, _heap.GenerationTable[2].StartSegment);
         }
 
         private void AddSegments(ClrHeap clrHeap, List<ClrSegment> segments, ulong address)

--- a/src/Microsoft.Diagnostics.Runtime/src/Implementation/RuntimeBuilder.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Implementation/RuntimeBuilder.cs
@@ -839,7 +839,7 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
             }
 
             _cache.ReportMemory(type.TypeHandle, fieldInfo.NumInstanceFields * _instFieldSize + fieldInfo.NumStaticFields * _staticFieldSize);
-            ClrInstanceField[] fieldOut = new ClrInstanceField[fieldInfo.NumInstanceFields + type.BaseType.Fields.Count];
+            ClrInstanceField[] fieldOut = new ClrInstanceField[fieldInfo.NumInstanceFields];
             ClrStaticField[] staticOut = new ClrStaticField[fieldInfo.NumStaticFields];
             if (fieldInfo.NumStaticFields == 0)
                 statics = Array.Empty<ClrStaticField>();
@@ -854,8 +854,8 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
             }
 
             ulong nextField = fieldInfo.FirstFieldAddress;
-            int overflow = 0;
-            while (overflow + fieldNum + staticNum < fieldOut.Length + staticOut.Length && nextField != 0)
+            int other = 0;
+            while (other + fieldNum + staticNum < fieldOut.Length + staticOut.Length && nextField != 0)
             {
                 if (!_sos.GetFieldData(nextField, out _fieldData))
                     break;
@@ -864,18 +864,16 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
                 {
                     if (_fieldData.IsStatic != 0)
                     {
-                        if (staticNum < staticOut.Length)
-                            staticOut[staticNum++] = new ClrmdStaticField(type, this);
-                        else
-                            overflow++;
+                        staticOut[staticNum++] = new ClrmdStaticField(type, this);
                     }
                     else
                     {
-                        if (fieldNum < fieldOut.Length)
-                            fieldOut[fieldNum++] = new ClrmdField(type, this);
-                        else
-                            overflow++;
+                        fieldOut[fieldNum++] = new ClrmdField(type, this);
                     }
+                }
+                else
+                {
+                    other++;
                 }
 
                 nextField = _fieldData.NextField;


### PR DESCRIPTION
-Segment enumeration was mistakenly started from the EphemeralHeapSegment instead of the first Gen2 segment.
- We did not properly account for the meaaning of fieldInfo.NumFields.  This includes the base type's field count, so we did not need to add that.
- ContextStatics and ThreadStatics are included in "NumStaticFields".  Need to be sure count those as we are walking fields.