### PR TITLE
Allow ClrMD to be used from multiple threads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ artifacts/
 *.userosscache
 *.sln.docstates
 *.lock.json
+*.xml
 
 # Build results
 [Dd]ebug/

--- a/Microsoft.Diagnostics.Runtime.sln
+++ b/Microsoft.Diagnostics.Runtime.sln
@@ -11,6 +11,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Diagnostics.Runti
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Diagnostics.Runtime.Utilities", "src\Microsoft.Diagnostics.Runtime.Utilities\Microsoft.Diagnostics.Runtime.Utilities.csproj", "{46E0ED79-1CAD-4876-919D-A736CE47A4F6}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ParallelStressTest", "ParallelStressTest\ParallelStressTest.csproj", "{9440A1F6-BF51-48C0-A382-09AE99C0DC30}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -101,6 +103,26 @@ Global
 		{46E0ED79-1CAD-4876-919D-A736CE47A4F6}.Release|x64.Build.0 = Release|Any CPU
 		{46E0ED79-1CAD-4876-919D-A736CE47A4F6}.Release|x86.ActiveCfg = Release|Any CPU
 		{46E0ED79-1CAD-4876-919D-A736CE47A4F6}.Release|x86.Build.0 = Release|Any CPU
+		{9440A1F6-BF51-48C0-A382-09AE99C0DC30}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9440A1F6-BF51-48C0-A382-09AE99C0DC30}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9440A1F6-BF51-48C0-A382-09AE99C0DC30}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{9440A1F6-BF51-48C0-A382-09AE99C0DC30}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{9440A1F6-BF51-48C0-A382-09AE99C0DC30}.Debug|Win32.ActiveCfg = Debug|Any CPU
+		{9440A1F6-BF51-48C0-A382-09AE99C0DC30}.Debug|Win32.Build.0 = Debug|Any CPU
+		{9440A1F6-BF51-48C0-A382-09AE99C0DC30}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{9440A1F6-BF51-48C0-A382-09AE99C0DC30}.Debug|x64.Build.0 = Debug|Any CPU
+		{9440A1F6-BF51-48C0-A382-09AE99C0DC30}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{9440A1F6-BF51-48C0-A382-09AE99C0DC30}.Debug|x86.Build.0 = Debug|Any CPU
+		{9440A1F6-BF51-48C0-A382-09AE99C0DC30}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9440A1F6-BF51-48C0-A382-09AE99C0DC30}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9440A1F6-BF51-48C0-A382-09AE99C0DC30}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{9440A1F6-BF51-48C0-A382-09AE99C0DC30}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{9440A1F6-BF51-48C0-A382-09AE99C0DC30}.Release|Win32.ActiveCfg = Release|Any CPU
+		{9440A1F6-BF51-48C0-A382-09AE99C0DC30}.Release|Win32.Build.0 = Release|Any CPU
+		{9440A1F6-BF51-48C0-A382-09AE99C0DC30}.Release|x64.ActiveCfg = Release|Any CPU
+		{9440A1F6-BF51-48C0-A382-09AE99C0DC30}.Release|x64.Build.0 = Release|Any CPU
+		{9440A1F6-BF51-48C0-A382-09AE99C0DC30}.Release|x86.ActiveCfg = Release|Any CPU
+		{9440A1F6-BF51-48C0-A382-09AE99C0DC30}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/ParallelStressTest/App.config
+++ b/ParallelStressTest/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" />
+    </startup>
+</configuration>

--- a/ParallelStressTest/ParallelStressTest.csproj
+++ b/ParallelStressTest/ParallelStressTest.csproj
@@ -1,0 +1,59 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{9440A1F6-BF51-48C0-A382-09AE99C0DC30}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>ParallelStressTest</RootNamespace>
+    <AssemblyName>ParallelStressTest</AssemblyName>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\src\Microsoft.Diagnostics.Runtime\Microsoft.Diagnostics.Runtime.csproj">
+      <Project>{a82126ca-23aa-41f1-8586-a5938d44d0a7}</Project>
+      <Name>Microsoft.Diagnostics.Runtime</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/ParallelStressTest/Program.cs
+++ b/ParallelStressTest/Program.cs
@@ -3,9 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Text;
 using System.Threading;
-using System.Threading.Tasks;
 
 namespace ParallelStressTest
 {
@@ -14,6 +12,7 @@ namespace ParallelStressTest
         const int Iterations = 500;
         const int Threads = 8;
         private static ClrObject[] _expectedObjects;
+        private static ClrSegment[] _segments;
         private static readonly ManualResetEvent _event = new ManualResetEvent(initialState: false);
 
         static void Main(string[] args)
@@ -28,68 +27,72 @@ namespace ParallelStressTest
             using (ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime())
             {
                 _expectedObjects = runtime.Heap.EnumerateObjects().ToArray();
+                _segments = runtime.Heap.Segments.ToArray();
             }
 
-
+            TimeSpan elapsed = default;
             for (int i = 0; i < Iterations; i++)
             {
-                Console.Write($"\rIteration: {i + 1:n0}");
+                Console.Write($"\rIteration: {i + 1:n0} {elapsed}");
+
+                dt.DataReader.FlushCachedData();
                 using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
 
-                List<Task<IReadOnlyList<ClrObject>>> tasks = new List<Task<IReadOnlyList<ClrObject>>>();
+                Thread[] threads = new Thread[Threads];
 
                 for (int j = 0; j < Threads; j++)
-                    tasks.Add(CreateAndStartThread(runtime));
+                    threads[j] = CreateAndStartThread(runtime);
 
+                Stopwatch sw = new Stopwatch();
+                sw.Start();
                 _event.Set();
 
+                foreach (Thread thread in threads)
+                    thread.Join();
 
-                while (tasks.Count > 0)
-                {
-                    int index = Task.WaitAny(tasks.ToArray());
-                    var curr = tasks[index].Result;
-                    tasks.RemoveAt(index);
-
-                    if (_expectedObjects.Length != curr.Count)
-                        throw new InvalidOperationException($"Expected objects enumerated was {_expectedObjects.Length:n0}, got {curr.Count:n0}");
-
-                    for (int j = 0; j < _expectedObjects.Length; j++)
-                    {
-                        if (_expectedObjects[j].Address != curr[j].Address)
-                            throw new InvalidOperationException($"Object {j} was incorrect address: Expected {_expectedObjects[j].Address:x}, got {curr[j].Address:x}");
-
-                        if (_expectedObjects[j].Type != curr[j].Type)
-                            throw new InvalidOperationException($"Object {j} was incorrect type: Expected {_expectedObjects[j].Type.Name}, got {curr[j].Type?.Name ?? ""}");
-                    }
-                }
-
+                sw.Stop();
+                elapsed = sw.Elapsed;
 
                 _event.Reset();
             }
         }
 
-        private static Task<IReadOnlyList<ClrObject>> CreateAndStartThread(ClrRuntime runtime)
+        private static Thread CreateAndStartThread(ClrRuntime runtime)
         {
-            TaskCompletionSource<IReadOnlyList<ClrObject>> source = new TaskCompletionSource<IReadOnlyList<ClrObject>>();
-
-            Thread t = new Thread(() => WorkerThread(runtime, source));
+            Thread t = new Thread(() => WorkerThread(runtime));
             t.Start();
 
-            return source.Task;
+            return t;
         }
 
-        private static void WorkerThread(ClrRuntime runtime, TaskCompletionSource<IReadOnlyList<ClrObject>> source)
+        private static void WorkerThread(ClrRuntime runtime)
         {
             _event.WaitOne();
-            try
+
+            if (_segments.Length != runtime.Heap.Segments.Count)
+                throw new InvalidOperationException($"Segment count mismatch.  Expected {_segments.Length} segments, found {runtime.Heap.Segments.Count}.");
+
+            for (int i = 0; i < _segments.Length; i++)
+                if (runtime.Heap.Segments[i].FirstObject != _segments[i].FirstObject || runtime.Heap.Segments[i].CommittedEnd != _segments[i].CommittedEnd)
+                    throw new InvalidOperationException($"Segment[{i}] range [{runtime.Heap.Segments[i].FirstObject:x12}-{runtime.Heap.Segments[i].CommittedEnd:x12}], expected [{_segments[i].FirstObject:x12}-{_segments[i].CommittedEnd:x12}]");
+
+
+            int count = 0;
+            IEnumerator<ClrObject> enumerator = runtime.Heap.EnumerateObjects().GetEnumerator();
+            while (enumerator.MoveNext())
             {
-                ClrObject[] objects = runtime.Heap.EnumerateObjects().ToArray();
-                source.SetResult(objects);
+                ClrObject curr = enumerator.Current;
+                if (curr.Address != _expectedObjects[count].Address)
+                    throw new InvalidOperationException($"Object {count} was incorrect address: Expected {_expectedObjects[count].Address:x12}, got {curr.Address:x12}");
+
+                if (curr.Type != _expectedObjects[count].Type)
+                    throw new InvalidOperationException($"Object {count} was incorrect type: Expected {_expectedObjects[count].Type.Name}, got {curr.Type?.Name ?? ""}");
+
+                count++;
             }
-            catch (Exception e)
-            {
-                source.SetException(e);
-            }
+
+            if (count != _expectedObjects.Count())
+                throw new InvalidOperationException($"Expected {_expectedObjects.Length:n0} objects, found {count:n0}.");
         }
     }
 }

--- a/ParallelStressTest/Program.cs
+++ b/ParallelStressTest/Program.cs
@@ -1,0 +1,95 @@
+﻿using Microsoft.Diagnostics.Runtime;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ParallelStressTest
+{
+    static class Program
+    {
+        const int Iterations = 500;
+        const int Threads = 8;
+        private static ClrObject[] _expectedObjects;
+        private static readonly ManualResetEvent _event = new ManualResetEvent(initialState: false);
+
+        static void Main(string[] args)
+        {
+            if (args.Length != 1)
+            {
+                Console.WriteLine("Must specify a crash dump to inspect.");
+                Environment.Exit(1);
+            }
+
+            using DataTarget dt = DataTarget.LoadCrashDump(args[0]);
+            using (ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime())
+            {
+                _expectedObjects = runtime.Heap.EnumerateObjects().ToArray();
+            }
+
+
+            for (int i = 0; i < Iterations; i++)
+            {
+                Console.Write($"\rIteration: {i + 1:n0}");
+                using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
+
+                List<Task<IReadOnlyList<ClrObject>>> tasks = new List<Task<IReadOnlyList<ClrObject>>>();
+
+                for (int j = 0; j < Threads; j++)
+                    tasks.Add(CreateAndStartThread(runtime));
+
+                _event.Set();
+
+
+                while (tasks.Count > 0)
+                {
+                    int index = Task.WaitAny(tasks.ToArray());
+                    var curr = tasks[index].Result;
+                    tasks.RemoveAt(index);
+
+                    if (_expectedObjects.Length != curr.Count)
+                        throw new InvalidOperationException($"Expected objects enumerated was {_expectedObjects.Length:n0}, got {curr.Count:n0}");
+
+                    for (int j = 0; j < _expectedObjects.Length; j++)
+                    {
+                        if (_expectedObjects[j].Address != curr[j].Address)
+                            throw new InvalidOperationException($"Object {j} was incorrect address: Expected {_expectedObjects[j].Address:x}, got {curr[j].Address:x}");
+
+                        if (_expectedObjects[j].Type != curr[j].Type)
+                            throw new InvalidOperationException($"Object {j} was incorrect type: Expected {_expectedObjects[j].Type.Name}, got {curr[j].Type?.Name ?? ""}");
+                    }
+                }
+
+
+                _event.Reset();
+            }
+        }
+
+        private static Task<IReadOnlyList<ClrObject>> CreateAndStartThread(ClrRuntime runtime)
+        {
+            TaskCompletionSource<IReadOnlyList<ClrObject>> source = new TaskCompletionSource<IReadOnlyList<ClrObject>>();
+
+            Thread t = new Thread(() => WorkerThread(runtime, source));
+            t.Start();
+
+            return source.Task;
+        }
+
+        private static void WorkerThread(ClrRuntime runtime, TaskCompletionSource<IReadOnlyList<ClrObject>> source)
+        {
+            _event.WaitOne();
+            try
+            {
+                ClrObject[] objects = runtime.Heap.EnumerateObjects().ToArray();
+                source.SetResult(objects);
+            }
+            catch (Exception e)
+            {
+                source.SetException(e);
+            }
+        }
+    }
+}

--- a/ParallelStressTest/Properties/AssemblyInfo.cs
+++ b/ParallelStressTest/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("ParallelStressTest")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("ParallelStressTest")]
+[assembly: AssemblyCopyright("Copyright ©  2019")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("9440a1f6-bf51-48c0-a382-09ae99c0dc30")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/Microsoft.Diagnostics.Runtime/src/Builders/RuntimeBuilder.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Builders/RuntimeBuilder.cs
@@ -463,7 +463,9 @@ namespace Microsoft.Diagnostics.Runtime.Builders
         {
             _heap = null;
             _dac.Flush();
-            _cache.Clear();
+
+            lock (_cache)
+                _cache.Clear();
 
             lock (_domains)
                 _domains.Clear();

--- a/src/Microsoft.Diagnostics.Runtime/src/Builders/RuntimeBuilder.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Builders/RuntimeBuilder.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Buffers;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -42,6 +41,8 @@ namespace Microsoft.Diagnostics.Runtime.Builders
         private readonly ObjectPool<MethodBuilder> _methodBuilders;
         private readonly ObjectPool<FieldBuilder> _fieldBuilders;
         private ModuleBuilder _moduleBuilder;
+
+        public bool IsThreadSafe => true;
 
         public IDataReader DataReader { get; }
         public IHeapBuilder HeapBuilder => new HeapBuilder(this, _sos, DataReader, _firstThread);

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/ClrRuntime.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/ClrRuntime.cs
@@ -29,6 +29,12 @@ namespace Microsoft.Diagnostics.Runtime
         public abstract DataTarget DataTarget { get; }
 
         /// <summary>
+        /// Returns whether you are allowed to call into the transitive closure of ClrMD objects created from
+        /// this runtime on multiple threads.
+        /// </summary>
+        public abstract bool IsThreadSafe { get; }
+
+        /// <summary>
         /// Enumerates the list of appdomains in the process.
         /// </summary>
         public abstract IReadOnlyList<ClrAppDomain> AppDomains { get; }

--- a/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Core/CoreDumpReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Core/CoreDumpReader.cs
@@ -54,6 +54,7 @@ namespace Microsoft.Diagnostics.Runtime
             }
         }
 
+        public bool IsThreadSafe => false;
         public bool IsFullMemoryAvailable => true; // TODO
 
         public void Dispose()

--- a/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Core/CoreDumpReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Core/CoreDumpReader.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Diagnostics.Runtime
             }
         }
 
-        public bool IsMinidump => false; // TODO
+        public bool IsFullMemoryAvailable => true; // TODO
 
         public void Dispose()
         {

--- a/src/Microsoft.Diagnostics.Runtime/src/DataReaders/DbgEng/DbgEngDataReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataReaders/DbgEng/DbgEngDataReader.cs
@@ -88,23 +88,23 @@ namespace Microsoft.Diagnostics.Runtime
 
         public uint ProcessId => _systemObjects.GetProcessId();
 
-        public bool IsMinidump
+        public bool IsFullMemoryAvailable
         {
             get
             {
                 if (_minidump.HasValue)
-                    return _minidump.Value;
+                    return !_minidump.Value;
 
                 DEBUG_CLASS_QUALIFIER qual = _control.GetDebuggeeClassQualifier();
                 if (qual == DEBUG_CLASS_QUALIFIER.USER_WINDOWS_SMALL_DUMP)
                 {
                     DEBUG_FORMAT flags = _control.GetDumpFormat();
                     _minidump = (flags & DEBUG_FORMAT.USER_SMALL_FULL_MEMORY) == 0;
-                    return _minidump.Value;
+                    return !_minidump.Value;
                 }
 
                 _minidump = false;
-                return false;
+                return true;
             }
         }
 

--- a/src/Microsoft.Diagnostics.Runtime/src/DataReaders/DbgEng/DbgEngDataReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataReaders/DbgEng/DbgEngDataReader.cs
@@ -86,6 +86,8 @@ namespace Microsoft.Diagnostics.Runtime
             }
         }
 
+        public bool IsThreadSafe => true; // Enforced by Debug* wrappers.
+
         public uint ProcessId => _systemObjects.GetProcessId();
 
         public bool IsFullMemoryAvailable

--- a/src/Microsoft.Diagnostics.Runtime/src/DataReaders/IDataReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataReaders/IDataReader.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Diagnostics.Runtime
         /// <summary>
         /// Returns true if the data target is a minidump which might not contain full heap data.
         /// </summary>
-        bool IsMinidump { get; }
+        bool IsFullMemoryAvailable { get; }
 
         /// <summary>
         /// Enumerates the OS thread ID of all threads in the process.

--- a/src/Microsoft.Diagnostics.Runtime/src/DataReaders/IDataReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataReaders/IDataReader.cs
@@ -13,6 +13,11 @@ namespace Microsoft.Diagnostics.Runtime
     public interface IDataReader : IDisposable
     {
         /// <summary>
+        /// Returns whether this data reader is safe to use in parallel from multiple threads.
+        /// </summary>
+        bool IsThreadSafe { get; }
+
+        /// <summary>
         /// Gets the architecture of the target.
         /// </summary>
         /// <returns>The architecture of the target.</returns>

--- a/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Live/LiveDataReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Live/LiveDataReader.cs
@@ -101,7 +101,7 @@ namespace Microsoft.Diagnostics.Runtime
 
         public uint ProcessId => (uint)_pid;
 
-        public bool IsMinidump => false;
+        public bool IsFullMemoryAvailable => true;
 
         public void FlushCachedData()
         {

--- a/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Live/LiveDataReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Live/LiveDataReader.cs
@@ -101,6 +101,8 @@ namespace Microsoft.Diagnostics.Runtime
 
         public uint ProcessId => (uint)_pid;
 
+        public bool IsThreadSafe => true;
+
         public bool IsFullMemoryAvailable => true;
 
         public void FlushCachedData()

--- a/src/Microsoft.Diagnostics.Runtime/src/DataTargets/ClrInfo.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataTargets/ClrInfo.cs
@@ -16,8 +16,6 @@ namespace Microsoft.Diagnostics.Runtime
     {
         public DataTarget DataTarget { get; }
 
-        internal ITypeFactory RuntimeFactory { get; private set; }
-
         internal ClrInfo(DataTarget dt, ClrFlavor flavor, ModuleInfo module, DacInfo dacInfo, string dacLocation)
         {
             DataTarget = dt ?? throw new ArgumentNullException(nameof(dt));
@@ -25,12 +23,6 @@ namespace Microsoft.Diagnostics.Runtime
             DacInfo = dacInfo ?? throw new ArgumentNullException(nameof(dacInfo));
             ModuleInfo = module ?? throw new ArgumentNullException(nameof(module));
             LocalMatchingDac = dacLocation;
-        }
-
-        internal void Dispose()
-        {
-            // Intentionally internal and not IDisposable.
-            RuntimeFactory?.Dispose();
         }
 
         /// <summary>
@@ -74,7 +66,6 @@ namespace Microsoft.Diagnostics.Runtime
         /// <returns></returns>
         public ClrRuntime CreateRuntime(string dacFilename, bool ignoreMismatch = false)
         {
-            ThrowIfRuntimeCreated();
             if (string.IsNullOrEmpty(dacFilename)) throw new ArgumentNullException(nameof(dacFilename));
 
             if (!File.Exists(dacFilename))
@@ -92,7 +83,6 @@ namespace Microsoft.Diagnostics.Runtime
 
         public ClrRuntime CreateRuntime()
         {
-            ThrowIfRuntimeCreated();
             string dac = LocalMatchingDac;
             if (dac != null && !File.Exists(dac))
                 dac = null;
@@ -109,12 +99,6 @@ namespace Microsoft.Diagnostics.Runtime
             return ConstructRuntime(dac);
         }
 
-        private void ThrowIfRuntimeCreated()
-        {
-            if (RuntimeFactory != null)
-                throw new InvalidOperationException($"ClrRuntime for version {Version} has already been created.");
-        }
-
 
 #pragma warning disable CA2000 // Dispose objects before losing scope
         private ClrRuntime ConstructRuntime(string dac)
@@ -122,14 +106,14 @@ namespace Microsoft.Diagnostics.Runtime
             if (IntPtr.Size != DataTarget.DataReader.PointerSize)
                 throw new InvalidOperationException("Mismatched architecture between this process and the dac.");
 
-            RuntimeFactory = new RuntimeBuilder(this, new DacLibrary(DataTarget, dac));
+            var factory = new RuntimeBuilder(this, new DacLibrary(DataTarget, dac));
             if (Flavor == ClrFlavor.Core)
-                return RuntimeFactory.GetOrCreateRuntime();
+                return factory.GetOrCreateRuntime();
 
             if (Version.Major < 4 || (Version.Major == 4 && Version.Minor == 5 && Version.Patch < 10000))
                 throw new NotSupportedException($"CLR version '{Version}' is not supported by ClrMD.  For Desktop CLR, only CLR 4.6 and beyond are supported.");
 
-            return RuntimeFactory.GetOrCreateRuntime();
+            return factory.GetOrCreateRuntime();
         }
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/src/Implementation/ClrmdHeap.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Implementation/ClrmdHeap.cs
@@ -88,7 +88,22 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
                 ClrObject result = new ClrObject(obj, type);
                 yield return result;
 
-                ulong size = result.Size;
+                ulong size;
+                if (type.ComponentSize == 0)
+                {
+                    size = (uint)type.BaseSize;
+                }
+                else
+                {
+                    _memoryReader.ReadDword(obj + (uint)IntPtr.Size, out uint count);
+                    
+                    // Strings in v4+ contain a trailing null terminator not accounted for.
+                    if (StringType == type)
+                        count++;
+
+                    size = count * (ulong)type.ComponentSize + (ulong)type.BaseSize;
+                }
+
                 size = Align(size, large);
                 if (size < minObjSize)
                     size = minObjSize;

--- a/src/Microsoft.Diagnostics.Runtime/src/Implementation/ClrmdRuntime.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Implementation/ClrmdRuntime.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
         private ClrAppDomain _sharedDomain;
         private bool _disposed;
 
+        public override bool IsThreadSafe => _helpers.Factory.IsThreadSafe && _helpers.DataReader.IsThreadSafe;
         public override DataTarget DataTarget => ClrInfo?.DataTarget;
         public override DacLibrary DacLibrary { get; }
         public override ClrInfo ClrInfo { get; }

--- a/src/Microsoft.Diagnostics.Runtime/src/Implementation/HeapWalkStep.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Implementation/HeapWalkStep.cs
@@ -1,0 +1,21 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+
+#pragma warning disable CA1721 // Property names should not match get methods
+
+namespace Microsoft.Diagnostics.Runtime.Implementation
+{
+    /// <summary>
+    /// This struct represents a single step in ClrmdHeap's heap walk.  This is used for diagnostic purposes.
+    /// </summary>
+    public struct HeapWalkStep
+    {
+        public ulong Address { get; set; }
+        public ulong MethodTable { get; set; }
+        public uint Count { get; set; }
+        public int BaseSize { get; set; }
+        public int ComponentSize { get; set; }
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/src/Implementation/ITypeFactory.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Implementation/ITypeFactory.cs
@@ -9,6 +9,8 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
 {
     public interface ITypeFactory : IDisposable
     {
+        bool IsThreadSafe { get; }
+
         ClrRuntime GetOrCreateRuntime();
         ClrHeap GetOrCreateHeap();
         ClrModule GetOrCreateModule(ClrAppDomain domain, ulong address);

--- a/src/Microsoft.Diagnostics.Runtime/src/Linux/LinuxLiveDataReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Linux/LinuxLiveDataReader.cs
@@ -51,6 +51,8 @@ namespace Microsoft.Diagnostics.Runtime.Linux
 
         public uint ProcessId { get; private set; }
 
+        public bool IsThreadSafe => false;
+
         public bool IsFullMemoryAvailable => true;
 
         public void Dispose()

--- a/src/Microsoft.Diagnostics.Runtime/src/Linux/LinuxLiveDataReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Linux/LinuxLiveDataReader.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Diagnostics.Runtime.Linux
 
         public uint ProcessId { get; private set; }
 
-        public bool IsMinidump => false;
+        public bool IsFullMemoryAvailable => true;
 
         public void Dispose()
         {


### PR DESCRIPTION
Initial implementation of support for parallel processing.  Not all data targets have been marked as threadsafe yet.  Only DbgEngDataReader and Windows's LiveDataReader are currently thread safe.

Note that we do _not_ expect to see any perf improvements by running ClrMD operations in parallel.  This is because the underlying diagnostics API mscordac*.dll takes a giant lock around any call we make, and many IDataTarget implementations will similarly need to take a lock around from the target.

Using ClrMD from multiple threads is primarily for convenience.  That is, not having to keep ClrMD locked to a single thread, you can now use it with in an async/await context, for example.  This also allows parallel processing for user code if you are in a scenario where you only need to read from the dac/data target a little and do a lot of processing yourself.