### PR TITLE
Don't set System Id in DbgEng

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/src/DbgEng/DebugSystemObjects.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DbgEng/DebugSystemObjects.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Diagnostics.Runtime.DbgEng
 
         private ref readonly IDebugSystemObjects3VTable VTable => ref Unsafe.AsRef<IDebugSystemObjects3VTable>(_vtable);
 
-        public IDisposable Enter() => new SystemHolder(this, _systemId);
+        public IDisposable Enter() => new SystemHolder();
 
         public uint GetProcessId()
         {
@@ -121,16 +121,10 @@ namespace Microsoft.Diagnostics.Runtime.DbgEng
         private class SystemHolder : IDisposable
         {
             private static readonly object _sync = new object();
-            private static int _current = -1;
 
-            public SystemHolder(DebugSystemObjects sysObjs, int id)
+            public SystemHolder()
             {
                 Monitor.Enter(_sync);
-                if (id != -1 && _current != id)
-                {
-                    _current = id;
-                    sysObjs.SetCurrentSystemId(id);
-                }
             }
 
             public void Dispose()


### PR DESCRIPTION
DbgEng does not actually support loading multiple dumps at the same time.  It is designed in a way that *should* support it, but the actual implementation is not well tested and contains many bugs.  This means that loading two dumpfiles at the same time will not be successful.