### PR TITLE
Properly handle interior stack pointers

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/ByReferenceTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/ByReferenceTests.cs
@@ -1,0 +1,59 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Microsoft.Diagnostics.Runtime.Tests
+{
+    public class ByReferenceTests : IDisposable
+    {
+        private readonly DataTarget dataTarget;
+        private readonly ClrRuntime runtime;
+
+        public ByReferenceTests()
+        {
+            dataTarget = TestTargets.ByReference.LoadFullDump();
+            runtime = dataTarget.ClrVersions.Single().CreateRuntime();
+        }
+
+        public void Dispose()
+        {
+            runtime.Dispose();
+            dataTarget.Dispose();
+        }
+
+        private IEnumerable<IClrStackRoot> GetStackRoots(string methodName)
+        {
+            return runtime.Threads.Single(thread => thread.EnumerateStackTrace().Any(frame => frame.Method?.Name == methodName))
+                .EnumerateStackRoots().Where(root => root.StackFrame.Method?.Name == methodName);
+        }
+
+        private void AssertReferenceType(IEnumerable<IClrStackRoot> stackRoots)
+        {
+            IClrStackRoot stackRoot = Assert.Single(stackRoots);
+            Assert.True(stackRoot.IsInterior);
+            Assert.True(stackRoot.Object.IsValidObject);
+        }
+
+        private void AssertValueType(IEnumerable<IClrStackRoot> stackRoots)
+        {
+            Assert.Empty(stackRoots);
+        }
+
+        [Fact]
+        public void HeapReferenceType() => AssertReferenceType(GetStackRoots(nameof(HeapReferenceType)));
+
+        [Fact]
+        public void HeapValueType() => AssertValueType(GetStackRoots(nameof(HeapValueType)));
+
+        [Fact]
+        public void StackReferenceType() => AssertReferenceType(GetStackRoots(nameof(StackReferenceType)));
+
+        [Fact]
+        public void StackValueType() => AssertValueType(GetStackRoots(nameof(StackValueType)));
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/HeapTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/HeapTests.cs
@@ -36,6 +36,50 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         }
 
         [Fact]
+        public void SegmentEnumeration()
+        {
+            // Simply test that we can enumerate the heap.
+            using DataTarget dt = TestTargets.Types.LoadFullDump();
+            using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
+            ClrHeap heap = runtime.Heap;
+
+            ClrObject[] objs = heap.EnumerateObjects().ToArray();
+
+            // Enumerating each segment and then each object on each segment should produce
+            // the same enumeration as ClrHeap.EnumerateObjects().
+            int index = 0;
+            foreach (ClrSegment seg in heap.Segments)
+            {
+                foreach (ClrObject obj in seg.EnumerateObjects())
+                {
+                    Assert.Equal(objs[index], obj);
+                    index++;
+                }
+            }
+
+            Assert.Equal(objs.Length, index);
+        }
+
+
+        [Fact]
+        public void NextObject()
+        {
+            using DataTarget dt = TestTargets.Types.LoadFullDump();
+            using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
+            ClrHeap heap = runtime.Heap;
+
+            foreach (ClrSegment seg in heap.Segments)
+            {
+                ulong nextObj = seg.NextObject(seg.FirstObjectAddress);
+                foreach (ClrObject obj in seg.EnumerateObjects().Skip(1))
+                {
+                    Assert.Equal(nextObj, obj.Address);
+                    nextObj = seg.NextObject(obj);
+                }
+            }
+        }
+
+        [Fact]
         public void HeapEnumerationWhileClearingCache()
         {
             // Simply test that we can enumerate the heap.

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/TestTargets.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/TestTargets.cs
@@ -36,6 +36,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         private static readonly Lazy<TestTarget> _appDomains = new Lazy<TestTarget>(() => new TestTarget("AppDomains"));
         private static readonly Lazy<TestTarget> _finalizationQueue = new Lazy<TestTarget>(() => new TestTarget("FinalizationQueue"));
         private static readonly Lazy<TestTarget> _spin = new Lazy<TestTarget>(() => new TestTarget("Spin"));
+        private static readonly Lazy<TestTarget> _byReference = new Lazy<TestTarget>(() => new TestTarget("ByReference"));
 
         public static TestTarget GCRoot => _gcroot.Value;
         public static TestTarget GCRoot2 => _gcroot2.Value;
@@ -48,6 +49,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         public static TestTarget ClrObjects => _clrObjects.Value;
         public static TestTarget Arrays => _arrays.Value;
         public static TestTarget Spin => _spin.Value;
+        public static TestTarget ByReference => _byReference.Value;
     }
 
     public class TestTarget

--- a/src/Microsoft.Diagnostics.Runtime/src/Builders/RuntimeBuilder.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Builders/RuntimeBuilder.cs
@@ -10,6 +10,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
 using Microsoft.Diagnostics.Runtime.DacInterface;
@@ -158,7 +159,7 @@ namespace Microsoft.Diagnostics.Runtime.Builders
             return result;
         }
 
-        private static void ProcessHeap(
+        private void ProcessHeap(
             SegmentBuilder segBuilder,
             ClrHeap clrHeap,
             in HeapDetails heap,
@@ -177,7 +178,7 @@ namespace Microsoft.Diagnostics.Runtime.Builders
             AddSegments(segBuilder, clrHeap, large: false, heap, segments, heap.GenerationTable[2].StartSegment);
         }
 
-        private static void AddSegments(SegmentBuilder segBuilder, ClrHeap clrHeap, bool large, in HeapDetails heap, List<ClrSegment> segments, ulong address)
+        private void AddSegments(SegmentBuilder segBuilder, ClrHeap clrHeap, bool large, in HeapDetails heap, List<ClrSegment> segments, ulong address)
         {
             HashSet<ulong> seenSegments = new HashSet<ulong> { 0 };
             segBuilder.IsLargeObjectSegment = large;
@@ -187,7 +188,7 @@ namespace Microsoft.Diagnostics.Runtime.Builders
                 // Unfortunately ClrmdSegment is tightly coupled to ClrmdHeap to make implementation vastly simpler and it can't
                 // be used with any generic ClrHeap.  There should be no way that this runtime builder ever mismatches the two
                 // so this cast will always succeed.
-                segments.Add(new ClrmdSegment((ClrmdHeap)clrHeap, segBuilder));
+                segments.Add(new ClrmdSegment((ClrmdHeap)clrHeap, this, segBuilder));
                 address = segBuilder.Next;
             }
         }

--- a/src/Microsoft.Diagnostics.Runtime/src/Builders/RuntimeBuilder.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Builders/RuntimeBuilder.cs
@@ -184,7 +184,10 @@ namespace Microsoft.Diagnostics.Runtime.Builders
 
             while (seenSegments.Add(address) && segBuilder.Initialize(address, heap))
             {
-                segments.Add(new ClrmdSegment(clrHeap, segBuilder));
+                // Unfortunately ClrmdSegment is tightly coupled to ClrmdHeap to make implementation vastly simpler and it can't
+                // be used with any generic ClrHeap.  There should be no way that this runtime builder ever mismatches the two
+                // so this cast will always succeed.
+                segments.Add(new ClrmdSegment((ClrmdHeap)clrHeap, segBuilder));
                 address = segBuilder.Next;
             }
         }

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/ClrSegment.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/ClrSegment.cs
@@ -112,8 +112,17 @@ namespace Microsoft.Diagnostics.Runtime
         /// Returns the object after the given object.
         /// </summary>
         /// <param name="obj">A valid object address that resides on this segment.</param>
-        /// <returns>The next object on this segment, or 0 if <paramref name="obj"/> is the last object in the segment.</returns>
-        public abstract ulong NextObject(ulong obj);
+        /// <returns>The next object on this segment, or 0 if <paramref name="obj"/> is the last object on the segment.</returns>
+        public abstract ulong GetNextObjectAddress(ulong obj);
+
+
+        /// <summary>
+        /// Returns the object before the given object.  Note that this function may take a while because in the worst case
+        /// scenario we have to linearly walk all the way from the beginning of the segment to the object.
+        /// </summary>
+        /// <param name="obj">An address that resides on this segment.  This does not need to point directly to a good object.</param>
+        /// <returns>The previous object on this segment, or 0 if <paramref name="obj"/> is the first object on the segment.</returns>
+        public abstract ulong GetPreviousObjectAddress(ulong obj);
 
         /// <summary>
         /// Returns the generation of an object in this segment.

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/ClrSegment.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/ClrSegment.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Diagnostics.Runtime
         /// <summary>
         /// Gets the first object on this segment or 0 if this segment contains no objects.
         /// </summary>
-        public abstract ulong FirstObject { get; }
+        public abstract ulong FirstObjectAddress { get; }
 
         /// <summary>
         /// Returns true if this is a segment for the Large Object Heap.  False otherwise.
@@ -107,6 +107,13 @@ namespace Microsoft.Diagnostics.Runtime
         /// Enumerates all objects on the segment.
         /// </summary>
         public abstract IEnumerable<ClrObject> EnumerateObjects();
+
+        /// <summary>
+        /// Returns the object after the given object.
+        /// </summary>
+        /// <param name="obj">A valid object address that resides on this segment.</param>
+        /// <returns>The next object on this segment, or 0 if <paramref name="obj"/> is the last object in the segment.</returns>
+        public abstract ulong NextObject(ulong obj);
 
         /// <summary>
         /// Returns the generation of an object in this segment.

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/ClrStackInteriorRoot.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/ClrStackInteriorRoot.cs
@@ -1,0 +1,68 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Microsoft.Diagnostics.Runtime
+{
+    public class ClrStackInteriorRoot : IClrStackRoot
+    {
+        private ClrObject? _object;
+        private ClrSegment _segment;
+
+        public ulong Address { get; }
+
+        public ClrObject Object => AsObject() ?? default;
+
+        public ClrStackFrame StackFrame { get; }
+
+        public ClrRootKind RootKind => ClrRootKind.Stack;
+
+        public bool IsInterior => true;
+
+        public bool IsPinned { get; }
+
+        public ulong ObjectPointer { get; }
+
+        public ClrStackInteriorRoot(ClrSegment seg, ulong address, ulong objAddr, ClrStackFrame stackFrame, bool pinned)
+        {
+            _segment = seg;
+            ObjectPointer = objAddr;
+
+            Address = address;
+            StackFrame = stackFrame;
+            IsPinned = pinned;
+        }
+
+        public ClrObject? AsObject()
+        {
+            if (_object.HasValue)
+                return _object.Value;
+
+            // It's possible that ObjectPointer points the the beginning of an object, though that's rare.  Check that first.
+            ClrType? type = _segment.Heap.GetObjectType(ObjectPointer);
+            if (!(type is null))
+            {
+                _object = new ClrObject(ObjectPointer, type);
+                return _object.Value;
+            }
+
+            // ObjectPointer is pointing in the middle of an object, get the previous object for the address.
+            ulong obj = _segment.GetPreviousObjectAddress(ObjectPointer);
+            if (obj == 0)
+                return null;
+
+            type = _segment.Heap.GetObjectType(obj);
+            if (type is null)
+            {
+                // This is heap corruption, or an inconsistent dump.  We should have found a real object here.
+                return null;
+            }
+
+            ClrObject result = new ClrObject(obj, type);
+            _object = result;
+            return result;
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/ClrStackRoot.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/ClrStackRoot.cs
@@ -6,21 +6,20 @@ using System.Text;
 
 namespace Microsoft.Diagnostics.Runtime
 {
-    public struct ClrStackRoot : IClrRoot
+    public struct ClrStackRoot : IClrStackRoot
     {
         public ulong Address { get; }
         public ClrObject Object { get; }
         public ClrStackFrame StackFrame { get; }
         public ClrRootKind RootKind => ClrRootKind.Stack;
-        public bool IsInterior { get; }
+        public bool IsInterior => false;
         public bool IsPinned { get; }
 
-        public ClrStackRoot(ulong address, ClrObject obj, ClrStackFrame stackFrame, bool interior, bool pinned)
+        public ClrStackRoot(ulong address, ClrObject obj, ClrStackFrame stackFrame, bool pinned)
         {
             Address = address;
             Object = obj;
             StackFrame = stackFrame;
-            IsInterior = interior;
             IsPinned = pinned;
         }
 

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/ClrThread.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/ClrThread.cs
@@ -71,11 +71,11 @@ namespace Microsoft.Diagnostics.Runtime
         public abstract ulong StackLimit { get; }
 
         /// <summary>
-        /// Enumerates the GC references (objects) on the stack.  This is equivalent to
-        /// EnumerateStackObjects(true).
+        /// Enumerates the GC references (objects) on the stack.  The returned IClrRoot may either be an
+        /// <see cref="ClrStackRoot"/> or a <see cref="ClrStackInteriorRoot"/>.
         /// </summary>
         /// <returns>An enumeration of GC references on the stack as the GC sees them.</returns>
-        public abstract IEnumerable<ClrStackRoot> EnumerateStackRoots();
+        public abstract IEnumerable<IClrStackRoot> EnumerateStackRoots();
 
         /// <summary>
         /// Enumerates a stack trace for a given thread.  Note this method may loop infinitely in the case of

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/IClrStackRoot.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/IClrStackRoot.cs
@@ -1,0 +1,11 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.Diagnostics.Runtime
+{
+    public interface IClrStackRoot : IClrRoot
+    {
+        ClrStackFrame StackFrame { get; }
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/src/Implementation/ClrmdSegment.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Implementation/ClrmdSegment.cs
@@ -3,19 +3,26 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Buffers;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 
 namespace Microsoft.Diagnostics.Runtime.Implementation
 {
     public class ClrmdSegment : ClrSegment
     {
+        private readonly IHeapHelpers _helpers;
         private readonly ClrmdHeap _clrmdHeap;
 
-        public ClrmdSegment(ClrmdHeap heap, ISegmentData data)
+        public ClrmdSegment(ClrmdHeap heap, IHeapHelpers helpers, ISegmentData data)
         {
+            if (helpers is null)
+                throw new ArgumentNullException(nameof(helpers));
+
             if (data is null)
                 throw new ArgumentNullException(nameof(data));
 
+            _helpers = helpers;
             _clrmdHeap = heap;
 
             LogicalHeap = data.LogicalHeap;
@@ -54,11 +61,135 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
         public override ulong Gen1Length { get; }
         public override ulong Gen2Start { get; }
         public override ulong Gen2Length { get; }
-
-        public override IEnumerable<ClrObject> EnumerateObjects() => _clrmdHeap.EnumerateObjects(this);
-
-        public override ulong NextObject(ulong obj) => _clrmdHeap.NextObject(this, obj);
-
         public override ulong FirstObjectAddress => Gen2Start < End ? Gen2Start : 0;
+
+        public override IEnumerable<ClrObject> EnumerateObjects() => EnumerateObjects(null);
+        
+        public IEnumerable<ClrObject> EnumerateObjects(Action<ulong, ulong, int, int, uint>? callback)
+        {
+            bool large = IsLargeObjectSegment;
+            uint minObjSize = (uint)IntPtr.Size * 3;
+            ulong obj = FirstObjectAddress;
+            IDataReader dataReader = _helpers.DataReader;
+
+            // C# isn't smart enough to understand that !large means memoryReader is non-null.  We will just be
+            // careful here.
+            using MemoryReader memoryReader = (!large ? new MemoryReader(dataReader, 0x10000) : null)!;
+            byte[] buffer = ArrayPool<byte>.Shared.Rent(IntPtr.Size * 2 + sizeof(uint));
+
+            // The large object heap
+            if (!large)
+                memoryReader.EnsureRangeInCache(obj);
+
+            while (obj < CommittedEnd)
+            {
+                ulong mt;
+                if (large)
+                {
+                    if (!dataReader.Read(obj, buffer, out int read) || read != buffer.Length)
+                        break;
+
+                    if (IntPtr.Size == 4)
+                        mt = Unsafe.As<byte, uint>(ref buffer[0]);
+                    else
+                        mt = Unsafe.As<byte, ulong>(ref buffer[0]);
+                }
+                else
+                {
+                    if (!memoryReader.ReadPtr(obj, out mt))
+                        break;
+                }
+
+                ClrType? type = _helpers.Factory.GetOrCreateType(_clrmdHeap, mt, obj);
+                if (type is null)
+                {
+                    callback?.Invoke(obj, mt, int.MinValue + 1, -1, 0);
+                    break;
+                }
+
+                ClrObject result = new ClrObject(obj, type);
+                yield return result;
+
+                ulong size;
+                if (type.ComponentSize == 0)
+                {
+                    size = (uint)type.StaticSize;
+                    callback?.Invoke(obj, mt, type.StaticSize, -1, 0);
+                }
+                else
+                {
+                    uint count;
+                    if (large)
+                        count = Unsafe.As<byte, uint>(ref buffer[IntPtr.Size * 2]);
+                    else
+                        memoryReader.ReadDword(obj + (uint)IntPtr.Size, out count);
+
+                    // Strings in v4+ contain a trailing null terminator not accounted for.
+                    if (_clrmdHeap.StringType == type)
+                        count++;
+
+                    size = count * (ulong)type.ComponentSize + (ulong)type.StaticSize;
+                    callback?.Invoke(obj, mt, type.StaticSize, type.ComponentSize, count);
+                }
+
+                size = ClrmdHeap.Align(size, large);
+                if (size < minObjSize)
+                    size = minObjSize;
+
+                obj += size;
+                obj = _clrmdHeap.SkipAllocationContext(this, obj, mt, callback);
+            }
+
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+
+
+        public override ulong NextObject(ulong addr)
+        {
+            if (addr == 0)
+                return 0;
+
+            if (addr < FirstObjectAddress || addr >= CommittedEnd)
+                throw new InvalidOperationException($"Segment [{FirstObjectAddress:x},{CommittedEnd:x}] does not contain object {addr:x}");
+
+            bool large = IsLargeObjectSegment;
+            uint minObjSize = (uint)IntPtr.Size * 3;
+            IMemoryReader memoryReader = _helpers.DataReader;
+            ulong mt = memoryReader.ReadPointer(addr);
+
+            ClrType? type = _helpers.Factory.GetOrCreateType(Heap, mt, addr);
+            if (type is null)
+                return 0;
+
+            ulong size;
+            if (type.ComponentSize == 0)
+            {
+                size = (uint)type.StaticSize;
+            }
+            else
+            {
+                uint count = memoryReader.Read<uint>(addr + (uint)IntPtr.Size);
+
+                // Strings in v4+ contain a trailing null terminator not accounted for.
+                if (Heap.StringType == type)
+                    count++;
+
+                size = count * (ulong)type.ComponentSize + (ulong)type.StaticSize;
+            }
+
+            size = ClrmdHeap.Align(size, large);
+            if (size < minObjSize)
+                size = minObjSize;
+
+            ulong obj = addr + size;
+
+            if (!large)
+                obj = _clrmdHeap.SkipAllocationContext(this, obj, 0, null); // ignore mt here because it won't be used
+
+            if (obj >= End)
+                return 0;
+
+            return obj;
+        }
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/src/Implementation/ClrmdSegment.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Implementation/ClrmdSegment.cs
@@ -9,12 +9,14 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
 {
     public class ClrmdSegment : ClrSegment
     {
-        public ClrmdSegment(ClrHeap clrHeap, ISegmentData data)
+        private readonly ClrmdHeap _clrmdHeap;
+
+        public ClrmdSegment(ClrmdHeap heap, ISegmentData data)
         {
             if (data is null)
                 throw new ArgumentNullException(nameof(data));
 
-            Heap = clrHeap;
+            _clrmdHeap = heap;
 
             LogicalHeap = data.LogicalHeap;
             Start = data.Start;
@@ -34,7 +36,7 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
             Gen2Length = data.Gen2Length;
         }
 
-        public override ClrHeap Heap { get; }
+        public override ClrHeap Heap => _clrmdHeap;
 
         public override int LogicalHeap { get; }
         public override ulong Start { get; }
@@ -53,8 +55,10 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
         public override ulong Gen2Start { get; }
         public override ulong Gen2Length { get; }
 
-        public override IEnumerable<ClrObject> EnumerateObjects() => ((ClrmdHeap)Heap).EnumerateObjects(this);
+        public override IEnumerable<ClrObject> EnumerateObjects() => _clrmdHeap.EnumerateObjects(this);
 
-        public override ulong FirstObject => Gen2Start < End ? Gen2Start : 0;
+        public override ulong NextObject(ulong obj) => _clrmdHeap.NextObject(this, obj);
+
+        public override ulong FirstObjectAddress => Gen2Start < End ? Gen2Start : 0;
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/src/Implementation/ClrmdThread.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Implementation/ClrmdThread.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Diagnostics.Runtime
             }
         }
 
-        public override IEnumerable<ClrStackRoot> EnumerateStackRoots() => _helpers.EnumerateStackRoots(this);
+        public override IEnumerable<IClrStackRoot> EnumerateStackRoots() => _helpers.EnumerateStackRoots(this);
         public override IEnumerable<ClrStackFrame> EnumerateStackTrace(bool includeContext) => _helpers.EnumerateStackTrace(this, includeContext);
 
         public override bool IsAborted => (_threadState & (int)ThreadState.TS_Aborted) == (int)ThreadState.TS_Aborted;

--- a/src/Microsoft.Diagnostics.Runtime/src/Implementation/IThreadHelpers.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Implementation/IThreadHelpers.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
         ITypeFactory Factory { get; }
         IExceptionHelpers ExceptionHelpers { get; }
 
-        IEnumerable<ClrStackRoot> EnumerateStackRoots(ClrThread thread);
+        IEnumerable<IClrStackRoot> EnumerateStackRoots(ClrThread thread);
         IEnumerable<ClrStackFrame> EnumerateStackTrace(ClrThread thread, bool includeContext);
     }
 }

--- a/src/TestTargets/ByReference/ByReference.cs
+++ b/src/TestTargets/ByReference/ByReference.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Threading;
+
+internal static class Program
+{
+    private static readonly Barrier B = new Barrier(4 + 1);
+
+    private static object O = new object();
+    private static IntPtr I = new IntPtr();
+
+    private static void Main()
+    {
+        new Thread(HeapReferenceTypeOuter).Start();
+        new Thread(HeapValueTypeOuter).Start();
+        new Thread(StackReferenceTypeOuter).Start();
+        new Thread(StackValueTypeOuter).Start();
+
+        B.SignalAndWait();
+        Throw();
+    }
+
+    private static void HeapReferenceTypeOuter()
+    {
+        HeapReferenceType(ref O);
+    }
+
+    private static void HeapReferenceType(ref object o)
+    {
+        SignalAndSleep();
+    }
+
+    private static void HeapValueTypeOuter()
+    {
+        HeapValueType(ref I);
+    }
+
+    private static void HeapValueType(ref IntPtr i)
+    {
+        SignalAndSleep();
+    }
+
+    private static void StackReferenceTypeOuter()
+    {
+        object o = new object();
+        StackReferenceType(ref o);
+    }
+
+    private static void StackReferenceType(ref object o)
+    {
+        SignalAndSleep();
+    }
+
+    private static void StackValueTypeOuter()
+    {
+        IntPtr i = new IntPtr();
+        StackValueType(ref i);
+    }
+
+    private static void StackValueType(ref IntPtr i)
+    {
+        SignalAndSleep();
+    }
+
+    private static void SignalAndSleep()
+    {
+        B.SignalAndWait();
+        Thread.Sleep(int.MaxValue);
+    }
+
+    private static void Throw()
+    {
+        throw new Exception();
+    }
+}

--- a/src/TestTargets/ByReference/ByReference.csproj
+++ b/src/TestTargets/ByReference/ByReference.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Shared\SharedLibrary.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Fixes https://github.com/microsoft/clrmd/issues/539 and https://github.com/microsoft/clrmd/issues/532.

This change ensures we properly enumerate interior stack pointers.  I also added back ClrSegment.NextObject as GetNextObjectAddress.