### PR TITLE
Implement IDataReader.SearchMemory

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/MemoryReaderTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/MemoryReaderTests.cs
@@ -1,0 +1,58 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Xunit;
+
+namespace Microsoft.Diagnostics.Runtime.Tests
+{
+    public class MemoryReaderTests
+    {
+        [Fact]
+        public void SearchMemoryTest()
+        {
+            using DataTarget dt = TestTargets.Types.LoadFullDump();
+            using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
+            ClrHeap heap = runtime.Heap;
+
+            foreach (var segment in heap.Segments)
+            {
+                HashSet<ulong> seen = new HashSet<ulong>() { 0 };
+                List<ClrObject> firstSeenObjectOfType = new List<ClrObject>();
+
+                // We will search for method tables so make sure we 
+                foreach (ClrObject obj in segment.EnumerateObjects())
+                    if (seen.Add(obj.Type.MethodTable))
+                        firstSeenObjectOfType.Add(obj);
+
+                foreach (ClrObject obj in firstSeenObjectOfType)
+                {
+                    // We make sure SearchMemory will find things that are not pointer aligned with 'i' here.
+                    Span<byte> buffer = stackalloc byte[sizeof(ulong) + sizeof(int)];
+                    for (int i = 0; i < sizeof(int); i++)
+                    {
+                        ulong expectedOffset = obj.Address - (uint)i;
+                        if (expectedOffset < segment.Start)
+                            continue;
+
+                        Span<byte> slice = buffer.Slice(0, sizeof(ulong) + i);
+                        if (!dt.DataReader.Read(expectedOffset, slice, out int read) || read != slice.Length)
+                            continue;
+
+                        ulong addressFound = dt.DataReader.SearchMemory(segment.Start, segment.End, buffer.Slice(0, i + sizeof(ulong)));
+
+                        // There could still accidently be a pattern that matches this somewhere
+                        while (addressFound != 0 && addressFound < expectedOffset)
+                            addressFound = dt.DataReader.SearchMemory(addressFound + 1, segment.End, buffer.Slice(0, i + sizeof(ulong)));
+
+                        Assert.Equal(expectedOffset, addressFound);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Core/CoreDumpReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Core/CoreDumpReader.cs
@@ -102,7 +102,7 @@ namespace Microsoft.Diagnostics.Runtime
         {
             ElfFile? file = image.Open();
 
-            VersionInfo version = default;
+            VersionInfo version;
             uint filesize = (uint)image.Size;
             uint timestamp = 0;
 
@@ -112,6 +112,10 @@ namespace Microsoft.Diagnostics.Runtime
                 filesize = (uint)pe.IndexFileSize;
                 timestamp = (uint)pe.IndexTimeStamp;
                 version = pe.GetFileVersionInfo()?.VersionInfo ?? default;
+            }
+            else
+            {
+                LinuxFunctions.GetVersionInfo(this, (ulong)image.BaseAddress, file, out version);
             }
 
             return new ModuleInfo(this, (ulong)image.BaseAddress, filesize, timestamp, image.Path, file?.BuildId ?? default, version);

--- a/src/Microsoft.Diagnostics.Runtime/src/Extensions/MemorySearcher.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Extensions/MemorySearcher.cs
@@ -1,0 +1,83 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Buffers;
+using System.Linq;
+
+namespace Microsoft.Diagnostics.Runtime
+{
+    /// <summary>
+    /// A public extension methods to support searching an IMemoryReader for a given span.
+    /// </summary>
+    public static class MemorySearcher
+    {
+        /// <summary>
+        /// Searches memory from startAddress to endAddress, looking for the memory specified by `searchFor`.  Note
+        /// that this is NOT meant to be used to search the entire address space.  This method will attempt to read
+        /// all memory from startAddress to endAddress, so providing very large ranges of memory will make this take
+        /// a long time.
+        /// </summary>
+        /// <param name="reader">The memory reader to search through.</param>
+        /// <param name="startAddress">The address to start searching memory.</param>
+        /// <param name="endAddress">The address to stop searching memory.</param>
+        /// <param name="searchFor">The memory to search for.</param>
+        /// <returns>The address of the value if found, 0 if not found.</returns>
+        public static ulong SearchMemory(this IMemoryReader reader, ulong startAddress, ulong endAddress, ReadOnlySpan<byte> searchFor)
+        {
+            if (reader is null)
+                throw new ArgumentNullException(nameof(reader));
+
+            // While not strictly disallowed, providing a sanity check to make sure the user isn't
+            // searching from 0 to ulong.MaxValue is a good idea.
+            if (startAddress == 0 || endAddress == ulong.MaxValue)
+                throw new ArgumentException($"The start and end addresses must be within allocated memory.");
+
+            if (endAddress - startAddress > int.MaxValue)
+                throw new ArgumentException($"The range of memory to search must be less than {int.MaxValue:n0} bytes.");
+
+            if (startAddress > endAddress)
+                throw new ArgumentException($"Expected {nameof(startAddress)} <= {nameof(endAddress)}");
+
+            // Reading memory is slow, we want to read in reasonably large chunks.
+            byte[] array = ArrayPool<byte>.Shared.Rent(768 + searchFor.Length);
+            try
+            {
+                while (startAddress < endAddress)
+                {
+                    int bytesRemaining = (int)(endAddress - startAddress);
+                    if (bytesRemaining < searchFor.Length)
+                        break;
+
+                    Span<byte> buffer = new Span<byte>(array, 0, Math.Min(bytesRemaining, array.Length));
+                    if (!reader.Read(startAddress, buffer, out int read) || read < searchFor.Length)
+                        break;
+
+                    buffer = buffer.Slice(0, read);
+                    for (int i = 0; i + searchFor.Length < buffer.Length; i++)
+                    {
+                        Span<byte> slice = buffer.Slice(i, searchFor.Length);
+                        if (slice.SequenceEqual(searchFor))
+                            return startAddress + (uint)i;
+                    }
+
+                    // To keep the code simple, we'll re-read the last bit of the buffer each time instead of
+                    // block copying the leftover bits at the end and having to keep track of the buffer offset
+                    // along the way.
+                    uint increment = (uint)(buffer.Length - searchFor.Length);
+                    if (increment == 0)
+                        break;
+
+                    startAddress += increment;
+                }
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(array);
+            }
+
+            return 0;
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/src/Extensions/MemorySearcher.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Extensions/MemorySearcher.cs
@@ -55,12 +55,9 @@ namespace Microsoft.Diagnostics.Runtime
                         break;
 
                     buffer = buffer.Slice(0, read);
-                    for (int i = 0; i + searchFor.Length < buffer.Length; i++)
-                    {
-                        Span<byte> slice = buffer.Slice(i, searchFor.Length);
-                        if (slice.SequenceEqual(searchFor))
-                            return startAddress + (uint)i;
-                    }
+                    int index = buffer.IndexOf(searchFor);
+                    if (index != -1)
+                        return startAddress + (uint)index;
 
                     // To keep the code simple, we'll re-read the last bit of the buffer each time instead of
                     // block copying the leftover bits at the end and having to keep track of the buffer offset

--- a/src/Microsoft.Diagnostics.Runtime/src/Extensions/MemorySearcher.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Extensions/MemorySearcher.cs
@@ -65,11 +65,11 @@ namespace Microsoft.Diagnostics.Runtime
                     // To keep the code simple, we'll re-read the last bit of the buffer each time instead of
                     // block copying the leftover bits at the end and having to keep track of the buffer offset
                     // along the way.
-                    uint increment = (uint)(buffer.Length - searchFor.Length);
-                    if (increment == 0)
+                    int increment = buffer.Length - searchFor.Length;
+                    if (increment <= 0)
                         break;
 
-                    startAddress += increment;
+                    startAddress += (uint)increment;
                 }
             }
             finally


### PR DESCRIPTION
- Searching through memory to look for a sequence of bytes is a useful thing to have.
- Simplify GetVersionInfo on Linux by using SearchMemory, and by manually parsing the ascii version string.
- Simplify reading of Ascii characters in ReadNullTerminatedAscii.  Since the text we are looking for will have the matching code points between ascii and unicode we can just Append them directly to StringBuilder and not go through Encoding.