### PR TITLE
Use HRESULT instead of bool

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/src/Builders/RuntimeBuilder.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Builders/RuntimeBuilder.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Diagnostics.Runtime.Builders
             DataReader = _clrInfo.DataTarget.DataReader;
 
             int version = 0;
-            if (_dac.Request(DacRequests.VERSION, ReadOnlySpan<byte>.Empty, new Span<byte>(&version, sizeof(int))) != 0)
+            if (!_dac.Request(DacRequests.VERSION, ReadOnlySpan<byte>.Empty, new Span<byte>(&version, sizeof(int))))
                 throw new InvalidDataException("This instance of CLR either has not been initialized or does not contain any data.  Failed to request DacVersion.");
 
             if (version != 9)

--- a/src/Microsoft.Diagnostics.Runtime/src/Builders/RuntimeBuilder.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Builders/RuntimeBuilder.cs
@@ -353,7 +353,7 @@ namespace Microsoft.Diagnostics.Runtime.Builders
 
                     ClrStackFrame frame = GetStackFrame(thread, contextCopy, ip, sp, frameVtbl);
                     yield return frame;
-                } while (stackwalk.Next());
+                } while (stackwalk.Next().IsOK);
             }
             finally
             {

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/ClrObject.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/ClrObject.cs
@@ -330,7 +330,7 @@ namespace Microsoft.Diagnostics.Runtime
             return Address.GetHashCode();
         }
 
-        public bool Equals(IAddressableTypedEntity entity) => entity is ClrObject other && Equals(other);
+        public bool Equals(IAddressableTypedEntity? entity) => entity is ClrObject other && Equals(other);
 
         /// <summary>
         /// Determines whether two specified <see cref="ClrObject" /> have the same value.

--- a/src/Microsoft.Diagnostics.Runtime/src/DacInterface/ClrDataMethod.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DacInterface/ClrDataMethod.cs
@@ -26,23 +26,17 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
         {
             InitDelegate(ref _getILAddressMap, VTable.GetILAddressMap);
 
-            int hr = _getILAddressMap(Self, 0, out uint needed, null);
-            if (hr != S_OK)
+            HResult hr = _getILAddressMap(Self, 0, out uint needed, null);
+            if (!hr)
                 return null;
 
             ILToNativeMap[] map = new ILToNativeMap[needed];
             hr = _getILAddressMap(Self, needed, out needed, map);
 
-            return hr == S_OK ? map : null;
+            return hr ? map : null;
         }
 
-        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
-        private delegate int GetILAddressMapDelegate(
-            IntPtr self,
-            uint mapLen,
-            out uint mapNeeded,
-            [Out][MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 0)]
-            ILToNativeMap[]? map);
+        private delegate HResult GetILAddressMapDelegate(IntPtr self, uint mapLen, out uint mapNeeded, [Out][MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 0)] ILToNativeMap[]? map);
     }
 
     [StructLayout(LayoutKind.Sequential)]

--- a/src/Microsoft.Diagnostics.Runtime/src/DacInterface/ClrDataTask.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DacInterface/ClrDataTask.cs
@@ -23,15 +23,14 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
         public ClrStackWalk? CreateStackWalk(DacLibrary library, uint flags)
         {
             CreateStackWalkDelegate create = Marshal.GetDelegateForFunctionPointer<CreateStackWalkDelegate>(VTable.CreateStackWalk);
-            int hr = create(Self, flags, out IntPtr pUnk);
-            if (hr != S_OK)
+            if (!create(Self, flags, out IntPtr pUnk))
                 return null;
 
+            GC.KeepAlive(create);
             return new ClrStackWalk(library, pUnk);
         }
 
-        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
-        private delegate int CreateStackWalkDelegate(IntPtr self, uint flags, out IntPtr stackwalk);
+        private delegate HResult CreateStackWalkDelegate(IntPtr self, uint flags, out IntPtr stackwalk);
     }
 
     [StructLayout(LayoutKind.Sequential)]

--- a/src/Microsoft.Diagnostics.Runtime/src/DacInterface/DacDataTargetWrapper.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DacInterface/DacDataTargetWrapper.cs
@@ -27,9 +27,6 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
         private Action? _callback;
         private volatile int _callbackContext;
 
-        private uint? _nextThreadId;
-        private ulong? _nextTLSValue;
-
         public IntPtr IDacDataTarget { get; }
 
         public DacDataTargetWrapper(DataTarget dataTarget)
@@ -188,25 +185,8 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             return HResult.S_OK;
         }
 
-        public void SetNextCurrentThreadId(uint? threadId)
-        {
-            // TODO: Remove?
-            _nextThreadId = threadId;
-        }
-
-        internal void SetNextTLSValue(ulong? value)
-        {
-            _nextTLSValue = value;
-        }
-
         public HResult GetTLSValue(IntPtr self, uint threadID, uint index, out ulong value)
         {
-            if (_nextTLSValue is ulong nextTLSValue)
-            {
-                value = nextTLSValue;
-                return HResult.S_OK;
-            }
-
             value = 0;
             return HResult.E_FAIL;
         }
@@ -218,12 +198,6 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
 
         public HResult GetCurrentThreadID(IntPtr self, out uint threadID)
         {
-            if (_nextThreadId is uint nextThreadId)
-            {
-                threadID = nextThreadId;
-                return HResult.S_OK;
-            }
-
             threadID = 0;
             return HResult.E_FAIL;
         }

--- a/src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac.cs
@@ -33,6 +33,633 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             _library = lib;
         }
 
+        public RejitData[] GetRejitData(ulong md, ulong ip = 0)
+        {
+            InitDelegate(ref _getMethodDescData, VTable.GetMethodDescData);
+            HResult hr = _getMethodDescData(Self, md, ip, out MethodDescData data, 0, null, out int needed);
+            if (hr && needed >= 1)
+            {
+                RejitData[] result = new RejitData[needed];
+                hr = _getMethodDescData(Self, md, ip, out data, result.Length, result, out needed);
+                if (hr)
+                    return result;
+            }
+
+            return Array.Empty<RejitData>();
+        }
+
+        public HResult GetMethodDescData(ulong md, ulong ip, out MethodDescData data)
+        {
+            InitDelegate(ref _getMethodDescData, VTable.GetMethodDescData);
+            return _getMethodDescData(Self, md, ip, out data, 0, null, out int needed);
+        }
+
+        public HResult GetThreadStoreData(out ThreadStoreData data)
+        {
+            InitDelegate(ref _getThreadStoreData, VTable.GetThreadStoreData);
+            return _getThreadStoreData(Self, out data);
+        }
+
+        public uint GetTlsIndex()
+        {
+            InitDelegate(ref _getTlsIndex, VTable.GetTLSIndex);
+            if (_getTlsIndex(Self, out uint index))
+                return index;
+
+            return uint.MaxValue;
+        }
+
+        public ClrDataAddress GetThreadFromThinlockId(uint id)
+        {
+            InitDelegate(ref _getThreadFromThinlockId, VTable.GetThreadFromThinlockID);
+            if (_getThreadFromThinlockId(Self, id, out ClrDataAddress thread))
+                return thread;
+
+            return default;
+        }
+
+        public string? GetMethodDescName(ulong md)
+        {
+            if (md == 0)
+                return null;
+
+            InitDelegate(ref _getMethodDescName, VTable.GetMethodDescName);
+
+            if (!_getMethodDescName(Self, md, 0, null, out int needed))
+                return null;
+
+            byte[] buffer = ArrayPool<byte>.Shared.Rent(needed * sizeof(char));
+            try
+            {
+                int actuallyNeeded;
+                fixed (byte* bufferPtr = buffer)
+                    if (!_getMethodDescName(Self, md, needed, bufferPtr, out actuallyNeeded))
+                        return null;
+
+                // Patch for a bug on sos side :
+                //  Sometimes, when the target method has parameters with generic types
+                //  the first call to GetMethodDescName sets an incorrect value into pNeeded.
+                //  In those cases, a second call directly after the first returns the correct value.
+                if (needed != actuallyNeeded)
+                {
+                    ArrayPool<byte>.Shared.Return(buffer);
+                    buffer = ArrayPool<byte>.Shared.Rent(actuallyNeeded * sizeof(char));
+                    fixed (byte* bufferPtr = buffer)
+                        if (!_getMethodDescName(Self, md, actuallyNeeded, bufferPtr, out actuallyNeeded))
+                            return null;
+                }
+
+                return Encoding.Unicode.GetString(buffer, 0, (actuallyNeeded - 1) * sizeof(char));
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(buffer);
+            }
+        }
+
+        public ulong GetMethodTableSlot(ulong mt, int slot)
+        {
+            if (mt == 0)
+                return 0;
+
+            InitDelegate(ref _getMethodTableSlot, VTable.GetMethodTableSlot);
+
+            if (_getMethodTableSlot(Self, mt, (uint)slot, out ClrDataAddress ip))
+                return ip;
+
+            return 0;
+        }
+
+        public HResult GetThreadLocalModuleData(ulong thread, uint index, out ThreadLocalModuleData data)
+        {
+            InitDelegate(ref _getThreadLocalModuleData, VTable.GetThreadLocalModuleData);
+
+            return _getThreadLocalModuleData(Self, thread, index, out data);
+        }
+
+        public ulong GetILForModule(ulong moduleAddr, uint rva)
+        {
+            InitDelegate(ref _getILForModule, VTable.GetILForModule);
+
+            if (_getILForModule(Self, moduleAddr, rva, out ClrDataAddress result))
+                return result;
+
+            return 0;
+        }
+
+        public COMInterfacePointerData[]? GetCCWInterfaces(ulong ccw, int count)
+        {
+            InitDelegate(ref _getCCWInterfaces, VTable.GetCCWInterfaces);
+
+            COMInterfacePointerData[] data = new COMInterfacePointerData[count];
+            if (_getCCWInterfaces(Self, ccw, count, data, out int pNeeded))
+                return data;
+
+            return null;
+        }
+
+        public COMInterfacePointerData[]? GetRCWInterfaces(ulong ccw, int count)
+        {
+            InitDelegate(ref _getRCWInterfaces, VTable.GetRCWInterfaces);
+
+            COMInterfacePointerData[] data = new COMInterfacePointerData[count];
+            if (_getRCWInterfaces(Self, ccw, count, data, out int pNeeded))
+                return data;
+
+            return null;
+        }
+
+        public HResult GetDomainLocalModuleDataFromModule(ulong module, out DomainLocalModuleData data)
+        {
+            InitDelegate(ref _getDomainLocalModuleDataFromModule, VTable.GetDomainLocalModuleDataFromModule);
+            return _getDomainLocalModuleDataFromModule(Self, module, out data);
+        }
+
+        public HResult GetDomainLocalModuleDataFromAppDomain(ulong appDomain, int id, out DomainLocalModuleData data)
+        {
+            InitDelegate(ref _getDomainLocalModuleDataFromAppDomain, VTable.GetDomainLocalModuleDataFromAppDomain);
+            return _getDomainLocalModuleDataFromAppDomain(Self, appDomain, id, out data);
+        }
+
+        public HResult GetWorkRequestData(ulong request, out WorkRequestData data)
+        {
+            InitDelegate(ref _getWorkRequestData, VTable.GetWorkRequestData);
+            return _getWorkRequestData(Self, request, out data);
+        }
+
+        public HResult GetThreadPoolData(out ThreadPoolData data)
+        {
+            InitDelegate(ref _getThreadPoolData, VTable.GetThreadpoolData);
+            return _getThreadPoolData(Self, out data);
+        }
+
+        public HResult GetSyncBlockData(int index, out SyncBlockData data)
+        {
+            InitDelegate(ref _getSyncBlock, VTable.GetSyncBlockData);
+            return _getSyncBlock(Self, index, out data);
+        }
+
+        public string? GetAppBase(ulong domain)
+        {
+            InitDelegate(ref _getAppBase, VTable.GetApplicationBase);
+            return GetString(_getAppBase, domain);
+        }
+
+        public string? GetConfigFile(ulong domain)
+        {
+            InitDelegate(ref _getConfigFile, VTable.GetAppDomainConfigFile);
+            return GetString(_getConfigFile, domain);
+        }
+
+        public HResult GetCodeHeaderData(ulong ip, out CodeHeaderData codeHeaderData)
+        {
+            if (ip == 0)
+            {
+                codeHeaderData = default;
+                return HResult.E_INVALIDARG;
+            }
+
+            InitDelegate(ref _getCodeHeaderData, VTable.GetCodeHeaderData);
+            return _getCodeHeaderData(Self, ip, out codeHeaderData);
+        }
+
+        public ClrDataAddress GetMethodDescPtrFromFrame(ulong frame)
+        {
+            InitDelegate(ref _getMethodDescPtrFromFrame, VTable.GetMethodDescPtrFromFrame);
+            if (_getMethodDescPtrFromFrame(Self, frame, out ClrDataAddress data))
+                return data;
+
+            return default;
+        }
+
+        public ClrDataAddress GetMethodDescPtrFromIP(ulong frame)
+        {
+            InitDelegate(ref _getMethodDescPtrFromIP, VTable.GetMethodDescPtrFromIP);
+            if (_getMethodDescPtrFromIP(Self, frame, out ClrDataAddress data))
+                return data;
+
+            return default;
+        }
+
+        public string GetFrameName(ulong vtable)
+        {
+            InitDelegate(ref _getFrameName, VTable.GetFrameName);
+            return GetString(_getFrameName, vtable, false) ?? "Unknown Frame";
+        }
+
+        public HResult GetFieldInfo(ulong mt, out V4FieldInfo data)
+        {
+            InitDelegate(ref _getFieldInfo, VTable.GetMethodTableFieldData);
+            return _getFieldInfo(Self, mt, out data);
+        }
+
+        public HResult GetFieldData(ulong fieldDesc, out FieldData data)
+        {
+            InitDelegate(ref _getFieldData, VTable.GetFieldDescData);
+            return _getFieldData(Self, fieldDesc, out data);
+        }
+
+        public HResult GetObjectData(ulong obj, out V45ObjectData data)
+        {
+            InitDelegate(ref _getObjectData, VTable.GetObjectData);
+            return _getObjectData(Self, obj, out data);
+        }
+
+        public HResult GetCCWData(ulong ccw, out CcwData data)
+        {
+            InitDelegate(ref _getCCWData, VTable.GetCCWData);
+            return _getCCWData(Self, ccw, out data);
+        }
+
+        public HResult GetRCWData(ulong rcw, out RcwData data)
+        {
+            InitDelegate(ref _getRCWData, VTable.GetRCWData);
+            return _getRCWData(Self, rcw, out data);
+        }
+
+        public ClrDataModule? GetClrDataModule(ulong module)
+        {
+            if (module == 0)
+                return null;
+
+            InitDelegate(ref _getModule, VTable.GetModule);
+            if (_getModule(Self, module, out IntPtr iunk))
+                return new ClrDataModule(_library, iunk);
+
+            return null;
+        }
+
+        public MetadataImport? GetMetadataImport(ulong module)
+        {
+            if (module == 0)
+                return null;
+
+            InitDelegate(ref _getModule, VTable.GetModule);
+            if (!_getModule(Self, module, out IntPtr iunk))
+                return null;
+
+            try
+            {
+                return new MetadataImport(_library, iunk);
+            }
+            catch (InvalidCastException)
+            {
+                // QueryInterface on MetaDataImport seems to fail when we don't have full
+                // metadata available.
+                return null;
+            }
+        }
+
+        public HResult GetCommonMethodTables(out CommonMethodTables commonMTs)
+        {
+            InitDelegate(ref _getCommonMethodTables, VTable.GetUsefulGlobals);
+            return _getCommonMethodTables(Self, out commonMTs);
+        }
+
+        public ClrDataAddress[] GetAssemblyList(ulong appDomain) => GetAssemblyList(appDomain, 0);
+        public ClrDataAddress[] GetAssemblyList(ulong appDomain, int count) =>  GetModuleOrAssembly(appDomain, count, ref _getAssemblyList, VTable.GetAssemblyList);
+        public ClrDataAddress[] GetModuleList(ulong assembly) => GetModuleList(assembly, 0);
+        public ClrDataAddress[] GetModuleList(ulong assembly, int count) => GetModuleOrAssembly(assembly, count, ref _getModuleList, VTable.GetAssemblyModuleList);
+
+        public HResult GetAssemblyData(ulong domain, ulong assembly, out AssemblyData data)
+        {
+            InitDelegate(ref _getAssemblyData, VTable.GetAssemblyData);
+
+            // The dac seems to have an issue where the assembly data can be filled in for a minidump.
+            // If the data is partially filled in, we'll use it.
+
+            HResult hr = _getAssemblyData(Self, domain, assembly, out data);
+            if (!hr && data.Address == assembly)
+                return HResult.S_FALSE;
+
+            return hr;
+        }
+
+        public HResult GetAppDomainData(ulong addr, out AppDomainData data)
+        {
+            InitDelegate(ref _getAppDomainData, VTable.GetAppDomainData);
+
+            // We can face an exception while walking domain data if we catch the process
+            // at a bad state.  As a workaround we will return partial data if data.Address
+            // and data.StubHeap are set.
+
+            HResult hr = _getAppDomainData(Self, addr, out data);
+            if (!hr && data.Address == addr && data.StubHeap != 0)
+                return HResult.S_FALSE;
+
+            return hr;
+        }
+
+        public string? GetAppDomainName(ulong appDomain)
+        {
+            InitDelegate(ref _getAppDomainName, VTable.GetAppDomainName);
+            return GetString(_getAppDomainName, appDomain);
+        }
+
+        public string? GetAssemblyName(ulong assembly)
+        {
+            InitDelegate(ref _getAssemblyName, VTable.GetAssemblyName);
+            return GetString(_getAssemblyName, assembly);
+        }
+
+        public HResult GetAppDomainStoreData(out AppDomainStoreData data)
+        {
+            InitDelegate(ref _getAppDomainStoreData, VTable.GetAppDomainStoreData);
+            return _getAppDomainStoreData(Self, out data);
+        }
+
+        public HResult GetMethodTableData(ulong addr, out MethodTableData data)
+        {
+            // If the 2nd bit is set it means addr is actually a TypeHandle (which GetMethodTable does not support).
+            if ((addr & 2) == 2)
+            {
+                data = default;
+                return HResult.E_INVALIDARG;
+            }
+
+            InitDelegate(ref _getMethodTableData, VTable.GetMethodTableData);
+            return _getMethodTableData(Self, addr, out data);
+        }
+
+        public string? GetMethodTableName(ulong mt)
+        {
+            InitDelegate(ref _getMethodTableName, VTable.GetMethodTableName);
+            return GetString(_getMethodTableName, mt);
+        }
+
+        public string? GetJitHelperFunctionName(ulong addr)
+        {
+            InitDelegate(ref _getJitHelperFunctionName, VTable.GetJitHelperFunctionName);
+            return GetAsciiString(_getJitHelperFunctionName, addr);
+        }
+
+        public string? GetPEFileName(ulong pefile)
+        {
+            InitDelegate(ref _getPEFileName, VTable.GetPEFileName);
+            return GetString(_getPEFileName, pefile);
+        }
+
+        private string? GetString(DacGetCharArrayWithArg func, ulong addr, bool skipNull = true)
+        {
+            HResult hr = func(Self, addr, 0, null, out int needed);
+            if (!hr)
+                return null;
+
+            if (needed == 0)
+                return string.Empty;
+
+            byte[]? array = null;
+            int size = needed * sizeof(char);
+            Span<byte> buffer = size <= 32 ? stackalloc byte[size] : (array = ArrayPool<byte>.Shared.Rent(size)).AsSpan(0, size);
+
+            try
+            {
+                fixed (byte* bufferPtr = buffer)
+                    hr = func(Self, addr, needed, bufferPtr, out needed);
+
+                if (!hr)
+                    return null;
+
+                if (skipNull)
+                    needed--;
+
+                return Encoding.Unicode.GetString(buffer.Slice(0, needed * sizeof(char)));
+            }
+            finally
+            {
+                if (array != null)
+                    ArrayPool<byte>.Shared.Return(array);
+            }
+        }
+
+        private string? GetAsciiString(DacGetByteArrayWithArg func, ulong addr)
+        {
+            HResult hr = func(Self, addr, 0, null, out int needed);
+            if (!hr)
+                return null;
+
+            if (needed == 0)
+                return string.Empty;
+
+            byte[]? array = null;
+            Span<byte> buffer = needed <= 32 ? stackalloc byte[needed] : (array = ArrayPool<byte>.Shared.Rent(needed)).AsSpan(0, needed);
+
+            try
+            {
+                fixed (byte* bufferPtr = buffer)
+                    hr = func(Self, addr, needed, bufferPtr, out needed);
+
+                if (!hr)
+                    return null;
+
+                int len = buffer.IndexOf((byte)'\0');
+                if (len >= 0)
+                    needed = len;
+
+                return Encoding.ASCII.GetString(buffer.Slice(0, needed));
+            }
+            finally
+            {
+                if (array != null)
+                    ArrayPool<byte>.Shared.Return(array);
+            }
+        }
+
+        public ClrDataAddress GetMethodTableByEEClass(ulong eeclass)
+        {
+            InitDelegate(ref _getMTForEEClass, VTable.GetMethodTableForEEClass);
+            if (_getMTForEEClass(Self, eeclass, out ClrDataAddress data))
+                return data;
+
+            return default;
+        }
+
+        public HResult GetModuleData(ulong module, out ModuleData data)
+        {
+            InitDelegate(ref _getModuleData, VTable.GetModuleData);
+            return _getModuleData(Self, module, out data);
+        }
+
+        private ClrDataAddress[] GetModuleOrAssembly(ulong address, int count, ref DacGetAddrArrayWithArg? func, IntPtr vtableEntry)
+        {
+            InitDelegate(ref func, vtableEntry);
+
+            int needed;
+            if (count <= 0)
+            {
+                if (func(Self, address, 0, null, out needed) < 0)
+                    return Array.Empty<ClrDataAddress>();
+
+                count = needed;
+            }
+
+            // We ignore the return value here since the list may be partially filled
+            ClrDataAddress[] modules = new ClrDataAddress[count];
+            func(Self, address, modules.Length, modules, out needed);
+
+            return modules;
+        }
+
+        public ClrDataAddress[] GetAppDomainList(int count = 0)
+        {
+            InitDelegate(ref _getAppDomainList, VTable.GetAppDomainList);
+
+            if (count <= 0)
+            {
+                if (!GetAppDomainStoreData(out AppDomainStoreData addata))
+                    return Array.Empty<ClrDataAddress>();
+
+                count = addata.AppDomainCount;
+            }
+
+            ClrDataAddress[] data = new ClrDataAddress[count];
+            HResult hr = _getAppDomainList(Self, data.Length, data, out int needed);
+            return hr ? data : Array.Empty<ClrDataAddress>();
+        }
+
+        public HResult GetThreadData(ulong address, out ThreadData data)
+        {
+            if (address == 0)
+            {
+                data = default;
+                return HResult.E_INVALIDARG;
+            }
+
+            InitDelegate(ref _getThreadData, VTable.GetThreadData);
+            return _getThreadData(Self, address, out data);
+        }
+
+        public HResult GetGCHeapData(out GCInfo data)
+        {
+            InitDelegate(ref _getGCHeapData, VTable.GetGCHeapData);
+            return _getGCHeapData(Self, out data);
+        }
+
+        public HResult GetSegmentData(ulong addr, out SegmentData data)
+        {
+            InitDelegate(ref _getSegmentData, VTable.GetHeapSegmentData);
+            return _getSegmentData(Self, addr, out data);
+        }
+
+        public ClrDataAddress[] GetHeapList(int heapCount)
+        {
+            InitDelegate(ref _getGCHeapList, VTable.GetGCHeapList);
+
+            ClrDataAddress[] refs = new ClrDataAddress[heapCount];
+            HResult hr = _getGCHeapList(Self, heapCount, refs, out int needed);
+            return hr ? refs : Array.Empty<ClrDataAddress>();
+        }
+
+        public HResult GetServerHeapDetails(ulong addr, out HeapDetails data)
+        {
+            InitDelegate(ref _getGCHeapDetails, VTable.GetGCHeapDetails);
+            return _getGCHeapDetails(Self, addr, out data);
+        }
+
+        public HResult GetWksHeapDetails(out HeapDetails data)
+        {
+            InitDelegate(ref _getGCHeapStaticData, VTable.GetGCHeapStaticData);
+            return _getGCHeapStaticData(Self, out data);
+        }
+
+        public JitManagerInfo[] GetJitManagers()
+        {
+            InitDelegate(ref _getJitManagers, VTable.GetJitManagerList);
+            HResult hr = _getJitManagers(Self, 0, null, out int needed);
+            if (!hr || needed == 0)
+                return Array.Empty<JitManagerInfo>();
+
+            JitManagerInfo[] result = new JitManagerInfo[needed];
+            hr = _getJitManagers(Self, result.Length, result, out needed);
+
+            return hr ? result : Array.Empty<JitManagerInfo>();
+        }
+
+        public JitCodeHeapInfo[] GetCodeHeapList(ulong jitManager)
+        {
+            InitDelegate(ref _getCodeHeaps, VTable.GetCodeHeapList);
+            HResult hr = _getCodeHeaps(Self, jitManager, 0, null, out int needed);
+            if (!hr || needed == 0)
+                return Array.Empty<JitCodeHeapInfo>();
+
+            JitCodeHeapInfo[] result = new JitCodeHeapInfo[needed];
+            hr = _getCodeHeaps(Self, jitManager, result.Length, result, out needed);
+
+            return hr ? result : Array.Empty<JitCodeHeapInfo>();
+        }
+
+        public enum ModuleMapTraverseKind
+        {
+            TypeDefToMethodTable,
+            TypeRefToMethodTable
+        }
+
+        public delegate void ModuleMapTraverse(int index, ulong methodTable, IntPtr token);
+
+        public HResult TraverseModuleMap(ModuleMapTraverseKind mt, ulong module, ModuleMapTraverse traverse)
+        {
+            InitDelegate(ref _traverseModuleMap, VTable.TraverseModuleMap);
+
+            HResult hr = _traverseModuleMap(Self, (int)mt, module, Marshal.GetFunctionPointerForDelegate(traverse), IntPtr.Zero);
+            GC.KeepAlive(traverse);
+            return hr;
+        }
+
+        public delegate void LoaderHeapTraverse(ulong address, IntPtr size, int isCurrent);
+
+        public HResult TraverseLoaderHeap(ulong heap, LoaderHeapTraverse callback)
+        {
+            InitDelegate(ref _traverseLoaderHeap, VTable.TraverseLoaderHeap);
+
+            HResult hr = _traverseLoaderHeap(Self, heap, Marshal.GetFunctionPointerForDelegate(callback));
+            GC.KeepAlive(callback);
+            return hr;
+        }
+
+        public HResult TraverseStubHeap(ulong heap, int type, LoaderHeapTraverse callback)
+        {
+            InitDelegate(ref _traverseStubHeap, VTable.TraverseVirtCallStubHeap);
+
+            HResult hr = _traverseStubHeap(Self, heap, type, Marshal.GetFunctionPointerForDelegate(callback));
+            GC.KeepAlive(callback);
+            return hr;
+        }
+
+        public SOSHandleEnum? EnumerateHandles(params ClrHandleKind[] types)
+        {
+            InitDelegate(ref _getHandleEnumForTypes, VTable.GetHandleEnumForTypes);
+
+            HResult hr = _getHandleEnumForTypes(Self, types, types.Length, out IntPtr ptrEnum);
+            return hr ? new SOSHandleEnum(_library, ptrEnum) : null;
+        }
+
+        public SOSHandleEnum? EnumerateHandles()
+        {
+            InitDelegate(ref _getHandleEnum, VTable.GetHandleEnum);
+
+            HResult hr = _getHandleEnum(Self, out IntPtr ptrEnum);
+            return hr ? new SOSHandleEnum(_library, ptrEnum) : null;
+        }
+
+        public SOSStackRefEnum? EnumerateStackRefs(uint osThreadId)
+        {
+            InitDelegate(ref _getStackRefEnum, VTable.GetStackReferences);
+
+            HResult hr = _getStackRefEnum(Self, osThreadId, out IntPtr ptrEnum);
+            return hr ? new SOSStackRefEnum(_library, ptrEnum) : null;
+        }
+
+        public ulong GetMethodDescFromToken(ulong module, int token)
+        {
+            InitDelegate(ref _getMethodDescFromToken, VTable.GetMethodDescFromToken);
+
+            if (_getMethodDescFromToken(Self, module, token, out ClrDataAddress md))
+                return md;
+
+            return 0;
+        }
+
+
         private DacGetIntPtr? _getHandleEnum;
         private GetHandleEnumForTypesDelegate? _getHandleEnumForTypes;
         private DacGetIntPtrWithArg? _getStackRefEnum;
@@ -91,796 +718,51 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
         private GetModuleDelegate? _getModule;
         private GetMethodDescFromTokenDelegate? _getMethodDescFromToken;
 
-        public RejitData[] GetRejitData(ulong md, ulong ip = 0)
-        {
-            InitDelegate(ref _getMethodDescData, VTable.GetMethodDescData);
-            int hr = _getMethodDescData(Self, md, ip, out MethodDescData data, 0, null, out int needed);
-
-            if (SUCCEEDED(hr) && needed > 1)
-            {
-                RejitData[] result = new RejitData[needed];
-                hr = _getMethodDescData(Self, md, ip, out data, result.Length, result, out needed);
-                if (SUCCEEDED(hr))
-                    return result;
-            }
-
-            return Array.Empty<RejitData>();
-        }
-
-        public bool GetMethodDescData(ulong md, ulong ip, out MethodDescData data)
-        {
-            InitDelegate(ref _getMethodDescData, VTable.GetMethodDescData);
-            int hr = _getMethodDescData(Self, md, ip, out data, 0, null, out int needed);
-            return SUCCEEDED(hr);
-        }
-
-        public bool GetThreadStoreData(out ThreadStoreData data)
-        {
-            InitDelegate(ref _getThreadStoreData, VTable.GetThreadStoreData);
-            return _getThreadStoreData(Self, out data) == S_OK;
-        }
-
-        public uint GetTlsIndex()
-        {
-            InitDelegate(ref _getTlsIndex, VTable.GetTLSIndex);
-            if (_getTlsIndex(Self, out uint index) == S_OK)
-                return index;
-
-            return uint.MaxValue;
-        }
-
-        public ClrDataAddress GetThreadFromThinlockId(uint id)
-        {
-            InitDelegate(ref _getThreadFromThinlockId, VTable.GetThreadFromThinlockID);
-            if (_getThreadFromThinlockId(Self, id, out ClrDataAddress thread) == S_OK)
-                return thread;
-
-            return default;
-        }
-
-        public string? GetMethodDescName(ulong md)
-        {
-            if (md == 0)
-                return null;
-
-            InitDelegate(ref _getMethodDescName, VTable.GetMethodDescName);
-
-            if (_getMethodDescName(Self, md, 0, null, out int needed) < S_OK)
-                return null;
-
-            byte[] buffer = ArrayPool<byte>.Shared.Rent(needed * sizeof(char));
-            try
-            {
-                int actuallyNeeded;
-                fixed (byte* bufferPtr = buffer)
-                    if (_getMethodDescName(Self, md, needed, bufferPtr, out actuallyNeeded) < S_OK)
-                        return null;
-
-                // Patch for a bug on sos side :
-                //  Sometimes, when the target method has parameters with generic types
-                //  the first call to GetMethodDescName sets an incorrect value into pNeeded.
-                //  In those cases, a second call directly after the first returns the correct value.
-                if (needed != actuallyNeeded)
-                {
-                    ArrayPool<byte>.Shared.Return(buffer);
-                    buffer = ArrayPool<byte>.Shared.Rent(actuallyNeeded * sizeof(char));
-                    fixed (byte* bufferPtr = buffer)
-                        if (_getMethodDescName(Self, md, actuallyNeeded, bufferPtr, out actuallyNeeded) < S_OK)
-                            return null;
-                }
-
-                return Encoding.Unicode.GetString(buffer, 0, (actuallyNeeded - 1) * sizeof(char));
-            }
-            finally
-            {
-                ArrayPool<byte>.Shared.Return(buffer);
-            }
-        }
-
-        public ulong GetMethodTableSlot(ulong mt, int slot)
-        {
-            if (mt == 0)
-                return 0;
-
-            InitDelegate(ref _getMethodTableSlot, VTable.GetMethodTableSlot);
-
-            if (_getMethodTableSlot(Self, mt, (uint)slot, out ClrDataAddress ip) == S_OK)
-                return ip;
-
-            return 0;
-        }
-
-        public bool GetThreadLocalModuleData(ulong thread, uint index, out ThreadLocalModuleData data)
-        {
-            InitDelegate(ref _getThreadLocalModuleData, VTable.GetThreadLocalModuleData);
-
-            return _getThreadLocalModuleData(Self, thread, index, out data) == S_OK;
-        }
-
-        public ulong GetILForModule(ulong moduleAddr, uint rva)
-        {
-            InitDelegate(ref _getILForModule, VTable.GetILForModule);
-
-            int hr = _getILForModule(Self, moduleAddr, rva, out ClrDataAddress result);
-            return hr == S_OK ? (ulong)result : 0ul;
-        }
-
-        public COMInterfacePointerData[]? GetCCWInterfaces(ulong ccw, int count)
-        {
-            InitDelegate(ref _getCCWInterfaces, VTable.GetCCWInterfaces);
-
-            COMInterfacePointerData[] data = new COMInterfacePointerData[count];
-            if (_getCCWInterfaces(Self, ccw, count, data, out int pNeeded) >= 0)
-                return data;
-
-            return null;
-        }
-
-        public COMInterfacePointerData[]? GetRCWInterfaces(ulong ccw, int count)
-        {
-            InitDelegate(ref _getRCWInterfaces, VTable.GetRCWInterfaces);
-
-            COMInterfacePointerData[] data = new COMInterfacePointerData[count];
-            if (_getRCWInterfaces(Self, ccw, count, data, out int pNeeded) >= 0)
-                return data;
-
-            return null;
-        }
-
-        public bool GetDomainLocalModuleDataFromModule(ulong module, out DomainLocalModuleData data)
-        {
-            InitDelegate(ref _getDomainLocalModuleDataFromModule, VTable.GetDomainLocalModuleDataFromModule);
-            int res = _getDomainLocalModuleDataFromModule(Self, module, out data);
-            return SUCCEEDED(res);
-        }
-
-        public bool GetDomainLocalModuleDataFromAppDomain(ulong appDomain, int id, out DomainLocalModuleData data)
-        {
-            InitDelegate(ref _getDomainLocalModuleDataFromAppDomain, VTable.GetDomainLocalModuleDataFromAppDomain);
-            int res = _getDomainLocalModuleDataFromAppDomain(Self, appDomain, id, out data);
-            return SUCCEEDED(res);
-        }
-
-        public bool GetWorkRequestData(ulong request, out WorkRequestData data)
-        {
-            InitDelegate(ref _getWorkRequestData, VTable.GetWorkRequestData);
-            int hr = _getWorkRequestData(Self, request, out data);
-            return SUCCEEDED(hr);
-        }
-
-        public bool GetThreadPoolData(out ThreadPoolData data)
-        {
-            InitDelegate(ref _getThreadPoolData, VTable.GetThreadpoolData);
-            int hr = _getThreadPoolData(Self, out data);
-            return SUCCEEDED(hr);
-        }
-
-        public bool GetSyncBlockData(int index, out SyncBlockData data)
-        {
-            InitDelegate(ref _getSyncBlock, VTable.GetSyncBlockData);
-            int hr = _getSyncBlock(Self, index, out data);
-            return SUCCEEDED(hr);
-        }
-
-        public string? GetAppBase(ulong domain)
-        {
-            InitDelegate(ref _getAppBase, VTable.GetApplicationBase);
-            return GetString(_getAppBase, domain);
-        }
-
-        public string? GetConfigFile(ulong domain)
-        {
-            InitDelegate(ref _getConfigFile, VTable.GetAppDomainConfigFile);
-            return GetString(_getConfigFile, domain);
-        }
-
-        public bool GetCodeHeaderData(ulong ip, out CodeHeaderData codeHeaderData)
-        {
-            if (ip == 0)
-            {
-                codeHeaderData = default;
-                return false;
-            }
-
-            InitDelegate(ref _getCodeHeaderData, VTable.GetCodeHeaderData);
-
-            int hr = _getCodeHeaderData(Self, ip, out codeHeaderData);
-            return hr == S_OK;
-        }
-
-        public ClrDataAddress GetMethodDescPtrFromFrame(ulong frame)
-        {
-            InitDelegate(ref _getMethodDescPtrFromFrame, VTable.GetMethodDescPtrFromFrame);
-            if (_getMethodDescPtrFromFrame(Self, frame, out ClrDataAddress data) == S_OK)
-                return data;
-
-            return default;
-        }
-
-        public ClrDataAddress GetMethodDescPtrFromIP(ulong frame)
-        {
-            InitDelegate(ref _getMethodDescPtrFromIP, VTable.GetMethodDescPtrFromIP);
-            if (_getMethodDescPtrFromIP(Self, frame, out ClrDataAddress data) == S_OK)
-                return data;
-
-            return default;
-        }
-
-        public string GetFrameName(ulong vtable)
-        {
-            InitDelegate(ref _getFrameName, VTable.GetFrameName);
-            return GetString(_getFrameName, vtable, false) ?? "Unknown Frame";
-        }
-
-        public bool GetFieldInfo(ulong mt, out V4FieldInfo data)
-        {
-            InitDelegate(ref _getFieldInfo, VTable.GetMethodTableFieldData);
-            int hr = _getFieldInfo(Self, mt, out data);
-            return SUCCEEDED(hr);
-        }
-
-        public bool GetFieldData(ulong fieldDesc, out FieldData data)
-        {
-            InitDelegate(ref _getFieldData, VTable.GetFieldDescData);
-            int hr = _getFieldData(Self, fieldDesc, out data);
-            return SUCCEEDED(hr);
-        }
-
-        public bool GetObjectData(ulong obj, out V45ObjectData data)
-        {
-            InitDelegate(ref _getObjectData, VTable.GetObjectData);
-            int hr = _getObjectData(Self, obj, out data);
-            return SUCCEEDED(hr);
-        }
-
-        public bool GetCCWData(ulong ccw, out CcwData data)
-        {
-            InitDelegate(ref _getCCWData, VTable.GetCCWData);
-            int hr = _getCCWData(Self, ccw, out data);
-            return SUCCEEDED(hr);
-        }
-
-        public bool GetRCWData(ulong rcw, out RcwData data)
-        {
-            InitDelegate(ref _getRCWData, VTable.GetRCWData);
-            int hr = _getRCWData(Self, rcw, out data);
-            return SUCCEEDED(hr);
-        }
-
-        public ClrDataModule? GetClrDataModule(ulong module)
-        {
-            if (module == 0)
-                return null;
-
-            InitDelegate(ref _getModule, VTable.GetModule);
-            if (_getModule(Self, module, out IntPtr iunk) != S_OK)
-                return null;
-
-            return new ClrDataModule(_library, iunk);
-        }
-
-        public MetadataImport? GetMetadataImport(ulong module)
-        {
-            if (module == 0)
-                return null;
-
-            InitDelegate(ref _getModule, VTable.GetModule);
-            if (_getModule(Self, module, out IntPtr iunk) != S_OK)
-                return null;
-
-            try
-            {
-                return new MetadataImport(_library, iunk);
-            }
-            catch (InvalidCastException)
-            {
-                // QueryInterface on MetaDataImport seems to fail when we don't have full
-                // metadata available.
-                return null;
-            }
-        }
-
-        public bool GetCommonMethodTables(out CommonMethodTables commonMTs)
-        {
-            InitDelegate(ref _getCommonMethodTables, VTable.GetUsefulGlobals);
-            return _getCommonMethodTables(Self, out commonMTs) == S_OK;
-        }
-
-        public ClrDataAddress[] GetAssemblyList(ulong appDomain)
-        {
-            return GetAssemblyList(appDomain, 0);
-        }
-
-        public ClrDataAddress[] GetAssemblyList(ulong appDomain, int count)
-        {
-            return GetModuleOrAssembly(appDomain, count, ref _getAssemblyList, VTable.GetAssemblyList);
-        }
-
-        public bool GetAssemblyData(ulong domain, ulong assembly, out AssemblyData data)
-        {
-            InitDelegate(ref _getAssemblyData, VTable.GetAssemblyData);
-
-            // The dac seems to have an issue where the assembly data can be filled in for a minidump.
-            // If the data is partially filled in, we'll use it.
-
-            int hr = _getAssemblyData(Self, domain, assembly, out data);
-            return SUCCEEDED(hr) || data.Address == assembly;
-        }
-
-        public bool GetAppDomainData(ulong addr, out AppDomainData data)
-        {
-            InitDelegate(ref _getAppDomainData, VTable.GetAppDomainData);
-
-            // We can face an exception while walking domain data if we catch the process
-            // at a bad state.  As a workaround we will return partial data if data.Address
-            // and data.StubHeap are set.
-
-            int hr = _getAppDomainData(Self, addr, out data);
-            return SUCCEEDED(hr) || data.Address == addr && data.StubHeap != 0;
-        }
-
-        public string? GetAppDomainName(ulong appDomain)
-        {
-            InitDelegate(ref _getAppDomainName, VTable.GetAppDomainName);
-            return GetString(_getAppDomainName, appDomain);
-        }
-
-        public string? GetAssemblyName(ulong assembly)
-        {
-            InitDelegate(ref _getAssemblyName, VTable.GetAssemblyName);
-            return GetString(_getAssemblyName, assembly);
-        }
-
-        public bool GetAppDomainStoreData(out AppDomainStoreData data)
-        {
-            InitDelegate(ref _getAppDomainStoreData, VTable.GetAppDomainStoreData);
-            int hr = _getAppDomainStoreData(Self, out data);
-            return SUCCEEDED(hr);
-        }
-
-        public bool GetMethodTableData(ulong addr, out MethodTableData data)
-        {
-            // If the 2nd bit is set it means addr is actually a TypeHandle (which GetMethodTable does not support).
-            if ((addr & 2) == 2)
-            {
-                data = default;
-                return false;
-            }
-
-            InitDelegate(ref _getMethodTableData, VTable.GetMethodTableData);
-            int hr = _getMethodTableData(Self, addr, out data);
-            return SUCCEEDED(hr);
-        }
-
-        public string? GetMethodTableName(ulong mt)
-        {
-            InitDelegate(ref _getMethodTableName, VTable.GetMethodTableName);
-            return GetString(_getMethodTableName, mt);
-        }
-
-        public string? GetJitHelperFunctionName(ulong addr)
-        {
-            InitDelegate(ref _getJitHelperFunctionName, VTable.GetJitHelperFunctionName);
-            return GetAsciiString(_getJitHelperFunctionName, addr);
-        }
-
-        public string? GetPEFileName(ulong pefile)
-        {
-            InitDelegate(ref _getPEFileName, VTable.GetPEFileName);
-            return GetString(_getPEFileName, pefile);
-        }
-
-        private string? GetString(DacGetCharArrayWithArg func, ulong addr, bool skipNull = true)
-        {
-            int hr = func(Self, addr, 0, null, out int needed);
-            if (hr != S_OK)
-                return null;
-
-            if (needed == 0)
-                return string.Empty;
-
-            byte[]? array = null;
-            int size = needed * sizeof(char);
-            Span<byte> buffer = size <= 32 ? stackalloc byte[size] : (array = ArrayPool<byte>.Shared.Rent(size)).AsSpan(0, size);
-
-            try
-            {
-                fixed (byte* bufferPtr = buffer)
-                    hr = func(Self, addr, needed, bufferPtr, out needed);
-
-                if (hr != S_OK)
-                    return null;
-
-                if (skipNull)
-                    needed--;
-
-                return Encoding.Unicode.GetString(buffer.Slice(0, needed * sizeof(char)));
-            }
-            finally
-            {
-                if (array != null)
-                    ArrayPool<byte>.Shared.Return(array);
-            }
-        }
-
-        private string? GetAsciiString(DacGetByteArrayWithArg func, ulong addr)
-        {
-            int hr = func(Self, addr, 0, null, out int needed);
-            if (hr != S_OK)
-                return null;
-
-            if (needed == 0)
-                return string.Empty;
-
-            byte[]? array = null;
-            Span<byte> buffer = needed <= 32 ? stackalloc byte[needed] : (array = ArrayPool<byte>.Shared.Rent(needed)).AsSpan(0, needed);
-
-            try
-            {
-                fixed (byte* bufferPtr = buffer)
-                    hr = func(Self, addr, needed, bufferPtr, out needed);
-
-                if (hr != S_OK)
-                    return null;
-
-                int len = buffer.IndexOf((byte)'\0');
-                if (len >= 0)
-                    needed = len;
-
-                return Encoding.ASCII.GetString(buffer.Slice(0, needed));
-            }
-            finally
-            {
-                if (array != null)
-                    ArrayPool<byte>.Shared.Return(array);
-            }
-        }
-
-        public ClrDataAddress GetMethodTableByEEClass(ulong eeclass)
-        {
-            InitDelegate(ref _getMTForEEClass, VTable.GetMethodTableForEEClass);
-            if (_getMTForEEClass(Self, eeclass, out ClrDataAddress data) == S_OK)
-                return data;
-
-            return default;
-        }
-
-        public bool GetModuleData(ulong module, out ModuleData data)
-        {
-            InitDelegate(ref _getModuleData, VTable.GetModuleData);
-            int hr = _getModuleData(Self, module, out data);
-            return SUCCEEDED(hr);
-        }
-
-        public ClrDataAddress[] GetModuleList(ulong assembly)
-        {
-            return GetModuleList(assembly, 0);
-        }
-
-        public ClrDataAddress[] GetModuleList(ulong assembly, int count)
-        {
-            return GetModuleOrAssembly(assembly, count, ref _getModuleList, VTable.GetAssemblyModuleList);
-        }
-
-        private ClrDataAddress[] GetModuleOrAssembly(ulong address, int count, ref DacGetAddrArrayWithArg? func, IntPtr vtableEntry)
-        {
-            InitDelegate(ref func, vtableEntry);
-
-            int needed;
-            if (count <= 0)
-            {
-                if (func(Self, address, 0, null, out needed) < 0)
-                    return Array.Empty<ClrDataAddress>();
-
-                count = needed;
-            }
-
-            // We ignore the return value here since the list may be partially filled
-            ClrDataAddress[] modules = new ClrDataAddress[count];
-            func(Self, address, modules.Length, modules, out needed);
-
-            return modules;
-        }
-
-        public ClrDataAddress[] GetAppDomainList(int count = 0)
-        {
-            InitDelegate(ref _getAppDomainList, VTable.GetAppDomainList);
-
-            if (count <= 0)
-            {
-                if (!GetAppDomainStoreData(out AppDomainStoreData addata))
-                    return Array.Empty<ClrDataAddress>();
-
-                count = addata.AppDomainCount;
-            }
-
-            ClrDataAddress[] data = new ClrDataAddress[count];
-            int hr = _getAppDomainList(Self, data.Length, data, out int needed);
-            return hr == S_OK ? data : Array.Empty<ClrDataAddress>();
-        }
-
-        public bool GetThreadData(ulong address, out ThreadData data)
-        {
-            if (address == 0)
-            {
-                data = default;
-                return false;
-            }
-
-            InitDelegate(ref _getThreadData, VTable.GetThreadData);
-            int hr = _getThreadData(Self, address, out data);
-            return SUCCEEDED(hr);
-        }
-
-        public bool GetGCHeapData(out GCInfo data)
-        {
-            InitDelegate(ref _getGCHeapData, VTable.GetGCHeapData);
-            int hr = _getGCHeapData(Self, out data);
-            return SUCCEEDED(hr);
-        }
-
-        public bool GetSegmentData(ulong addr, out SegmentData data)
-        {
-            InitDelegate(ref _getSegmentData, VTable.GetHeapSegmentData);
-            int hr = _getSegmentData(Self, addr, out data);
-            return SUCCEEDED(hr);
-        }
-
-        public ClrDataAddress[] GetHeapList(int heapCount)
-        {
-            InitDelegate(ref _getGCHeapList, VTable.GetGCHeapList);
-
-            ClrDataAddress[] refs = new ClrDataAddress[heapCount];
-            int hr = _getGCHeapList(Self, heapCount, refs, out int needed);
-            return hr == S_OK ? refs : Array.Empty<ClrDataAddress>();
-        }
-
-        public bool GetServerHeapDetails(ulong addr, out HeapDetails data)
-        {
-            InitDelegate(ref _getGCHeapDetails, VTable.GetGCHeapDetails);
-            int hr = _getGCHeapDetails(Self, addr, out data);
-
-            return SUCCEEDED(hr);
-        }
-
-        public bool GetWksHeapDetails(out HeapDetails data)
-        {
-            InitDelegate(ref _getGCHeapStaticData, VTable.GetGCHeapStaticData);
-            int hr = _getGCHeapStaticData(Self, out data);
-            return SUCCEEDED(hr);
-        }
-
-        public JitManagerInfo[] GetJitManagers()
-        {
-            InitDelegate(ref _getJitManagers, VTable.GetJitManagerList);
-            int hr = _getJitManagers(Self, 0, null, out int needed);
-            if (hr != S_OK || needed == 0)
-                return Array.Empty<JitManagerInfo>();
-
-            JitManagerInfo[] result = new JitManagerInfo[needed];
-            hr = _getJitManagers(Self, result.Length, result, out needed);
-
-            return hr == S_OK ? result : Array.Empty<JitManagerInfo>();
-        }
-
-        public JitCodeHeapInfo[] GetCodeHeapList(ulong jitManager)
-        {
-            InitDelegate(ref _getCodeHeaps, VTable.GetCodeHeapList);
-            int hr = _getCodeHeaps(Self, jitManager, 0, null, out int needed);
-            if (hr != S_OK || needed == 0)
-                return Array.Empty<JitCodeHeapInfo>();
-
-            JitCodeHeapInfo[] result = new JitCodeHeapInfo[needed];
-            hr = _getCodeHeaps(Self, jitManager, result.Length, result, out needed);
-
-            return hr == S_OK ? result : Array.Empty<JitCodeHeapInfo>();
-        }
-
-        public enum ModuleMapTraverseKind
-        {
-            TypeDefToMethodTable,
-            TypeRefToMethodTable
-        }
-
-        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
-        public delegate void ModuleMapTraverse(int index, ulong methodTable, IntPtr token);
-
-        public bool TraverseModuleMap(ModuleMapTraverseKind mt, ulong module, ModuleMapTraverse traverse)
-        {
-            InitDelegate(ref _traverseModuleMap, VTable.TraverseModuleMap);
-
-            int hr = _traverseModuleMap(Self, (int)mt, module, Marshal.GetFunctionPointerForDelegate(traverse), IntPtr.Zero);
-            GC.KeepAlive(traverse);
-            return hr == S_OK;
-        }
-
-        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
-        public delegate void LoaderHeapTraverse(ulong address, IntPtr size, int isCurrent);
-
-        public bool TraverseLoaderHeap(ulong heap, LoaderHeapTraverse callback)
-        {
-            InitDelegate(ref _traverseLoaderHeap, VTable.TraverseLoaderHeap);
-
-            int hr = _traverseLoaderHeap(Self, heap, Marshal.GetFunctionPointerForDelegate(callback));
-            GC.KeepAlive(callback);
-            return hr == S_OK;
-        }
-
-        public bool TraverseStubHeap(ulong heap, int type, LoaderHeapTraverse callback)
-        {
-            InitDelegate(ref _traverseStubHeap, VTable.TraverseVirtCallStubHeap);
-
-            int hr = _traverseStubHeap(Self, heap, type, Marshal.GetFunctionPointerForDelegate(callback));
-            GC.KeepAlive(callback);
-            return hr == S_OK;
-        }
-
-        public SOSHandleEnum? EnumerateHandles(params ClrHandleKind[] types)
-        {
-            InitDelegate(ref _getHandleEnumForTypes, VTable.GetHandleEnumForTypes);
-
-            int hr = _getHandleEnumForTypes(Self, types, types.Length, out IntPtr ptrEnum);
-            return hr == S_OK ? new SOSHandleEnum(_library, ptrEnum) : null;
-        }
-
-        public SOSHandleEnum? EnumerateHandles()
-        {
-            InitDelegate(ref _getHandleEnum, VTable.GetHandleEnum);
-
-            int hr = _getHandleEnum(Self, out IntPtr ptrEnum);
-            return hr == S_OK ? new SOSHandleEnum(_library, ptrEnum) : null;
-        }
-
-        public SOSStackRefEnum? EnumerateStackRefs(uint osThreadId)
-        {
-            InitDelegate(ref _getStackRefEnum, VTable.GetStackReferences);
-
-            int hr = _getStackRefEnum(Self, osThreadId, out IntPtr ptrEnum);
-            return hr == S_OK ? new SOSStackRefEnum(_library, ptrEnum) : null;
-        }
-
-        public ulong GetMethodDescFromToken(ulong module, int token)
-        {
-            InitDelegate(ref _getMethodDescFromToken, VTable.GetMethodDescFromToken);
-
-            int hr = _getMethodDescFromToken(Self, module, token, out ClrDataAddress md);
-            return hr == S_OK ? (ulong)md : 0ul;
-        }
-
-        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
-        private delegate int GetHandleEnumForTypesDelegate(IntPtr self, [In] ClrHandleKind[] types, int count, out IntPtr handleEnum);
-
-        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
-        private delegate int GetMethodDescFromTokenDelegate(IntPtr self, ClrDataAddress module, int token, out ClrDataAddress methodDesc);
-
-        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
-        private delegate int GetMethodDescDataDelegate(IntPtr self, ClrDataAddress md, ulong ip, out MethodDescData data, int count, [Out] RejitData[]? rejitData, out int needed);
-
-        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
-        private delegate int DacGetIntPtr(IntPtr self, out IntPtr data);
-
-        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
-        private delegate int DacGetAddrWithArg(IntPtr self, ClrDataAddress arg, out ClrDataAddress data);
-
-        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
-        private delegate int DacGetAddrWithArgs(IntPtr self, ClrDataAddress arg, uint id, out ClrDataAddress data);
-
-        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
-        private delegate int DacGetUInt(IntPtr self, out uint data);
-
-        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
-        private delegate int DacGetIntPtrWithArg(IntPtr self, uint addr, out IntPtr data);
-
-        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
-        private delegate int DacGetThreadData(IntPtr self, ClrDataAddress addr, [Out] out ThreadData data);
-
-        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
-        private delegate int DacGetHeapDetailsWithArg(IntPtr self, ClrDataAddress addr, out HeapDetails data);
-
-        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
-        private delegate int DacGetHeapDetails(IntPtr self, out HeapDetails data);
-
-        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
-        private delegate int DacGetAddrArray(IntPtr self, int count, [Out] ClrDataAddress[] values, out int needed);
-
-        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
-        private delegate int DacGetAddrArrayWithArg(IntPtr self, ClrDataAddress arg, int count, [Out] ClrDataAddress[]? values, out int needed);
-
-        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
-        private delegate int DacGetCharArrayWithArg(IntPtr self, ClrDataAddress arg, int count, byte* values, [Out] out int needed);
-
-        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
-        private delegate int DacGetByteArrayWithArg(IntPtr self, ClrDataAddress arg, int count, byte* values, [Out] out int needed);
-
-        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
-        private delegate int DacGetAssemblyData(IntPtr self, ClrDataAddress in1, ClrDataAddress in2, out AssemblyData data);
-
-        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
-        private delegate int DacGetADStoreData(IntPtr self, out AppDomainStoreData data);
-
-        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
-        private delegate int DacGetGCInfoData(IntPtr self, out GCInfo data);
-
-        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
-        private delegate int DacGetCommonMethodTables(IntPtr self, out CommonMethodTables data);
-
-        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
-        private delegate int DacGetThreadPoolData(IntPtr self, out ThreadPoolData data);
-
-        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
-        private delegate int DacGetThreadStoreData(IntPtr self, out ThreadStoreData data);
-
-        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
-        private delegate int DacGetMTData(IntPtr self, ClrDataAddress addr, out MethodTableData data);
-
-        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
-        private delegate int DacGetModuleData(IntPtr self, ClrDataAddress addr, out ModuleData data);
-
-        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
-        private delegate int DacGetSegmentData(IntPtr self, ClrDataAddress addr, out SegmentData data);
-
-        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
-        private delegate int DacGetAppDomainData(IntPtr self, ClrDataAddress addr, out AppDomainData data);
-
-        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
-        private delegate int DacGetJitManagerInfo(IntPtr self, ClrDataAddress addr, out JitManagerInfo data);
-
-        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
-        private delegate int DacGetSyncBlockData(IntPtr self, int index, out SyncBlockData data);
-
-        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
-        private delegate int DacGetCodeHeaderData(IntPtr self, ClrDataAddress addr, out CodeHeaderData data);
-
-        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
-        private delegate int DacGetFieldInfo(IntPtr self, ClrDataAddress addr, out V4FieldInfo data);
-
-        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
-        private delegate int DacGetFieldData(IntPtr self, ClrDataAddress addr, out FieldData data);
-
-        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
-        private delegate int DacGetObjectData(IntPtr self, ClrDataAddress addr, out V45ObjectData data);
-
-        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
-        private delegate int DacGetCCWData(IntPtr self, ClrDataAddress addr, out CcwData data);
-
-        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
-        private delegate int DacGetRCWData(IntPtr self, ClrDataAddress addr, out RcwData data);
-
-        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
-        private delegate int DacGetWorkRequestData(IntPtr self, ClrDataAddress addr, out WorkRequestData data);
-
-        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
-        private delegate int DacGetLocalModuleData(IntPtr self, ClrDataAddress addr, out DomainLocalModuleData data);
-
-        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
-        private delegate int DacGetThreadFromThinLock(IntPtr self, uint id, out ClrDataAddress data);
-
-        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
-        private delegate int DacGetCodeHeaps(IntPtr self, ClrDataAddress addr, int count, [Out] JitCodeHeapInfo[]? values, out int needed);
-
-        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
-        private delegate int DacGetCOMPointers(IntPtr self, ClrDataAddress addr, int count, [Out] COMInterfacePointerData[] values, out int needed);
-
-        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
-        private delegate int DacGetDomainLocalModuleDataFromAppDomain(IntPtr self, ClrDataAddress appDomainAddr, int moduleID, out DomainLocalModuleData data);
-
-        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
-        private delegate int DacGetThreadLocalModuleData(IntPtr self, ClrDataAddress addr, uint id, out ThreadLocalModuleData data);
-
-        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
-        private delegate int DacTraverseLoaderHeap(IntPtr self, ClrDataAddress addr, IntPtr callback);
-
-        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
-        private delegate int DacTraverseStubHeap(IntPtr self, ClrDataAddress addr, int type, IntPtr callback);
-
-        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
-        private delegate int DacTraverseModuleMap(IntPtr self, int type, ClrDataAddress addr, IntPtr callback, IntPtr param);
-
-        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
-        private delegate int DacGetJitManagers(IntPtr self, int count, [Out] JitManagerInfo[]? jitManagers, out int pNeeded);
-
-        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
-        private delegate int GetModuleDelegate(IntPtr self, ClrDataAddress addr, out IntPtr iunk);
+        private delegate HResult GetHandleEnumForTypesDelegate(IntPtr self, [In] ClrHandleKind[] types, int count, out IntPtr handleEnum);
+        private delegate HResult GetMethodDescFromTokenDelegate(IntPtr self, ClrDataAddress module, int token, out ClrDataAddress methodDesc);
+        private delegate HResult GetMethodDescDataDelegate(IntPtr self, ClrDataAddress md, ulong ip, out MethodDescData data, int count, [Out] RejitData[]? rejitData, out int needed);
+        private delegate HResult DacGetIntPtr(IntPtr self, out IntPtr data);
+        private delegate HResult DacGetAddrWithArg(IntPtr self, ClrDataAddress arg, out ClrDataAddress data);
+        private delegate HResult DacGetAddrWithArgs(IntPtr self, ClrDataAddress arg, uint id, out ClrDataAddress data);
+        private delegate HResult DacGetUInt(IntPtr self, out uint data);
+        private delegate HResult DacGetIntPtrWithArg(IntPtr self, uint addr, out IntPtr data);
+        private delegate HResult DacGetThreadData(IntPtr self, ClrDataAddress addr, [Out] out ThreadData data);
+        private delegate HResult DacGetHeapDetailsWithArg(IntPtr self, ClrDataAddress addr, out HeapDetails data);
+        private delegate HResult DacGetHeapDetails(IntPtr self, out HeapDetails data);
+        private delegate HResult DacGetAddrArray(IntPtr self, int count, [Out] ClrDataAddress[] values, out int needed);
+        private delegate HResult DacGetAddrArrayWithArg(IntPtr self, ClrDataAddress arg, int count, [Out] ClrDataAddress[]? values, out int needed);
+        private delegate HResult DacGetCharArrayWithArg(IntPtr self, ClrDataAddress arg, int count, byte* values, [Out] out int needed);
+        private delegate HResult DacGetByteArrayWithArg(IntPtr self, ClrDataAddress arg, int count, byte* values, [Out] out int needed);
+        private delegate HResult DacGetAssemblyData(IntPtr self, ClrDataAddress in1, ClrDataAddress in2, out AssemblyData data);
+        private delegate HResult DacGetADStoreData(IntPtr self, out AppDomainStoreData data);
+        private delegate HResult DacGetGCInfoData(IntPtr self, out GCInfo data);
+        private delegate HResult DacGetCommonMethodTables(IntPtr self, out CommonMethodTables data);
+        private delegate HResult DacGetThreadPoolData(IntPtr self, out ThreadPoolData data);
+        private delegate HResult DacGetThreadStoreData(IntPtr self, out ThreadStoreData data);
+        private delegate HResult DacGetMTData(IntPtr self, ClrDataAddress addr, out MethodTableData data);
+        private delegate HResult DacGetModuleData(IntPtr self, ClrDataAddress addr, out ModuleData data);
+        private delegate HResult DacGetSegmentData(IntPtr self, ClrDataAddress addr, out SegmentData data);
+        private delegate HResult DacGetAppDomainData(IntPtr self, ClrDataAddress addr, out AppDomainData data);
+        private delegate HResult DacGetJitManagerInfo(IntPtr self, ClrDataAddress addr, out JitManagerInfo data);
+        private delegate HResult DacGetSyncBlockData(IntPtr self, int index, out SyncBlockData data);
+        private delegate HResult DacGetCodeHeaderData(IntPtr self, ClrDataAddress addr, out CodeHeaderData data);
+        private delegate HResult DacGetFieldInfo(IntPtr self, ClrDataAddress addr, out V4FieldInfo data);
+        private delegate HResult DacGetFieldData(IntPtr self, ClrDataAddress addr, out FieldData data);
+        private delegate HResult DacGetObjectData(IntPtr self, ClrDataAddress addr, out V45ObjectData data);
+        private delegate HResult DacGetCCWData(IntPtr self, ClrDataAddress addr, out CcwData data);
+        private delegate HResult DacGetRCWData(IntPtr self, ClrDataAddress addr, out RcwData data);
+        private delegate HResult DacGetWorkRequestData(IntPtr self, ClrDataAddress addr, out WorkRequestData data);
+        private delegate HResult DacGetLocalModuleData(IntPtr self, ClrDataAddress addr, out DomainLocalModuleData data);
+        private delegate HResult DacGetThreadFromThinLock(IntPtr self, uint id, out ClrDataAddress data);
+        private delegate HResult DacGetCodeHeaps(IntPtr self, ClrDataAddress addr, int count, [Out] JitCodeHeapInfo[]? values, out int needed);
+        private delegate HResult DacGetCOMPointers(IntPtr self, ClrDataAddress addr, int count, [Out] COMInterfacePointerData[] values, out int needed);
+        private delegate HResult DacGetDomainLocalModuleDataFromAppDomain(IntPtr self, ClrDataAddress appDomainAddr, int moduleID, out DomainLocalModuleData data);
+        private delegate HResult DacGetThreadLocalModuleData(IntPtr self, ClrDataAddress addr, uint id, out ThreadLocalModuleData data);
+        private delegate HResult DacTraverseLoaderHeap(IntPtr self, ClrDataAddress addr, IntPtr callback);
+        private delegate HResult DacTraverseStubHeap(IntPtr self, ClrDataAddress addr, int type, IntPtr callback);
+        private delegate HResult DacTraverseModuleMap(IntPtr self, int type, ClrDataAddress addr, IntPtr callback, IntPtr param);
+        private delegate HResult DacGetJitManagers(IntPtr self, int count, [Out] JitManagerInfo[]? jitManagers, out int pNeeded);
+        private delegate HResult GetModuleDelegate(IntPtr self, ClrDataAddress addr, out IntPtr iunk);
     }
 
     [StructLayout(LayoutKind.Sequential)]

--- a/src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac6.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac6.cs
@@ -27,16 +27,14 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
         {
         }
 
-        private DacGetMethodTableCollectibleData? _getMethodTableCollectibleData;
 
-        public bool GetMethodTableCollectibleData(ulong mt, out MethodTableCollectibleData data)
+        public HResult GetMethodTableCollectibleData(ulong mt, out MethodTableCollectibleData data)
         {
             InitDelegate(ref _getMethodTableCollectibleData, VTable.GetMethodTableCollectibleData);
-            int hr = _getMethodTableCollectibleData(Self, mt, out data);
-            return SUCCEEDED(hr);
+            return _getMethodTableCollectibleData(Self, mt, out data);
         }
 
-        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
+        private DacGetMethodTableCollectibleData? _getMethodTableCollectibleData;
         private delegate int DacGetMethodTableCollectibleData(IntPtr self, ClrDataAddress addr, out MethodTableCollectibleData data);
     }
 

--- a/src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosHandleEnum.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosHandleEnum.cs
@@ -13,8 +13,6 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
     {
         private static readonly Guid IID_ISOSHandleEnum = new Guid("3E269830-4A2B-4301-8EE2-D6805B29B2FA");
 
-        private readonly Next _next;
-
         public SOSHandleEnum(DacLibrary library, IntPtr pUnk)
             : base(library?.OwningLibrary, IID_ISOSHandleEnum, pUnk)
         {
@@ -29,17 +27,13 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
 
             fixed (HandleData* ptr = handles)
             {
-                int hr = _next(Self, handles.Length, ptr, out int read);
-                return hr >= S_OK ? read : 0;
+                HResult hr = _next(Self, handles.Length, ptr, out int read);
+                return hr ? read : 0;
             }
         }
 
-        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
-        private delegate int Next(
-            IntPtr self,
-            int count,
-            HandleData* handles,
-            out int pNeeded);
+        private readonly Next _next;
+        private delegate HResult Next(IntPtr self, int count, HandleData* handles, out int pNeeded);
     }
 
     [StructLayout(LayoutKind.Sequential)]

--- a/src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosStackRefEnum.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosStackRefEnum.cs
@@ -13,7 +13,6 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
     {
         private static readonly Guid IID_ISOSStackRefEnum = new Guid("8FA642BD-9F10-4799-9AA3-512AE78C77EE");
 
-        private readonly Next _next;
 
         public SOSStackRefEnum(DacLibrary library, IntPtr pUnk)
             : base(library?.OwningLibrary, IID_ISOSStackRefEnum, pUnk)
@@ -27,17 +26,12 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             if (stackRefs is null)
                 throw new ArgumentNullException(nameof(stackRefs));
 
-            int hr = _next(Self, stackRefs.Length, stackRefs, out int read);
-            return hr >= S_OK ? read : 0;
+            HResult hr = _next(Self, stackRefs.Length, stackRefs, out int read);
+            return hr ? read : 0;
         }
 
-        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
-        private delegate int Next(
-            IntPtr self,
-            int count,
-            [Out][MarshalAs(UnmanagedType.LPArray)]
-            StackRefData[] stackRefs,
-            out int pNeeded);
+        private readonly Next _next;
+        private delegate int Next(IntPtr self, int count, [Out][MarshalAs(UnmanagedType.LPArray)] StackRefData[] stackRefs, out int pNeeded);
     }
 
     [StructLayout(LayoutKind.Sequential)]

--- a/src/Microsoft.Diagnostics.Runtime/src/DataReaders/DbgEng/DbgEngDataReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataReaders/DbgEng/DbgEngDataReader.cs
@@ -48,23 +48,23 @@ namespace Microsoft.Diagnostics.Runtime
 
             IntPtr pClient = CreateIDebugClient();
             CreateClient(pClient);
-            int hr = _client.OpenDumpFile(dumpFile);
+            HResult hr = _client.OpenDumpFile(dumpFile);
             if (hr != 0)
             {
-                const int E_INVALIDARG = unchecked((int)0x80070057);
                 const int STATUS_MAPPED_FILE_SIZE_ZERO = unchecked((int)0xC000011E);
 
-                if (hr == E_INVALIDARG || hr == HRESULT_FROM_NT(STATUS_MAPPED_FILE_SIZE_ZERO))
+                if (hr == HResult.E_INVALIDARG || hr == HRESULT_FROM_NT(STATUS_MAPPED_FILE_SIZE_ZERO))
                     throw new InvalidDataException($"'{dumpFile}' is not a crash dump.");
 
-                var kind = (uint)hr == 0x80004005 ? ClrDiagnosticsExceptionKind.CorruptedFileOrUnknownFormat : ClrDiagnosticsExceptionKind.DebuggerError;
-                throw new ClrDiagnosticsException($"Could not load crash dump, HRESULT: 0x{hr:x8}", kind, hr).AddData("DumpFile", dumpFile);
+                var kind = hr == HResult.E_FAIL ? ClrDiagnosticsExceptionKind.CorruptedFileOrUnknownFormat : ClrDiagnosticsExceptionKind.DebuggerError;
+                throw new ClrDiagnosticsException($"Could not load crash dump, HRESULT: {hr}", kind, hr).AddData("DumpFile", dumpFile);
 
                 static int HRESULT_FROM_NT(int status) => status | 0x10000000;
             }
 
             // This actually "attaches" to the crash dump.
-            bool result = _control.WaitForEvent(0xffffffff);
+            HResult result = _control.WaitForEvent(0xffffffff);
+            _systemObjects.Init();
             DebugOnly.Assert(result);
         }
 

--- a/src/Microsoft.Diagnostics.Runtime/src/DataReaders/DbgEng/DbgEngDataReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataReaders/DbgEng/DbgEngDataReader.cs
@@ -76,19 +76,19 @@ namespace Microsoft.Diagnostics.Runtime
             DebugAttach attach = invasive ? DebugAttach.Default : DebugAttach.NonInvasive;
             _control.AddEngineOptions(DebugControl.INITIAL_BREAK);
 
-            int hr = _client.AttachProcess((uint)processId, attach);
+            HResult hr = _client.AttachProcess((uint)processId, attach);
 
-            if (hr == 0)
-                hr = _control.WaitForEvent(msecTimeout) ? 0 : -1;
+            if (hr)
+                hr = _control.WaitForEvent(msecTimeout);
 
-            if (hr == 1)
+            if (hr == HResult.S_FALSE)
             {
                 throw new TimeoutException("Break in did not occur within the allotted timeout.");
             }
 
             if (hr != 0)
             {
-                if ((uint)hr == 0xd00000bb)
+                if ((uint)hr.Value == 0xd00000bb)
                     throw new InvalidOperationException("Mismatched architecture between this process and the target process.");
 
                 if (!WindowsFunctions.IsProcessRunning(processId))

--- a/src/Microsoft.Diagnostics.Runtime/src/DbgEng/DebugAdvanced.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DbgEng/DebugAdvanced.cs
@@ -22,20 +22,19 @@ namespace Microsoft.Diagnostics.Runtime.DbgEng
 
         private ref readonly IDebugAdvancedVTable VTable => ref Unsafe.AsRef<IDebugAdvancedVTable>(_vtable);
 
-        public bool GetThreadContext(Span<byte> context)
+        public HResult GetThreadContext(Span<byte> context)
         {
             InitDelegate(ref _getThreadContext, VTable.GetThreadContext);
 
             using IDisposable holder = _sys.Enter();
             fixed (byte* ptr = context)
-                return _getThreadContext(Self, ptr, context.Length) >= 0;
+                return _getThreadContext(Self, ptr, context.Length);
         }
 
-        private GetThreadContextDelegate? _getThreadContext;
         private readonly DebugSystemObjects _sys;
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
-        private delegate int GetThreadContextDelegate(IntPtr self, byte* context, int contextSize);
+        private GetThreadContextDelegate? _getThreadContext;
+        private delegate HResult GetThreadContextDelegate(IntPtr self, byte* context, int contextSize);
     }
 
     [StructLayout(LayoutKind.Sequential)]

--- a/src/Microsoft.Diagnostics.Runtime/src/DbgEng/DebugClient.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DbgEng/DebugClient.cs
@@ -13,10 +13,6 @@ namespace Microsoft.Diagnostics.Runtime.DbgEng
     {
         internal static readonly Guid IID_IDebugClient = new Guid("27fe5639-8407-4f47-8364-ee118fb08ac8");
 
-        private EndSessionDelegate? _endSession;
-        private DetatchProcessesDelegate? _detatchProcesses;
-        private AttachProcessDelegate? _attachProcess;
-        private OpenDumpFileDelegate? _openDumpFile;
         private readonly DebugSystemObjects _sys;
 
         public DebugClient(RefCountedFreeLibrary library, IntPtr pUnk, DebugSystemObjects system)
@@ -46,32 +42,33 @@ namespace Microsoft.Diagnostics.Runtime.DbgEng
             DebugOnly.Assert(hr == 0);
         }
 
-        public int AttachProcess(uint pid, DebugAttach flags)
+        public HResult AttachProcess(uint pid, DebugAttach flags)
         {
             InitDelegate(ref _attachProcess, VTable.AttachProcess);
-            int hr = _attachProcess(Self, 0, pid, flags);
+            HResult hr = _attachProcess(Self, 0, pid, flags);
 
             _sys.Init();
             return hr;
         }
 
-        public int OpenDumpFile(string dumpFile)
+        public HResult OpenDumpFile(string dumpFile)
         {
             InitDelegate(ref _openDumpFile, VTable.OpenDumpFile);
-            int hr = _openDumpFile(Self, dumpFile);
+            HResult hr = _openDumpFile(Self, dumpFile);
 
             _sys.Init();
             return hr;
         }
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
-        private delegate int EndSessionDelegate(IntPtr self, DebugEnd mode);
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
-        private delegate int DetatchProcessesDelegate(IntPtr self);
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
-        private delegate int AttachProcessDelegate(IntPtr self, ulong server, uint pid, DebugAttach AttachFlags);
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
-        private delegate int OpenDumpFileDelegate(IntPtr self, [In][MarshalAs(UnmanagedType.LPStr)] string file);
+        private EndSessionDelegate? _endSession;
+        private DetatchProcessesDelegate? _detatchProcesses;
+        private AttachProcessDelegate? _attachProcess;
+        private OpenDumpFileDelegate? _openDumpFile;
+
+        private delegate HResult EndSessionDelegate(IntPtr self, DebugEnd mode);
+        private delegate HResult DetatchProcessesDelegate(IntPtr self);
+        private delegate HResult AttachProcessDelegate(IntPtr self, ulong server, uint pid, DebugAttach AttachFlags);
+        private delegate HResult OpenDumpFileDelegate(IntPtr self, [In][MarshalAs(UnmanagedType.LPStr)] string file);
     }
 
     [StructLayout(LayoutKind.Sequential)]

--- a/src/Microsoft.Diagnostics.Runtime/src/DbgEng/DebugClient.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DbgEng/DebugClient.cs
@@ -54,10 +54,7 @@ namespace Microsoft.Diagnostics.Runtime.DbgEng
         public HResult OpenDumpFile(string dumpFile)
         {
             InitDelegate(ref _openDumpFile, VTable.OpenDumpFile);
-            HResult hr = _openDumpFile(Self, dumpFile);
-
-            _sys.Init();
-            return hr;
+            return _openDumpFile(Self, dumpFile);
         }
 
         private EndSessionDelegate? _endSession;

--- a/src/Microsoft.Diagnostics.Runtime/src/DbgEng/DebugDataSpaces.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DbgEng/DebugDataSpaces.cs
@@ -33,21 +33,19 @@ namespace Microsoft.Diagnostics.Runtime.DbgEng
             }
         }
 
-        public bool QueryVirtual(ulong address, out MEMORY_BASIC_INFORMATION64 info)
+        public HResult QueryVirtual(ulong address, out MEMORY_BASIC_INFORMATION64 info)
         {
             InitDelegate(ref _queryVirtual, VTable.QueryVirtual);
             using IDisposable holder = _sys.Enter();
-            return _queryVirtual(Self, address, out info) >= 0;
+            return _queryVirtual(Self, address, out info);
         }
 
         private ReadVirtualDelegate? _readVirtual;
         private QueryVirtualDelegate? _queryVirtual;
         private readonly DebugSystemObjects _sys;
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
-        private delegate int ReadVirtualDelegate(IntPtr self, ulong address, byte* buffer, int size, out int read);
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
-        private delegate int QueryVirtualDelegate(IntPtr self, ulong address, out MEMORY_BASIC_INFORMATION64 info);
+        private delegate HResult ReadVirtualDelegate(IntPtr self, ulong address, byte* buffer, int size, out int read);
+        private delegate HResult QueryVirtualDelegate(IntPtr self, ulong address, out MEMORY_BASIC_INFORMATION64 info);
     }
 
     [StructLayout(LayoutKind.Sequential)]

--- a/src/Microsoft.Diagnostics.Runtime/src/DbgEng/DebugDataSpaces.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DbgEng/DebugDataSpaces.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Diagnostics.Runtime.DbgEng
             using IDisposable holder = _sys.Enter();
             fixed (byte* ptr = buffer)
             {
-                _readVirtual(Self, address, ptr, buffer.Length, out int read);
+                HResult hr = _readVirtual(Self, address, ptr, buffer.Length, out int read);
                 return read;
             }
         }

--- a/src/Microsoft.Diagnostics.Runtime/src/Utilities/COMInterop/CallableComWrapper.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Utilities/COMInterop/CallableComWrapper.cs
@@ -104,7 +104,7 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
         private static void InitDelegateWorker<T>([NotNull] ref T? t, IntPtr entry)
             where T : Delegate
         {
-            DebugOnly.Assert(t != null);
+            DebugOnly.Assert(t == null);
 
             t = Marshal.GetDelegateForFunctionPointer<T>(entry);
 

--- a/src/Microsoft.Diagnostics.Runtime/src/Utilities/COMInterop/CallableComWrapper.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Utilities/COMInterop/CallableComWrapper.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 #pragma warning disable CA1816 // Dispose methods should call SuppressFinalize
@@ -86,20 +87,24 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
         {
             QueryInterfaceDelegate queryInterface = Marshal.GetDelegateForFunctionPointer<QueryInterfaceDelegate>(_unknownVTable->QueryInterface);
 
-            int hr = queryInterface(Self, riid, out IntPtr unk);
-            return hr == S_OK ? unk : IntPtr.Zero;
+            HResult hr = queryInterface(Self, riid, out IntPtr unk);
+            return hr.IsOK ? unk : IntPtr.Zero;
         }
 
-        protected static bool SUCCEEDED(int hresult)
-        {
-            return hresult >= 0;
-        }
-
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected static void InitDelegate<T>([NotNull] ref T? t, IntPtr entry)
             where T : Delegate
         {
             if (t != null)
                 return;
+
+            InitDelegateWorker(ref t, entry);
+        }
+
+        private static void InitDelegateWorker<T>([NotNull] ref T? t, IntPtr entry)
+            where T : Delegate
+        {
+            DebugOnly.Assert(t != null);
 
             t = Marshal.GetDelegateForFunctionPointer<T>(entry);
 

--- a/src/Microsoft.Diagnostics.Runtime/src/Utilities/COMInterop/ComCallableIUnknown.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Utilities/COMInterop/ComCallableIUnknown.cs
@@ -93,17 +93,17 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
             _delegates.AddRange(keepAlive);
         }
 
-        private int QueryInterfaceImpl(IntPtr self, in Guid guid, out IntPtr ptr)
+        private HResult QueryInterfaceImpl(IntPtr _, in Guid guid, out IntPtr ptr)
         {
             if (_interfaces.TryGetValue(guid, out IntPtr value))
             {
                 Interlocked.Increment(ref _refCount);
                 ptr = value;
-                return S_OK;
+                return HResult.S_OK;
             }
 
             ptr = IntPtr.Zero;
-            return E_NOINTERFACE;
+            return HResult.E_NOINTERFACE;
         }
 
         private int ReleaseImpl(IntPtr self)

--- a/src/Microsoft.Diagnostics.Runtime/src/Utilities/COMInterop/ComHelper.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Utilities/COMInterop/ComHelper.cs
@@ -12,12 +12,6 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
     /// </summary>
     public abstract class COMHelper
     {
-        protected const int S_OK = 0;
-        protected const int E_INVALIDARG = unchecked((int)0x80070057);
-        protected const int E_FAIL = unchecked((int)0x80004005);
-        protected const int E_NOTIMPL = unchecked((int)0x80004001);
-        protected const int E_NOINTERFACE = unchecked((int)0x80004002);
-
         protected static readonly Guid IUnknownGuid = new Guid("00000000-0000-0000-C000-000000000046");
 
         [UnmanagedFunctionPointer(CallingConvention.Winapi)]
@@ -27,7 +21,7 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
         protected delegate int ReleaseDelegate(IntPtr self);
 
         [UnmanagedFunctionPointer(CallingConvention.Winapi)]
-        protected delegate int QueryInterfaceDelegate(IntPtr self, in Guid guid, out IntPtr ptr);
+        protected delegate HResult QueryInterfaceDelegate(IntPtr self, in Guid guid, out IntPtr ptr);
 
         /// <summary>
         /// Release an IUnknown pointer.

--- a/src/Microsoft.Diagnostics.Runtime/src/Utilities/COMInterop/HResult.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Utilities/COMInterop/HResult.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
     {
         public const int S_OK = 0;
         public const int S_FALSE = 1;
-        public const int E_FAIL = -1;
+        public const int E_FAIL = unchecked((int)0x80004005);
         public const int E_INVALIDARG = unchecked((int)0x80070057);
         public const int E_NOTIMPL = unchecked((int)0x80004001);
         public const int E_NOINTERFACE = unchecked((int)0x80004002);

--- a/src/Microsoft.Diagnostics.Runtime/src/Utilities/COMInterop/HResult.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Utilities/COMInterop/HResult.cs
@@ -1,0 +1,48 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.Diagnostics.Runtime.Utilities
+{
+    public struct HResult
+    {
+        public const int S_OK = 0;
+        public const int S_FALSE = 1;
+        public const int E_FAIL = -1;
+        public const int E_INVALIDARG = unchecked((int)0x80070057);
+        public const int E_NOTIMPL = unchecked((int)0x80004001);
+        public const int E_NOINTERFACE = unchecked((int)0x80004002);
+
+        public bool IsOK => Value == S_OK;
+
+        public int Value { get; set; }
+
+        public HResult(int hr) => Value = hr;
+
+        public static implicit operator HResult(int hr) => new HResult(hr);
+
+        /// <summary>
+        /// Helper to convert to int for comparisons.
+        /// </summary>
+        public static implicit operator int(HResult hr) => hr.Value;
+
+        /// <summary>
+        /// This makes "if (hr)" equivalent to SUCCEEDED(hr).
+        /// </summary>
+        public static implicit operator bool(HResult hr) => hr.Value >= 0;
+
+        public override string ToString()
+        {
+            return Value switch
+            {
+                S_OK => "S_OK",
+                S_FALSE => "S_FALSE",
+                E_FAIL => "E_FAIL",
+                E_INVALIDARG => "E_INVALIDARG",
+                E_NOTIMPL => "E_NOTIMPL",
+                E_NOINTERFACE => "E_NOINTERFACE",
+                _ => $"{Value:x8}",
+            };
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/src/Utilities/COMInterop/VTableBuilder.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Utilities/COMInterop/VTableBuilder.cs
@@ -46,10 +46,6 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
             {
                 if (func.Method.GetParameters().First().ParameterType != typeof(IntPtr))
                     throw new InvalidOperationException();
-
-                object[] attrs = func.GetType().GetCustomAttributes(false);
-                if (attrs.Count(c => c is UnmanagedFunctionPointerAttribute) != 1)
-                    throw new InvalidOperationException();
             }
 
             _delegates.Add(func);


### PR DESCRIPTION
- Intentionally start accepting more SUCCEEDED(hr) instead of hr == S_OK.
- Created an HResult struct to wrap COM's HRESULT.
- HResult has an implicit int cast operator for convenience.
- HResult has an implicit bool cast operator which is the equivalent of "SUCCEEDED(hr)".
- Change most wrappers to use and return HResult instead of bool.
- Functionality should be mostly unchanged, but allows for better control/error flow.