### PR TITLE
Switch to ImmutableArray

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/AppDomainTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/AppDomainTests.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
 
             Assert.NotEqual(systemDomain.Address, sharedDomain.Address);
 
-            Assert.Equal(2, runtime.AppDomains.Count);
+            Assert.Equal(2, runtime.AppDomains.Length);
             ClrAppDomain AppDomainsExe = runtime.AppDomains[0];
             Assert.Equal("AppDomains.exe", AppDomainsExe.Name);
             Assert.Equal(1, AppDomainsExe.Id);
@@ -89,18 +89,18 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
 
             ClrAppDomain systemDomain = runtime.SystemDomain;
-            Assert.Equal(0, systemDomain.Modules.Count);
+            Assert.Empty(systemDomain.Modules);
 
             ClrAppDomain sharedDomain = runtime.SharedDomain;
 
             if (runtime.ClrInfo.Version.Major == 2)
             {
-                Assert.Equal(3, sharedDomain.Modules.Count);
+                Assert.Equal(3, sharedDomain.Modules.Length);
                 Assert.Contains("mscorlib.dll", sharedDomain.Modules.Select(m => Path.GetFileName("mscorlib.dll")));
             }
             else
             {
-                Assert.Equal(1, sharedDomain.Modules.Count);
+                Assert.Single(sharedDomain.Modules);
 
                 ClrModule mscorlib = sharedDomain.Modules.Single();
                 Assert.Equal("mscorlib.dll", Path.GetFileName(mscorlib.FileName), true);

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/CacheOptionsTest.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/CacheOptionsTest.cs
@@ -1,7 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System.Linq;
-using System.Text;
 using Xunit;
 
 namespace Microsoft.Diagnostics.Runtime.Tests
@@ -132,8 +133,8 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             ClrType type = module.GetTypeByName("Foo");
             Assert.NotEqual(0ul, type.MethodTable);  // Sanity test
 
-            Assert.Same(type.Fields, type.Fields);
-            Assert.Same(type.StaticFields, type.StaticFields);
+            Assert.Equal(type.Fields, type.Fields);
+            Assert.Equal(type.StaticFields, type.StaticFields);
 
             ClrField field = type.GetFieldByName("o");
             ClrField field2 = type.Fields.Single(f => f.Name == "o");
@@ -154,7 +155,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             ClrType type = module.GetTypeByName("Foo");
             Assert.NotEqual(0ul, type.MethodTable);  // Sanity test
 
-            Assert.NotSame(type.Fields, type.Fields);
+            Assert.NotEqual(type.Fields, type.Fields);
 
             ClrField field = type.GetFieldByName("o");
             ClrField field2 = type.Fields.Single(f => f.Name == "o");

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/GCRootTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/GCRootTests.cs
@@ -4,11 +4,10 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using Microsoft.Diagnostics.Runtime.Utilities;
-using Microsoft.VisualStudio.TestPlatform.Utilities;
 using Xunit;
 
 namespace Microsoft.Diagnostics.Runtime.Tests
@@ -258,7 +257,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
 
             LinkedList<ClrObject> path = gcroot.FindSinglePath(source, target, CancellationToken.None);
 
-            AssertPathIsCorrect(heap, path.ToArray(), source, target);
+            AssertPathIsCorrect(heap, path.ToImmutableArray(), source, target);
         }
 
         [Fact]
@@ -282,7 +281,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             Assert.Equal(3, paths.Length);
 
             foreach (LinkedList<ClrObject> path in paths)
-                AssertPathIsCorrect(heap, path.ToArray(), source, target);
+                AssertPathIsCorrect(heap, path.ToImmutableArray(), source, target);
         }
 
         private static void GetKnownSourceAndTarget(ClrHeap heap, out ulong source, out ulong target)
@@ -294,15 +293,15 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             target = heap.GetObjectsOfType("TargetType").Single();
         }
 
-        private void AssertPathIsCorrect(ClrHeap heap, IReadOnlyList<ClrObject> path, ulong source, ulong target)
+        private void AssertPathIsCorrect(ClrHeap heap, ImmutableArray<ClrObject> path, ulong source, ulong target)
         {
-            Assert.NotNull(path);
-            Assert.True(path.Count > 0);
+            Assert.NotEqual(default, path);
+            Assert.True(path.Length > 0);
 
             ClrObject first = path.First();
             Assert.Equal(source, first.Address);
 
-            for (int i = 0; i < path.Count - 1; i++)
+            for (int i = 0; i < path.Length - 1; i++)
             {
                 ClrObject curr = path[i];
                 Assert.Equal(curr.Type, heap.GetObjectType(curr.Address));

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/RuntimeTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/RuntimeTests.cs
@@ -114,15 +114,15 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             Assert.NotEmpty(oldMethods);
 
             // Make sure we aren't regenerating this list every time.
-            Assert.Same(oldDomains, runtime.AppDomains);
+            Assert.Equal(oldDomains, runtime.AppDomains);
 
             // Clear all cached data.
             runtime.FlushCachedData();
 
             CheckDomainNotSame(oldShared, runtime.SharedDomain);
             CheckDomainNotSame(oldSystem, runtime.SystemDomain);
-            Assert.Equal(oldDomains.Count, runtime.AppDomains.Count);
-            for (int i = 0; i < oldDomains.Count; i++)
+            Assert.Equal(oldDomains.Length, runtime.AppDomains.Length);
+            for (int i = 0; i < oldDomains.Length; i++)
                 CheckDomainNotSame(oldDomains[i], runtime.AppDomains[i]);
 
             var newModules = runtime.EnumerateModules().ToArray();
@@ -140,9 +140,9 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             }
 
             var newThreads = runtime.Threads;
-            Assert.Same(newThreads, runtime.Threads);
-            Assert.Equal(oldThreads.Count, newThreads.Count);
-            for (int i = 0; i < oldThreads.Count; i++)
+            Assert.Equal(newThreads, runtime.Threads);
+            Assert.Equal(oldThreads.Length, newThreads.Length);
+            for (int i = 0; i < oldThreads.Length; i++)
             {
                 Assert.Equal(oldThreads[i].OSThreadId, newThreads[i].OSThreadId);
                 Assert.NotSame(oldThreads[i], newThreads[i]);
@@ -155,13 +155,13 @@ namespace Microsoft.Diagnostics.Runtime.Tests
 
             AssertEqualNotSame(oldType.Name, newType.Name);
 
-            for (int i = 0; i < oldType.Fields.Count; i++)
+            for (int i = 0; i < oldType.Fields.Length; i++)
                 AssertEqualNotSame(oldType.Fields[i].Name, newType.Fields[i].Name);
 
-            for (int i = 0; i < oldType.StaticFields.Count; i++)
+            for (int i = 0; i < oldType.StaticFields.Length; i++)
                 AssertEqualNotSame(oldType.StaticFields[i].Name, newType.StaticFields[i].Name);
 
-            for (int i = 0; i < oldType.Methods.Count; i++)
+            for (int i = 0; i < oldType.Methods.Length; i++)
                 AssertEqualNotSame(oldType.Methods[i].Name, newType.Methods[i].Name);
         }
 

--- a/src/Microsoft.Diagnostics.Runtime/Microsoft.Diagnostics.Runtime.csproj
+++ b/src/Microsoft.Diagnostics.Runtime/Microsoft.Diagnostics.Runtime.csproj
@@ -38,6 +38,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="System.Buffers" Version="4.5.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.7.0" />
     <PackageReference Include="System.Memory" Version="4.5.3" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.6.0" />
   </ItemGroup>

--- a/src/Microsoft.Diagnostics.Runtime/src/Builders/CCWBuilder.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Builders/CCWBuilder.cs
@@ -2,8 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
+using System.Collections.Immutable;
 using Microsoft.Diagnostics.Runtime.DacInterface;
 using Microsoft.Diagnostics.Runtime.Implementation;
 
@@ -42,11 +41,11 @@ namespace Microsoft.Diagnostics.Runtime.Builders
         int ICCWData.RefCount => _ccwData.RefCount + _ccwData.JupiterRefCount;
         int ICCWData.JupiterRefCount => _ccwData.JupiterRefCount;
 
-        IReadOnlyList<ComInterfaceData> ICCWData.GetInterfaces()
+        ImmutableArray<ComInterfaceData> ICCWData.GetInterfaces()
         {
             COMInterfacePointerData[]? ifs = _sos.GetCCWInterfaces(Address, _ccwData.InterfaceCount);
             if (ifs is null)
-                return Array.Empty<ComInterfaceData>();
+                return ImmutableArray<ComInterfaceData>.Empty;
 
             return _builder.CreateComInterfaces(ifs);
         }

--- a/src/Microsoft.Diagnostics.Runtime/src/Builders/RCWBuilder.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Builders/RCWBuilder.cs
@@ -2,8 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
+using System.Collections.Immutable;
 using Microsoft.Diagnostics.Runtime.DacInterface;
 using Microsoft.Diagnostics.Runtime.Implementation;
 
@@ -42,11 +41,11 @@ namespace Microsoft.Diagnostics.Runtime.Builders
         bool IRCWData.Disconnected => _rcwData.IsDisconnected != 0;
         ulong IRCWData.CreatorThread => _rcwData.CreatorThread;
 
-        IReadOnlyList<ComInterfaceData> IRCWData.GetInterfaces()
+        ImmutableArray<ComInterfaceData> IRCWData.GetInterfaces()
         {
             COMInterfacePointerData[]? ifs = _sos.GetRCWInterfaces(Address, _rcwData.InterfaceCount);
             if (ifs is null)
-                return Array.Empty<ComInterfaceData>();
+                return ImmutableArray<ComInterfaceData>.Empty;
 
             return _builder.CreateComInterfaces(ifs);
         }

--- a/src/Microsoft.Diagnostics.Runtime/src/Builders/RuntimeBuilder.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Builders/RuntimeBuilder.cs
@@ -122,19 +122,16 @@ namespace Microsoft.Diagnostics.Runtime.Builders
             List<FinalizerQueueSegment> finalizerRoots = new List<FinalizerQueueSegment>();
             List<FinalizerQueueSegment> finalizerObjects = new List<FinalizerQueueSegment>();
 
-            if (true)
+            ulong next = _firstThread;
+            HashSet<ulong> seen = new HashSet<ulong>() { next };  // Ensure we don't hit an infinite loop
+            while (_sos.GetThreadData(next, out ThreadData thread))
             {
-                ulong next = _firstThread;
-                HashSet<ulong> seen = new HashSet<ulong>() { next };  // Ensure we don't hit an infinite loop
-                while (_sos.GetThreadData(next, out ThreadData thread))
-                {
-                    if (thread.AllocationContextPointer != 0 && thread.AllocationContextPointer != thread.AllocationContextLimit)
-                        allocContexts.Add(new AllocationContext(thread.AllocationContextPointer, thread.AllocationContextLimit));
+                if (thread.AllocationContextPointer != 0 && thread.AllocationContextPointer != thread.AllocationContextLimit)
+                    allocContexts.Add(new AllocationContext(thread.AllocationContextPointer, thread.AllocationContextLimit));
 
-                    next = thread.NextThread;
-                    if (next == 0 || !seen.Add(next))
-                        break;
-                }
+                next = thread.NextThread;
+                if (next == 0 || !seen.Add(next))
+                    break;
             }
 
             bool result = false;

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/ClrAppDomain.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/ClrAppDomain.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
+using System.Collections.Immutable;
 
 namespace Microsoft.Diagnostics.Runtime
 {
@@ -34,7 +34,7 @@ namespace Microsoft.Diagnostics.Runtime
         /// <summary>
         /// Returns a list of modules loaded into this AppDomain.
         /// </summary>
-        public abstract IReadOnlyList<ClrModule> Modules { get; }
+        public abstract ImmutableArray<ClrModule> Modules { get; }
 
         /// <summary>
         /// Returns the config file used for the AppDomain.  This may be null if there was no config file

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/ClrException.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/ClrException.cs
@@ -3,8 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
-using System.Diagnostics;
+using System.Collections.Immutable;
 using Microsoft.Diagnostics.Runtime.Implementation;
 
 namespace Microsoft.Diagnostics.Runtime
@@ -77,6 +76,6 @@ namespace Microsoft.Diagnostics.Runtime
         /// the middle of constructing the stackwalk.)  This returns an empty list if no stack trace is
         /// associated with this exception object.
         /// </summary>
-        public IReadOnlyList<ClrStackFrame> StackTrace => _helpers.GetExceptionStackTrace(Thread, _object);
+        public ImmutableArray<ClrStackFrame> StackTrace => _helpers.GetExceptionStackTrace(Thread, _object);
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/ClrMethod.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/ClrMethod.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
+using System.Collections.Immutable;
 
 namespace Microsoft.Diagnostics.Runtime
 {
@@ -64,7 +64,7 @@ namespace Microsoft.Diagnostics.Runtime
         /// <summary>
         /// Returns the IL to native offset mapping.
         /// </summary>
-        public abstract IReadOnlyList<ILToNativeMap>? ILOffsetMap { get; }
+        public abstract ImmutableArray<ILToNativeMap> ILOffsetMap { get; }
 
         /// <summary>
         /// Returns the metadata token of the current method.

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/ClrRuntime.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/ClrRuntime.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 
 namespace Microsoft.Diagnostics.Runtime
 {
@@ -37,7 +38,7 @@ namespace Microsoft.Diagnostics.Runtime
         /// <summary>
         /// Enumerates the list of appdomains in the process.
         /// </summary>
-        public abstract IReadOnlyList<ClrAppDomain> AppDomains { get; }
+        public abstract ImmutableArray<ClrAppDomain> AppDomains { get; }
 
         /// <summary>
         /// The System AppDomain for Desktop CLR (null on .Net Core).
@@ -55,7 +56,7 @@ namespace Microsoft.Diagnostics.Runtime
         /// Enumerates all managed threads in the process.  Only threads which have previously run managed
         /// code will be enumerated.
         /// </summary>
-        public abstract IReadOnlyList<ClrThread> Threads { get; }
+        public abstract ImmutableArray<ClrThread> Threads { get; }
 
         /// <summary>
         /// Returns a ClrMethod by its internal runtime handle (on desktop CLR this is a MethodDesc).

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/ClrType.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/ClrType.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using Microsoft.Diagnostics.Runtime.Implementation;
 
 namespace Microsoft.Diagnostics.Runtime
@@ -144,17 +145,17 @@ namespace Microsoft.Diagnostics.Runtime
         /// Returns all possible fields in this type.   It does not return dynamically typed fields.
         /// Returns an empty list if there are no fields.
         /// </summary>
-        public abstract IReadOnlyList<ClrInstanceField> Fields { get; }
+        public abstract ImmutableArray<ClrInstanceField> Fields { get; }
 
         /// <summary>
         /// Returns a list of static fields on this type.  Returns an empty list if there are no fields.
         /// </summary>
-        public abstract IReadOnlyList<ClrStaticField> StaticFields { get; }
+        public abstract ImmutableArray<ClrStaticField> StaticFields { get; }
 
         /// <summary>
         /// Gets the list of methods this type implements.
         /// </summary>
-        public abstract IReadOnlyList<ClrMethod> Methods { get; }
+        public abstract ImmutableArray<ClrMethod> Methods { get; }
 
         /// <summary>
         /// Returns the field given by <paramref name="name"/>, case sensitive. Returns <see langword="null" /> if no such field name exists (or on error).

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/ComCallWrapper.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/ComCallWrapper.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
+using System.Collections.Immutable;
 using Microsoft.Diagnostics.Runtime.Implementation;
 
 namespace Microsoft.Diagnostics.Runtime
@@ -38,7 +38,7 @@ namespace Microsoft.Diagnostics.Runtime
         /// <summary>
         /// Returns the interfaces that this CCW implements.
         /// </summary>
-        public IReadOnlyList<ComInterfaceData> Interfaces { get; }
+        public ImmutableArray<ComInterfaceData> Interfaces { get; }
 
         public ComCallableWrapper(ICCWData data)
         {

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/GCRoot.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/GCRoot.cs
@@ -2,13 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.Diagnostics.Runtime.Implementation;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
+using Microsoft.Diagnostics.Runtime.Implementation;
 
 namespace Microsoft.Diagnostics.Runtime.Utilities
 {
@@ -102,7 +103,7 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
                 {
                     LinkedList<ClrObject> path = PathsTo(processedObjects, knownEndPoints, root.Object, target, unique, cancelToken).FirstOrDefault();
                     if (path != null)
-                        yield return new GCRootPath(root, path.ToArray());
+                        yield return new GCRootPath(root, path.ToImmutableArray());
 
                     if (count != processedObjects.Count)
                     {
@@ -120,7 +121,7 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
                 Thread[] threads = new Thread[Math.Min(maxDegreeOfParallelism, Environment.ProcessorCount)];
                 for (int i = 0; i < threads.Length; i++)
                 {
-                    threads[i] = new Thread(() => WorkerThread(queue, results, processedObjects, knownEndPoints, target, all:true, unique, cancelToken)) { Name = "GCRoot Worker Thread" };
+                    threads[i] = new Thread(() => WorkerThread(queue, results, processedObjects, knownEndPoints, target, all: true, unique, cancelToken)) { Name = "GCRoot Worker Thread" };
                     threads[i].Start();
                 }
 
@@ -187,7 +188,7 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
                 {
                     if (path != null)
                     {
-                        results.Enqueue(new GCRootPath(root, path.ToArray()));
+                        results.Enqueue(new GCRootPath(root, path.ToImmutableArray()));
 
                         if (!all)
                             break;

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/GCRootPath.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/GCRootPath.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
+using System.Collections.Immutable;
 
 namespace Microsoft.Diagnostics.Runtime
 {
@@ -19,9 +19,9 @@ namespace Microsoft.Diagnostics.Runtime
         /// <summary>
         /// The path from Root to a given target object.
         /// </summary>
-        public IReadOnlyList<ClrObject> Path { get; }
+        public ImmutableArray<ClrObject> Path { get; }
 
-        public GCRootPath(IClrRoot root, IReadOnlyList<ClrObject> path)
+        public GCRootPath(IClrRoot root, ImmutableArray<ClrObject> path)
         {
             Root = root;
             Path = path;

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/ModuleInfo.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/ModuleInfo.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
+using System.Collections.Immutable;
 using Microsoft.Diagnostics.Runtime.Utilities;
 
 namespace Microsoft.Diagnostics.Runtime
@@ -60,7 +60,7 @@ namespace Microsoft.Diagnostics.Runtime
         /// <summary>
         /// The Linux BuildId of this module.  This will be null if the module does not have a BuildId.
         /// </summary>
-        public IReadOnlyList<byte>? BuildId { get; }
+        public ImmutableArray<byte> BuildId { get; }
 
         /// <summary>
         /// Whether the module is managed or not.
@@ -98,7 +98,7 @@ namespace Microsoft.Diagnostics.Runtime
         /// lazily evaluating VersionInfo.
         /// </summary>
         public ModuleInfo(IDataReader reader, ulong imgBase, uint filesize, uint timestamp, string? filename,
-            IReadOnlyList<byte>? buildId = null, VersionInfo? version = null)
+            ImmutableArray<byte> buildId = default, VersionInfo? version = null)
         {
             _dataReader = reader ?? throw new ArgumentNullException(nameof(reader));
             ImageBase = imgBase;

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/RuntimeCallableWrapper.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/RuntimeCallableWrapper.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.Diagnostics.Runtime.Implementation;
 
@@ -55,7 +55,7 @@ namespace Microsoft.Diagnostics.Runtime
         /// <summary>
         /// Returns the list of interfaces this RCW implements.
         /// </summary>
-        public IReadOnlyList<ComInterfaceData> Interfaces { get; }
+        public ImmutableArray<ComInterfaceData> Interfaces { get; }
 
         public RuntimeCallableWrapper(ClrRuntime runtime, IRCWData data)
         {

--- a/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Core/CoreDumpReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Core/CoreDumpReader.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Diagnostics.Runtime
                 // memory range overlaps with actual modules.
                 ulong interpreter = _core.GetAuxvValue(ElfAuxvType.Base);
 
-                _modules = new List<ModuleInfo>(_core.LoadedImages.Count);
+                _modules = new List<ModuleInfo>(_core.LoadedImages.Length);
                 foreach (ElfLoadedImage image in _core.LoadedImages)
                     if ((ulong)image.BaseAddress != interpreter && !image.Path.StartsWith("/dev"))
                         _modules.Add(CreateModuleInfo(image));
@@ -112,7 +112,7 @@ namespace Microsoft.Diagnostics.Runtime
                 timestamp = (uint)pe.IndexTimeStamp;
             }
 
-            return new ModuleInfo(this, (ulong)image.BaseAddress, filesize, timestamp, image.Path, file?.BuildId);
+            return new ModuleInfo(this, (ulong)image.BaseAddress, filesize, timestamp, image.Path, file?.BuildId ?? default);
         }
 
         public void FlushCachedData()

--- a/src/Microsoft.Diagnostics.Runtime/src/DataTargets/DacInfo.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataTargets/DacInfo.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
+using System.Collections.Immutable;
 
 #pragma warning disable 0618
 
@@ -26,8 +26,16 @@ namespace Microsoft.Diagnostics.Runtime
         /// <summary>
         /// Constructs a DacInfo object with the appropriate properties initialized.
         /// </summary>
-        public DacInfo(IDataReader reader, string agnosticName, Architecture targetArch, ulong imgBase,
-                        uint filesize, uint timestamp, string filename, VersionInfo version, IReadOnlyList<byte>? buildId = null)
+        public DacInfo(
+            IDataReader reader,
+            string agnosticName,
+            Architecture targetArch,
+            ulong imgBase,
+            uint filesize,
+            uint timestamp,
+            string filename,
+            VersionInfo version,
+            ImmutableArray<byte> buildId = default)
             : base(reader, imgBase, filesize, timestamp, filename, buildId, version)
         {
             PlatformAgnosticFileName = agnosticName;

--- a/src/Microsoft.Diagnostics.Runtime/src/DataTargets/DacLibrary.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataTargets/DacLibrary.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Diagnostics.Runtime
             if (dataTarget is null)
                 throw new ArgumentNullException(nameof(dataTarget));
 
-            if (dataTarget.ClrVersions.Count == 0)
+            if (dataTarget.ClrVersions.Length == 0)
                 throw new ClrDiagnosticsException("Process is not a CLR process!");
 
             IntPtr dacLibrary = DataTarget.PlatformFunctions.LoadLibrary(dacDll);

--- a/src/Microsoft.Diagnostics.Runtime/src/Extensions/ImmutableArrayExtensions.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Extensions/ImmutableArrayExtensions.cs
@@ -2,23 +2,18 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
+using System.Diagnostics;
 using System.Collections.Immutable;
+using System.Runtime.CompilerServices;
 
 namespace Microsoft.Diagnostics.Runtime
 {
-    internal static class ImmutableArrayExtension
+    internal static class ImmutableArrayExtensions
     {
-        /// <summary>
-        /// <b>WARNING:</b> Typing this method may cause Visual Studio IntelliCode 2.2 to crash.
-        /// </summary>
-        internal static unsafe Span<T> DangerousGetSpan<T>(this ImmutableArray<T>.Builder builder) where T : unmanaged
+        internal static ImmutableArray<T> AsImmutableArray<T>(this T[] array)
         {
-            // MemoryMarshal.CreateSpan isn't available on .NET Standard 2.0
-            fixed (T* pointer = &builder.ItemRef(0))
-            {
-                return new Span<T>(pointer, builder.Count);
-            }
+            Debug.Assert(Unsafe.SizeOf<T[]>() == Unsafe.SizeOf<ImmutableArray<T>>());
+            return Unsafe.As<T[], ImmutableArray<T>>(ref array);
         }
 
         internal static ImmutableArray<T> MoveOrCopyToImmutable<T>(this ImmutableArray<T>.Builder builder)

--- a/src/Microsoft.Diagnostics.Runtime/src/ImmutableArrayExtension.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/ImmutableArrayExtension.cs
@@ -1,0 +1,29 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Immutable;
+
+namespace Microsoft.Diagnostics.Runtime
+{
+    internal static class ImmutableArrayExtension
+    {
+        /// <summary>
+        /// <b>WARNING:</b> Typing this method may cause Visual Studio IntelliCode 2.2 to crash.
+        /// </summary>
+        internal static unsafe Span<T> DangerousGetSpan<T>(this ImmutableArray<T>.Builder builder) where T : unmanaged
+        {
+            // MemoryMarshal.CreateSpan isn't available on .NET Standard 2.0
+            fixed (T* pointer = &builder.ItemRef(0))
+            {
+                return new Span<T>(pointer, builder.Count);
+            }
+        }
+
+        internal static ImmutableArray<T> MoveOrCopyToImmutable<T>(this ImmutableArray<T>.Builder builder)
+        {
+            return builder.Capacity == builder.Count ? builder.MoveToImmutable() : builder.ToImmutable();
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/src/Implementation/ClrmdAppDomain.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Implementation/ClrmdAppDomain.cs
@@ -3,8 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
+using System.Collections.Immutable;
 
 namespace Microsoft.Diagnostics.Runtime.Implementation
 {
@@ -16,7 +15,7 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
         public override ulong Address { get; }
         public override int Id { get; }
         public override string? Name { get; }
-        public override IReadOnlyList<ClrModule> Modules { get; }
+        public override ImmutableArray<ClrModule> Modules { get; }
 
         public override string? ConfigurationFile => _helpers.GetConfigFile(this);
         public override string? ApplicationBase => _helpers.GetApplicationBase(this);
@@ -32,7 +31,7 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
             Address = data.Address;
             Name = data.Name;
             Runtime = runtime;
-            Modules = _helpers.EnumerateModules(this).ToArray();
+            Modules = _helpers.EnumerateModules(this).ToImmutableArray();
         }
 
         /// <summary>
@@ -53,7 +52,7 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
             _helpers = helpers;
             Address = address;
             Id = -1;
-            Modules = _helpers.EnumerateModules(this).ToArray();
+            Modules = _helpers.EnumerateModules(this).ToImmutableArray();
         }
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/src/Implementation/ClrmdConstructedType.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Implementation/ClrmdConstructedType.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Text;
 
 namespace Microsoft.Diagnostics.Runtime.Implementation
@@ -58,9 +59,9 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
         public override ulong MethodTable => 0;
         public override bool IsFinalizeSuppressed(ulong obj) => false;
         public override bool IsPointer => true;
-        public override IReadOnlyList<ClrInstanceField> Fields => Array.Empty<ClrInstanceField>();
-        public override IReadOnlyList<ClrStaticField> StaticFields => Array.Empty<ClrStaticField>();
-        public override IReadOnlyList<ClrMethod> Methods => Array.Empty<ClrMethod>();
+        public override ImmutableArray<ClrInstanceField> Fields => ImmutableArray<ClrInstanceField>.Empty;
+        public override ImmutableArray<ClrStaticField> StaticFields => ImmutableArray<ClrStaticField>.Empty;
+        public override ImmutableArray<ClrMethod> Methods => ImmutableArray<ClrMethod>.Empty;
         public override IEnumerable<ClrInterface> EnumerateInterfaces() => Array.Empty<ClrInterface>();
         public override bool IsFinalizable => false;
         public override bool IsPublic => true;

--- a/src/Microsoft.Diagnostics.Runtime/src/Implementation/ClrmdField.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Implementation/ClrmdField.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Reflection;
 using Microsoft.Diagnostics.Runtime.Utilities;
@@ -329,7 +329,7 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
                         return 1;
 
                     ClrField? last = null;
-                    IReadOnlyList<ClrInstanceField> fields = type.Fields;
+                    ImmutableArray<ClrInstanceField> fields = type.Fields;
                     foreach (ClrField field in fields)
                     {
                         if (last is null)

--- a/src/Microsoft.Diagnostics.Runtime/src/Implementation/ClrmdMethod.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Implementation/ClrmdMethod.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Reflection;
 using Microsoft.Diagnostics.Runtime.DacInterface;
 
@@ -34,7 +34,7 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
             }
         }
 
-        public override IReadOnlyList<ILToNativeMap>? ILOffsetMap => _helpers?.GetILMap(NativeCode, in _hotCold);
+        public override ImmutableArray<ILToNativeMap> ILOffsetMap => _helpers?.GetILMap(NativeCode, in _hotCold) ?? default;
 
         public override HotColdRegions HotColdInfo => _hotCold;
 
@@ -81,15 +81,15 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
 
         public override int GetILOffset(ulong addr)
         {
-            IReadOnlyList<ILToNativeMap>? map = ILOffsetMap;
-            if (map is null)
+            ImmutableArray<ILToNativeMap> map = ILOffsetMap;
+            if (map.IsDefault)
                 return 0;
 
             int ilOffset = 0;
-            if (map.Count > 1)
+            if (map.Length > 1)
                 ilOffset = map[1].ILOffset;
 
-            for (int i = 0; i < map.Count; ++i)
+            for (int i = 0; i < map.Length; ++i)
                 if (map[i].StartAddress <= addr && addr <= map[i].EndAddress)
                     return map[i].ILOffset;
 

--- a/src/Microsoft.Diagnostics.Runtime/src/Implementation/ClrmdPrimitiveType.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Implementation/ClrmdPrimitiveType.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 
 namespace Microsoft.Diagnostics.Runtime.Implementation
 {
@@ -65,18 +66,18 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
         public override object? GetArrayElementValue(ulong objRef, int index) => null;
 
         public override ClrInstanceField? GetFieldByName(string name) => null;
-        
+
         public override ClrStaticField? GetStaticFieldByName(string name) => null;
-    
+
         public override bool IsFinalizeSuppressed(ulong obj) => false;
 
-        public override IReadOnlyList<ClrInstanceField> Fields => Array.Empty<ClrInstanceField>();
+        public override ImmutableArray<ClrInstanceField> Fields => ImmutableArray<ClrInstanceField>.Empty;
 
         public override GCDesc GCDesc => default;
 
-        public override IReadOnlyList<ClrStaticField> StaticFields => Array.Empty<ClrStaticField>();
+        public override ImmutableArray<ClrStaticField> StaticFields => ImmutableArray<ClrStaticField>.Empty;
 
-        public override IReadOnlyList<ClrMethod> Methods => Array.Empty<ClrMethod>();
+        public override ImmutableArray<ClrMethod> Methods => ImmutableArray<ClrMethod>.Empty;
 
         public override ClrType? ComponentType => null;
 

--- a/src/Microsoft.Diagnostics.Runtime/src/Implementation/ICCWData.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Implementation/ICCWData.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
+using System.Collections.Immutable;
 
 namespace Microsoft.Diagnostics.Runtime.Implementation
 {
@@ -15,6 +15,6 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
         int RefCount { get; }
         int JupiterRefCount { get; }
 
-        IReadOnlyList<ComInterfaceData> GetInterfaces();
+        ImmutableArray<ComInterfaceData> GetInterfaces();
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/src/Implementation/IExceptionHelpers.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Implementation/IExceptionHelpers.cs
@@ -2,12 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
+using System.Collections.Immutable;
 
 namespace Microsoft.Diagnostics.Runtime.Implementation
 {
     public interface IExceptionHelpers
     {
-        IReadOnlyList<ClrStackFrame> GetExceptionStackTrace(ClrThread? thread, ClrObject obj);
+        ImmutableArray<ClrStackFrame> GetExceptionStackTrace(ClrThread? thread, ClrObject obj);
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/src/Implementation/IHeapHelpers.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Implementation/IHeapHelpers.cs
@@ -12,7 +12,11 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
         ITypeFactory Factory { get; }
 
         IEnumerable<(ulong, ulong)> EnumerateDependentHandleLinks();
-        bool CreateSegments(ClrHeap clrHeap, out IReadOnlyList<ClrSegment> segemnts, out IReadOnlyList<AllocationContext> allocationContexts,
-                            out IReadOnlyList<FinalizerQueueSegment> fqRoots, out IReadOnlyList<FinalizerQueueSegment> fqObjects);
+        bool CreateSegments(
+            ClrHeap clrHeap,
+            out IReadOnlyList<ClrSegment> segemnts,
+            out IReadOnlyList<AllocationContext> allocationContexts,
+            out IReadOnlyList<FinalizerQueueSegment> fqRoots,
+            out IReadOnlyList<FinalizerQueueSegment> fqObjects);
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/src/Implementation/IMethodHelpers.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Implementation/IMethodHelpers.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
+using System.Collections.Immutable;
 
 namespace Microsoft.Diagnostics.Runtime.Implementation
 {
@@ -11,7 +11,7 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
         IDataReader DataReader { get; }
 
         bool GetSignature(ulong methodDesc, out string? signature);
-        IReadOnlyList<ILToNativeMap> GetILMap(ulong nativeCode, in HotColdRegions hotColdInfo);
+        ImmutableArray<ILToNativeMap> GetILMap(ulong nativeCode, in HotColdRegions hotColdInfo);
         ulong GetILForModule(ulong address, uint rva);
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/src/Implementation/IRCWData.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Implementation/IRCWData.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
+using System.Collections.Immutable;
 
 namespace Microsoft.Diagnostics.Runtime.Implementation
 {
@@ -16,6 +16,6 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
         bool Disconnected { get; }
         ulong CreatorThread { get; }
 
-        IReadOnlyList<ComInterfaceData> GetInterfaces();
+        ImmutableArray<ComInterfaceData> GetInterfaces();
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/src/Implementation/IRuntimeHelpers.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Implementation/IRuntimeHelpers.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 
 namespace Microsoft.Diagnostics.Runtime.Implementation
 {
@@ -11,8 +12,8 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
     {
         ITypeFactory Factory { get; }
         IDataReader DataReader { get; }
-        IReadOnlyList<ClrThread> GetThreads(ClrRuntime runtime);
-        IReadOnlyList<ClrAppDomain> GetAppDomains(ClrRuntime runtime, out ClrAppDomain? system, out ClrAppDomain? shared);
+        ImmutableArray<ClrThread> GetThreads(ClrRuntime runtime);
+        ImmutableArray<ClrAppDomain> GetAppDomains(ClrRuntime runtime, out ClrAppDomain? system, out ClrAppDomain? shared);
         IEnumerable<ClrHandle> EnumerateHandleTable(ClrRuntime runtime);
         void FlushCachedData();
         ulong GetMethodDesc(ulong ip);

--- a/src/Microsoft.Diagnostics.Runtime/src/Implementation/ITypeFactory.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Implementation/ITypeFactory.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
+using System.Collections.Immutable;
 
 namespace Microsoft.Diagnostics.Runtime.Implementation
 {
@@ -14,8 +14,8 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
         ClrRuntime GetOrCreateRuntime();
         ClrHeap GetOrCreateHeap();
         ClrModule GetOrCreateModule(ClrAppDomain domain, ulong address);
-        bool CreateMethodsForType(ClrType type, out IReadOnlyList<ClrMethod> methods);
-        bool CreateFieldsForType(ClrType type, out IReadOnlyList<ClrInstanceField> fields, out IReadOnlyList<ClrStaticField> staticFields);
+        bool CreateMethodsForType(ClrType type, out ImmutableArray<ClrMethod> methods);
+        bool CreateFieldsForType(ClrType type, out ImmutableArray<ClrInstanceField> fields, out ImmutableArray<ClrStaticField> staticFields);
         ComCallableWrapper? CreateCCWForObject(ulong obj);
         RuntimeCallableWrapper? CreateRCWForObject(ulong obj);
         ClrType CreateSystemType(ClrHeap heap, ulong mt, string kind);

--- a/src/Microsoft.Diagnostics.Runtime/src/Linux/ElfCoreFile.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Linux/ElfCoreFile.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Buffers;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -14,7 +15,7 @@ namespace Microsoft.Diagnostics.Runtime.Linux
     internal class ElfCoreFile
     {
         private readonly Reader _reader;
-        private ElfLoadedImage[]? _loadedImages;
+        private ImmutableArray<ElfLoadedImage> _loadedImages;
         private readonly Dictionary<ulong, ulong> _auxvEntries = new Dictionary<ulong, ulong>();
         private ELFVirtualAddressSpace? _virtualAddressSpace;
 
@@ -43,7 +44,7 @@ namespace Microsoft.Diagnostics.Runtime.Linux
             return value;
         }
 
-        public IReadOnlyCollection<ElfLoadedImage> LoadedImages => LoadFileTable();
+        public ImmutableArray<ElfLoadedImage> LoadedImages => LoadFileTable();
 
         public ElfCoreFile(Stream stream)
         {
@@ -103,9 +104,9 @@ namespace Microsoft.Diagnostics.Runtime.Linux
             }
         }
 
-        private IReadOnlyCollection<ElfLoadedImage> LoadFileTable()
+        private ImmutableArray<ElfLoadedImage> LoadFileTable()
         {
-            if (_loadedImages != null)
+            if (!_loadedImages.IsDefault)
                 return _loadedImages;
 
             ElfNote fileNote = GetNotes(ElfNoteType.File).Single();
@@ -167,7 +168,7 @@ namespace Microsoft.Diagnostics.Runtime.Linux
                 ArrayPool<byte>.Shared.Return(bytes);
             }
 
-            return _loadedImages = lookup.Values.OrderBy(i => i.BaseAddress).ToArray();
+            return _loadedImages = lookup.Values.OrderBy(i => i.BaseAddress).ToImmutableArray();
         }
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/src/Linux/ElfFile.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Linux/ElfFile.cs
@@ -61,13 +61,9 @@ namespace Microsoft.Diagnostics.Runtime.Linux
                         {
                             if (note.Type == ElfNoteType.PrpsInfo && note.Name.Equals("GNU"))
                             {
-                                ImmutableArray<byte>.Builder buildId = ImmutableArray.CreateBuilder<byte>((int)note.Header.ContentSize);
-                                buildId.Count = buildId.Capacity;
-
-                                note.ReadContents(0, buildId.DangerousGetSpan());
-
-                                _buildId = buildId.MoveToImmutable();
-                                return _buildId;
+                                byte[] buildId = new byte[note.Header.ContentSize];
+                                note.ReadContents(0, buildId);
+                                return _buildId = buildId.AsImmutableArray();
                             }
                         }
                     }

--- a/src/Microsoft.Diagnostics.Runtime/src/Utilities/PEImage/PEImage.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Utilities/PEImage/PEImage.cs
@@ -204,11 +204,11 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
         public FileVersionInfo? GetFileVersionInfo()
         {
             ResourceEntry? versionNode = Resources.Children.FirstOrDefault(r => r.Name == "Version");
-            if (versionNode == null || versionNode.Children.Count != 1)
+            if (versionNode is null || versionNode.Children.Length != 1)
                 return null;
 
             versionNode = versionNode.Children[0];
-            if (!versionNode.IsLeaf && versionNode.Children.Count == 1)
+            if (!versionNode.IsLeaf && versionNode.Children.Length == 1)
                 versionNode = versionNode.Children[0];
 
             int size = versionNode.Size;


### PR DESCRIPTION
Contributes to #163 

Creating `ImmutableArray<T>`s has copying overheads if the exact size can't be known in advance.

Remaining public APIs that have interface type results:

- `IModuleHelpers.GetSortedTypeDefMap`
- `IModuleHelpers.GetSortedTypeRefMap`

The result size can sometimes be large.

- `IHeapHelpers.CreateSegments`

Needs evaluation.