### PR TITLE
Use PEReader to get metadata info from PEImage

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/Microsoft.Diagnostics.Runtime.csproj
+++ b/src/Microsoft.Diagnostics.Runtime/Microsoft.Diagnostics.Runtime.csproj
@@ -40,6 +40,7 @@
     <PackageReference Include="System.Buffers" Version="4.5.0" />
     <PackageReference Include="System.Collections.Immutable" Version="1.7.0" />
     <PackageReference Include="System.Memory" Version="4.5.3" />
+    <PackageReference Include="System.Reflection.Metadata" Version="1.7.0" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.6.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Although it's not such a critical issue, there are some cases that `DacDataTargetWrapper.GetMetadata()` fails to get metadata information from IL images, because the `mdRva` value given by the Dac is 0 and it's not available from `PEImage.OptionalHeader.ComDescriptorDirectory.VirtualAddress` either.

Instead, we may use `PEReader.GetMetadata()` to get the information from any images. The idea is from `SOS.MetadataHelper.GetMetadataLocator()` in [SOS.MetadataHelper](https://github.com/dotnet/diagnostics/blob/master/src/SOS/SOS.NETCore/MetadataHelper.cs). We may also add support for pdbs if required.

I know that this is a kind of issue stated by https://github.com/microsoft/clrmd/issues/311#issuecomment-565125956, so please just take a look for motivation. There's no need to merge this.