### PR TITLE
Don't restore when building test targets

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime.Tests/Microsoft.Diagnostics.Runtime.Tests.csproj
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/Microsoft.Diagnostics.Runtime.Tests.csproj
@@ -22,8 +22,8 @@
   </ItemGroup>
 
   <Target Condition="'$(OS)' == 'Windows_NT'" Name="BuildTargetsWindows" BeforeTargets="AfterBuild">
-    <Exec Command="dotnet.exe build -c $(Configuration) ..\TestTasks\TestTasks.csproj" />
-    <Exec Command="dotnet.exe build -c $(Configuration) ..\TestTargets\TestTargets.proj" />
+    <Exec Command="dotnet.exe build --no-restore -c $(Configuration) ..\TestTasks\TestTasks.csproj" />
+    <Exec Command="dotnet.exe build --no-restore -c $(Configuration) ..\TestTargets\TestTargets.proj" />
   </Target>
 
   <Target Condition="'$(OS)' == 'Unix'" Name="BuildTargetsLinux" BeforeTargets="AfterBuild">


### PR DESCRIPTION
Testing changes to see if the restore from building unit tests is what's interfering with the pack phase of arcade's internal build.