### PR TITLE
Stop using ConcurrentBag

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/src/Builders/FieldBuilder.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Builders/FieldBuilder.cs
@@ -10,10 +10,10 @@ namespace Microsoft.Diagnostics.Runtime.Builders
 {
     internal class FieldBuilder : IFieldData, IDisposable
     {
-        private readonly SOSDac _sos;
+        private IFieldHelpers? _helpers;
         private FieldData _fieldData;
 
-        public IFieldHelpers Helpers { get; }
+        public IFieldHelpers Helpers => _helpers!;
 
         public ClrElementType ElementType => (ClrElementType)_fieldData.ElementType;
 
@@ -31,16 +31,15 @@ namespace Microsoft.Diagnostics.Runtime.Builders
         public bool IsStatic => _fieldData.IsStatic != 0;
         public bool IsThreadLocal => _fieldData.IsThreadLocal != 0;
 
-        public FieldBuilder(SOSDac sos, IFieldHelpers helpers)
+        internal bool Init(SOSDac sos, ulong fieldDesc, IFieldHelpers helpers)
         {
-            _sos = sos;
-            Helpers = helpers;
+            _helpers = helpers;
+            return sos.GetFieldData(fieldDesc, out _fieldData);
         }
-
-        internal bool Init(ulong fieldDesc) => _sos.GetFieldData(fieldDesc, out _fieldData);
 
         public void Dispose()
         {
+            _helpers = null;
             var owner = Owner;
             Owner = null;
             owner?.Return(this);

--- a/src/Microsoft.Diagnostics.Runtime/src/Builders/ObjectPool.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Builders/ObjectPool.cs
@@ -3,34 +3,36 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Concurrent;
+using System.Collections.Generic;
 
 namespace Microsoft.Diagnostics.Runtime.Builders
 {
     internal sealed class ObjectPool<T>
+        where T : new()
     {
-        private readonly ConcurrentBag<T> _bag = new ConcurrentBag<T>();
-        private readonly Func<T> _generator;
+        private readonly Queue<T> _bag = new Queue<T>();
         private readonly Action<ObjectPool<T>, T> _setOwner;
 
-        public ObjectPool(Func<T> generator, Action<ObjectPool<T>, T> setOwner)
+        public ObjectPool(Action<ObjectPool<T>, T> setOwner)
         {
-            _generator = generator;
             _setOwner = setOwner;
         }
 
         public T Rent()
         {
-            if (!_bag.TryTake(out T result))
-                result = _generator();
+            lock (_bag)
+                if (_bag.Count > 0)
+                    return _bag.Dequeue();
 
+            T result = new T();
             _setOwner(this, result);
             return result;
         }
 
         public void Return(T t)
         {
-            _bag.Add(t);
+            lock (_bag)
+                _bag.Enqueue(t);
         }
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/src/Builders/TypeBuilder.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Builders/TypeBuilder.cs
@@ -11,26 +11,21 @@ namespace Microsoft.Diagnostics.Runtime.Builders
     internal class TypeBuilder : ITypeData, IDisposable
     {
         private MethodTableData _mtData;
-        private readonly SOSDac _sos;
+        private ITypeHelpers? _helpers;
 
-        public TypeBuilder(SOSDac sos, ITypeHelpers helpers)
+        public bool Init(SOSDac sos, ulong methodTable, ITypeHelpers helpers)
         {
-            _sos = sos;
-            Helpers = helpers;
-        }
-
-        public bool Init(ulong methodTable)
-        {
-            MethodTable = methodTable;
-            if (!_sos.GetMethodTableData(MethodTable, out _mtData))
+            if (!sos.GetMethodTableData(methodTable, out _mtData))
                 return false;
 
+            MethodTable = methodTable;
+            _helpers = helpers;
             return true;
         }
 
         public ObjectPool<TypeBuilder>? Owner { get; set; }
 
-        public ITypeHelpers Helpers { get; }
+        public ITypeHelpers Helpers => _helpers!;
         public bool IsShared => _mtData.Shared != 0;
         public uint Token => _mtData.Token;
         public ulong MethodTable { get; private set; }
@@ -46,6 +41,7 @@ namespace Microsoft.Diagnostics.Runtime.Builders
         {
             var owner = Owner;
             Owner = null;
+            _helpers = null;
             owner?.Return(this);
         }
     }


### PR DESCRIPTION
Thread static fields keep ConcurrentBag alive too long.  This lead to fast growing memory leaks.

We don't need something as heavyweight as ConcurrentBag.  A queue with a lock is just fine.