### PR TITLE
Fix dac loading

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/src/DataTargets/DataTarget.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataTargets/DataTarget.cs
@@ -172,7 +172,7 @@ namespace Microsoft.Diagnostics.Runtime
                     }
                     else
                     {
-                        dacLocation = dacFileName;
+                        dacLocation = null;
                     }
                 }
                 else if (!File.Exists(dacLocation) || !PlatformFunctions.IsEqualFileVersion(dacLocation, module.Version))

--- a/src/Microsoft.Diagnostics.Runtime/src/Implementation/SymbolServerLocator.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Implementation/SymbolServerLocator.cs
@@ -103,7 +103,13 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
 
                 if (!entry.IsHttp)
                 {
+                    // Don't check the properties if it's in the right index location
                     fullPath = Path.Combine(entry.Location, indexPath);
+                    if (CheckLocalFile(indexPath, fullPath, buildTimeStamp, imageSize, checkProperties, out result))
+                        return result!;
+
+                    // if it's just some file on disk, check the properties
+                    fullPath = Path.Combine(entry.Cache, fileName);
                     if (CheckLocalFile(indexPath, fullPath, buildTimeStamp, imageSize, checkProperties, out result))
                         return result!;
                 }

--- a/src/Microsoft.Diagnostics.Runtime/src/Implementation/SymbolServerLocator.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Implementation/SymbolServerLocator.cs
@@ -109,7 +109,7 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
                         return result!;
 
                     // if it's just some file on disk, check the properties
-                    fullPath = Path.Combine(entry.Cache, fileName);
+                    fullPath = Path.Combine(entry.Location, fileName);
                     if (CheckLocalFile(indexPath, fullPath, buildTimeStamp, imageSize, checkProperties, out result))
                         return result!;
                 }


### PR DESCRIPTION
I am proposing two fixes in this PR.

The first fix eliminates an unhandled exception on Linux when:

- I am processing a .NET Core 3.0 Linux core dump,
- I don't have .NET Core 3.0 installed on the Linux box, and
- I placed `libmscordaccore.so` at the current directory running the tool using CLRMD.

This was done as an attempt to make CLRMD loads the DAC I wanted, that doesn't worked because:

`DataTarget.GetOrCreateClrVersions()` was returning the DAC file name as DAC location.

Eventually, the file name is used in `ClrInfo.CreateRuntime()` as the `LocalMatchingDac`:

https://github.com/microsoft/clrmd/blob/0dad83b95254477aa91682e51dcec7d2cb192904/src/Microsoft.Diagnostics.Runtime/src/DataTargets/ClrInfo.cs#L83-L99

The file name will pass the `File.Exists()` tests if `libmscordaccore.so` is available at the current directory, but then later it will fail the library loading at Linux because we didn't give it a full path.

Returning null will make sure this does not happen, after all, there is no local matching DAC in this case. We should fall back to the locator route.

The second fix allows the user to specify a path to the folder containing the DAC. If I specify `_NT_SYMBOL_PATH` to a folder containing the `libmscordaccore.so`, without the fix, the `SymbolServerLocator` would insist the path must have the index part (for the non-cached case) (which the user wouldn't know). We already handled the case in the cached branch, so we might as well allow it for the non-cached branch.