### PR TITLE
Temporarily disable test asset building

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime.Tests/Microsoft.Diagnostics.Runtime.Tests.csproj
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/Microsoft.Diagnostics.Runtime.Tests.csproj
@@ -3,6 +3,9 @@
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <NoWarn>1701;1702;1705;1591;436</NoWarn>
+
+    <!-- This _IS_ a Unit Test Project, but because of build_test_assets.cmd, we don't want to run as part of CI right now -->	
+    <IsUnitTestProject Condition="'$(ContinuousIntegrationBuild)' == 'true'">false</IsUnitTestProject>
   </PropertyGroup>
 
   <ItemGroup>
@@ -21,6 +24,7 @@
     <PackageReference Include="AutoFixture.Xunit2" Version="4.6.0" />
   </ItemGroup>
 
+<!--
   <Target Condition="'$(OS)' == 'Windows_NT'" Name="BuildTargetsWindows" AfterTargets="Build">
     <Exec Command="dotnet.exe build -c $(Configuration) ..\TestTasks\TestTasks.csproj" />
     <Exec Command="dotnet.exe build -c $(Configuration) ..\TestTargets\TestTargets.proj" />
@@ -29,5 +33,7 @@
   <Target Condition="'$(OS)' == 'Unix'" Name="BuildTargetsLinux" AfterTargets="Build">
     <MSBuild Projects="..\TestTargets\TestTargets.proj" />
   </Target>
+
+!-->
 
 </Project>


### PR DESCRIPTION
Building test assets with "AfterTargets=Build" is currently breaking the arcade build system signing step.  This only happens within Arcade and no one on that team has been able to figure out why.  Disabling this part of the build for now so we can get 2.0-beta builds out the door.