### PR TITLE
Make PEImage usage thread safe

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/PEImagePdbTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/PEImagePdbTests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             using DataTarget dt = TestTargets.AppDomains.LoadFullDump();
             ModuleInfo clrModule = dt.EnumerateModules().SingleOrDefault(m => Path.GetFileNameWithoutExtension(m.FileName).Equals("clr", StringComparison.OrdinalIgnoreCase));
 
-            PEImage img = clrModule.GetPEImage();
+            using PEImage img = clrModule.GetPEImage();
             Assert.NotNull(img);
 
             PdbInfo imgPdb = img.DefaultPdb;

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/PEImageResourceTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/PEImageResourceTests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             using DataTarget dt = TestTargets.AppDomains.LoadFullDump();
             ModuleInfo clrModule = dt.EnumerateModules().SingleOrDefault(m => Path.GetFileNameWithoutExtension(m.FileName).Equals("clr", StringComparison.OrdinalIgnoreCase));
 
-            PEImage img = clrModule.GetPEImage();
+            using PEImage img = clrModule.GetPEImage();
             Assert.NotNull(img);
 
             FileVersionInfo fileVersion = img.GetFileVersionInfo();
@@ -35,7 +35,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         {
             using DataTarget dt = TestTargets.AppDomains.LoadFullDump();
             ClrInfo clr = dt.ClrVersions.Single();
-            PEImage image = clr.ModuleInfo.GetPEImage();
+            using PEImage image = clr.ModuleInfo.GetPEImage();
             ResourceEntry entry = image.Resources;
             WalkEntry(entry);
         }

--- a/src/Microsoft.Diagnostics.Runtime/src/Utilities/PEImage/PEImage.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Utilities/PEImage/PEImage.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
     /// <summary>
     /// A class to read information out of PE images (dll/exe).
     /// </summary>
-    public unsafe class PEImage
+    public sealed unsafe class PEImage : IDisposable
     {
         private const ushort ExpectedDosHeaderMagic = 0x5A4D;   // MZ
         private const int PESignatureOffsetLocation = 0x3C;
@@ -90,6 +90,8 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
             _pdbs = new Lazy<List<PdbInfo>>(ReadPdbs);
             _resources = new Lazy<ResourceEntry>(CreateResourceRoot);
         }
+
+        public void Dispose() { }
 
         internal int ResourceVirtualAddress => (int)GetDirectory(2).VirtualAddress;
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/clrmd/issues/465.

- Removed the shared PEImage from ModuleInfo.
- Ensure thread safety when reading PEImage from multiple threads by taking a lock when calling into PEImage.
- Made PEImage artificially IDisposable for future work.