### PR TITLE
Ensure ClrRuntime properly cleans up

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/AppDomainTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/AppDomainTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         public void ModuleDomainTest()
         {
             using DataTarget dt = TestTargets.AppDomains.LoadFullDump();
-            ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
+            using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
 
             ClrAppDomain appDomainExe = runtime.GetDomainByName("AppDomains.exe");
             ClrAppDomain nestedDomain = runtime.GetDomainByName("Second AppDomain");
@@ -56,7 +56,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         public void AppDomainPropertyTest()
         {
             using DataTarget dt = TestTargets.AppDomains.LoadFullDump();
-            ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
+            using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
 
             ClrAppDomain systemDomain = runtime.SystemDomain;
             Assert.Equal("System Domain", systemDomain.Name);
@@ -86,7 +86,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         public void SystemAndSharedLibraryModulesTest()
         {
             using DataTarget dt = TestTargets.AppDomains.LoadFullDump();
-            ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
+            using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
 
             ClrAppDomain systemDomain = runtime.SystemDomain;
             Assert.Equal(0, systemDomain.Modules.Count);
@@ -111,7 +111,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         public void ModuleAppDomainEqualityTest()
         {
             using DataTarget dt = TestTargets.AppDomains.LoadFullDump();
-            ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
+            using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
 
             ClrAppDomain appDomainsExe = runtime.GetDomainByName("AppDomains.exe");
             ClrAppDomain nestedExceptionExe = runtime.GetDomainByName("Second AppDomain");

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/DataTargetTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/DataTargetTests.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
 
         private static ProcessThread GetMainThread(Process process, DataTarget dataTarget)
         {
-            ClrRuntime runtime = dataTarget.ClrVersions.Single().CreateRuntime();
+            using ClrRuntime runtime = dataTarget.ClrVersions.Single().CreateRuntime();
             uint mainThreadId = runtime.GetMainThread().OSThreadId;
             return process.Threads.Cast<ProcessThread>().Single(thread => thread.Id == mainThreadId);
         }

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/ExceptionTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/ExceptionTests.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         public void ExceptionPropertyTest()
         {
             using DataTarget dt = TestTargets.NestedException.LoadFullDump();
-            ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
+            using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
             TestProperties(runtime);
         }
 

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/FieldTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/FieldTests.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         public void InstanceFieldProperties()
         {
             using DataTarget dt = TestTargets.Types.LoadFullDump();
-            ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
+            using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
             ClrHeap heap = runtime.Heap;
 
             ClrType foo = runtime.GetModule("sharedlibrary.dll").GetTypeByName("Foo");

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/FinalizationQueueTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/FinalizationQueueTests.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         public void TestAllFinalizableObjects()
         {
             using DataTarget dt = TestTargets.FinalizationQueue.LoadFullDump();
-            ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
+            using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
             Stats stats = GetStats(runtime.Heap.EnumerateFinalizableObjects());
 
             Assert.Equal(0, stats.A);
@@ -26,7 +26,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         public void TestFinalizerQueueObjects()
         {
             using DataTarget dt = TestTargets.FinalizationQueue.LoadFullDump();
-            ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
+            using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
             Stats stats = GetStats(runtime.Heap.EnumerateFinalizerRoots().Select(r => r.Object));
 
             Assert.Equal(42, stats.A);

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/GCHandleTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/GCHandleTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             // I made some changes to v4.5 handle enumeration to enumerate handles out faster.
             // This test makes sure I have a stable enumeration.
             using DataTarget dt = TestTargets.GCHandles.LoadFullDump();
-            ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
+            using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
 
             List<ClrHandle> handles = new List<ClrHandle>(runtime.EnumerateHandles());
 
@@ -41,7 +41,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             HashSet<ClrHandle> handles = new HashSet<ClrHandle>();
 
             using DataTarget dt = TestTargets.GCHandles.LoadFullDump();
-            ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
+            using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
 
             foreach (ClrHandle handle in runtime.EnumerateHandles())
                 Assert.True(handles.Add(handle));

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/GCRootTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/GCRootTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         public void EnumerateGCRefs()
         {
             using DataTarget dataTarget = TestTargets.GCRoot.LoadFullDump();
-            ClrRuntime runtime = dataTarget.ClrVersions.Single().CreateRuntime();
+            using ClrRuntime runtime = dataTarget.ClrVersions.Single().CreateRuntime();
             ClrHeap heap = runtime.Heap;
 
             ClrObject obj = heap.GetObjectsOfType("DoubleRef").Single();
@@ -46,7 +46,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         public void EnumerateGCRefsArray()
         {
             using DataTarget dataTarget = TestTargets.GCRoot.LoadFullDump();
-            ClrRuntime runtime = dataTarget.ClrVersions.Single().CreateRuntime();
+            using ClrRuntime runtime = dataTarget.ClrVersions.Single().CreateRuntime();
             ClrHeap heap = runtime.Heap;
 
             ClrModule module = heap.Runtime.GetMainModule();
@@ -66,7 +66,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         public void ObjectSetAddRemove()
         {
             using DataTarget dataTarget = TestTargets.Types.LoadFullDump();
-            ClrRuntime runtime = dataTarget.ClrVersions.Single().CreateRuntime();
+            using ClrRuntime runtime = dataTarget.ClrVersions.Single().CreateRuntime();
             ClrHeap heap = runtime.Heap;
 
             ObjectSet hash = new ObjectSet(heap);
@@ -89,7 +89,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         public void ObjectSetTryAdd()
         {
             using DataTarget dataTarget = TestTargets.Types.LoadFullDump();
-            ClrRuntime runtime = dataTarget.ClrVersions.Single().CreateRuntime();
+            using ClrRuntime runtime = dataTarget.ClrVersions.Single().CreateRuntime();
             ClrHeap heap = runtime.Heap;
 
             ObjectSet hash = new ObjectSet(heap);
@@ -107,7 +107,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         public void FindSinglePathCancel()
         {
             using DataTarget dataTarget = TestTargets.GCRoot.LoadFullDump();
-            ClrRuntime runtime = dataTarget.ClrVersions.Single().CreateRuntime();
+            using ClrRuntime runtime = dataTarget.ClrVersions.Single().CreateRuntime();
             ClrHeap heap = runtime.Heap;
             GCRoot gcroot = new GCRoot(runtime.Heap);
 
@@ -129,7 +129,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         public void EnumerateAllPathshCancel()
         {
             using DataTarget dataTarget = TestTargets.GCRoot.LoadFullDump();
-            ClrRuntime runtime = dataTarget.ClrVersions.Single().CreateRuntime();
+            using ClrRuntime runtime = dataTarget.ClrVersions.Single().CreateRuntime();
             ClrHeap heap = runtime.Heap;
             GCRoot gcroot = new GCRoot(runtime.Heap);
 
@@ -151,7 +151,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         public void GCRoots()
         {
             using DataTarget dataTarget = TestTargets.GCRoot.LoadFullDump();
-            ClrRuntime runtime = dataTarget.ClrVersions.Single().CreateRuntime();
+            using ClrRuntime runtime = dataTarget.ClrVersions.Single().CreateRuntime();
             ClrHeap heap = runtime.Heap;
 
             GCRoot gcroot = new GCRoot(heap);
@@ -187,7 +187,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         {
             using DataTarget dataTarget = TestTargets.GCRoot2.LoadFullDump();
 
-            ClrRuntime runtime = dataTarget.ClrVersions.Single().CreateRuntime();
+            using ClrRuntime runtime = dataTarget.ClrVersions.Single().CreateRuntime();
             ClrHeap heap = runtime.Heap;
             GCRoot gcroot = new GCRoot(heap);
 
@@ -203,7 +203,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         {
             using DataTarget dataTarget = TestTargets.GCRoot2.LoadFullDump();
 
-            ClrRuntime runtime = dataTarget.ClrVersions.Single().CreateRuntime();
+            using ClrRuntime runtime = dataTarget.ClrVersions.Single().CreateRuntime();
             ClrHeap heap = runtime.Heap;
             GCRoot gcroot = new GCRoot(heap);
 
@@ -218,7 +218,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         public void FindSinglePath()
         {
             using DataTarget dataTarget = TestTargets.GCRoot.LoadFullDump();
-            ClrRuntime runtime = dataTarget.ClrVersions.Single().CreateRuntime();
+            using ClrRuntime runtime = dataTarget.ClrVersions.Single().CreateRuntime();
             GCRoot gcroot = new GCRoot(runtime.Heap);
 
             FindSinglePathImpl(gcroot);
@@ -238,7 +238,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         public void FindAllPaths()
         {
             using DataTarget dataTarget = TestTargets.GCRoot.LoadFullDump();
-            ClrRuntime runtime = dataTarget.ClrVersions.Single().CreateRuntime();
+            using ClrRuntime runtime = dataTarget.ClrVersions.Single().CreateRuntime();
             GCRoot gcroot = new GCRoot(runtime.Heap);
 
             FindAllPathsImpl(gcroot);

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/HeapTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/HeapTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         {
             // Simply test that we can enumerate the heap.
             using DataTarget dt = TestTargets.Types.LoadFullDump();
-            ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
+            using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
             ClrHeap heap = runtime.Heap;
 
             bool encounteredFoo = false;
@@ -42,7 +42,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         public void ServerSegmentTests()
         {
             using DataTarget dt = TestTargets.Types.LoadFullDump(GCMode.Server);
-            ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
+            using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
             ClrHeap heap = runtime.Heap;
 
             Assert.True(heap.IsServer);
@@ -54,7 +54,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         public void WorkstationSegmentTests()
         {
             using DataTarget dt = TestTargets.Types.LoadFullDump(GCMode.Workstation);
-            ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
+            using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
             ClrHeap heap = runtime.Heap;
 
             Assert.False(heap.IsServer);

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/MethodTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/MethodTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             ulong[] methodDescs;
             using (DataTarget dt = TestTargets.AppDomains.LoadFullDump())
             {
-                ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
+                using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
 
                 ClrType[] types = runtime.EnumerateModules().Where(m => m.FileName.EndsWith("sharedlibrary.dll", System.StringComparison.OrdinalIgnoreCase)).Select(m => m.GetTypeByName("Foo")).Where(t => t != null).ToArray();
 
@@ -27,7 +27,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
 
             using (DataTarget dt = TestTargets.AppDomains.LoadFullDump())
             {
-                ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
+                using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
                 ClrMethod method = runtime.GetMethodByHandle(methodDescs[0]);
 
                 Assert.NotNull(method);
@@ -37,7 +37,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
 
             using (DataTarget dt = TestTargets.AppDomains.LoadFullDump())
             {
-                ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
+                using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
                 ClrMethod method = runtime.GetMethodByHandle(methodDescs[1]);
 
                 Assert.NotNull(method);
@@ -52,7 +52,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             ulong methodDesc;
             using (DataTarget dt = TestTargets.Types.LoadFullDump())
             {
-                ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
+                using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
 
                 ClrModule module = runtime.GetModule("sharedlibrary.dll");
                 ClrType type = module.GetTypeByName("Foo");
@@ -64,7 +64,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
 
             using (DataTarget dt = TestTargets.Types.LoadFullDump())
             {
-                ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
+                using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
                 ClrMethod method = runtime.GetMethodByHandle(methodDesc);
 
                 Assert.NotNull(method);
@@ -74,7 +74,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
 
             using (DataTarget dt = TestTargets.Types.LoadFullDump())
             {
-                ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
+                using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
 
                 ClrModule module = runtime.GetModule("sharedlibrary.dll");
                 ClrType type = module.GetTypeByName("Foo");
@@ -92,7 +92,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         public void CompleteSignatureIsRetrievedForMethodsWithGenericParameters()
         {
             using DataTarget dt = TestTargets.AppDomains.LoadFullDump();
-            ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
+            using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
 
             ClrModule module = runtime.GetModule("sharedlibrary.dll");
             ClrType type = module.GetTypeByName("Foo");

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/MinidumpTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/MinidumpTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         public void MinidumpCallstackTest()
         {
             using DataTarget dt = TestTargets.NestedException.LoadMiniDump();
-            ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
+            using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
             ClrThread thread = runtime.GetMainThread();
 
             string[] frames = IntPtr.Size == 8 ? new[] { "Inner", "Inner", "Middle", "Outer", "Main" } : new[] { "Inner", "Middle", "Outer", "Main" };
@@ -46,7 +46,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         public void MinidumpExceptionPropertiesTest()
         {
             using DataTarget dt = TestTargets.NestedException.LoadMiniDump();
-            ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
+            using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
             ExceptionTests.TestProperties(runtime);
         }
     }

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/ModuleTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/ModuleTests.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         public void TestGetTypeByName()
         {
             using DataTarget dt = TestTargets.Types.LoadFullDump();
-            ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
+            using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
             ClrHeap heap = runtime.Heap;
 
             ClrModule shared = runtime.GetModule("sharedlibrary.dll");

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/PdbTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/PdbTests.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         {
             // Ensure all methods in our source file is in the pdb.
             using DataTarget dt = TestTargets.NestedException.LoadFullDump();
-            ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
+            using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
 
             PdbInfo[] allPdbs = runtime.EnumerateModules().Select(m => m.Pdb).ToArray();
             Assert.True(allPdbs.Length > 1);

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/RuntimeTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/RuntimeTests.cs
@@ -67,5 +67,121 @@ namespace Microsoft.Diagnostics.Runtime.Tests
                 }
             }
         }
+
+        [Fact]
+        public void EnsureFlushClearsData()
+        {
+            using DataTarget dt = TestTargets.AppDomains.LoadFullDump();
+            using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
+
+            var oldShared = runtime.SharedDomain;
+            var oldSystem = runtime.SystemDomain;
+            var oldDomains = runtime.AppDomains;
+            var oldHeap = runtime.Heap;
+            var oldModules = runtime.EnumerateModules().ToArray();
+            var oldObjects = oldHeap.EnumerateObjects().Take(20).ToArray();
+            var oldFields = oldObjects.SelectMany(o => o.Type.Fields).ToArray();
+            var oldStaticFields = oldObjects.SelectMany(o => o.Type.StaticFields).ToArray();
+            var oldMethods = oldObjects.SelectMany(o => o.Type.Methods).ToArray();
+
+            // Ensure names are read and cached
+            foreach (var obj in oldObjects)
+            {
+                _ = obj.Type.Name;
+                foreach (var item in obj.Type.Methods)
+                    _ = item.Name;
+                foreach (var item in obj.Type.Fields)
+                    _ = item.Name;
+                foreach (var item in obj.Type.StaticFields)
+                    _ = item.Name;
+            }
+
+            foreach (var module in oldModules)
+            {
+                _ = module.Name;
+                _ = module.FileName;
+                _ = module.AssemblyName;
+            }
+
+            // Ensure we have some data to compare against
+            Assert.NotEmpty(oldDomains);
+            Assert.NotEmpty(oldModules);
+            Assert.NotEmpty(oldObjects);
+
+            // Make sure we aren't regenerating this list every time.
+            Assert.Same(oldDomains, runtime.AppDomains);
+
+            // Clear all cached data.
+            runtime.FlushCachedData();
+
+            CheckDomainNotSame(oldShared, runtime.SharedDomain);
+            CheckDomainNotSame(oldSystem, runtime.SystemDomain);
+            Assert.Equal(oldDomains.Count, runtime.AppDomains.Count);
+            for (int i = 0; i < oldDomains.Count; i++)
+                CheckDomainNotSame(oldDomains[i], runtime.AppDomains[i]);
+
+            var newModules = runtime.EnumerateModules().ToArray();
+            for (int i = 0; i < oldModules.Length; i++)
+                CheckModuleNotSame(oldModules[i], newModules[i]);
+
+            ClrHeap newHeap = runtime.Heap;
+            Assert.Same(runtime.Heap, newHeap); // make sure we don't recreate the object every call
+            Assert.NotSame(oldHeap, newHeap);   // but also that we did recreate after flush
+
+            CheckTypeNotSame(oldHeap.ObjectType, newHeap.ObjectType);
+            CheckTypeNotSame(oldHeap.ExceptionType, newHeap.ExceptionType);
+            CheckTypeNotSame(oldHeap.StringType, newHeap.StringType);
+
+            var newObjs = newHeap.EnumerateObjects().Take(20).ToArray();
+            for (int i = 0; i < oldObjects.Length; i++)
+            {
+                Assert.Equal(oldObjects[i].Address, newObjs[i].Address);
+                CheckTypeNotSame(oldObjects[i].Type, newObjs[i].Type);
+            }
+        }
+
+        private void CheckTypeNotSame(ClrType oldType, ClrType newType)
+        {
+            Assert.Equal(oldType.TypeHandle, newType.TypeHandle);
+
+            AssertEqualNotSame(oldType.Name, newType.Name);
+
+            for (int i = 0; i < oldType.Fields.Count; i++)
+                AssertEqualNotSame(oldType.Fields[i].Name, newType.Fields[i].Name);
+
+            for (int i = 0; i < oldType.StaticFields.Count; i++)
+                AssertEqualNotSame(oldType.StaticFields[i].Name, newType.StaticFields[i].Name);
+
+            for (int i = 0; i < oldType.Methods.Count; i++)
+                AssertEqualNotSame(oldType.Methods[i].Name, newType.Methods[i].Name);
+        }
+
+        private void AssertEqualNotSame(string t1, string t2)
+        {
+            Assert.Equal(t1, t2);
+            Assert.NotSame(t1, t2);
+        }
+
+        private void CheckModuleNotSame(ClrModule oldModule, ClrModule newModule)
+        {
+            // These should be different physical objects, and they should have been enumerated in the same order
+
+            Assert.Equal(oldModule.Address, newModule.Address);
+            Assert.NotSame(oldModule, newModule);
+
+            CheckDomainNotSame(oldModule.AppDomain, newModule.AppDomain);
+
+            AssertEqualNotSame(oldModule.FileName, newModule.FileName);
+            AssertEqualNotSame(oldModule.AssemblyName, newModule.AssemblyName);
+        }
+
+        private static void CheckDomainNotSame(ClrAppDomain oldDomain, ClrAppDomain domain)
+        {
+            if (oldDomain != null)
+            {
+                Assert.Equal(oldDomain.Address, domain.Address);
+                Assert.NotSame(oldDomain, domain);
+            }
+        }
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/RuntimeTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/RuntimeTests.cs
@@ -83,6 +83,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             var oldFields = oldObjects.SelectMany(o => o.Type.Fields).ToArray();
             var oldStaticFields = oldObjects.SelectMany(o => o.Type.StaticFields).ToArray();
             var oldMethods = oldObjects.SelectMany(o => o.Type.Methods).ToArray();
+            var oldThreads = runtime.Threads;
 
             // Ensure names are read and cached
             foreach (var obj in oldObjects)
@@ -107,6 +108,10 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             Assert.NotEmpty(oldDomains);
             Assert.NotEmpty(oldModules);
             Assert.NotEmpty(oldObjects);
+            Assert.NotEmpty(oldThreads);
+            Assert.NotEmpty(oldFields);
+            Assert.NotEmpty(oldStaticFields);
+            Assert.NotEmpty(oldMethods);
 
             // Make sure we aren't regenerating this list every time.
             Assert.Same(oldDomains, runtime.AppDomains);
@@ -133,10 +138,20 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             CheckTypeNotSame(oldHeap.StringType, newHeap.StringType);
 
             var newObjs = newHeap.EnumerateObjects().Take(20).ToArray();
+            Assert.Equal(oldObjects.Length, newObjs.Length);
             for (int i = 0; i < oldObjects.Length; i++)
             {
                 Assert.Equal(oldObjects[i].Address, newObjs[i].Address);
                 CheckTypeNotSame(oldObjects[i].Type, newObjs[i].Type);
+            }
+
+            var newThreads = runtime.Threads;
+            Assert.Same(newThreads, runtime.Threads);
+            Assert.Equal(oldThreads.Count, newThreads.Count);
+            for (int i = 0; i < oldThreads.Count; i++)
+            {
+                Assert.Equal(oldThreads[i].OSThreadId, newThreads[i].OSThreadId);
+                Assert.NotSame(oldThreads[i], newThreads[i]);
             }
         }
 

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/RuntimeTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/RuntimeTests.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
 
             Assert.NotNull(dac);
 
-            ClrRuntime runtime = info.CreateRuntime(dac);
+            using ClrRuntime runtime = info.CreateRuntime(dac);
             Assert.NotNull(runtime);
         }
 
@@ -39,7 +39,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         {
             using DataTarget dt = TestTargets.NestedException.LoadFullDump();
             ClrInfo info = dt.ClrVersions.Single();
-            ClrRuntime runtime = info.CreateRuntime();
+            using ClrRuntime runtime = info.CreateRuntime();
 
             Assert.Equal(info, runtime.ClrInfo);
         }
@@ -50,7 +50,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             // This test ensures that we enumerate all modules in the process exactly once.
 
             using DataTarget dt = TestTargets.AppDomains.LoadFullDump();
-            ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
+            using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
 
             HashSet<string> expected = new HashSet<string>(new[] { "mscorlib.dll", "system.dll", "system.core.dll", "sharedlibrary.dll", "nestedexception.exe", "appdomains.exe" }, StringComparer.OrdinalIgnoreCase);
             foreach (ClrAppDomain domain in runtime.AppDomains)

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/TypeTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/TypeTests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         public void IntegerObjectClrType()
         {
             using DataTarget dt = TestTargets.Types.LoadFullDump();
-            ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
+            using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
             ClrHeap heap = runtime.Heap;
 
             ClrModule module = runtime.GetModule(ModuleName);
@@ -52,7 +52,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         public void ArrayComponentTypeTest()
         {
             using DataTarget dt = TestTargets.AppDomains.LoadFullDump();
-            ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
+            using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
             ClrHeap heap = runtime.Heap;
 
             // Ensure that we always have a component for every array type.
@@ -84,7 +84,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             // Simply test that we can enumerate the heap.
 
             using DataTarget dt = TestTargets.Types.LoadFullDump();
-            ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
+            using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
             ClrHeap heap = runtime.Heap;
 
             foreach (ClrObject obj in heap.EnumerateObjects())
@@ -107,7 +107,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
 
             const string TypeName = "Foo";
             using DataTarget dt = TestTargets.AppDomains.LoadFullDump();
-            ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
+            using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
             ClrHeap heap = runtime.Heap;
 
             ClrType[] types = (from obj in heap.EnumerateObjects()
@@ -140,7 +140,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             // Test to make sure that a specific static and local variable exist.
 
             using DataTarget dt = TestTargets.Types.LoadFullDump();
-            ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
+            using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
             ClrHeap heap = runtime.Heap;
 
             IEnumerable<IClrRoot> fooRoots = from root in heap.EnumerateRoots()
@@ -172,7 +172,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         public void MethodTableHeapEnumeration()
         {
             using DataTarget dt = TestTargets.Types.LoadFullDump();
-            ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
+            using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
             ClrHeap heap = runtime.Heap;
 
             foreach (ClrType type in heap.EnumerateObjects().Select(obj => heap.GetObjectType(obj.Address)).Unique())
@@ -202,7 +202,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         public void GetObjectMethodTableTest()
         {
             using DataTarget dt = TestTargets.AppDomains.LoadFullDump();
-            ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
+            using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
             ClrHeap heap = runtime.Heap;
 
             int i = 0;
@@ -224,7 +224,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         public void EnumerateMethodTableTest()
         {
             using DataTarget dt = TestTargets.AppDomains.LoadFullDump();
-            ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
+            using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
             ClrHeap heap = runtime.Heap;
 
             ClrObject[] fooObjects = (from obj in heap.EnumerateObjects()
@@ -261,7 +261,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         {
             // https://github.com/microsoft/clrmd/issues/101
             using DataTarget dt = TestTargets.Types.LoadFullDump();
-            ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
+            using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
 
             ClrModule sharedLibrary = runtime.GetModule("sharedlibrary.dll");
             ClrType structTestClass = sharedLibrary.GetTypeByName("StructTestClass");
@@ -283,7 +283,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         public void StringEmptyIsObtainableTest()
         {
             using DataTarget dt = TestTargets.Types.LoadFullDump();
-            ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
+            using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
             ClrHeap heap = runtime.Heap;
 
             ClrType stringType = heap.StringType;
@@ -304,7 +304,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             // gets its ComponentType set.
 
             using DataTarget dt = TestTargets.Types.LoadFullDump();
-            ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
+            using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
             
             ClrType fooType = runtime.GetModule(ModuleName).GetTypeByName("Types");
             ClrStaticField cq = fooType.GetStaticFieldByName("s_cq");
@@ -336,7 +336,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         {
             // TODO: test reading structs from instance/static fields
             using DataTarget dt = TestTargets.Types.LoadFullDump();
-            ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
+            using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
             ClrHeap heap = runtime.Heap;
 
             ClrAppDomain domain = runtime.AppDomains.Single();
@@ -437,7 +437,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         public void ArrayOffsetsTest()
         {
             using DataTarget dt = TestTargets.Types.LoadFullDump();
-            ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
+            using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
             ClrHeap heap = runtime.Heap;
 
             ClrAppDomain domain = runtime.AppDomains.Single();
@@ -470,7 +470,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         public void ArrayLengthTest()
         {
             using DataTarget dt = TestTargets.Types.LoadFullDump();
-            ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
+            using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
             ClrHeap heap = runtime.Heap;
 
             ClrAppDomain domain = runtime.AppDomains.Single();
@@ -486,7 +486,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         public void ArrayReferenceEnumeration()
         {
             using DataTarget dt = TestTargets.Types.LoadFullDump();
-            ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
+            using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
             ClrHeap heap = runtime.Heap;
 
             ClrAppDomain domain = runtime.AppDomains.Single();

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/ClrRuntime.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/ClrRuntime.cs
@@ -97,7 +97,7 @@ namespace Microsoft.Diagnostics.Runtime
         /// (E.G. if you want to use the ClrHeap object after calling flush, you must call ClrRuntime.GetHeap
         /// again after Flush to get a new instance.)
         /// </summary>
-        public abstract void ClearCachedData();
+        public abstract void FlushCachedData();
 
         /// <summary>
         /// Gets the name of a JIT helper function
@@ -105,23 +105,6 @@ namespace Microsoft.Diagnostics.Runtime
         /// <param name="address">Address of a possible JIT helper function</param>
         /// <returns>The name of the JIT helper function or null if <paramref name="address"/> isn't a JIT helper function</returns>
         public abstract string GetJitHelperFunctionName(ulong address);
-
-        /// <summary>
-        /// Delegate called when the RuntimeFlushed event is triggered.
-        /// </summary>
-        /// <param name="runtime">Which runtime was flushed.</param>
-        public delegate void RuntimeFlushedCallback(ClrRuntime runtime);
-
-        /// <summary>
-        /// Called whenever the runtime is being flushed.  All references to ClrMD objects need to be released
-        /// and not used for the given runtime after this call.
-        /// </summary>
-        public event RuntimeFlushedCallback RuntimeFlushed;
-
-        /// <summary>
-        /// Call when flushing the runtime.
-        /// </summary>
-        protected void OnRuntimeFlushed() => RuntimeFlushed?.Invoke(this);
 
         /// <summary>
         /// Cleans up all resources and releases them.  You may not use this ClrRuntime or any object it transitively

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/ClrRuntime.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/ClrRuntime.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 
 namespace Microsoft.Diagnostics.Runtime
@@ -10,7 +11,7 @@ namespace Microsoft.Diagnostics.Runtime
     /// Represents a single runtime in a target process or crash dump.  This serves as the primary
     /// entry point for getting diagnostic information.
     /// </summary>
-    public abstract class ClrRuntime
+    public abstract class ClrRuntime : IDisposable
     {
         /// <summary>
         /// Used for internal purposes.
@@ -122,9 +123,20 @@ namespace Microsoft.Diagnostics.Runtime
         /// </summary>
         protected void OnRuntimeFlushed() => RuntimeFlushed?.Invoke(this);
 
-        internal void Dispose()
+        /// <summary>
+        /// Cleans up all resources and releases them.  You may not use this ClrRuntime or any object it transitively
+        /// created after calling this method.
+        /// </summary>
+        public void Dispose()
         {
-            DacLibrary?.Dispose();
+            Dispose(true);
+            GC.SuppressFinalize(this);
         }
+
+        /// <summary>
+        /// Called when disposing ClrRuntime.
+        /// </summary>
+        /// <param name="disposing">Whether Dispose() was called or not.</param>
+        protected abstract void Dispose(bool disposing);
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Core/CoreDumpReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Core/CoreDumpReader.cs
@@ -113,7 +113,7 @@ namespace Microsoft.Diagnostics.Runtime
             return new ModuleInfo(this, (ulong)image.BaseAddress, filesize, timestamp, image.Path, file?.BuildId);
         }
 
-        public void ClearCachedData()
+        public void FlushCachedData()
         {
             _threads = null;
             _modules = null;

--- a/src/Microsoft.Diagnostics.Runtime/src/DataReaders/DbgEng/DbgEngDataReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataReaders/DbgEng/DbgEngDataReader.cs
@@ -166,7 +166,7 @@ namespace Microsoft.Diagnostics.Runtime
             }
         }
 
-        public void ClearCachedData()
+        public void FlushCachedData()
         {
             _modules = null;
         }

--- a/src/Microsoft.Diagnostics.Runtime/src/DataReaders/IDataReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataReaders/IDataReader.cs
@@ -96,6 +96,6 @@ namespace Microsoft.Diagnostics.Runtime
         /// <summary>
         /// Informs the data reader that the user has requested all data be flushed.
         /// </summary>
-        void ClearCachedData();
+        void FlushCachedData();
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Live/LiveDataReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Live/LiveDataReader.cs
@@ -105,7 +105,7 @@ namespace Microsoft.Diagnostics.Runtime
 
 
 
-        public void ClearCachedData()
+        public void FlushCachedData()
         {
         }
 

--- a/src/Microsoft.Diagnostics.Runtime/src/DataTargets/DacLibrary.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataTargets/DacLibrary.cs
@@ -13,30 +13,21 @@ namespace Microsoft.Diagnostics.Runtime
     {
         private bool _disposed;
         private SOSDac _sos;
-        private SOSDac6 _sos6;
 
         internal DacDataTargetWrapper DacDataTarget { get; }
 
-        internal RefCountedFreeLibrary OwningLibrary { get; }
+        public RefCountedFreeLibrary OwningLibrary { get; }
 
         internal ClrDataProcess InternalDacPrivateInterface { get; }
 
         public ClrDataProcess DacPrivateInterface => new ClrDataProcess(this, InternalDacPrivateInterface);
 
-        internal SOSDac GetSOSInterfaceNoAddRef()
+        private SOSDac GetSOSInterfaceNoAddRef()
         {
             if (_sos == null)
                 _sos = InternalDacPrivateInterface.GetSOSDacInterface();
 
             return _sos;
-        }
-
-        internal SOSDac6 GetSOSInterface6NoAddRef()
-        {
-            if (_sos6 == null)
-                _sos6 = InternalDacPrivateInterface.GetSOSDacInterface6();
-
-            return _sos6;
         }
 
         public SOSDac SOSDacInterface
@@ -47,6 +38,8 @@ namespace Microsoft.Diagnostics.Runtime
                 return sos != null ? new SOSDac(this, sos) : null;
             }
         }
+
+        public SOSDac6 SOSDacInterface6 => InternalDacPrivateInterface.GetSOSDacInterface6();
 
         public T GetInterface<T>(ref Guid riid)
             where T : CallableCOMWrapper
@@ -141,7 +134,6 @@ namespace Microsoft.Diagnostics.Runtime
             {
                 InternalDacPrivateInterface?.Dispose();
                 _sos?.Dispose();
-                _sos6?.Dispose();
                 OwningLibrary?.Release();
 
                 _disposed = true;

--- a/src/Microsoft.Diagnostics.Runtime/src/Implementation/ClrmdRuntime.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Implementation/ClrmdRuntime.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
         private IReadOnlyList<ClrAppDomain> _domains;
         private ClrAppDomain _systemDomain;
         private ClrAppDomain _sharedDomain;
+        private bool _disposed;
 
         public override DataTarget DataTarget => ClrInfo?.DataTarget;
         public override DacLibrary DacLibrary { get; }
@@ -70,6 +71,15 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
         {
             _ = AppDomains;
             _bcl = _helpers.GetBaseClassLibrary(this);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (!_disposed)
+            {
+                _disposed = true;
+                _helpers?.Dispose();
+            }
         }
 
         /// <summary>

--- a/src/Microsoft.Diagnostics.Runtime/src/Implementation/ClrmdRuntime.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Implementation/ClrmdRuntime.cs
@@ -95,14 +95,20 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
         /// but expect different results.  For example, after walking the heap, you need to call Flush before
         /// attempting to walk the heap again.
         /// </summary>
-        public override void ClearCachedData()
+        public override void FlushCachedData()
         {
-            OnRuntimeFlushed();
-            _helpers.DataReader.ClearCachedData();
-            _helpers.ClearCachedData();
+            if (_disposed)
+                throw new ObjectDisposedException(nameof(ClrRuntime));
+
             _heap = null;
             _bcl = null;
             _threads = null;
+            _domains = null;
+            _systemDomain = null;
+            _sharedDomain = null;
+
+            _helpers.DataReader.FlushCachedData();
+            _helpers.FlushCachedData();
         }
 
         public override IEnumerable<ClrModule> EnumerateModules()
@@ -123,18 +129,6 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
         public override string GetJitHelperFunctionName(ulong ip) => _helpers.GetJitHelperFunctionName(ip);
 
         public override ClrMethod GetMethodByHandle(ulong methodHandle) => _helpers.Factory.CreateMethodFromHandle(methodHandle);
-
-        /// <summary>
-        /// Converts an address into an AppDomain.
-        /// </summary>
-        internal ClrAppDomain GetAppDomainByAddress(ulong address)
-        {
-            foreach (ClrAppDomain ad in AppDomains)
-                if (ad.Address == address)
-                    return ad;
-
-            return null;
-        }
 
         public override ClrMethod GetMethodByInstructionPointer(ulong ip)
         {

--- a/src/Microsoft.Diagnostics.Runtime/src/Implementation/IRuntimeHelpers.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Implementation/IRuntimeHelpers.cs
@@ -2,11 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 
 namespace Microsoft.Diagnostics.Runtime.Implementation
 {
-    public interface IRuntimeHelpers
+    public interface IRuntimeHelpers : IDisposable
     {
         ITypeFactory Factory { get; }
         IDataReader DataReader { get; }

--- a/src/Microsoft.Diagnostics.Runtime/src/Implementation/IRuntimeHelpers.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Implementation/IRuntimeHelpers.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
         IReadOnlyList<ClrThread> GetThreads(ClrRuntime runtime);
         IReadOnlyList<ClrAppDomain> GetAppDomains(ClrRuntime runtime, out ClrAppDomain system, out ClrAppDomain shared);
         IEnumerable<ClrHandle> EnumerateHandleTable(ClrRuntime runtime);
-        void ClearCachedData();
+        void FlushCachedData();
         ulong GetMethodDesc(ulong ip);
         string GetJitHelperFunctionName(ulong ip);
         ClrModule GetBaseClassLibrary(ClrRuntime runtime);

--- a/src/Microsoft.Diagnostics.Runtime/src/Linux/LinuxLiveDataReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Linux/LinuxLiveDataReader.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Diagnostics.Runtime.Linux
             _disposed = true;
         }
 
-        public void ClearCachedData()
+        public void FlushCachedData()
         {
             _threadIDs.Clear();
             _memoryMapEntries = LoadMemoryMap();

--- a/src/Microsoft.Diagnostics.Runtime/src/Utilities/COMInterop/CallableComWrapper.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Utilities/COMInterop/CallableComWrapper.cs
@@ -125,7 +125,6 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
             Dispose(false);
         }
 
-        // This code added to correctly implement the disposable pattern.
         public void Dispose()
         {
             Dispose(true);


### PR DESCRIPTION
- ClrRuntime is now an IDisposable.
- Properly disposing of ClrRuntime ensures that all interfaces and the DacLibrary are completely released.  Not disposing of ClrRuntime is fine, but cleanup and release of libraries and interfaces will happen on the finalizer thread.
- ClrRuntime.FlushCachedData is now properly implemented and mostly tested.