### PR TITLE
Fix for Linux ARM

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/src/Builders/RuntimeBuilder.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Builders/RuntimeBuilder.cs
@@ -271,15 +271,27 @@ namespace Microsoft.Diagnostics.Runtime.Builders
             int ipOffset;
             int spOffset;
             int contextSize;
-            uint contextFlags;
-            if (IntPtr.Size == 4)
+            uint contextFlags = 0;
+            if (DataReader.Architecture == Architecture.Arm)
+            {
+                ipOffset = 64;
+                spOffset = 56;
+                contextSize = 416;
+            }
+            else if (DataReader.Architecture == Architecture.Arm64)
+            {
+                ipOffset = 264;
+                spOffset = 256;
+                contextSize = 912;
+            }
+            else if (DataReader.Architecture == Architecture.X86)
             {
                 ipOffset = 184;
                 spOffset = 196;
                 contextSize = 716;
                 contextFlags = 0x1003f;
             }
-            else
+            else // Architecture.Amd64
             {
                 ipOffset = 248;
                 spOffset = 152;

--- a/src/Microsoft.Diagnostics.Runtime/src/Linux/LinuxDefaultSymbolLocator.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Linux/LinuxDefaultSymbolLocator.cs
@@ -47,9 +47,6 @@ namespace Microsoft.Diagnostics.Runtime.Linux
             string name = Path.GetFileName(fileName);
             foreach (var m in _modules)
             {
-                if (name == Path.GetFileName(m))
-                    return m;
-
                 string path = Path.Combine(Path.GetDirectoryName(m), name);
                 if (File.Exists(path))
                     return path;


### PR DESCRIPTION
- When enumerating stack traces, use valid context offsets depending on the target architecture.
- When resolving symbols in LinuxDefaultSymbolLocator, enforce File.Exists() check for module paths provided by CoreDumpReader to verify their existence in the current filesystem, to avoid any IOExceptions.

A side note:
Instead of using hard-coded offsets, the values can be programatically obtained from existing structures ([ArmContext](https://github.com/microsoft/clrmd/blob/master/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Registers/ArmContext.cs), [Arm64Context](https://github.com/microsoft/clrmd/blob/master/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Registers/Arm64Context.cs), etc.), or even we can marshal the `byte[] context` array into those structures.