### PR TITLE
Ensure valid ClrObject for by-ref stack refs

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/ByReferenceTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/ByReferenceTests.cs
@@ -1,0 +1,58 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Microsoft.Diagnostics.Runtime.Tests
+{
+    public class ByReferenceTests : IDisposable
+    {
+        private readonly DataTarget dataTarget;
+        private readonly ClrRuntime runtime;
+
+        public ByReferenceTests()
+        {
+            dataTarget = TestTargets.ByReference.LoadFullDump();
+            runtime = dataTarget.ClrVersions.Single().CreateRuntime();
+        }
+
+        public void Dispose()
+        {
+            runtime.Dispose();
+            dataTarget.Dispose();
+        }
+
+        private IEnumerable<ClrStackRoot> GetStackRoots(string methodName)
+        {
+            return runtime.Threads.Single(thread => thread.EnumerateStackTrace().Any(frame => frame.Method?.Name == methodName))
+                .EnumerateStackRoots().Where(root => root.StackFrame.Method?.Name == methodName);
+        }
+
+        private void AssertReferenceType(IEnumerable<ClrStackRoot> stackRoots)
+        {
+            ClrStackRoot stackRoot = Assert.Single(stackRoots);
+            Assert.True(stackRoot.IsInterior);
+        }
+
+        private void AssertValueType(IEnumerable<ClrStackRoot> stackRoots)
+        {
+            Assert.Empty(stackRoots);
+        }
+
+        [Fact]
+        public void HeapReferenceType() => AssertReferenceType(GetStackRoots(nameof(HeapReferenceType)));
+
+        [Fact]
+        public void HeapValueType() => AssertValueType(GetStackRoots(nameof(HeapValueType)));
+
+        [Fact]
+        public void StackReferenceType() => AssertReferenceType(GetStackRoots(nameof(StackReferenceType)));
+
+        [Fact]
+        public void StackValueType() => AssertValueType(GetStackRoots(nameof(StackValueType)));
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/TestTargets.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/TestTargets.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         private static readonly Lazy<TestTarget> _types = new Lazy<TestTarget>(() => new TestTarget("Types"));
         private static readonly Lazy<TestTarget> _appDomains = new Lazy<TestTarget>(() => new TestTarget("AppDomains"));
         private static readonly Lazy<TestTarget> _finalizationQueue = new Lazy<TestTarget>(() => new TestTarget("FinalizationQueue"));
-        private static readonly Lazy<TestTarget> _spin = new Lazy<TestTarget>(() => new TestTarget("Spin"));
+        private static readonly Lazy<TestTarget> _byReference = new Lazy<TestTarget>(() => new TestTarget("ByReference"));
 
         public static TestTarget GCRoot => _gcroot.Value;
         public static TestTarget GCRoot2 => _gcroot2.Value;
@@ -47,7 +47,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         public static TestTarget FinalizationQueue => _finalizationQueue.Value;
         public static TestTarget ClrObjects => _clrObjects.Value;
         public static TestTarget Arrays => _arrays.Value;
-        public static TestTarget Spin => _spin.Value;
+        public static TestTarget ByReference => _byReference.Value;
     }
 
     public class TestTarget

--- a/src/TestTargets/ByReference/ByReference.cs
+++ b/src/TestTargets/ByReference/ByReference.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Threading;
+
+internal static class Program
+{
+    private static readonly Barrier B = new Barrier(4 + 1);
+
+    private static object O = new object();
+    private static IntPtr I = new IntPtr();
+
+    private static void Main()
+    {
+        new Thread(HeapReferenceTypeOuter).Start();
+        new Thread(HeapValueTypeOuter).Start();
+        new Thread(StackReferenceTypeOuter).Start();
+        new Thread(StackValueTypeOuter).Start();
+
+        B.SignalAndWait();
+        Throw();
+    }
+
+    private static void HeapReferenceTypeOuter()
+    {
+        HeapReferenceType(ref O);
+    }
+
+    private static void HeapReferenceType(ref object o)
+    {
+        SignalAndSleep();
+    }
+
+    private static void HeapValueTypeOuter()
+    {
+        HeapValueType(ref I);
+    }
+
+    private static void HeapValueType(ref IntPtr i)
+    {
+        SignalAndSleep();
+    }
+
+    private static void StackReferenceTypeOuter()
+    {
+        object o = new object();
+        StackReferenceType(ref o);
+    }
+
+    private static void StackReferenceType(ref object o)
+    {
+        SignalAndSleep();
+    }
+
+    private static void StackValueTypeOuter()
+    {
+        IntPtr i = new IntPtr();
+        StackValueType(ref i);
+    }
+
+    private static void StackValueType(ref IntPtr i)
+    {
+        SignalAndSleep();
+    }
+
+    private static void SignalAndSleep()
+    {
+        B.SignalAndWait();
+        Thread.Sleep(int.MaxValue);
+    }
+
+    private static void Throw()
+    {
+        throw new Exception();
+    }
+}

--- a/src/TestTargets/ByReference/ByReference.csproj
+++ b/src/TestTargets/ByReference/ByReference.csproj
@@ -1,0 +1,12 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Shared\SharedLibrary.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Partial fix for #532 

||Ref to Reference Type on Heap|Ref to Reference Type on Stack|Ref to Value Type on Heap/Stack|
|-|-|-|-|
|**Before**|handled by DAC|invalid `ClrObject`|invalid `ClrObject`|
|**After**|handled by DAC|pointer indirection|skipped|