### PR TITLE
Don't create inner exceptions if the type is null

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/src/Desktop/DesktopException.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Desktop/DesktopException.cs
@@ -54,6 +54,8 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
 
                 ulong ex = (ulong)inner;
                 BaseDesktopHeapType type = (BaseDesktopHeapType)_type.DesktopHeap.GetObjectType(ex);
+                if (type == null)
+                    return null;
 
                 return new DesktopException(ex, type);
             }


### PR DESCRIPTION
If we fail to get the type of an inner exception, do not produce a ClrException object for it.  This prevents us from hitting random null ref exceptions later in execution.