### PR TITLE
Fix sign extension issues

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/src/Builders/RuntimeBuilder.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Builders/RuntimeBuilder.cs
@@ -136,7 +136,7 @@ namespace Microsoft.Diagnostics.Runtime.Builders
             SegmentBuilder segBuilder = new SegmentBuilder(_sos);
             if (clrHeap.IsServer)
             {
-                ulong[] heapList = _sos.GetHeapList(clrHeap.LogicalHeapCount);
+                ClrDataAddress[] heapList = _sos.GetHeapList(clrHeap.LogicalHeapCount);
                 for (int i = 0; i < heapList.Length; i++)
                 {
                     segBuilder.LogicalHeap = i;
@@ -430,7 +430,7 @@ namespace Microsoft.Diagnostics.Runtime.Builders
             if (builder.SharedDomain != 0)
                 shared = GetOrCreateAppDomain(builder, builder.SharedDomain);
 
-            ulong[] domainList = _sos.GetAppDomainList(builder.AppDomainCount);
+            ClrDataAddress[] domainList = _sos.GetAppDomainList(builder.AppDomainCount);
             ClrAppDomain[] result = new ClrAppDomain[domainList.Length];
 
             int i = 0;

--- a/src/Microsoft.Diagnostics.Runtime/src/DacInterface/ClrDataAddress.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DacInterface/ClrDataAddress.cs
@@ -1,0 +1,50 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Microsoft.Diagnostics.Runtime.DacInterface
+{
+
+    /// <summary>
+    /// A representation of CLR's CLRDATA_ADDRESS, which is a signed 64bit integer.
+    /// Unfortuantely this can cause issues when inspecting 32bit processes, since
+    /// if the highest bit is set the value will be sign-extended.  This struct is
+    /// meant to 
+    /// </summary>
+    public struct ClrDataAddress
+    {
+        /// <summary>
+        /// Raw value of this address.  May be sign-extended if inspecting a 32bit process.
+        /// </summary>
+        public long Value { get; }
+
+        /// <summary>
+        /// Creates an instance of ClrDataAddress.
+        /// </summary>
+        /// <param name="value"></param>
+        public ClrDataAddress(long value)
+        {
+            Value = value;
+        }
+
+        /// <summary>
+        /// Returns the value of this address and un-sign extends the value if appropriate.
+        /// </summary>
+        /// <param name="cda">The address to convert.</param>
+        public static implicit operator ulong(ClrDataAddress cda) => cda.AsUInt64();
+
+        /// <summary>
+        /// Returns the value of this address and un-sign extends the value if appropriate.
+        /// </summary>
+        /// <returns>The value of this address and un-sign extends the value if appropriate.</returns>
+        private ulong AsUInt64()
+        {
+            if (IntPtr.Size == 4)
+                return (uint)Value;
+
+            return (ulong)Value;
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/src/DacInterface/ClrStackWalk.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DacInterface/ClrStackWalk.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
         {
         }
 
-        public ulong GetFrameVtable()
+        public ClrDataAddress GetFrameVtable()
         {
             InitDelegate(ref _request, VTable->Request);
 
@@ -35,11 +35,11 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             int hr = _request(Self, 0xf0000000, 0, null, 8u, ptrBuffer);
             if (hr == S_OK)
             {
-                ulong result = Unsafe.ReadUnaligned<ulong>(ptrBuffer);
+                ClrDataAddress result = new ClrDataAddress(Unsafe.ReadUnaligned<long>(ptrBuffer));
                 return result;
             }
 
-            return 0;
+            return default;
         }
 
         public bool Next()

--- a/src/Microsoft.Diagnostics.Runtime/src/DacInterface/DacDataTargetWrapper.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DacInterface/DacDataTargetWrapper.cs
@@ -121,8 +121,9 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             return E_FAIL;
         }
 
-        public int ReadVirtual(IntPtr self, ulong address, IntPtr buffer, int bytesRequested, out int bytesRead)
+        public int ReadVirtual(IntPtr _, ClrDataAddress cda, IntPtr buffer, int bytesRequested, out int bytesRead)
         {
+            ulong address = cda;
             Span<byte> span = new Span<byte>(buffer.ToPointer(), bytesRequested);
 
             if (address == MagicCallbackConstant && _callbackContext > 0)
@@ -174,7 +175,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             return E_FAIL;
         }
 
-        public int WriteVirtual(IntPtr self, ulong address, IntPtr buffer, uint bytesRequested, out uint bytesWritten)
+        public int WriteVirtual(IntPtr self, ClrDataAddress address, IntPtr buffer, uint bytesRequested, out uint bytesWritten)
         {
             // This gets used by MemoryBarrier() calls in the dac, which really shouldn't matter what we do here.
             bytesWritten = bytesRequested;
@@ -203,7 +204,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             return E_FAIL;
         }
 
-        public int SetTLSValue(IntPtr self, uint threadID, uint index, ulong value)
+        public int SetTLSValue(IntPtr self, uint threadID, uint index, ClrDataAddress value)
         {
             return E_FAIL;
         }
@@ -308,7 +309,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
         [UnmanagedFunctionPointer(CallingConvention.StdCall)]
         private delegate int ReadVirtualDelegate(
             IntPtr self,
-            ulong address,
+            ClrDataAddress address,
             IntPtr buffer,
             int bytesRequested,
             out int bytesRead);
@@ -316,7 +317,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
         [UnmanagedFunctionPointer(CallingConvention.StdCall)]
         private delegate int WriteVirtualDelegate(
             IntPtr self,
-            ulong address,
+            ClrDataAddress address,
             IntPtr buffer,
             uint bytesRequested,
             out uint bytesWritten);
@@ -333,7 +334,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             IntPtr self,
             uint threadID,
             uint index,
-            ulong value);
+            ClrDataAddress value);
 
         [UnmanagedFunctionPointer(CallingConvention.StdCall)]
         private delegate int GetCurrentThreadIDDelegate(IntPtr self, out uint threadID);

--- a/src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac.cs
@@ -126,13 +126,13 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             return uint.MaxValue;
         }
 
-        public ulong GetThreadFromThinlockId(uint id)
+        public ClrDataAddress GetThreadFromThinlockId(uint id)
         {
             InitDelegate(ref _getThreadFromThinlockId, VTable->GetThreadFromThinlockID);
-            if (_getThreadFromThinlockId(Self, id, out ulong thread) == S_OK)
+            if (_getThreadFromThinlockId(Self, id, out ClrDataAddress thread) == S_OK)
                 return thread;
 
-            return 0;
+            return default;
         }
 
         public string? GetMethodDescName(ulong md)
@@ -282,22 +282,22 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             return hr == S_OK;
         }
 
-        public ulong GetMethodDescPtrFromFrame(ulong frame)
+        public ClrDataAddress GetMethodDescPtrFromFrame(ulong frame)
         {
             InitDelegate(ref _getMethodDescPtrFromFrame, VTable->GetMethodDescPtrFromFrame);
-            if (_getMethodDescPtrFromFrame(Self, frame, out ulong data) == S_OK)
+            if (_getMethodDescPtrFromFrame(Self, frame, out ClrDataAddress data) == S_OK)
                 return data;
 
-            return 0;
+            return default;
         }
 
-        public ulong GetMethodDescPtrFromIP(ulong frame)
+        public ClrDataAddress GetMethodDescPtrFromIP(ulong frame)
         {
             InitDelegate(ref _getMethodDescPtrFromIP, VTable->GetMethodDescPtrFromIP);
-            if (_getMethodDescPtrFromIP(Self, frame, out ulong data) == S_OK)
+            if (_getMethodDescPtrFromIP(Self, frame, out ClrDataAddress data) == S_OK)
                 return data;
 
-            return 0;
+            return default;
         }
 
         public string GetFrameName(ulong vtable)
@@ -368,12 +368,12 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             return _getCommonMethodTables(Self, out commonMTs) == S_OK;
         }
 
-        public ulong[] GetAssemblyList(ulong appDomain)
+        public ClrDataAddress[] GetAssemblyList(ulong appDomain)
         {
             return GetAssemblyList(appDomain, 0);
         }
 
-        public ulong[] GetAssemblyList(ulong appDomain, int count)
+        public ClrDataAddress[] GetAssemblyList(ulong appDomain, int count)
         {
             return GetModuleOrAssembly(appDomain, count, ref _getAssemblyList, VTable->GetAssemblyList);
         }
@@ -502,13 +502,13 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             }
         }
 
-        public ulong GetMethodTableByEEClass(ulong eeclass)
+        public ClrDataAddress GetMethodTableByEEClass(ulong eeclass)
         {
             InitDelegate(ref _getMTForEEClass, VTable->GetMethodTableForEEClass);
-            if (_getMTForEEClass(Self, eeclass, out ulong data) == S_OK)
+            if (_getMTForEEClass(Self, eeclass, out ClrDataAddress data) == S_OK)
                 return data;
 
-            return 0;
+            return default;
         }
 
         public bool GetModuleData(ulong module, out ModuleData data)
@@ -518,17 +518,17 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             return SUCCEEDED(hr);
         }
 
-        public ulong[] GetModuleList(ulong assembly)
+        public ClrDataAddress[] GetModuleList(ulong assembly)
         {
             return GetModuleList(assembly, 0);
         }
 
-        public ulong[] GetModuleList(ulong assembly, int count)
+        public ClrDataAddress[] GetModuleList(ulong assembly, int count)
         {
             return GetModuleOrAssembly(assembly, count, ref _getModuleList, VTable->GetAssemblyModuleList);
         }
 
-        private ulong[] GetModuleOrAssembly(ulong address, int count, ref DacGetUlongArrayWithArg? func, IntPtr vtableEntry)
+        private ClrDataAddress[] GetModuleOrAssembly(ulong address, int count, ref DacGetUlongArrayWithArg? func, IntPtr vtableEntry)
         {
             InitDelegate(ref func, vtableEntry);
 
@@ -536,33 +536,33 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             if (count <= 0)
             {
                 if (func(Self, address, 0, null, out needed) < 0)
-                    return Array.Empty<ulong>();
+                    return Array.Empty<ClrDataAddress>();
 
                 count = needed;
             }
 
             // We ignore the return value here since the list may be partially filled
-            ulong[] modules = new ulong[count];
+            ClrDataAddress[] modules = new ClrDataAddress[count];
             func(Self, address, modules.Length, modules, out needed);
 
             return modules;
         }
 
-        public ulong[] GetAppDomainList(int count = 0)
+        public ClrDataAddress[] GetAppDomainList(int count = 0)
         {
             InitDelegate(ref _getAppDomainList, VTable->GetAppDomainList);
 
             if (count <= 0)
             {
                 if (!GetAppDomainStoreData(out AppDomainStoreData addata))
-                    return Array.Empty<ulong>();
+                    return Array.Empty<ClrDataAddress>();
 
                 count = addata.AppDomainCount;
             }
 
-            ulong[] data = new ulong[count];
+            ClrDataAddress[] data = new ClrDataAddress[count];
             int hr = _getAppDomainList(Self, data.Length, data, out int needed);
-            return hr == S_OK ? data : Array.Empty<ulong>();
+            return hr == S_OK ? data : Array.Empty<ClrDataAddress>();
         }
 
         public bool GetThreadData(ulong address, out ThreadData data)
@@ -592,13 +592,13 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             return SUCCEEDED(hr);
         }
 
-        public ulong[] GetHeapList(int heapCount)
+        public ClrDataAddress[] GetHeapList(int heapCount)
         {
             InitDelegate(ref _getGCHeapList, VTable->GetGCHeapList);
 
-            ulong[] refs = new ulong[heapCount];
+            ClrDataAddress[] refs = new ClrDataAddress[heapCount];
             int hr = _getGCHeapList(Self, heapCount, refs, out int needed);
-            return hr == S_OK ? refs : Array.Empty<ulong>();
+            return hr == S_OK ? refs : Array.Empty<ClrDataAddress>();
         }
 
         public bool GetServerHeapDetails(ulong addr, out HeapDetails data)
@@ -726,7 +726,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
         private delegate int DacGetIntPtr(IntPtr self, out IntPtr data);
 
         [UnmanagedFunctionPointer(CallingConvention.StdCall)]
-        private delegate int DacGetUlongWithArg(IntPtr self, ulong arg, out ulong data);
+        private delegate int DacGetUlongWithArg(IntPtr self, ulong arg, out ClrDataAddress data);
 
         [UnmanagedFunctionPointer(CallingConvention.StdCall)]
         private delegate int DacGetUlongWithArgs(IntPtr self, ulong arg, uint id, out ulong data);
@@ -747,10 +747,10 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
         private delegate int DacGetHeapDetails(IntPtr self, out HeapDetails data);
 
         [UnmanagedFunctionPointer(CallingConvention.StdCall)]
-        private delegate int DacGetUlongArray(IntPtr self, int count, [Out] ulong[] values, out int needed);
+        private delegate int DacGetUlongArray(IntPtr self, int count, [Out] ClrDataAddress[] values, out int needed);
 
         [UnmanagedFunctionPointer(CallingConvention.StdCall)]
-        private delegate int DacGetUlongArrayWithArg(IntPtr self, ulong arg, int count, [Out] ulong[]? values, out int needed);
+        private delegate int DacGetUlongArrayWithArg(IntPtr self, ulong arg, int count, [Out] ClrDataAddress[]? values, out int needed);
 
         [UnmanagedFunctionPointer(CallingConvention.StdCall)]
         private delegate int DacGetCharArrayWithArg(IntPtr self, ulong arg, int count, [Out] byte[]? values, [Out] out int needed);
@@ -819,7 +819,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
         private delegate int DacGetLocalModuleData(IntPtr self, ulong addr, out DomainLocalModuleData data);
 
         [UnmanagedFunctionPointer(CallingConvention.StdCall)]
-        private delegate int DacGetThreadFromThinLock(IntPtr self, uint id, out ulong data);
+        private delegate int DacGetThreadFromThinLock(IntPtr self, uint id, out ClrDataAddress data);
 
         [UnmanagedFunctionPointer(CallingConvention.StdCall)]
         private delegate int DacGetCodeHeaps(IntPtr self, ulong addr, int count, [Out] JitCodeHeapInfo[]? values, out int needed);

--- a/src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac.cs
@@ -574,12 +574,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             }
 
             InitDelegate(ref _getThreadData, VTable->GetThreadData);
-
             int hr = _getThreadData(Self, address, out data);
-
-            if (IntPtr.Size == 4)
-                ThreadData.Fixup(ref data);
-
             return SUCCEEDED(hr);
         }
 
@@ -594,8 +589,6 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
         {
             InitDelegate(ref _getSegmentData, VTable->GetHeapSegmentData);
             int hr = _getSegmentData(Self, addr, out data);
-            if (hr == 0 && IntPtr.Size == 4)
-                data = new SegmentData(ref data);
             return SUCCEEDED(hr);
         }
 
@@ -613,9 +606,6 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             InitDelegate(ref _getGCHeapDetails, VTable->GetGCHeapDetails);
             int hr = _getGCHeapDetails(Self, addr, out data);
 
-            if (IntPtr.Size == 4)
-                data = new HeapDetails(ref data);
-
             return SUCCEEDED(hr);
         }
 
@@ -623,9 +613,6 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
         {
             InitDelegate(ref _getGCHeapStaticData, VTable->GetGCHeapStaticData);
             int hr = _getGCHeapStaticData(Self, out data);
-
-            if (IntPtr.Size == 4)
-                data = new HeapDetails(ref data);
             return SUCCEEDED(hr);
         }
 

--- a/src/Microsoft.Diagnostics.Runtime/src/DacInterface/Structs/AppDomainData.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DacInterface/Structs/AppDomainData.cs
@@ -9,13 +9,13 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
     [StructLayout(LayoutKind.Sequential)]
     public readonly struct AppDomainData
     {
-        public readonly ulong Address;
-        public readonly ulong SecurityDescriptor;
-        public readonly ulong LowFrequencyHeap;
-        public readonly ulong HighFrequencyHeap;
-        public readonly ulong StubHeap;
-        public readonly ulong DomainLocalBlock;
-        public readonly ulong DomainLocalModules;
+        public readonly ClrDataAddress Address;
+        public readonly ClrDataAddress SecurityDescriptor;
+        public readonly ClrDataAddress LowFrequencyHeap;
+        public readonly ClrDataAddress HighFrequencyHeap;
+        public readonly ClrDataAddress StubHeap;
+        public readonly ClrDataAddress DomainLocalBlock;
+        public readonly ClrDataAddress DomainLocalModules;
         public readonly int Id;
         public readonly int AssemblyCount;
         public readonly int FailedAssemblyCount;

--- a/src/Microsoft.Diagnostics.Runtime/src/DacInterface/Structs/AppDomainStoreData.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DacInterface/Structs/AppDomainStoreData.cs
@@ -9,8 +9,8 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
     [StructLayout(LayoutKind.Sequential)]
     public readonly struct AppDomainStoreData
     {
-        public readonly ulong SharedDomain;
-        public readonly ulong SystemDomain;
+        public readonly ClrDataAddress SharedDomain;
+        public readonly ClrDataAddress SystemDomain;
         public readonly int AppDomainCount;
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/src/DacInterface/Structs/AssemblyData.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DacInterface/Structs/AssemblyData.cs
@@ -9,11 +9,11 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
     [StructLayout(LayoutKind.Sequential)]
     public readonly struct AssemblyData
     {
-        public readonly ulong Address;
-        public readonly ulong ClassLoader;
-        public readonly ulong ParentDomain;
-        public readonly ulong AppDomain;
-        public readonly ulong AssemblySecurityDescriptor;
+        public readonly ClrDataAddress Address;
+        public readonly ClrDataAddress ClassLoader;
+        public readonly ClrDataAddress ParentDomain;
+        public readonly ClrDataAddress AppDomain;
+        public readonly ClrDataAddress AssemblySecurityDescriptor;
         public readonly int Dynamic;
         public readonly int ModuleCount;
         public readonly uint LoadContext;

--- a/src/Microsoft.Diagnostics.Runtime/src/DacInterface/Structs/CcwData.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DacInterface/Structs/CcwData.cs
@@ -9,10 +9,10 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
     [StructLayout(LayoutKind.Sequential)]
     public readonly struct CCWData
     {
-        public readonly ulong OuterIUnknown;
-        public readonly ulong ManagedObject;
-        public readonly ulong Handle;
-        public readonly ulong CCWAddress;
+        public readonly ClrDataAddress OuterIUnknown;
+        public readonly ClrDataAddress ManagedObject;
+        public readonly ClrDataAddress Handle;
+        public readonly ClrDataAddress CCWAddress;
 
         public readonly int RefCount;
         public readonly int InterfaceCount;

--- a/src/Microsoft.Diagnostics.Runtime/src/DacInterface/Structs/CodeHeaderData.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DacInterface/Structs/CodeHeaderData.cs
@@ -9,12 +9,12 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
     [StructLayout(LayoutKind.Sequential)]
     public readonly struct CodeHeaderData
     {
-        public readonly ulong GCInfo;
+        public readonly ClrDataAddress GCInfo;
         public readonly uint JITType;
-        public readonly ulong MethodDesc;
-        public readonly ulong MethodStart;
+        public readonly ClrDataAddress MethodDesc;
+        public readonly ClrDataAddress MethodStart;
         public readonly uint MethodSize;
-        public readonly ulong ColdRegionStart;
+        public readonly ClrDataAddress ColdRegionStart;
         public readonly uint ColdRegionSize;
         public readonly uint HotRegionSize;
     }

--- a/src/Microsoft.Diagnostics.Runtime/src/DacInterface/Structs/ComInterfacePointerData.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DacInterface/Structs/ComInterfacePointerData.cs
@@ -9,8 +9,8 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
     [StructLayout(LayoutKind.Sequential)]
     public readonly struct COMInterfacePointerData
     {
-        public readonly ulong MethodTable;
-        public readonly ulong InterfacePointer;
-        public readonly ulong ComContext;
+        public readonly ClrDataAddress MethodTable;
+        public readonly ClrDataAddress InterfacePointer;
+        public readonly ClrDataAddress ComContext;
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/src/DacInterface/Structs/CommonMethodTables.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DacInterface/Structs/CommonMethodTables.cs
@@ -9,19 +9,10 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
     [StructLayout(LayoutKind.Sequential)]
     public readonly struct CommonMethodTables
     {
-        public readonly ulong ArrayMethodTable;
-        public readonly ulong StringMethodTable;
-        public readonly ulong ObjectMethodTable;
-        public readonly ulong ExceptionMethodTable;
-        public readonly ulong FreeMethodTable;
-
-        internal bool Validate()
-        {
-            return ArrayMethodTable != 0 &&
-                StringMethodTable != 0 &&
-                ObjectMethodTable != 0 &&
-                ExceptionMethodTable != 0 &&
-                FreeMethodTable != 0;
-        }
+        public readonly ClrDataAddress ArrayMethodTable;
+        public readonly ClrDataAddress StringMethodTable;
+        public readonly ClrDataAddress ObjectMethodTable;
+        public readonly ClrDataAddress ExceptionMethodTable;
+        public readonly ClrDataAddress FreeMethodTable;
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/src/DacInterface/Structs/DomainLocalModuleData.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DacInterface/Structs/DomainLocalModuleData.cs
@@ -9,12 +9,12 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
     [StructLayout(LayoutKind.Sequential)]
     public readonly struct DomainLocalModuleData
     {
-        public readonly ulong AppDomainAddress;
+        public readonly ClrDataAddress AppDomainAddress;
         public readonly ulong ModuleID;
 
-        public readonly ulong ClassData;
-        public readonly ulong DynamicClassTable;
-        public readonly ulong GCStaticDataStart;
-        public readonly ulong NonGCStaticDataStart;
+        public readonly ClrDataAddress ClassData;
+        public readonly ClrDataAddress DynamicClassTable;
+        public readonly ClrDataAddress GCStaticDataStart;
+        public readonly ClrDataAddress NonGCStaticDataStart;
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/src/DacInterface/Structs/FieldData.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DacInterface/Structs/FieldData.cs
@@ -11,15 +11,15 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
     {
         public readonly uint ElementType; // CorElementType
         public readonly uint SigType; // CorElementType
-        public readonly ulong TypeMethodTable; // NULL if Type is not loaded
-        public readonly ulong TypeModule;
+        public readonly ClrDataAddress TypeMethodTable; // NULL if Type is not loaded
+        public readonly ClrDataAddress TypeModule;
         public readonly uint TypeToken;
         public readonly uint FieldToken;
-        public readonly ulong MTOfEnclosingClass;
+        public readonly ClrDataAddress MTOfEnclosingClass;
         public readonly uint Offset;
         public readonly uint IsThreadLocal;
         public readonly uint IsContextLocal;
         public readonly uint IsStatic;
-        public readonly ulong NextField;
+        public readonly ClrDataAddress NextField;
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/src/DacInterface/Structs/GenerationData.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DacInterface/Structs/GenerationData.cs
@@ -10,29 +10,11 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
     [StructLayout(LayoutKind.Sequential)]
     public readonly struct GenerationData
     {
-        public readonly ulong StartSegment;
-        public readonly ulong AllocationStart;
+        public readonly ClrDataAddress StartSegment;
+        public readonly ClrDataAddress AllocationStart;
 
         // These are examined only for generation 0, otherwise NULL
-        public readonly ulong AllocationContextPointer;
-        public readonly ulong AllocationContextLimit;
-
-        internal GenerationData(ref GenerationData other)
-        {
-            this = other;
-
-            if (IntPtr.Size == 4)
-            {
-                FixupPointer(ref StartSegment);
-                FixupPointer(ref AllocationStart);
-                FixupPointer(ref AllocationContextPointer);
-                FixupPointer(ref AllocationContextLimit);
-            }
-        }
-
-        private static void FixupPointer(ref ulong ptr)
-        {
-            ptr = (uint)ptr;
-        }
+        public readonly ClrDataAddress AllocationContextPointer;
+        public readonly ClrDataAddress AllocationContextLimit;
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/src/DacInterface/Structs/HandleData.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DacInterface/Structs/HandleData.cs
@@ -9,9 +9,9 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
     [StructLayout(LayoutKind.Sequential)]
     public readonly struct HandleData
     {
-        public readonly ulong AppDomain;
-        public readonly ulong Handle;
-        public readonly ulong Secondary;
+        public readonly ClrDataAddress AppDomain;
+        public readonly ClrDataAddress Handle;
+        public readonly ClrDataAddress Secondary;
         public readonly uint Type;
         public readonly uint StrongReference;
 

--- a/src/Microsoft.Diagnostics.Runtime/src/DacInterface/Structs/HeapDetails.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DacInterface/Structs/HeapDetails.cs
@@ -10,65 +10,28 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
     [StructLayout(LayoutKind.Sequential)]
     public readonly struct HeapDetails
     {
-        public readonly ulong Address; // Only filled in in server mode, otherwise NULL
-        public readonly ulong Allocated;
-        public readonly ulong MarkArray;
-        public readonly ulong CAllocateLH;
-        public readonly ulong NextSweepObj;
-        public readonly ulong SavedSweepEphemeralSeg;
-        public readonly ulong SavedSweepEphemeralStart;
-        public readonly ulong BackgroundSavedLowestAddress;
-        public readonly ulong BackgroundSavedHighestAddress;
+        public readonly ClrDataAddress Address; // Only filled in in server mode, otherwise NULL
+        public readonly ClrDataAddress Allocated;
+        public readonly ClrDataAddress MarkArray;
+        public readonly ClrDataAddress CAllocateLH;
+        public readonly ClrDataAddress NextSweepObj;
+        public readonly ClrDataAddress SavedSweepEphemeralSeg;
+        public readonly ClrDataAddress SavedSweepEphemeralStart;
+        public readonly ClrDataAddress BackgroundSavedLowestAddress;
+        public readonly ClrDataAddress BackgroundSavedHighestAddress;
 
         [MarshalAs(UnmanagedType.ByValArray, SizeConst = 4)]
         public readonly GenerationData[] GenerationTable;
         public readonly ulong EphemeralHeapSegment;
 
         [MarshalAs(UnmanagedType.ByValArray, SizeConst = 7)]
-        public readonly ulong[] FinalizationFillPointers;
-        public readonly ulong LowestAddress;
-        public readonly ulong HighestAddress;
-        public readonly ulong CardTable;
+        public readonly ClrDataAddress[] FinalizationFillPointers;
+        public readonly ClrDataAddress LowestAddress;
+        public readonly ClrDataAddress HighestAddress;
+        public readonly ClrDataAddress CardTable;
 
         public ulong EphemeralAllocContextPtr => GenerationTable[0].AllocationContextPointer;
         public ulong EphemeralAllocContextLimit => GenerationTable[0].AllocationContextLimit;
-
-        internal HeapDetails(ref HeapDetails other)
-        {
-            this = other;
-
-            unchecked
-            {
-                if (IntPtr.Size == 4)
-                {
-                    FixupPointer(ref Address);
-                    FixupPointer(ref Allocated);
-                    FixupPointer(ref MarkArray);
-                    FixupPointer(ref CAllocateLH);
-                    FixupPointer(ref NextSweepObj);
-                    FixupPointer(ref SavedSweepEphemeralSeg);
-                    FixupPointer(ref SavedSweepEphemeralStart);
-                    FixupPointer(ref BackgroundSavedHighestAddress);
-                    FixupPointer(ref BackgroundSavedLowestAddress);
-
-                    FixupPointer(ref EphemeralHeapSegment);
-                    FixupPointer(ref LowestAddress);
-                    FixupPointer(ref HighestAddress);
-                    FixupPointer(ref CardTable);
-
-                    for (int i = 0; i < FinalizationFillPointers.Length; i++)
-                        FixupPointer(ref FinalizationFillPointers[i]);
-
-                    for (int i = 0; i < GenerationTable.Length; i++)
-                        GenerationTable[i] = new GenerationData(ref GenerationTable[i]);
-                }
-            }
-        }
-
-        private static void FixupPointer(ref ulong ptr)
-        {
-            ptr = (uint)ptr;
-        }
 
         public ulong FQAllObjectsStart => FinalizationFillPointers[0];
         public ulong FQAllObjectsStop => FinalizationFillPointers[3];

--- a/src/Microsoft.Diagnostics.Runtime/src/DacInterface/Structs/JitCodeHeapInfo.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DacInterface/Structs/JitCodeHeapInfo.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
     public readonly struct JitCodeHeapInfo
     {
         public readonly CodeHeapType Type;
-        public readonly ulong Address;
-        public readonly ulong CurrentAddress;
+        public readonly ClrDataAddress Address;
+        public readonly ClrDataAddress CurrentAddress;
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/src/DacInterface/Structs/JitManagerInfo.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DacInterface/Structs/JitManagerInfo.cs
@@ -9,8 +9,8 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
     [StructLayout(LayoutKind.Sequential)]
     public readonly struct JitManagerInfo
     {
-        public readonly ulong Address;
+        public readonly ClrDataAddress Address;
         public readonly CodeHeapType Type;
-        public readonly ulong HeapList;
+        public readonly ClrDataAddress HeapList;
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/src/DacInterface/Structs/MethodDescData.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DacInterface/Structs/MethodDescData.cs
@@ -12,23 +12,23 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
         public readonly uint HasNativeCode;
         public readonly uint IsDynamic;
         public readonly short SlotNumber;
-        public readonly ulong NativeCodeAddr;
+        public readonly ClrDataAddress NativeCodeAddr;
 
         // Useful for breaking when a method is jitted.
-        public readonly ulong AddressOfNativeCodeSlot;
+        public readonly ClrDataAddress AddressOfNativeCodeSlot;
 
-        public readonly ulong MethodDesc;
-        public readonly ulong MethodTable;
-        public readonly ulong Module;
+        public readonly ClrDataAddress MethodDesc;
+        public readonly ClrDataAddress MethodTable;
+        public readonly ClrDataAddress Module;
 
         public readonly uint MDToken;
-        public readonly ulong GCInfo;
-        public readonly ulong GCStressCodeCopy;
+        public readonly ClrDataAddress GCInfo;
+        public readonly ClrDataAddress GCStressCodeCopy;
 
         // This is only valid if bIsDynamic is true
-        public readonly ulong ManagedDynamicMethodObject;
+        public readonly ClrDataAddress ManagedDynamicMethodObject;
 
-        public readonly ulong RequestedIP;
+        public readonly ClrDataAddress RequestedIP;
 
         // Gives info for the single currently active version of a method
         public readonly RejitData RejitDataCurrent;

--- a/src/Microsoft.Diagnostics.Runtime/src/DacInterface/Structs/MethodTableCollectibleData.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DacInterface/Structs/MethodTableCollectibleData.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
 {
     public readonly struct MethodTableCollectibleData
     {
-        public readonly ulong LoaderAllocatorObjectHandle;
+        public readonly ClrDataAddress LoaderAllocatorObjectHandle;
         public readonly uint Collectible;
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/src/DacInterface/Structs/MethodTableData.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DacInterface/Structs/MethodTableData.cs
@@ -10,9 +10,9 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
     public readonly struct MethodTableData
     {
         public readonly uint IsFree; // everything else is NULL if this is true.
-        public readonly ulong Module;
-        public readonly ulong EEClass;
-        public readonly ulong ParentMethodTable;
+        public readonly ClrDataAddress Module;
+        public readonly ClrDataAddress EEClass;
+        public readonly ClrDataAddress ParentMethodTable;
         public readonly ushort NumInterfaces;
         public readonly ushort NumMethods;
         public readonly ushort NumVtableSlots;

--- a/src/Microsoft.Diagnostics.Runtime/src/DacInterface/Structs/ModuleData.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DacInterface/Structs/ModuleData.cs
@@ -9,26 +9,26 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
     [StructLayout(LayoutKind.Sequential)]
     public readonly struct ModuleData
     {
-        public readonly ulong Address;
-        public readonly ulong PEFile;
-        public readonly ulong ILBase;
-        public readonly ulong MetadataStart;
+        public readonly ClrDataAddress Address;
+        public readonly ClrDataAddress PEFile;
+        public readonly ClrDataAddress ILBase;
+        public readonly ClrDataAddress MetadataStart;
         public readonly ulong MetadataSize;
-        public readonly ulong Assembly;
+        public readonly ClrDataAddress Assembly;
         public readonly uint IsReflection;
         public readonly uint IsPEFile;
         public readonly ulong BaseClassIndex;
         public readonly ulong ModuleID;
         public readonly uint TransientFlags;
-        public readonly ulong TypeDefToMethodTableMap;
-        public readonly ulong TypeRefToMethodTableMap;
-        public readonly ulong MethodDefToDescMap;
-        public readonly ulong FieldDefToDescMap;
-        public readonly ulong MemberRefToDescMap;
-        public readonly ulong FileReferencesMap;
-        public readonly ulong ManifestModuleReferencesMap;
-        public readonly ulong LookupTableHeap;
-        public readonly ulong ThunkHeap;
+        public readonly ClrDataAddress TypeDefToMethodTableMap;
+        public readonly ClrDataAddress TypeRefToMethodTableMap;
+        public readonly ClrDataAddress MethodDefToDescMap;
+        public readonly ClrDataAddress FieldDefToDescMap;
+        public readonly ClrDataAddress MemberRefToDescMap;
+        public readonly ClrDataAddress FileReferencesMap;
+        public readonly ClrDataAddress ManifestModuleReferencesMap;
+        public readonly ClrDataAddress LookupTableHeap;
+        public readonly ClrDataAddress ThunkHeap;
         public readonly ulong ModuleIndex;
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/src/DacInterface/Structs/RCWData.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DacInterface/Structs/RCWData.cs
@@ -9,13 +9,13 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
     [StructLayout(LayoutKind.Sequential)]
     public readonly struct RCWData
     {
-        public readonly ulong IdentityPointer;
-        public readonly ulong IUnknownPointer;
-        public readonly ulong ManagedObject;
-        public readonly ulong JupiterObject;
-        public readonly ulong VTablePointer;
-        public readonly ulong CreatorThread;
-        public readonly ulong CTXCookie;
+        public readonly ClrDataAddress IdentityPointer;
+        public readonly ClrDataAddress IUnknownPointer;
+        public readonly ClrDataAddress ManagedObject;
+        public readonly ClrDataAddress JupiterObject;
+        public readonly ClrDataAddress VTablePointer;
+        public readonly ClrDataAddress CreatorThread;
+        public readonly ClrDataAddress CTXCookie;
 
         public readonly int RefCount;
         public readonly int InterfaceCount;

--- a/src/Microsoft.Diagnostics.Runtime/src/DacInterface/Structs/RejitData.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DacInterface/Structs/RejitData.cs
@@ -9,8 +9,8 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
     [StructLayout(LayoutKind.Sequential)]
     public readonly struct RejitData
     {
-        private readonly ulong RejitID;
+        private readonly ClrDataAddress RejitID;
         private readonly uint Flags;
-        private readonly ulong NativeCodeAddr;
+        private readonly ClrDataAddress NativeCodeAddr;
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/src/DacInterface/Structs/SegmentData.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DacInterface/Structs/SegmentData.cs
@@ -10,41 +10,16 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
     [StructLayout(LayoutKind.Sequential)]
     public readonly struct SegmentData
     {
-        public readonly ulong Address;
-        public readonly ulong Allocated;
-        public readonly ulong Committed;
-        public readonly ulong Reserved;
-        public readonly ulong Used;
-        public readonly ulong Start;
-        public readonly ulong Next;
-        public readonly ulong Heap;
-        public readonly ulong HighAllocMark;
+        public readonly ClrDataAddress Address;
+        public readonly ClrDataAddress Allocated;
+        public readonly ClrDataAddress Committed;
+        public readonly ClrDataAddress Reserved;
+        public readonly ClrDataAddress Used;
+        public readonly ClrDataAddress Start;
+        public readonly ClrDataAddress Next;
+        public readonly ClrDataAddress Heap;
+        public readonly ClrDataAddress HighAllocMark;
         public readonly IntPtr Flags;
-        public readonly ulong BackgroundAllocated;
-
-        internal SegmentData(ref SegmentData data)
-        {
-            this = data;
-
-            // Sign extension issues
-            if (IntPtr.Size == 4)
-            {
-                FixupPointer(ref Address);
-                FixupPointer(ref Allocated);
-                FixupPointer(ref Committed);
-                FixupPointer(ref Reserved);
-                FixupPointer(ref Used);
-                FixupPointer(ref Start);
-                FixupPointer(ref Next);
-                FixupPointer(ref Heap);
-                FixupPointer(ref HighAllocMark);
-                FixupPointer(ref BackgroundAllocated);
-            }
-        }
-
-        private static void FixupPointer(ref ulong ptr)
-        {
-            ptr = (uint)ptr;
-        }
+        public readonly ClrDataAddress BackgroundAllocated;
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/src/DacInterface/Structs/StackRefData.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DacInterface/Structs/StackRefData.cs
@@ -12,12 +12,12 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
         public readonly uint HasRegisterInformation;
         public readonly int Register;
         public readonly int Offset;
-        public readonly ulong Address;
-        public readonly ulong Object;
+        public readonly ClrDataAddress Address;
+        public readonly ClrDataAddress Object;
         public readonly uint Flags;
 
         public readonly uint SourceType;
-        public readonly ulong Source;
-        public readonly ulong StackPointer;
+        public readonly ClrDataAddress Source;
+        public readonly ClrDataAddress StackPointer;
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/src/DacInterface/Structs/SyncBlockData.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DacInterface/Structs/SyncBlockData.cs
@@ -9,15 +9,15 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
     [StructLayout(LayoutKind.Sequential)]
     public readonly struct SyncBlockData
     {
-        public readonly ulong Object;
+        public readonly ClrDataAddress Object;
         public readonly uint Free;
-        public readonly ulong Address;
+        public readonly ClrDataAddress Address;
         public readonly uint COMFlags;
         public readonly uint MonitorHeld;
         public readonly uint Recursion;
-        public readonly ulong HoldingThread;
+        public readonly ClrDataAddress HoldingThread;
         public readonly uint AdditionalThreadCount;
-        public readonly ulong AppDomain;
+        public readonly ClrDataAddress AppDomain;
         public readonly uint TotalSyncBlockCount;
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/src/DacInterface/Structs/ThreadData.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DacInterface/Structs/ThreadData.cs
@@ -14,39 +14,16 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
         public readonly uint OSThreadId;
         public readonly int State;
         public readonly uint PreemptiveGCDisabled;
-        public ulong AllocationContextPointer;
-        public ulong AllocationContextLimit;
-        public ulong Context;
-        public ulong Domain;
-        public ulong Frame;
+        public ClrDataAddress AllocationContextPointer;
+        public ClrDataAddress AllocationContextLimit;
+        public ClrDataAddress Context;
+        public ClrDataAddress Domain;
+        public ClrDataAddress Frame;
         public readonly uint LockCount;
-        public ulong FirstNestedException;
-        public ulong Teb;
-        public ulong FiberData;
-        public ulong LastThrownObjectHandle;
-        public ulong NextThread;
-
-        public static void Fixup(ref ThreadData data)
-        {
-            // Sign extension issues
-            if (IntPtr.Size == 4)
-            {
-                FixupPointer(ref data.AllocationContextPointer);
-                FixupPointer(ref data.AllocationContextLimit);
-                FixupPointer(ref data.Context);
-                FixupPointer(ref data.Domain);
-                FixupPointer(ref data.Frame);
-                FixupPointer(ref data.FirstNestedException);
-                FixupPointer(ref data.Teb);
-                FixupPointer(ref data.FiberData);
-                FixupPointer(ref data.LastThrownObjectHandle);
-                FixupPointer(ref data.NextThread);
-            }
-        }
-
-        private static void FixupPointer(ref ulong ptr)
-        {
-            ptr = (uint)ptr;
-        }
+        public ClrDataAddress FirstNestedException;
+        public ClrDataAddress Teb;
+        public ClrDataAddress FiberData;
+        public ClrDataAddress LastThrownObjectHandle;
+        public ClrDataAddress NextThread;
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/src/DacInterface/Structs/ThreadLocalModuleData.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DacInterface/Structs/ThreadLocalModuleData.cs
@@ -9,12 +9,12 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
     [StructLayout(LayoutKind.Sequential)]
     public readonly struct ThreadLocalModuleData
     {
-        public readonly ulong ThreadAddress;
-        public readonly ulong ModuleIndex;
+        public readonly ClrDataAddress ThreadAddress;
+        public readonly ClrDataAddress ModuleIndex;
 
-        public readonly ulong ClassData;
-        public readonly ulong DynamicClassTable;
-        public readonly ulong GCStaticDataStart;
-        public readonly ulong NonGCStaticDataStart;
+        public readonly ClrDataAddress ClassData;
+        public readonly ClrDataAddress DynamicClassTable;
+        public readonly ClrDataAddress GCStaticDataStart;
+        public readonly ClrDataAddress NonGCStaticDataStart;
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/src/DacInterface/Structs/ThreadPoolData.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DacInterface/Structs/ThreadPoolData.cs
@@ -16,9 +16,9 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
         public readonly int MinLimitTotalWorkerThreads;
         public readonly int MaxLimitTotalWorkerThreads;
 
-        public readonly ulong FirstUnmanagedWorkRequest;
+        public readonly ClrDataAddress FirstUnmanagedWorkRequest;
 
-        public readonly ulong HillClimbingLog;
+        public readonly ClrDataAddress HillClimbingLog;
         public readonly int HillClimbingLogFirstIndex;
         public readonly int HillClimbingLogSize;
 
@@ -32,6 +32,6 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
         public readonly int CurrentLimitTotalCPThreads;
         public readonly int MinLimitTotalCPThreads;
 
-        public readonly ulong AsyncTimerCallbackCompletionFPtr;
+        public readonly ClrDataAddress AsyncTimerCallbackCompletionFPtr;
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/src/DacInterface/Structs/ThreadStoreData.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DacInterface/Structs/ThreadStoreData.cs
@@ -14,9 +14,9 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
         public readonly int BackgroundThreadCount;
         public readonly int PendingThreadCount;
         public readonly int DeadThreadCount;
-        public readonly ulong FirstThread;
-        public readonly ulong FinalizerThread;
-        public readonly ulong GCThread;
+        public readonly ClrDataAddress FirstThread;
+        public readonly ClrDataAddress FinalizerThread;
+        public readonly ClrDataAddress GCThread;
         public readonly uint HostConfig;
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/src/DacInterface/Structs/V45ObjectData.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DacInterface/Structs/V45ObjectData.cs
@@ -10,19 +10,19 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
     [StructLayout(LayoutKind.Sequential)]
     public readonly struct V45ObjectData : IObjectData
     {
-        public readonly ulong MethodTable;
+        public readonly ClrDataAddress MethodTable;
         public readonly uint ObjectType;
         public readonly ulong Size;
-        public readonly ulong ElementTypeHandle;
+        public readonly ClrDataAddress ElementTypeHandle;
         public readonly uint ElementType;
         public readonly uint Rank;
         public readonly ulong NumComponents;
         public readonly ulong ComponentSize;
-        public readonly ulong ArrayDataPointer;
-        public readonly ulong ArrayBoundsPointer;
-        public readonly ulong ArrayLowerBoundsPointer;
-        public readonly ulong RCW;
-        public readonly ulong CCW;
+        public readonly ClrDataAddress ArrayDataPointer;
+        public readonly ClrDataAddress ArrayBoundsPointer;
+        public readonly ClrDataAddress ArrayLowerBoundsPointer;
+        public readonly ClrDataAddress RCW;
+        public readonly ClrDataAddress CCW;
 
         ClrElementType IObjectData.ElementType => (ClrElementType)ElementType;
         ulong IObjectData.ElementTypeHandle => ElementTypeHandle;

--- a/src/Microsoft.Diagnostics.Runtime/src/DacInterface/Structs/V4FieldInfo.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DacInterface/Structs/V4FieldInfo.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
         public readonly short NumInstanceFields;
         public readonly short NumStaticFields;
         public readonly short NumThreadStaticFields;
-        public readonly ulong FirstFieldAddress; // If non-null, you can retrieve more
+        public readonly ClrDataAddress FirstFieldAddress; // If non-null, you can retrieve more
         public readonly short ContextStaticOffset;
         public readonly short ContextStaticsSize;
     }

--- a/src/Microsoft.Diagnostics.Runtime/src/DacInterface/Structs/WorkRequestData.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DacInterface/Structs/WorkRequestData.cs
@@ -9,8 +9,8 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
     [StructLayout(LayoutKind.Sequential)]
     public readonly struct WorkRequestData
     {
-        public readonly ulong Function;
-        public readonly ulong Context;
-        public readonly ulong NextWorkRequest;
+        public readonly ClrDataAddress Function;
+        public readonly ClrDataAddress Context;
+        public readonly ClrDataAddress NextWorkRequest;
     }
 }


### PR DESCRIPTION
CLRDATA_ADDRESS is defined as a signed 64 bit integer in the CLR codebase.  When inspecting a 32bit process, this means that we cannot simply use ulong to represent these values when communicating with the dac because addresses with the highest bit set will be sign extended by the dac.

This change adds a ClrDataAddress struct to represent a possibly sign-extended data value.  All structs that the dac produces have been updated to match their definition in coreclr/src/inc/dacprivate.h.

This struct will do the right thing to un-sign extend the address when inspecting a 32bit process.