### PR TITLE
Don't request MethodTableData for TypeHandles

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/src/Desktop/V45Runtime.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Desktop/V45Runtime.cs
@@ -241,6 +241,9 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
 
         internal override IMethodTableData GetMethodTableData(ulong addr)
         {
+            if ((addr & 2) == 2)
+                return null;
+
             if (_sos.GetMethodTableData(addr, out MethodTableData data))
                 return data;
 


### PR DESCRIPTION
Calling ISOSDac::GetMethodTableData with a TypeHandle will always fail, and it will do some expensive C++ exception handling along the way.  Instead, don't bother calling GetMethodTableData if we know the value is a TypeHandle.

This is intentionally a minimal change.