### PR TITLE
Avoid reading empty string

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/src/Implementation/ValueReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Implementation/ValueReader.cs
@@ -192,6 +192,10 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
             ulong data = _firstChar.GetAddress(strAddr);
 
             length = Math.Min(length, maxLen);
+            if (length == 0)
+            {
+                return string.Empty;
+            }
             return ReadString(reader, data, length);
         }
 


### PR DESCRIPTION
In case the string is empty, the `ReadString()` method is reading exactly 0 bytes from the underlying `IDataReader`. For Windows, this will return true as `0 == 0`

https://github.com/microsoft/clrmd/blob/b43792a2dc63f51a400167b103d3dc8f8c663cc9/src/Microsoft.Diagnostics.Runtime/src/DataReaders/DbgEng/DbgEngDataReader.cs#L271-L275

But on Linux, this will return false as `0 > 0` is not true.

https://github.com/microsoft/clrmd/blob/b43792a2dc63f51a400167b103d3dc8f8c663cc9/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Core/CoreDumpReader.cs#L154-L160

While this inconsistency is worrisome, this can be easily avoided by not using the reader when we already knew it is an empty string, which is probably the right thing to do anyway.