### PR TITLE
Implement caching options

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/CacheOptionsTest.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/CacheOptionsTest.cs
@@ -11,69 +11,70 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         [Fact]
         public void MethodCachingTest()
         {
-            {
-                // Test that when we cache method names they are not re-read
-                using DataTarget dt = TestTargets.Types.LoadFullDump();
-                dt.CacheOptions.CacheMethods = true;
+            // Test that when we cache method names they are not re-read
+            using DataTarget dt = TestTargets.Types.LoadFullDump();
+            dt.CacheOptions.CacheMethods = true;
 
-                // We want to make sure we are getting the same string because it was cached,
-                // not because it was interned
-                dt.CacheOptions.CacheMethodNames = StringCaching.Cache;
+            // We want to make sure we are getting the same string because it was cached,
+            // not because it was interned
+            dt.CacheOptions.CacheMethodNames = StringCaching.Cache;
 
-                using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
-                ClrModule module = runtime.GetModule("sharedlibrary.dll");
-                ClrType type = module.GetTypeByName("Foo");
-                ClrMethod method = type.GetMethod("Bar");
-                Assert.NotEqual(0ul, method.MethodDesc);  // Sanity test
+            using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
+            ClrModule module = runtime.GetModule("sharedlibrary.dll");
+            ClrType type = module.GetTypeByName("Foo");
+            ClrMethod method = type.GetMethod("Bar");
+            Assert.NotEqual(0ul, method.MethodDesc);  // Sanity test
 
-                ClrMethod method2 = type.GetMethod("Bar");
-                Assert.Equal(method, method2);
-                Assert.Same(method, method2);
-
-
-                string signature1 = method.Signature;
-                string signature2 = method2.Signature;
-                Assert.NotNull(signature1);
-                Assert.Equal(signature1, signature2);
-
-                Assert.Equal(signature1, method.Signature);
-                Assert.Same(signature1, method.Signature);
-            }
-
-            {
-                using DataTarget dt = TestTargets.Types.LoadFullDump();
-                dt.CacheOptions.CacheMethods = false;
-                dt.CacheOptions.CacheMethodNames = StringCaching.None;
-
-                using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
+            ClrMethod method2 = type.GetMethod("Bar");
+            Assert.Equal(method, method2);
+            Assert.Same(method, method2);
 
 
-                ClrModule module = runtime.GetModule("sharedlibrary.dll");
-                ClrType type = module.GetTypeByName("Foo");
-                ClrMethod method = type.GetMethod("Bar");
-                Assert.NotEqual(0ul, method.MethodDesc);  // Sanity test
+            string signature1 = method.Signature;
+            string signature2 = method2.Signature;
+            Assert.NotNull(signature1);
+            Assert.Equal(signature1, signature2);
 
-                ClrMethod method2 = type.GetMethod("Bar");
-                Assert.Equal(method, method2);
-                Assert.NotSame(method, method2);
+            Assert.Equal(signature1, method.Signature);
+            Assert.Same(signature1, method.Signature);
+        }
+
+        [Fact]
+        public void NoMethodCachingTest()
+        {
+            using DataTarget dt = TestTargets.Types.LoadFullDump();
+            dt.CacheOptions.CacheMethods = false;
+            dt.CacheOptions.CacheMethodNames = StringCaching.None;
+
+            using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
 
 
-                string signature1 = method.Signature;
-                string signature2 = method2.Signature;
-                Assert.NotNull(signature1);
-                Assert.Equal(signature1, signature2);
+            ClrModule module = runtime.GetModule("sharedlibrary.dll");
+            ClrType type = module.GetTypeByName("Foo");
+            ClrMethod method = type.GetMethod("Bar");
+            Assert.NotEqual(0ul, method.MethodDesc);  // Sanity test
 
-                Assert.Equal(signature1, method.Signature);
-                Assert.NotSame(signature1, method.Signature);
-                Assert.NotSame(method2.Signature, method.Signature);
+            ClrMethod method2 = type.GetMethod("Bar");
+            Assert.Equal(method, method2);
+            Assert.NotSame(method, method2);
 
-                // Ensure that we can swap this at runtime and that we get interned strings
-                dt.CacheOptions.CacheMethodNames = StringCaching.Intern;
 
-                Assert.NotNull(method.Signature);
-                Assert.Same(method2.Signature, method.Signature);
-                Assert.Same(method.Signature, string.Intern(method.Signature));
-            }
+            string signature1 = method.Signature;
+            string signature2 = method2.Signature;
+            Assert.NotNull(signature1);
+            Assert.Equal(signature1, signature2);
+
+            Assert.Equal(signature1, method.Signature);
+            Assert.NotSame(signature1, method.Signature);
+            Assert.NotSame(method2.Signature, method.Signature);
+
+            // Ensure that we can swap this at runtime and that we get interned strings
+            dt.CacheOptions.CacheMethodNames = StringCaching.Intern;
+
+            Assert.NotNull(method.Signature);
+            Assert.Same(method2.Signature, method.Signature);
+            Assert.Same(method.Signature, string.Intern(method.Signature));
+
         }
 
 
@@ -118,8 +119,6 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             Assert.Same(type.Name, type.Name);
             Assert.Same(type.Name, string.Intern(type.Name));
         }
-
-
 
         [Fact]
         public void FieldCachingTest()

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/CacheOptionsTest.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/CacheOptionsTest.cs
@@ -80,43 +80,93 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         [Fact]
         public void TypeCachingTest()
         {
-            {
-                using DataTarget dt = TestTargets.Types.LoadFullDump();
-                dt.CacheOptions.CacheTypes = true;
-                dt.CacheOptions.CacheTypeNames = StringCaching.Cache;
+            using DataTarget dt = TestTargets.Types.LoadFullDump();
+            dt.CacheOptions.CacheTypes = true;
+            dt.CacheOptions.CacheTypeNames = StringCaching.Cache;
 
-                using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
-                ClrModule module = runtime.GetModule("sharedlibrary.dll");
-                ClrType type = module.GetTypeByName("Foo");
-                Assert.NotEqual(0ul, type.MethodTable);  // Sanity test
+            using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
+            ClrModule module = runtime.GetModule("sharedlibrary.dll");
+            ClrType type = module.GetTypeByName("Foo");
+            Assert.NotEqual(0ul, type.MethodTable);  // Sanity test
 
-                Assert.Equal("Foo", type.Name);
-                Assert.NotSame("Foo", type.Name);
-                Assert.Same(type.Name, type.Name);
-            }
+            Assert.Equal("Foo", type.Name);
+            Assert.NotSame("Foo", type.Name);
+            Assert.Same(type.Name, type.Name);
+        }
 
-            {
-                using DataTarget dt = TestTargets.Types.LoadFullDump();
-                dt.CacheOptions.CacheTypes = false;
-                dt.CacheOptions.CacheTypeNames = StringCaching.None;
+        [Fact]
+        public void NoTypeCachingTest()
+        {
+            using DataTarget dt = TestTargets.Types.LoadFullDump();
+            dt.CacheOptions.CacheTypes = false;
+            dt.CacheOptions.CacheTypeNames = StringCaching.None;
 
-                using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
-                ClrModule module = runtime.GetModule("sharedlibrary.dll");
-                ClrType type = module.GetTypeByName("Foo");
-                Assert.NotEqual(0ul, type.MethodTable);  // Sanity test
+            using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
+            ClrModule module = runtime.GetModule("sharedlibrary.dll");
+            ClrType type = module.GetTypeByName("Foo");
+            Assert.NotEqual(0ul, type.MethodTable);  // Sanity test
 
-                ClrType type2 = runtime.GetTypeByMethodTable(type.MethodTable);
-                Assert.Equal(type, type2);
-                Assert.NotSame(type, type2);
+            ClrType type2 = runtime.GetTypeByMethodTable(type.MethodTable);
+            Assert.Equal(type, type2);
+            Assert.NotSame(type, type2);
 
-                Assert.NotNull(type.Name);
-                Assert.Equal(type.Name, type.Name);
-                Assert.NotSame(type.Name, type.Name);
+            Assert.NotNull(type.Name);
+            Assert.Equal(type.Name, type.Name);
+            Assert.NotSame(type.Name, type.Name);
 
-                dt.CacheOptions.CacheTypeNames = StringCaching.Intern;
-                Assert.Same(type.Name, type.Name);
-                Assert.Same(type.Name, string.Intern(type.Name));
-            }
+            dt.CacheOptions.CacheTypeNames = StringCaching.Intern;
+            Assert.Same(type.Name, type.Name);
+            Assert.Same(type.Name, string.Intern(type.Name));
+        }
+
+
+
+        [Fact]
+        public void FieldCachingTest()
+        {
+            using DataTarget dt = TestTargets.Types.LoadFullDump();
+            dt.CacheOptions.CacheFields = true;
+            dt.CacheOptions.CacheFieldNames = StringCaching.Cache;
+
+            using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
+            ClrModule module = runtime.GetModule("sharedlibrary.dll");
+            ClrType type = module.GetTypeByName("Foo");
+            Assert.NotEqual(0ul, type.MethodTable);  // Sanity test
+
+            Assert.Same(type.Fields, type.Fields);
+            Assert.Same(type.StaticFields, type.StaticFields);
+
+            ClrField field = type.GetFieldByName("o");
+            ClrField field2 = type.Fields.Single(f => f.Name == "o");
+
+            Assert.Same(field, field2);
+            Assert.Same(field.Name, field.Name);
+        }
+
+        [Fact]
+        public void NoFieldCachingTest()
+        {
+            using DataTarget dt = TestTargets.Types.LoadFullDump();
+            dt.CacheOptions.CacheFields = false;
+            dt.CacheOptions.CacheFieldNames = StringCaching.None;
+
+            using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
+            ClrModule module = runtime.GetModule("sharedlibrary.dll");
+            ClrType type = module.GetTypeByName("Foo");
+            Assert.NotEqual(0ul, type.MethodTable);  // Sanity test
+
+            Assert.NotSame(type.Fields, type.Fields);
+
+            ClrField field = type.GetFieldByName("o");
+            ClrField field2 = type.Fields.Single(f => f.Name == "o");
+
+            Assert.NotSame(field, field2);
+            Assert.NotSame(field.Name, field.Name);
+
+            dt.CacheOptions.CacheFieldNames = StringCaching.Intern;
+
+            Assert.Same(field.Name, field.Name);
+            Assert.Same(field.Name, string.Intern(field.Name));
         }
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/CacheOptionsTest.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/CacheOptionsTest.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Xunit;
+
+namespace Microsoft.Diagnostics.Runtime.Tests
+{
+    public class CacheOptionsTest
+    {
+        [Fact]
+        public void MethodCachingTest()
+        {
+            {
+                // Test that when we cache method names they are not re-read
+                using DataTarget dt = TestTargets.Types.LoadFullDump();
+                dt.CacheOptions.CacheMethods = true;
+
+                // We want to make sure we are getting the same string because it was cached,
+                // not because it was interned
+                dt.CacheOptions.CacheMethodNames = StringCaching.Cache;
+
+                using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
+                ClrModule module = runtime.GetModule("sharedlibrary.dll");
+                ClrType type = module.GetTypeByName("Foo");
+                ClrMethod method = type.GetMethod("Bar");
+                Assert.NotEqual(0ul, method.MethodDesc);  // Sanity test
+
+                ClrMethod method2 = type.GetMethod("Bar");
+                Assert.Equal(method, method2);
+                Assert.Same(method, method2);
+
+
+                string signature1 = method.Signature;
+                string signature2 = method2.Signature;
+                Assert.NotNull(signature1);
+                Assert.Equal(signature1, signature2);
+
+                Assert.Equal(signature1, method.Signature);
+                Assert.Same(signature1, method.Signature);
+            }
+
+            {
+                using DataTarget dt = TestTargets.Types.LoadFullDump();
+                dt.CacheOptions.CacheMethods = false;
+                dt.CacheOptions.CacheMethodNames = StringCaching.None;
+
+                using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
+
+
+                ClrModule module = runtime.GetModule("sharedlibrary.dll");
+                ClrType type = module.GetTypeByName("Foo");
+                ClrMethod method = type.GetMethod("Bar");
+                Assert.NotEqual(0ul, method.MethodDesc);  // Sanity test
+
+                ClrMethod method2 = type.GetMethod("Bar");
+                Assert.Equal(method, method2);
+                Assert.NotSame(method, method2);
+
+
+                string signature1 = method.Signature;
+                string signature2 = method2.Signature;
+                Assert.NotNull(signature1);
+                Assert.Equal(signature1, signature2);
+
+                Assert.Equal(signature1, method.Signature);
+                Assert.NotSame(signature1, method.Signature);
+                Assert.NotSame(method2.Signature, method.Signature);
+
+                // Ensure that we can swap this at runtime and that we get interned strings
+                dt.CacheOptions.CacheMethodNames = StringCaching.Intern;
+
+                Assert.NotNull(method.Signature);
+                Assert.Same(method2.Signature, method.Signature);
+                Assert.Same(method.Signature, string.Intern(method.Signature));
+            }
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/src/Builders/RuntimeBuilder.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Builders/RuntimeBuilder.cs
@@ -848,17 +848,19 @@ namespace Microsoft.Diagnostics.Runtime.Builders
             return new ClrmdMethod(type, builder);
         }
 
-        void ITypeFactory.CreateFieldsForType(ClrType type, out IReadOnlyList<ClrInstanceField> fields, out IReadOnlyList<ClrStaticField> statics)
+        bool ITypeFactory.CreateFieldsForType(ClrType type, out IReadOnlyList<ClrInstanceField> fields, out IReadOnlyList<ClrStaticField> statics)
         {
             CheckDisposed();
 
-            CreateFieldsForMethodTableWorker(type, out fields, out statics);
+            CreateFieldsForMethodTableWorker(type, out fields!, out statics!);
 
             fields ??= Array.Empty<ClrInstanceField>();
             statics ??= Array.Empty<ClrStaticField>();
+
+            return _options.CacheFields;
         }
 
-        private void CreateFieldsForMethodTableWorker(ClrType type, [NotNull] out IReadOnlyList<ClrInstanceField>? fields, [NotNull] out IReadOnlyList<ClrStaticField>? statics)
+        private void CreateFieldsForMethodTableWorker(ClrType type, out IReadOnlyList<ClrInstanceField>? fields, out IReadOnlyList<ClrStaticField>? statics)
         {
             CheckDisposed();
 
@@ -885,7 +887,8 @@ namespace Microsoft.Diagnostics.Runtime.Builders
             // Add base type's fields.
             if (type.BaseType != null)
             {
-                foreach (ClrInstanceField field in type.BaseType.Fields)
+                IReadOnlyList<ClrInstanceField> baseFields = type.BaseType.Fields;
+                foreach (ClrInstanceField field in baseFields)
                     fieldOut[fieldNum++] = field;
             }
 

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/CacheOptions.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/CacheOptions.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.Diagnostics.Runtime
+{
+    public sealed class CacheOptions
+    {
+        public bool CacheTypes { get; set; } = true;
+        public bool CacheFields { get; set; } = true;
+        public bool CacheMethods { get; set; } = true;
+
+        public bool CacheTypeNames { get; set; } = true;
+        public bool CacheFieldNames { get; set; } = true;
+        public bool CacheMethodNames { get; set; } = true;
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/CacheOptions.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/CacheOptions.cs
@@ -10,8 +10,8 @@ namespace Microsoft.Diagnostics.Runtime
         public bool CacheFields { get; set; } = true;
         public bool CacheMethods { get; set; } = true;
 
-        public bool CacheTypeNames { get; set; } = true;
-        public bool CacheFieldNames { get; set; } = true;
-        public bool CacheMethodNames { get; set; } = true;
+        public StringCaching CacheTypeNames { get; set; } = StringCaching.Cache;
+        public StringCaching CacheFieldNames { get; set; } = StringCaching.Cache;
+        public StringCaching CacheMethodNames { get; set; } = StringCaching.Cache;
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/ClrMethod.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/ClrMethod.cs
@@ -138,5 +138,39 @@ namespace Microsoft.Diagnostics.Runtime
         /// Returns whether this method is a static constructor.
         /// </summary>
         public virtual bool IsClassConstructor => Name == ".cctor";
+
+
+        public override bool Equals(object? obj)
+        {
+            if (obj is ClrMethod method)
+            {
+                if (MethodDesc == method.MethodDesc)
+                    return true;
+
+                // MethodDesc shouldn't be 0, but we should check the other way equality mechanism anyway.
+                if (MethodDesc == 0 && Type == method.Type && MetadataToken == method.MetadataToken)
+                    return true;
+
+                // Fall back to reference equality
+                return base.Equals(obj);
+            }
+
+            return false;
+        }
+
+        public override int GetHashCode() => MethodDesc.GetHashCode();
+
+        public static bool operator ==(ClrMethod? left, ClrMethod? right)
+        {
+            if (left is null)
+                return right is null;
+
+            return left.Equals(right);
+        }
+
+        public static bool operator !=(ClrMethod? left, ClrMethod? right)
+        {
+            return !(left == right);
+        }
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/StringCaching.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/StringCaching.cs
@@ -1,0 +1,33 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.Diagnostics.Runtime
+{
+    public enum StringCaching
+    {
+        /// <summary>
+        /// Do not cache the value at all.  This will result in drastically lower memory
+        /// usage at the cost of performance.
+        /// </summary>
+        None,
+
+        /// <summary>
+        /// Strings will be cached by the objects which hold them.  This will make repeated
+        /// requests to get the same value MUCH faster, but at the cost of holding on to
+        /// extra memory.
+        /// </summary>
+        Cache,
+
+        /// <summary>
+        /// Strings will be cached by the objects which hold them and they will also be
+        /// interned, ensuring that the same string value will not be kept alive by multiple
+        /// objects.  The danger here is that interned strings are never freed until the
+        /// AppDomain they live in is unloaded (or never for .Net Core).  Field names will
+        /// benefit from interning if you read a lot of fields for a lot of types.  It's
+        /// unlikely that method names or type names will benefit from interning unless
+        /// the same types are loaded into multiple AppDomains in the target process.
+        /// </summary>
+        Intern,
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac.cs
@@ -163,7 +163,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
                         return null;
                 }
 
-                return string.Intern(Encoding.Unicode.GetString(buffer, 0, (actuallyNeeded - 1) * 2));
+                return Encoding.Unicode.GetString(buffer, 0, (actuallyNeeded - 1) * 2);
             }
             finally
             {

--- a/src/Microsoft.Diagnostics.Runtime/src/DataTargets/DataTarget.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataTargets/DataTarget.cs
@@ -23,6 +23,7 @@ namespace Microsoft.Diagnostics.Runtime
     /// </summary>
     public sealed class DataTarget : IDisposable
     {
+        private SymbolLocator? _symbolLocator;
         private bool _disposed;
         private ClrInfo[]? _clrs;
         private ModuleInfo[]? _modules;
@@ -33,7 +34,7 @@ namespace Microsoft.Diagnostics.Runtime
         /// </summary>
         public IDataReader DataReader { get; }
 
-        private SymbolLocator? _symbolLocator;
+        public CacheOptions CacheOptions { get; } = new CacheOptions();
 
         /// <summary>
         /// Instance to manage the symbol path(s).

--- a/src/Microsoft.Diagnostics.Runtime/src/Implementation/ClrmdField.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Implementation/ClrmdField.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection;
 using Microsoft.Diagnostics.Runtime.Utilities;
@@ -29,8 +30,7 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
                 if (_name != null)
                     return _name;
 
-                InitData();
-                return _name;
+                return ReadData();
             }
         }
 
@@ -127,14 +127,30 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
             if (_attributes != FieldAttributes.ReservedMask)
                 return;
 
-            if (!_helpers.ReadProperties(Parent, Token, out _name, out _attributes, out SigParser sigParser))
-                return;
+            ReadData();
+        }
+
+        private string? ReadData()
+        {
+            if (!_helpers.ReadProperties(Parent, Token, out string? name, out _attributes, out SigParser sigParser))
+                return null;
+
+            StringCaching options = Parent.Heap.Runtime.DataTarget?.CacheOptions.CacheFieldNames ?? StringCaching.Cache;
+            if (name != null)
+            {
+                if (options == StringCaching.Intern)
+                    name = string.Intern(name);
+
+                if (options != StringCaching.None)
+                    _name = name;
+            }
 
             // We may have to try to construct a type from the sigParser if the method table was a bust in the constructor
             if (_type != null)
-                return;
+                return name;
 
             _type = GetTypeForFieldSig(_helpers.Factory, sigParser, Parent.Heap, Parent.Module);
+            return name;
         }
 
         internal static ClrType? GetTypeForFieldSig(ITypeFactory factory, SigParser sigParser, ClrHeap heap, ClrModule? module)
@@ -318,7 +334,8 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
                         return 1;
 
                     ClrField? last = null;
-                    foreach (ClrField field in type.Fields)
+                    IReadOnlyList<ClrInstanceField> fields = type.Fields;
+                    foreach (ClrField field in fields)
                     {
                         if (last is null)
                             last = field;

--- a/src/Microsoft.Diagnostics.Runtime/src/Implementation/ClrmdHeap.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Implementation/ClrmdHeap.cs
@@ -80,10 +80,10 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
             IsServer = heapBuilder.IsServer;
 
             // Prepopulate a few important method tables.  This should never fail.
-            StringType = _helpers.Factory.GetOrCreateType(this, heapBuilder.StringMethodTable, 0) ?? throw new InvalidOperationException("Failed to create string type");
-            ObjectType = _helpers.Factory.GetOrCreateType(this, heapBuilder.ObjectMethodTable, 0) ?? throw new InvalidOperationException("Failed to create object type");
-            FreeType = _helpers.Factory.GetOrCreateType(this, heapBuilder.FreeMethodTable, 0) ?? throw new InvalidOperationException("Failed to create Free type");
-            ExceptionType = _helpers.Factory.GetOrCreateType(this, heapBuilder.ExceptionMethodTable, 0) ?? throw new InvalidOperationException("Failed to create exception type");
+            FreeType = _helpers.Factory.CreateSystemType(this, heapBuilder.FreeMethodTable, "Free");
+            ObjectType = _helpers.Factory.CreateSystemType(this, heapBuilder.ObjectMethodTable, "System.Object");
+            StringType = _helpers.Factory.CreateSystemType(this, heapBuilder.StringMethodTable, "System.String");
+            ExceptionType = _helpers.Factory.CreateSystemType(this, heapBuilder.ExceptionMethodTable, "System.Exception");
 
             // Segments must be in sorted order.  We won't check all of them but we will at least check the beginning and end
             Segments = heapBuilder.CreateSegments(this, out IReadOnlyList<AllocationContext> allocContext, out _fqRoots, out _fqObjects);

--- a/src/Microsoft.Diagnostics.Runtime/src/Implementation/ClrmdType.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Implementation/ClrmdType.cs
@@ -31,7 +31,19 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
         private ClrElementType _elementType;
         private GCDesc _gcDesc;
 
-        public override string? Name => _name ??= Helpers.GetTypeName(MethodTable);
+        public override string? Name
+        {
+            get
+            {
+                if (_name != null)
+                    return _name;
+
+                if (Helpers.GetTypeName(MethodTable, out string? name))
+                    _name = name;
+
+                return name;
+            }
+        }
 
         public override int BaseSize { get; }
         public override int ComponentSize => 0;

--- a/src/Microsoft.Diagnostics.Runtime/src/Implementation/ClrmdType.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Implementation/ClrmdType.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
         private TypeAttributes _attributes;
         private ulong _loaderAllocatorHandle = ulong.MaxValue - 1;
 
-        private ClrMethod[]? _methods;
+        private IReadOnlyList<ClrMethod>? _methods;
         private IReadOnlyList<ClrInstanceField>? _fields;
         private IReadOnlyList<ClrStaticField>? _statics;
 
@@ -440,7 +440,21 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
             _statics ??= Array.Empty<ClrStaticField>();
         }
 
-        public override IReadOnlyList<ClrMethod> Methods => _methods ??= Helpers.Factory.CreateMethodsForType(this);
+        public override IReadOnlyList<ClrMethod> Methods
+        {
+            get
+            {
+                if (_methods != null)
+                    return _methods;
+
+                // Returns whether or not we should cache methods or not
+                if (Helpers.Factory.CreateMethodsForType(this, out IReadOnlyList<ClrMethod> methods))
+                    _methods = methods;
+
+                return methods;
+            }
+
+        }
 
         //TODO: remove
         public override ClrStaticField? GetStaticFieldByName(string name) => StaticFields.FirstOrDefault(f => f.Name == name);

--- a/src/Microsoft.Diagnostics.Runtime/src/Implementation/IMethodHelpers.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Implementation/IMethodHelpers.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
     {
         IDataReader DataReader { get; }
 
-        string? GetSignature(ulong methodDesc);
+        bool GetSignature(ulong methodDesc, out string? signature);
         IReadOnlyList<ILToNativeMap> GetILMap(ulong nativeCode, in HotColdRegions hotColdInfo);
         ulong GetILForModule(ulong address, uint rva);
     }

--- a/src/Microsoft.Diagnostics.Runtime/src/Implementation/ITypeFactory.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Implementation/ITypeFactory.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
         ClrRuntime GetOrCreateRuntime();
         ClrHeap GetOrCreateHeap();
         ClrModule GetOrCreateModule(ClrAppDomain domain, ulong address);
-        ClrMethod[] CreateMethodsForType(ClrType type);
+        bool CreateMethodsForType(ClrType type, out IReadOnlyList<ClrMethod> methods);
         void CreateFieldsForType(ClrType type, out IReadOnlyList<ClrInstanceField> fields, out IReadOnlyList<ClrStaticField> staticFields);
         ComCallWrapper? CreateCCWForObject(ulong obj);
         RuntimeCallableWrapper? CreateRCWForObject(ulong obj);

--- a/src/Microsoft.Diagnostics.Runtime/src/Implementation/ITypeFactory.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Implementation/ITypeFactory.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
         void CreateFieldsForType(ClrType type, out IReadOnlyList<ClrInstanceField> fields, out IReadOnlyList<ClrStaticField> staticFields);
         ComCallWrapper? CreateCCWForObject(ulong obj);
         RuntimeCallableWrapper? CreateRCWForObject(ulong obj);
+        ClrType CreateSystemType(ClrHeap heap, ulong mt, string kind);
         ClrType? GetOrCreateType(ClrHeap heap, ulong mt, ulong obj);
         ClrType? GetOrCreateType(ulong mt, ulong obj);
         ClrType GetOrCreateBasicType(ClrElementType basicType);

--- a/src/Microsoft.Diagnostics.Runtime/src/Implementation/ITypeFactory.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Implementation/ITypeFactory.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
         ClrHeap GetOrCreateHeap();
         ClrModule GetOrCreateModule(ClrAppDomain domain, ulong address);
         bool CreateMethodsForType(ClrType type, out IReadOnlyList<ClrMethod> methods);
-        void CreateFieldsForType(ClrType type, out IReadOnlyList<ClrInstanceField> fields, out IReadOnlyList<ClrStaticField> staticFields);
+        bool CreateFieldsForType(ClrType type, out IReadOnlyList<ClrInstanceField> fields, out IReadOnlyList<ClrStaticField> staticFields);
         ComCallWrapper? CreateCCWForObject(ulong obj);
         RuntimeCallableWrapper? CreateRCWForObject(ulong obj);
         ClrType CreateSystemType(ClrHeap heap, ulong mt, string kind);

--- a/src/Microsoft.Diagnostics.Runtime/src/Implementation/ITypeHelpers.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Implementation/ITypeHelpers.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
         ITypeFactory Factory { get; }
         IClrObjectHelpers ClrObjectHelpers { get; }
 
-        string? GetTypeName(ulong mt);
+        bool GetTypeName(ulong mt, out string? name);
         ulong GetLoaderAllocatorHandle(ulong mt);
 
         // TODO: Should not expose this:


### PR DESCRIPTION
We need to give users a mechanism to tell ClrMD what to cache and what not to.  This change gives the user the ability to choose whether ClrMethods, ClrTypes, and Clr*Fields (and their respective names) get cached or are regenerated on every call.  The default behavior remains unchanged: All types are cached by default and all names are cached (but not interned) by default.

I may need to rewrite how we get fields, in only creating instance/static fields individually instead of both at the same time when we aren't going to cache the result.  In general though, I'm not super concerned about that right now, since not caching fields is going to be super slow anyway. 