### PR TITLE
Fixes a StackOverflowException in FixGenerics

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/src/Builders/RuntimeBuilder.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Builders/RuntimeBuilder.cs
@@ -1163,7 +1163,7 @@ namespace Microsoft.Diagnostics.Runtime.Builders
             while (i < len)
             {
                 if (name[i] == '`')
-                    while (i < len && name[i] != '[')
+                    while (i < len && name[i] != '[' && name[i] != ',')
                         i++;
 
                 if (name[i] == ',')


### PR DESCRIPTION
I wanted to add some test cases and was trying to research a bit and make sure I was doing things right, but the basic premise is that I encountered the following type, which has a `1 but no generic type parameters specified:

``System.Collections.Generic.List`1[[Syncfusion.EJ2.Blazor.Data.Group`1, Syncfusion.EJ2.Blazor]]``

If that type implies what I think it does I don't really know how an instance of it would get into memory, but that's what I encountered. Just to confirm what I thought I ran the following script in LINQPad:

```csharp
void Main()
{
	typeof(GenNameTest).AssemblyQualifiedName.Dump();
	typeof(GenNameTest<>).AssemblyQualifiedName.Dump();
	typeof(GenNameTest<int>).AssemblyQualifiedName.Dump();
}

public class GenNameTest { }

public class GenNameTest<T> : GenNameTest { }
```

and I got the following output (all types in a LINQPad script are nested types in a generated "UserQuery" class):

```
UserQuery+GenNameTest, query_hkfjhr, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
UserQuery+GenNameTest`1, query_hkfjhr, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
UserQuery+GenNameTest`1[[System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]], query_hkfjhr, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
```

I'm not sure how an instance would exist of a generic type definition as opposed to a generic type with type parameters specified, but that's what I perceive to be happening here. Maybe there are other conditions that translate to backticks in the naming system?