### PR TITLE
Revert "Don't restore when building test targets (#590)"

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime.Tests/Microsoft.Diagnostics.Runtime.Tests.csproj
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/Microsoft.Diagnostics.Runtime.Tests.csproj
@@ -22,8 +22,8 @@
   </ItemGroup>
 
   <Target Condition="'$(OS)' == 'Windows_NT'" Name="BuildTargetsWindows" BeforeTargets="AfterBuild">
-    <Exec Command="dotnet.exe build --no-restore -c $(Configuration) ..\TestTasks\TestTasks.csproj" />
-    <Exec Command="dotnet.exe build --no-restore -c $(Configuration) ..\TestTargets\TestTargets.proj" />
+    <Exec Command="dotnet.exe build -c $(Configuration) ..\TestTasks\TestTasks.csproj" />
+    <Exec Command="dotnet.exe build -c $(Configuration) ..\TestTargets\TestTargets.proj" />
   </Target>
 
   <Target Condition="'$(OS)' == 'Unix'" Name="BuildTargetsLinux" BeforeTargets="AfterBuild">


### PR DESCRIPTION
This reverts commit dc3f52229ee145b4de5d7fe610c076feb5a6d87a.

This was not the cause of the arcade build break, so I'm reverting this change.