### PR TITLE
Use .Net Core instead of Netstandard for the library

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime.Utilities/Microsoft.Diagnostics.Runtime.Utilities.csproj
+++ b/src/Microsoft.Diagnostics.Runtime.Utilities/Microsoft.Diagnostics.Runtime.Utilities.csproj
@@ -1,8 +1,8 @@
 ﻿<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net471;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net471;netcoreapp2.1</TargetFrameworks>
 
     <NoWarn>;1591;1701</NoWarn>
     <IsPackable>true</IsPackable>

--- a/src/Microsoft.Diagnostics.Runtime/Microsoft.Diagnostics.Runtime.csproj
+++ b/src/Microsoft.Diagnostics.Runtime/Microsoft.Diagnostics.Runtime.csproj
@@ -1,8 +1,8 @@
 ﻿<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net471;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net471;netcoreapp2.1</TargetFrameworks>
 
     <NoWarn>;1591;1701</NoWarn>
     <Nullable>enable</Nullable>

--- a/src/Microsoft.Diagnostics.Runtime/src/DbgEng/DebugSymbols.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DbgEng/DebugSymbols.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Buffers;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
 using Microsoft.Diagnostics.Runtime.Utilities;
@@ -91,10 +92,10 @@ namespace Microsoft.Diagnostics.Runtime.DbgEng
                 if (hr < 0)
                     return default;
 
-                int minor = (ushort)Marshal.ReadInt16(buffer, 8);
-                int major = (ushort)Marshal.ReadInt16(buffer, 10);
-                int patch = (ushort)Marshal.ReadInt16(buffer, 12);
-                int revision = (ushort)Marshal.ReadInt16(buffer, 14);
+                int minor = Unsafe.As<byte, ushort>(ref buffer[8]);
+                int major = Unsafe.As<byte, ushort>(ref buffer[10]);
+                int patch = Unsafe.As<byte, ushort>(ref buffer[12]);
+                int revision = Unsafe.As<byte, ushort>(ref buffer[14]);
 
                 return new VersionInfo(major, minor, revision, patch);
             }


### PR DESCRIPTION
Using netstandard isn't buying us anything since we already ship two copies of the library anyway.  Just use netcoreapp instead.