### PR TITLE
Memory searcher cleanups

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/MemoryReaderTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/MemoryReaderTests.cs
@@ -43,11 +43,11 @@ namespace Microsoft.Diagnostics.Runtime.Tests
                         if (!dt.DataReader.Read(expectedOffset, slice, out int read) || read != slice.Length)
                             continue;
 
-                        ulong addressFound = dt.DataReader.SearchMemory(segment.Start, segment.End, buffer.Slice(0, i + sizeof(ulong)));
+                        ulong addressFound = dt.DataReader.SearchMemory(segment.Start, (int)segment.Length, buffer.Slice(0, i + sizeof(ulong)));
 
                         // There could still accidently be a pattern that matches this somewhere
                         while (addressFound != 0 && addressFound < expectedOffset)
-                            addressFound = dt.DataReader.SearchMemory(addressFound + 1, segment.End, buffer.Slice(0, i + sizeof(ulong)));
+                            addressFound = dt.DataReader.SearchMemory(addressFound + 1, (int)segment.End, buffer.Slice(0, i + sizeof(ulong)));
 
                         Assert.Equal(expectedOffset, addressFound);
                     }

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/MemoryReaderTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/MemoryReaderTests.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
 
                         // There could still accidently be a pattern that matches this somewhere
                         while (addressFound != 0 && addressFound < expectedOffset)
-                            addressFound = dt.DataReader.SearchMemory(addressFound + 1, (int)segment.End, buffer.Slice(0, i + sizeof(ulong)));
+                            addressFound = dt.DataReader.SearchMemory(addressFound + 1, (int)(segment.End - (addressFound + 1)), buffer.Slice(0, i + sizeof(ulong)));
 
                         Assert.Equal(expectedOffset, addressFound);
                     }

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/GCRoot.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/GCRoot.cs
@@ -183,7 +183,6 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
                 if (cancelToken.IsCancellationRequested)
                     break;
 
-                Console.WriteLine($"Considering {root.Address:x} {root.RootKind} {root.Object}");
                 foreach (LinkedList<ClrObject> path in PathsTo(seen, knownEndPoints, root.Object, target, unique, cancelToken))
                 {
                     if (path != null)

--- a/src/Microsoft.Diagnostics.Runtime/src/Utilities/Platform/LinuxFunctions.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Utilities/Platform/LinuxFunctions.cs
@@ -113,7 +113,9 @@ namespace Microsoft.Diagnostics.Runtime
         internal static unsafe void GetVersionInfo(IDataReader dataReader, ulong startAddress, ulong size, out VersionInfo version)
         {
             version = default;
-            ulong address = dataReader.SearchMemory(startAddress, startAddress + size, s_versionString);
+
+            // (int)size underflow will result in returning 0 here, so this is acceptable
+            ulong address = dataReader.SearchMemory(startAddress, (int)size, s_versionString);
             if (address == 0)
                 return;
 

--- a/src/Microsoft.Diagnostics.Runtime/src/Utilities/Platform/LinuxFunctions.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Utilities/Platform/LinuxFunctions.cs
@@ -95,7 +95,6 @@ namespace Microsoft.Diagnostics.Runtime
 
         internal static void GetVersionInfo(IDataReader dataReader, ulong baseAddress, ElfFile loadedFile, out VersionInfo version)
         {
-            Console.WriteLine($"GetVersionInfo2");
             foreach (ElfProgramHeader programHeader in loadedFile.ProgramHeaders)
             {
                 if (programHeader.Type == ElfProgramHeaderType.Load && programHeader.IsWritable)

--- a/src/Microsoft.Diagnostics.Runtime/src/Utilities/Platform/LinuxFunctions.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Utilities/Platform/LinuxFunctions.cs
@@ -231,6 +231,8 @@ namespace Microsoft.Diagnostics.Runtime
 
                 address += s_versionLength;
 
+                // TODO:  This should be cleaned up to not read byte by byte in the future.  Leaving it here
+                // until we decide whether to rewrite the Linux coredumpreader or not.
                 StringBuilder builder = new StringBuilder();
                 while (address < endAddress)
                 {


### PR DESCRIPTION
- Add todo marker where we need to improve memory searching in the future.
- Remove Console.WriteLines.
- Change SearchMemory to use a length.