### PR TITLE
Temporarily disable code coverage

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,12 +2,6 @@
 <Project>
   <Import Project="Sdk.props" Sdk="Microsoft.DotNet.Arcade.Sdk" />
 
-  <PropertyGroup Condition="'$(ContinuousIntegrationBuild)' == 'true'">
-    <Coverage>true</Coverage>
-    <!-- Workaround for tonerdo/coverlet#363 -->
-    <DeterministicSourcePaths>false</DeterministicSourcePaths>
-  </PropertyGroup>
-
   <PropertyGroup>
     <LangVersion>Latest</LangVersion>
     <Features>strict</Features>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
-  <Import Project="$(RepositoryEngineeringDir)Coverage.targets" Condition="'$(Coverage)' == 'true'" />
   <Import Project="Sdk.targets" Sdk="Microsoft.DotNet.Arcade.Sdk" />
 </Project>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -74,22 +74,6 @@ stages:
         steps:
         - checkout: self
           clean: true
-        - script: eng\common\cibuild.cmd -configuration $(_BuildConfig) -prepareMachine $(_BuildArgs)
-          displayName: Build and Test
-        - script: .dotnet\dotnet.exe tool run reportgenerator
-            -reports:$(Build.SourcesDirectory)\src\*\coverage.cobertura.xml
-            -targetdir:$(Build.SourcesDirectory)\artifacts\coverage
-          displayName: Generate Code Coverage Reports
-        - task: PublishBuildArtifacts@1
-          displayName: Publish Code Coverage Reports
-          inputs:
-            pathToPublish: '$(Build.SourcesDirectory)\artifacts\coverage'
-            artifactName: Coverage_$(Agent.Os)_$(Agent.JobName)
-        - task: PublishCodeCoverageResults@1
-          displayName: Publish Code Coverage
-          inputs:
-            codeCoverageTool: cobertura
-            summaryFileLocation: '$(Build.SourcesDirectory)\src\*\coverage.cobertura.xml'
 
       - job: Linux
         displayName: 'Linux'
@@ -115,20 +99,6 @@ stages:
           clean: true
         - script: eng/common/cibuild.sh --configuration $(_BuildConfig) --prepareMachine
           displayName: Build and Test
-        - script: .dotnet/dotnet tool run reportgenerator
-            -reports:$(Build.SourcesDirectory)/src/*/coverage.cobertura.xml
-            -targetdir:$(Build.SourcesDirectory)/artifacts/coverage
-          displayName: Generate Code Coverage Reports
-        - task: PublishBuildArtifacts@1
-          displayName: Publish Code Coverage Reports
-          inputs:
-            pathToPublish: '$(Build.SourcesDirectory)/artifacts/coverage'
-            artifactName: Coverage_$(Agent.Os)_$(Agent.JobName)
-        - task: PublishCodeCoverageResults@1
-          displayName: Publish Code Coverage
-          inputs:
-            codeCoverageTool: cobertura
-            summaryFileLocation: '$(Build.SourcesDirectory)/src/*/coverage.cobertura.xml'
 
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
   - template: eng\common\templates\post-build\post-build.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -74,6 +74,8 @@ stages:
         steps:
         - checkout: self
           clean: true
+        - script: eng\common\cibuild.cmd -configuration $(_BuildConfig) -prepareMachine $(_BuildArgs)	
+          displayName: Build and Test
 
       - job: Linux
         displayName: 'Linux'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -74,7 +74,7 @@ stages:
         steps:
         - checkout: self
           clean: true
-        - script: eng\common\cibuild.cmd -configuration $(_BuildConfig) -prepareMachine $(_BuildArgs)	
+        - script: eng\common\cibuild.cmd -configuration $(_BuildConfig) -prepareMachine $(_BuildArgs)
           displayName: Build and Test
 
       - job: Linux


### PR DESCRIPTION
Temporarily disable code coverage to see if this is what is causing Arcade build breaks on the internal server.