### PR TITLE
Make FinalizerQueue tests fail less often

### DIFF
--- a/src/TestTargets/TestTargets.proj
+++ b/src/TestTargets/TestTargets.proj
@@ -9,8 +9,8 @@
   <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">
     <CscPath32>C:\Windows\Microsoft.NET\Framework\v4.0.30319\csc.exe</CscPath32>
     <CscPath64>C:\Windows\Microsoft.NET\Framework64\v4.0.30319\csc.exe</CscPath64>
-    <CdbPath32>C:\Program Files (x86)\Windows Kits\10\Debuggers\x86\cdb.exe</CdbPath32>
-    <CdbPath64>C:\Program Files (x86)\Windows Kits\10\Debuggers\x64\cdb.exe</CdbPath64>
+    <CdbPath32 Condition="'$(CdbPath32)' == ''">C:\Program Files (x86)\Windows Kits\10\Debuggers\x86\cdb.exe</CdbPath32>
+    <CdbPath64 Condition="'$(CdbPath64)' == ''">C:\Program Files (x86)\Windows Kits\10\Debuggers\x64\cdb.exe</CdbPath64>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(OS)' == 'Windows_NT'">


### PR DESCRIPTION
Fixes https://github.com/microsoft/clrmd/issues/436.

It's unclear to me if I've really fixed the problem or made it harder to observe.  I wasn't able to figure out how the previous version of the tests would get into their state even after debugging the offending crash dumps.