### PR TITLE
Remove double quotes in azure-pipelines.yml

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -64,8 +64,8 @@ jobs:
         continueOnError: true
         condition: always()
       - script: .dotnet\dotnet.exe tool run reportgenerator
-          "-reports:$(Build.SourcesDirectory)\src\*\coverage.cobertura.xml"
-          "-targetdir:$(Build.SourcesDirectory)\artifacts\coverage"
+          -reports:$(Build.SourcesDirectory)\src\*\coverage.cobertura.xml
+          -targetdir:$(Build.SourcesDirectory)\artifacts\coverage
         displayName: Generate Code Coverage Reports
       - task: PublishBuildArtifacts@1
         displayName: Publish Code Coverage Reports
@@ -97,8 +97,8 @@ jobs:
         displayName: Build
         condition: succeeded()
       - script: .dotnet/dotnet tool run reportgenerator
-          "-reports:$(Build.SourcesDirectory)/src/*/coverage.cobertura.xml"
-          "-targetdir:$(Build.SourcesDirectory)/artifacts/coverage"
+          -reports:$(Build.SourcesDirectory)/src/*/coverage.cobertura.xml
+          -targetdir:$(Build.SourcesDirectory)/artifacts/coverage
         displayName: Generate Code Coverage Reports
       - task: PublishBuildArtifacts@1
         displayName: Publish Code Coverage Reports


### PR DESCRIPTION
Continued from https://github.com/microsoft/clrmd/commit/526c03061dae6a2a5bc4c18a475281e1ec1fc09e

Editors are reporting that these strings are invalid, but Azure Pipelines' YAML parser works differently.