### PR TITLE
Add ClrObject.EnumerateReferencesWithFields

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/GCRootTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/GCRootTests.cs
@@ -64,6 +64,8 @@ namespace Microsoft.Diagnostics.Runtime.Tests
 
             Assert.False(fieldRef.IsDepenendentHandle);
             Assert.True(fieldRef.IsField);
+            Assert.NotNull(fieldRef.Field);
+            Assert.Equal("Item1", fieldRef.Field.Name);
         }
 
         private ClrObject FindSingleRefPointingToTarget(ClrHeap heap)

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/ClrFieldReference.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/ClrFieldReference.cs
@@ -1,0 +1,120 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Linq;
+
+namespace Microsoft.Diagnostics.Runtime
+{
+    public struct ClrFieldReference
+    {
+        const ulong OffsetFlag = 1 << 61;
+        const ulong DependentFlag = 1 << 60;
+        const ulong ValueMask = ~(OffsetFlag | DependentFlag);
+
+        private readonly ulong _offsetOrHandle;
+
+        /// <summary>
+        /// The object that <see cref="Field"/> contained.
+        /// </summary>
+        public ClrObject Object { get; }
+
+        /// <summary>
+        /// The offset into the containing object this address is found at.  Only valid if <see cref="IsObjectInterior"/> is true.
+        /// </summary>
+        public int Offset
+        {
+            get
+            {
+                if ((_offsetOrHandle & OffsetFlag) == OffsetFlag)
+                {
+                    unchecked
+                    {
+                        // The (uint) cast will slice off the high bits
+                        return (int)(uint)_offsetOrHandle;
+                    }
+                }
+
+                return -1;
+            }
+        }
+
+        /// <summary>
+        /// The field this object was contained in.  This property may be null if metadata is not available, if
+        /// this reference came from a dependent handle/loader allocator, or if this came from an array.
+        /// Only valid to call if <see cref="IsObjectInterior"/> is true.
+        /// </summary>
+        public ClrInstanceField? Field { get; }
+
+        /// <summary>
+        /// If this reference came from a CollectableType, it means there's a collectable type which keeps this object alive.
+        /// In that case, the <see cref="LoaderAllocator"/> property contains the address of the loader allocator's handle.
+        /// </summary>
+        public ulong LoaderAllocator
+        {
+            get
+            {
+                // Return the loader allocator handle if this doesn't have the high bits set.
+                if ((_offsetOrHandle & ValueMask) == _offsetOrHandle)
+                    return ValueMask & _offsetOrHandle;
+
+                return 0;
+            }
+        }
+
+        /// <summary>
+        /// Returns true if this reference came from a LoaderAllocator handle (e.g. collectable types).
+        /// </summary>
+        public bool IsLoaderAllocator => LoaderAllocator != 0;
+
+        /// <summary>
+        /// Returns true if this reference came from a dependent handle.
+        /// </summary>
+        public bool IsDepenendentHandle => (_offsetOrHandle & DependentFlag) == DependentFlag;
+
+        /// <summary>
+        /// Returns true if this reference came from a field in another object.
+        /// </summary>
+        public bool IsObjectInterior => LoaderAllocator == 0;
+
+        /// <summary>
+        /// Create a field reference from a dependent handle value.  We do not keep track of the dependent handle it came from
+        /// so we don't accept the value here.
+        /// </summary>
+        /// <param name="reference">The object referenced.</param>
+        public static ClrFieldReference CreateFromDependentHandle(ClrObject reference) => new ClrFieldReference(reference, null, DependentFlag);
+
+        /// <summary>
+        /// Creates a ClrFieldReference from an actual field.
+        /// </summary>
+        /// <param name="reference">The object referenced.</param>
+        /// <param name="containingType">The type of the object which points to <paramref name="reference"/>.</param>
+        /// <param name="offset">The offset within the source object where <paramref name="reference"/> was located.</param>
+        public static ClrFieldReference CreateFromField(ClrObject reference, ClrType containingType, int offset)
+        {
+            if (containingType == null)
+                throw new ArgumentNullException(nameof(containingType));
+
+            ClrInstanceField? field = containingType.Fields.FirstOrDefault(f => f.Offset <= offset && offset < f.Offset + f.Size);
+            unchecked
+            {
+                return new ClrFieldReference(reference, field, OffsetFlag | (uint)offset);
+            }
+        }
+
+        /// <summary>
+        /// Creates a ClrFieldReference from a collectable type's LoaderAllocator handle.
+        /// </summary>
+        /// <param name="reference">The object referenced.</param>
+        /// <param name="loaderAllocator">The address of the LoaderAllocator handle.</param>
+        public static ClrFieldReference CreateFromLoaderAllocatorHandle(ClrObject reference, ulong loaderAllocator) => new ClrFieldReference(reference, null, loaderAllocator);
+
+        private ClrFieldReference(ClrObject obj, ClrInstanceField? field, ulong offsetOrHandleValue)
+        {
+            _offsetOrHandle = offsetOrHandleValue;
+            Object = obj;
+            Field = field;
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/ClrFieldReference.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/ClrFieldReference.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Diagnostics.Runtime
         public ClrObject Object { get; }
 
         /// <summary>
-        /// The offset into the containing object this address is found at.  Only valid if <see cref="IsObjectInterior"/> is true.
+        /// The offset into the containing object this address is found at.  Only valid if <see cref="IsField"/> is true.
         /// </summary>
         public int Offset
         {
@@ -43,7 +43,7 @@ namespace Microsoft.Diagnostics.Runtime
         /// <summary>
         /// The field this object was contained in.  This property may be null if metadata is not available, if
         /// this reference came from a dependent handle/loader allocator, or if this came from an array.
-        /// Only valid to call if <see cref="IsObjectInterior"/> is true.
+        /// Only valid to call if <see cref="IsField"/> is true.
         /// </summary>
         public ClrInstanceField? Field { get; }
 
@@ -74,9 +74,9 @@ namespace Microsoft.Diagnostics.Runtime
         public bool IsDepenendentHandle => (_offsetOrHandle & DependentFlag) == DependentFlag;
 
         /// <summary>
-        /// Returns true if this reference came from a field in another object.
+        /// Returns true if this reference came from a field (or array element) in another object.
         /// </summary>
-        public bool IsObjectInterior => LoaderAllocator == 0;
+        public bool IsField => (_offsetOrHandle & OffsetFlag) == OffsetFlag;
 
         /// <summary>
         /// Create a field reference from a dependent handle value.  We do not keep track of the dependent handle it came from

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/ClrFieldReference.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/ClrFieldReference.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Diagnostics.Runtime
         }
 
         /// <summary>
-        /// Returns true if this reference came from a LoaderAllocator handle (e.g. collectable types).
+        /// Returns true if this reference came from a LoaderAllocator handle (e.g. collectible types).
         /// </summary>
         public bool IsLoaderAllocator => LoaderAllocator != 0;
 

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/ClrFieldReference.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/ClrFieldReference.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Diagnostics.Runtime
         public ClrInstanceField? Field { get; }
 
         /// <summary>
-        /// If this reference came from a CollectableType, it means there's a collectable type which keeps this object alive.
+        /// If this reference came from a collectible type, it means there's a collectible type which keeps this object alive.
         /// In that case, the <see cref="LoaderAllocator"/> property contains the address of the loader allocator's handle.
         /// </summary>
         public ulong LoaderAllocator

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/ClrFieldReference.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/ClrFieldReference.cs
@@ -11,7 +11,6 @@ namespace Microsoft.Diagnostics.Runtime
     {
         const ulong OffsetFlag = 8000000000000000ul;
         const ulong DependentFlag = 4000000000000000ul;
-        const ulong ValueMask = ~(OffsetFlag | DependentFlag);
 
         private readonly ulong _offsetOrHandle;
 

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/ClrHeap.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/ClrHeap.cs
@@ -136,5 +136,19 @@ namespace Microsoft.Diagnostics.Runtime
         /// the heap may be in an inconsistent state.)
         /// </param>
         public abstract IEnumerable<ClrObject> EnumerateObjectReferences(ulong obj, ClrType type, bool carefully, bool considerDependantHandles);
+
+
+        /// <summary>
+        /// Enumerates all objects that the given object references.  This method is meant for internal use to
+        /// implement ClrObject.EnumerateReferencesWithFields, which you should use instead of calling this directly.
+        /// </summary>
+        /// <param name="obj">The object in question.</param>
+        /// <param name="type">The type of the object.</param>
+        /// <param name="considerDependantHandles">Whether to consider dependant handle mappings.</param>
+        /// <param name="carefully">
+        /// Whether to bounds check along the way (useful in cases where
+        /// the heap may be in an inconsistent state.)
+        /// </param>
+        public abstract IEnumerable<ClrFieldReference> EnumerateReferencesWithFields(ulong obj, ClrType type, bool carefully, bool considerDependantHandles);
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/ClrObject.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/ClrObject.cs
@@ -35,6 +35,13 @@ namespace Microsoft.Diagnostics.Runtime
         /// <summary>
         /// Enumerates all objects that this object references.
         /// </summary>
+        /// <param name="carefully">Only returns pointers which lie on the managed heap.  In very rare cases it's possible to
+        /// create a crash dump where the GC was in the middle of updating data structures, or to create a crash dump of a process
+        /// with heap corruption.  In those cases, setting carefully=true would ensure we would not enumerate those bad references.
+        /// Note that setting carefully=true will cause a small performance penalty.</param>
+        /// <param name="considerDependantHandles">Setting this to true will have ClrMD check for dependent handle references.
+        /// Checking dependent handles does come at a performance penalty but will give you the true reference chain as the
+        /// GC sees it.</param>
         /// <returns>An enumeration of object references.</returns>
         public IEnumerable<ClrObject> EnumerateReferences(bool carefully = false, bool considerDependantHandles = true)
         {
@@ -43,6 +50,27 @@ namespace Microsoft.Diagnostics.Runtime
 
             return Type.Heap.EnumerateObjectReferences(Address, Type, carefully, considerDependantHandles);
         }
+
+        /// <summary>
+        /// Enumerates all objects that this object references.  This method also enumerates the field (or handle) that this
+        /// reference comes from.
+        /// </summary>
+        /// <param name="carefully">Only returns pointers which lie on the managed heap.  In very rare cases it's possible to
+        /// create a crash dump where the GC was in the middle of updating data structures, or to create a crash dump of a process
+        /// with heap corruption.  In those cases, setting carefully=true would ensure we would not enumerate those bad references.
+        /// Note that setting carefully=true will cause a small performance penalty.</param>
+        /// <param name="considerDependantHandles">Setting this to true will have ClrMD check for dependent handle references.
+        /// Checking dependent handles does come at a performance penalty but will give you the true reference chain as the
+        /// GC sees it.</param>
+        /// <returns>An enumeration of object references.</returns>
+        public IEnumerable<ClrFieldReference> EnumerateReferencesWithFields(bool carefully = false, bool considerDependantHandles = true)
+        {
+            if (Type is null)
+                return Enumerable.Empty<ClrFieldReference>();
+
+            return Type.Heap.EnumerateReferencesWithFields(Address, Type, carefully, considerDependantHandles);
+        }
+
 
         public T ReadBoxed<T>() where T : unmanaged
         {

--- a/src/Microsoft.Diagnostics.Runtime/src/Implementation/ClrmdField.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Implementation/ClrmdField.cs
@@ -208,9 +208,20 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
 
                     if (module != null)
                     {
-                        ClrType? innerType = factory.GetOrCreateTypeFromToken(module, token);
-                        if (innerType is null)
+                        ClrType? innerType;
+                        if (type.IsPrimitive())
+                        {
                             innerType = factory.GetOrCreateBasicType(type);
+                        }
+                        else
+                        {
+                            innerType = factory.GetOrCreateTypeFromToken(module, token);
+
+                            // Fallback just in case 
+                            if (innerType is null)
+                                innerType = factory.GetOrCreateBasicType(type);
+                        }
+                        
 
                         result = factory.GetOrCreatePointerType(innerType, 1);
                     }

--- a/src/Microsoft.Diagnostics.Runtime/src/Implementation/ClrmdHeap.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Implementation/ClrmdHeap.cs
@@ -431,16 +431,6 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
                 }
             }
 
-            if (type.IsCollectible)
-            {
-                ulong la = _helpers.DataReader.ReadPointer(type.LoaderAllocatorHandle);
-                if (la != 0)
-                {
-                    ClrObject target = new ClrObject(la, GetObjectType(la));
-                    yield return ClrFieldReference.CreateFromLoaderAllocatorHandle(target, type.LoaderAllocatorHandle);
-                }
-            }
-
             if (type.ContainsPointers)
             {
                 GCDesc gcdesc = type.GCDesc;
@@ -457,7 +447,7 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
                     foreach ((ulong reference, int offset) in gcdesc.WalkObject(obj, size, _helpers.DataReader))
                     {
                         ClrObject target = new ClrObject(reference, GetObjectType(reference));
-                        yield return ClrFieldReference.CreateFromField(target, type, offset);
+                        yield return ClrFieldReference.CreateFromFieldOrArray(target, type, offset);
                     }
                 }
             }

--- a/src/Microsoft.Diagnostics.Runtime/src/Implementation/ClrmdHeap.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Implementation/ClrmdHeap.cs
@@ -397,6 +397,73 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
             }
         }
 
+        public override IEnumerable<ClrFieldReference> EnumerateReferencesWithFields(ulong obj, ClrType type, bool carefully, bool considerDependantHandles)
+        {
+            if (type is null)
+                throw new ArgumentNullException(nameof(type));
+
+            if (considerDependantHandles)
+            {
+                var dependent = _dependentHandles;
+                if (dependent is null)
+                {
+                    dependent = _helpers.EnumerateDependentHandleLinks().ToArray();
+                    Array.Sort(dependent, (x, y) => x.Item1.CompareTo(y.Item1));
+
+                    _dependentHandles = dependent;
+                }
+
+                if (dependent.Length > 0)
+                {
+                    int index = dependent.Search(obj, (x, y) => x.Item1.CompareTo(y));
+                    if (index != -1)
+                    {
+                        while (index >= 1 && dependent[index - 1].Item1 == obj)
+                            index--;
+
+                        while (index < dependent.Length && dependent[index].Item1 == obj)
+                        {
+                            ulong dependantObj = dependent[index++].Item2;
+                            ClrObject target = new ClrObject(dependantObj, GetObjectType(dependantObj));
+                            yield return ClrFieldReference.CreateFromDependentHandle(target);
+                        }
+                    }
+                }
+            }
+
+            if (type.IsCollectible)
+            {
+                ulong la = _helpers.DataReader.ReadPointer(type.LoaderAllocatorHandle);
+                if (la != 0)
+                {
+                    ClrObject target = new ClrObject(la, GetObjectType(la));
+                    yield return ClrFieldReference.CreateFromLoaderAllocatorHandle(target, type.LoaderAllocatorHandle);
+                }
+            }
+
+            if (type.ContainsPointers)
+            {
+                GCDesc gcdesc = type.GCDesc;
+                if (!gcdesc.IsEmpty)
+                {
+                    ulong size = GetObjectSize(obj, type);
+                    if (carefully)
+                    {
+                        ClrSegment? seg = GetSegmentByAddress(obj);
+                        if (seg is null || obj + size > seg.End || (!seg.IsLargeObjectSegment && size > MaxGen2ObjectSize))
+                            yield break;
+                    }
+
+                    foreach ((ulong reference, int offset) in gcdesc.WalkObject(obj, size, _helpers.DataReader))
+                    {
+                        ClrObject target = new ClrObject(reference, GetObjectType(reference));
+                        yield return ClrFieldReference.CreateFromField(target, type, offset);
+                    }
+                }
+            }
+        }
+
+
         public override IEnumerable<IClrRoot> EnumerateRoots()
         {
             // Handle table

--- a/src/Microsoft.Diagnostics.Runtime/src/Implementation/ClrmdModule.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Implementation/ClrmdModule.cs
@@ -153,6 +153,9 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
 
         public override ClrType? ResolveToken(int typeDefOrRefToken)
         {
+            if (typeDefOrRefToken == 0)
+                return null;
+
             ClrHeap? heap = AppDomain?.Runtime?.Heap;
             if (heap is null)
                 return null;


### PR DESCRIPTION
Add a way to enumerate references of an object with a source of where that reference came from.