### PR TITLE
Add weak WinRT handle kind

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/src/Common/ClrHandle.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/ClrHandle.cs
@@ -64,6 +64,7 @@ namespace Microsoft.Diagnostics.Runtime
                     case ClrHandleKind.WeakLong:
                     case ClrHandleKind.WeakShort:
                     case ClrHandleKind.Dependent:
+                    case ClrHandleKind.WeakWinRT:
                         return false;
 
                     default:

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/ClrHandleKind.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/ClrHandleKind.cs
@@ -47,6 +47,8 @@ namespace Microsoft.Diagnostics.Runtime
         /// <summary>
         /// Strong handle used internally for book keeping.
         /// </summary>
-        SizedRef = 8
+        SizedRef = 8,
+
+        WeakWinRT = 9,
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/ClrHandleKind.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/ClrHandleKind.cs
@@ -49,6 +49,9 @@ namespace Microsoft.Diagnostics.Runtime
         /// </summary>
         SizedRef = 8,
 
+        /// <summary>
+        /// Weak WinRT handle.
+        /// </summary>
         WeakWinRT = 9,
     }
 }


### PR DESCRIPTION
To reproduce: follow the steps referenced by dotnet/coreclr#27860 and call `ClrmdRuntime.EnumerateHandles()` when the process crashes.

https://github.com/dotnet/runtime/blob/afc21e51af60a4d2cb11a1081fb38b1e3a8df0a2/src/coreclr/src/gc/gcinterface.h#L424-L436

https://github.com/dotnet/runtime/blob/afc21e51af60a4d2cb11a1081fb38b1e3a8df0a2/src/coreclr/src/debug/daccess/request.cpp#L3255-L3257