### PR TITLE
Make Read implementations consistent

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Core/CoreDumpReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Core/CoreDumpReader.cs
@@ -153,6 +153,7 @@ namespace Microsoft.Diagnostics.Runtime
 
         public bool Read(ulong address, Span<byte> buffer, out int bytesRead)
         {
+            DebugOnly.Assert(!buffer.IsEmpty);
             if (address > long.MaxValue)
             {
                 bytesRead = 0;

--- a/src/Microsoft.Diagnostics.Runtime/src/DataReaders/DbgEng/DbgEngDataReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataReaders/DbgEng/DbgEngDataReader.cs
@@ -271,7 +271,7 @@ namespace Microsoft.Diagnostics.Runtime
         public bool Read(ulong address, Span<byte> buffer, out int read)
         {
             read = _spaces.ReadVirtual(address, buffer);
-            return read == buffer.Length;
+            return read > 0;
         }
 
         public ulong ReadPointer(ulong address)

--- a/src/Microsoft.Diagnostics.Runtime/src/DataReaders/DbgEng/DbgEngDataReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataReaders/DbgEng/DbgEngDataReader.cs
@@ -270,6 +270,7 @@ namespace Microsoft.Diagnostics.Runtime
 
         public bool Read(ulong address, Span<byte> buffer, out int read)
         {
+            DebugOnly.Assert(!buffer.IsEmpty);
             read = _spaces.ReadVirtual(address, buffer);
             return read > 0;
         }

--- a/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Live/LiveDataReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Live/LiveDataReader.cs
@@ -163,6 +163,7 @@ namespace Microsoft.Diagnostics.Runtime
 
         public bool Read(ulong address, Span<byte> buffer, out int bytesRead)
         {
+            DebugOnly.Assert(!buffer.IsEmpty);
             try
             {
                 fixed (byte* ptr = buffer)

--- a/src/Microsoft.Diagnostics.Runtime/src/Linux/LinuxLiveDataReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Linux/LinuxLiveDataReader.cs
@@ -156,9 +156,10 @@ namespace Microsoft.Diagnostics.Runtime.Linux
             LinuxFunctions.GetVersionInfo(this, baseAddress, file, out version);
         }
 
-        public bool Read(ulong address, Span<byte> span, out int bytesRead)
+        public bool Read(ulong address, Span<byte> buffer, out int bytesRead)
         {
-            return ReadMemoryReadv(address, span, out bytesRead);
+            DebugOnly.Assert(!buffer.IsEmpty);
+            return ReadMemoryReadv(address, buffer, out bytesRead);
         }
 
         private unsafe bool ReadMemoryReadv(ulong address, Span<byte> buffer, out int bytesRead)

--- a/src/Microsoft.Diagnostics.Runtime/src/Linux/LinuxLiveDataReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Linux/LinuxLiveDataReader.cs
@@ -195,7 +195,7 @@ namespace Microsoft.Diagnostics.Runtime.Linux
                 }
 
                 bytesRead = read;
-                return true;
+                return read > 0;
             }
         }
 


### PR DESCRIPTION
`IMemoryReader.Read(ulong, Span<byte>, out int)` is documented to return "true if any bytes were read at all".

The call site needs to determine whether incomplete reads make sense.

/cc @cshung 