### PR TITLE
Add .NET Standard 2.0 to the list of TFMs

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/Microsoft.Diagnostics.Runtime.csproj
+++ b/src/Microsoft.Diagnostics.Runtime/Microsoft.Diagnostics.Runtime.csproj
@@ -26,10 +26,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <!-- <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.113">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference> -->
     <PackageReference Include="System.Buffers" Version="4.5.0" />
     <PackageReference Include="System.Collections.Immutable" Version="1.7.0" />
     <PackageReference Include="System.Memory" Version="4.5.3" />

--- a/src/Microsoft.Diagnostics.Runtime/Microsoft.Diagnostics.Runtime.csproj
+++ b/src/Microsoft.Diagnostics.Runtime/Microsoft.Diagnostics.Runtime.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net471</TargetFrameworks>
     <NoWarn>1591;1701</NoWarn>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
Yesterday I've tried to update BenchmarkDotNet to use the latest ClrMD and it turned out that the .NET Standard 2.0 was removed.

@leculver could you please restore it? It's a must-have thing for us (BenchmarkDotNet). We are still supporting .NET 4.6.1 (I wish I could stop, but we have too many users who for some reasons can't move to 4.7.2)