### PR TITLE
Don't request MethodTableData for TypeHandles

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac.cs
@@ -440,6 +440,13 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
 
         public bool GetMethodTableData(ulong addr, out MethodTableData data)
         {
+            // If the 2nd bit is set it means addr is actually a TypeHandle (which GetMethodTable does not support).
+            if ((addr & 2) == 2)
+            {
+                data = default;
+                return false;
+            }
+
             InitDelegate(ref _getMethodTableData, VTable.GetMethodTableData);
             int hr = _getMethodTableData(Self, addr, out data);
             return SUCCEEDED(hr);


### PR DESCRIPTION
Calling ISOSDac::GetMethodTableData with a TypeHandle will always fail, and it will do some expensive C++ exception handling along the way.  Instead, don't bother calling GetMethodTableData if we know the value is a TypeHandle.