### PR TITLE
Fix regression in ReadPdbs

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/src/Utilities/PEImage/PEImage.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Utilities/PEImage/PEImage.cs
@@ -291,7 +291,7 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
                     int ptr = tmp.Item1;
                     int size = tmp.Item2;
 
-                    if (TryRead(out int cvSig) && cvSig == CV_INFO_PDB70.PDB70CvSignature)
+                    if (TryRead(ptr, out int cvSig) && cvSig == CV_INFO_PDB70.PDB70CvSignature)
                     {
                         Guid guid = Read<Guid>();
                         int age = Read<int>();


### PR DESCRIPTION
2.0 had a regression wherein DefaultPdb would return null though the
binary had valid debug info embedded. The correct offset is now being
used to check for the CV7 signature, thereby fixing the regression.