### PR TITLE
Use IEnumerable instead of IList in IDataReader.EnumerateModules

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Core/CoreDumpReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Core/CoreDumpReader.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Diagnostics.Runtime
             return _threads!.Keys;
         }
 
-        public IList<ModuleInfo> EnumerateModules()
+        public IEnumerable<ModuleInfo> EnumerateModules()
         {
             if (_modules is null)
             {

--- a/src/Microsoft.Diagnostics.Runtime/src/DataReaders/DbgEng/DbgEngDataReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataReaders/DbgEng/DbgEngDataReader.cs
@@ -201,7 +201,7 @@ namespace Microsoft.Diagnostics.Runtime
             return bases.ToArray();
         }
 
-        public IList<ModuleInfo> EnumerateModules()
+        public IEnumerable<ModuleInfo> EnumerateModules()
         {
             if (_modules != null)
                 return _modules;

--- a/src/Microsoft.Diagnostics.Runtime/src/DataReaders/IDataReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataReaders/IDataReader.cs
@@ -42,8 +42,8 @@ namespace Microsoft.Diagnostics.Runtime
         /// <summary>
         /// Enumerates modules in the target process.
         /// </summary>
-        /// <returns>A list of the modules in the target process.</returns>
-        IList<ModuleInfo> EnumerateModules();
+        /// <returns>An enumerable of the modules in the target process.</returns>
+        IEnumerable<ModuleInfo> EnumerateModules();
 
         /// <summary>
         /// Gets the version information for a given module (given by the base address of the module).

--- a/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Live/LiveDataReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Live/LiveDataReader.cs
@@ -119,7 +119,7 @@ namespace Microsoft.Diagnostics.Runtime
 
         public int PointerSize => IntPtr.Size;
 
-        public IList<ModuleInfo> EnumerateModules()
+        public IEnumerable<ModuleInfo> EnumerateModules()
         {
             List<ModuleInfo> result = new List<ModuleInfo>();
 

--- a/src/Microsoft.Diagnostics.Runtime/src/Linux/LinuxLiveDataReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Linux/LinuxLiveDataReader.cs
@@ -95,7 +95,7 @@ namespace Microsoft.Diagnostics.Runtime.Linux
         public Architecture Architecture => IntPtr.Size == 4 ? Architecture.X86 : Architecture.Amd64;
         public int PointerSize => IntPtr.Size;
 
-        public IList<ModuleInfo> EnumerateModules()
+        public IEnumerable<ModuleInfo> EnumerateModules()
         {
             List<ModuleInfo> result = new List<ModuleInfo>();
             foreach (var entry in _memoryMapEntries)


### PR DESCRIPTION
This does not clean up implementations of EnumerateModules to do their work lazily.