### PR TITLE
Remove System.Array from GetOrCreateBasicType

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/src/Builders/RuntimeBuilder.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Builders/RuntimeBuilder.cs
@@ -750,7 +750,6 @@ namespace Microsoft.Diagnostics.Runtime.Builders
                             "System.IntPtr" => ClrElementType.NativeInt,
                             "System.UIntPtr" => ClrElementType.NativeUInt,
                             "System.ValueType" => ClrElementType.Struct,
-                            "System.Array" => ClrElementType.SZArray,
                             _ => ClrElementType.Unknown,
                         };
 


### PR DESCRIPTION
Fixes #506 

There is no "basic type" for `System.Array`.

`System.String` is missing here - not sure if it's intentional.