### PR TITLE
Usage of readonly structs and members on structs

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/Fixtures/ArrayConnection.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/Fixtures/ArrayConnection.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests.Fixtures
             public readonly SampleStruct[] StructArray = new SampleStruct[] { new SampleStruct(5, "Five"), new SampleStruct(10, "Ten") };
         }
 
-        public struct SampleStruct
+        public readonly struct SampleStruct
         {
             public readonly int Number;
             public readonly string ReferenceLoad;

--- a/src/Microsoft.Diagnostics.Runtime.Utilities/Debugger/Structs/DebugOffsetRegion.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Utilities/Debugger/Structs/DebugOffsetRegion.cs
@@ -7,7 +7,7 @@ using System.Runtime.InteropServices;
 namespace Microsoft.Diagnostics.Runtime.Interop
 {
     [StructLayout(LayoutKind.Sequential)]
-    public struct DEBUG_OFFSET_REGION
+    public readonly struct DEBUG_OFFSET_REGION
     {
         private readonly ulong _base;
         private readonly ulong _size;

--- a/src/Microsoft.Diagnostics.Runtime.Utilities/Debugger/Structs/DebugSymbolSourceEntry.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Utilities/Debugger/Structs/DebugSymbolSourceEntry.cs
@@ -7,7 +7,7 @@ using System.Runtime.InteropServices;
 namespace Microsoft.Diagnostics.Runtime.Interop
 {
     [StructLayout(LayoutKind.Sequential)]
-    public struct DEBUG_SYMBOL_SOURCE_ENTRY
+    public readonly struct DEBUG_SYMBOL_SOURCE_ENTRY
     {
         private readonly ulong _moduleBase;
         private readonly ulong _offset;

--- a/src/Microsoft.Diagnostics.Runtime.Utilities/Debugger/Structs/ImageCor20HeaderEntryPoint.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Utilities/Debugger/Structs/ImageCor20HeaderEntryPoint.cs
@@ -7,7 +7,7 @@ using System.Runtime.InteropServices;
 namespace Microsoft.Diagnostics.Runtime.Interop
 {
     [StructLayout(LayoutKind.Explicit)]
-    public struct IMAGE_COR20_HEADER_ENTRYPOINT
+    public readonly struct IMAGE_COR20_HEADER_ENTRYPOINT
     {
         [FieldOffset(0)]
         public readonly uint Token;

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/ClrArray.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/ClrArray.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Diagnostics.Runtime
             }
         }
 
-        public int Rank
+        public readonly int Rank
         {
             get
             {
@@ -50,9 +50,9 @@ namespace Microsoft.Diagnostics.Runtime
             }
         }
 
-        private bool IsMultiDimensional => Type.StaticSize > (uint)(3 * IntPtr.Size);
+        private readonly bool IsMultiDimensional => Type.StaticSize > (uint)(3 * IntPtr.Size);
 
-        private int MultiDimensionalRank => (int)((Type.StaticSize - (uint)(3 * IntPtr.Size)) / (2 * sizeof(int)));
+        private readonly int MultiDimensionalRank => (int)((Type.StaticSize - (uint)(3 * IntPtr.Size)) / (2 * sizeof(int)));
 
         public ClrArray(ulong address, ClrType type)
         {
@@ -84,7 +84,7 @@ namespace Microsoft.Diagnostics.Runtime
         /// </summary>
         /// <param name="obj">The <see cref="ClrArray"/> to compare to this instance.</param>
         /// <returns><see langword="true"/> if the <see cref="Address"/> of the parameter is the same as <see cref="Address"/> in this instance; <see langword="false"/> otherwise.</returns>
-        public override bool Equals(object? obj) => obj switch
+        public override readonly bool Equals(object? obj) => obj switch
         {
             null => false,
             ulong address => Address == address,
@@ -99,7 +99,7 @@ namespace Microsoft.Diagnostics.Runtime
         /// </summary>
         /// <param name="other">The <see cref="ClrArray"/> to compare to this instance.</param>
         /// <returns><see langword="true"/> if the <see cref="Address"/> of the parameter is the same as <see cref="Address"/> in this instance; <see langword="false"/> otherwise.</returns>
-        public bool Equals(ClrArray other) => Address == other.Address;
+        public readonly bool Equals(ClrArray other) => Address == other.Address;
 
         /// <summary>
         /// Determines whether this instance and a specified object.
@@ -109,13 +109,13 @@ namespace Microsoft.Diagnostics.Runtime
         /// <see langword="true"/> if <paramref name="other"/> is <see cref="ClrObject"/>, and its <see cref="Address"/> is the same as <see cref="Address"/> in this instance; <see langword="false"/>
         /// otherwise.
         /// </returns>
-        public bool Equals(ClrObject other) => Address == other.Address;
+        public readonly bool Equals(ClrObject other) => Address == other.Address;
 
         /// <summary>
         /// Returns the hash code for this <see cref="ClrArray"/>.
         /// </summary>
         /// <returns>An <see cref="int"/> hash code for this instance.</returns>
-        public override int GetHashCode() => Address.GetHashCode();
+        public override readonly int GetHashCode() => Address.GetHashCode();
 
         public int GetLength(int dimension)
         {
@@ -129,7 +129,7 @@ namespace Microsoft.Diagnostics.Runtime
             return GetMultiDimensionalBound(dimension);
         }
 
-        public int GetLowerBound(int dimension)
+        public readonly int GetLowerBound(int dimension)
         {
             int rank = MultiDimensionalRank;
             if (rank == 0 && dimension == 0)
@@ -261,7 +261,7 @@ namespace Microsoft.Diagnostics.Runtime
         // [ sync block || Type.MethodTable || Length || GetLength | GetLowerBound || elements ]
         //                 ^
         //                 | Address
-        private int GetMultiDimensionalBound(int offset) =>
+        private readonly int GetMultiDimensionalBound(int offset) =>
             Type.ClrObjectHelpers.DataReader.Read<int>(Address + (ulong)(2 * IntPtr.Size) + (ulong)(offset * sizeof(int)));
 
         /// <summary>

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/ClrException.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/ClrException.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Diagnostics.Runtime
     /// Create this using <see cref="ClrObject.AsException"/>. You may call that when <see cref="ClrObject.IsException"/>
     /// is <see langword="true"/>.
     /// </summary>
-    public struct ClrException
+    public readonly struct ClrException
     {
         private readonly IExceptionHelpers _helpers;
         private readonly ClrObject _object;

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/ClrObject.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/ClrObject.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Diagnostics.Runtime
     /// <summary>
     /// Represents an object in the target process.
     /// </summary>
-    public struct ClrObject : IAddressableTypedEntity, IEquatable<ClrObject>
+    public readonly struct ClrObject : IAddressableTypedEntity, IEquatable<ClrObject>
     {
         private const string RuntimeType = "System.RuntimeType";
 

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/ClrReference.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/ClrReference.cs
@@ -7,7 +7,7 @@ using System.Linq;
 
 namespace Microsoft.Diagnostics.Runtime
 {
-    public struct ClrReference
+    public readonly struct ClrReference
     {
         const ulong OffsetFlag = 8000000000000000ul;
         const ulong DependentFlag = 4000000000000000ul;

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/ClrStackRoot.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/ClrStackRoot.cs
@@ -6,7 +6,7 @@ using System.Text;
 
 namespace Microsoft.Diagnostics.Runtime
 {
-    public struct ClrStackRoot : IClrStackRoot
+    public readonly struct ClrStackRoot : IClrStackRoot
     {
         public ulong Address { get; }
         public ClrObject Object { get; }

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/ClrValueType.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/ClrValueType.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Diagnostics.Runtime
     /// <summary>
     /// Represents an instance of a type which inherits from <see cref="ValueType"/>.
     /// </summary>
-    public struct ClrValueType : IAddressableTypedEntity
+    public readonly struct ClrValueType : IAddressableTypedEntity
     {
         private IDataReader DataReader => GetTypeOrThrow().ClrObjectHelpers.DataReader;
         private readonly bool _interior;

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/ComInterfaceData.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/ComInterfaceData.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Diagnostics.Runtime
     /// <summary>
     /// The COM implementation details of a single CCW entry.
     /// </summary>
-    public struct ComInterfaceData
+    public readonly struct ComInterfaceData
     {
         /// <summary>
         /// Gets the CLR type this represents.

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/GCDesc.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/GCDesc.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 
 namespace Microsoft.Diagnostics.Runtime
 {
-    public struct GCDesc
+    public readonly struct GCDesc
     {
         private static readonly int s_GCDescSize = IntPtr.Size * 2;
 

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/HotColdRegions.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/HotColdRegions.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Diagnostics.Runtime
     /// <summary>
     /// Returns the addresses and sizes of the hot and cold regions of a method.
     /// </summary>
-    public struct HotColdRegions
+    public readonly struct HotColdRegions
     {
         /// <summary>
         /// Gets the start address of the method's hot region.

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/MemoryRegionInfo.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/MemoryRegionInfo.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Diagnostics.Runtime
     /// <summary>
     /// Contains information about a range of memory.
     /// </summary>
-    public struct MemoryRegionInfo
+    public readonly struct MemoryRegionInfo
     {
         /// <summary>
         /// Gets the base address of the allocation.

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/VersionInfo.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/VersionInfo.cs
@@ -14,22 +14,22 @@ namespace Microsoft.Diagnostics.Runtime
         /// <summary>
         /// In a version 'A.B.C.D', this field represents 'A'.
         /// </summary>
-        public readonly int Major { get; }
+        public int Major { get; }
 
         /// <summary>
         /// In a version 'A.B.C.D', this field represents 'B'.
         /// </summary>
-        public readonly int Minor { get; }
+        public int Minor { get; }
 
         /// <summary>
         /// In a version 'A.B.C.D', this field represents 'C'.
         /// </summary>
-        public readonly int Revision { get; }
+        public int Revision { get; }
 
         /// <summary>
         /// In a version 'A.B.C.D', this field represents 'D'.
         /// </summary>
-        public readonly int Patch { get; }
+        public int Patch { get; }
 
         public VersionInfo(int major, int minor, int revision, int patch)
         {

--- a/src/Microsoft.Diagnostics.Runtime/src/DacInterface/ClrDataAddress.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DacInterface/ClrDataAddress.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
     /// meant to
     /// </summary>
     [DebuggerDisplay("{AsUInt64()}")]
-    public struct ClrDataAddress
+    public readonly struct ClrDataAddress
     {
         /// <summary>
         /// Gets raw value of this address.  May be sign-extended if inspecting a 32bit process.

--- a/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Registers/Float80.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Registers/Float80.cs
@@ -10,12 +10,12 @@ namespace Microsoft.Diagnostics.Runtime
     /// Float in X86-specific windows thread context.
     /// </summary>
     [StructLayout(LayoutKind.Explicit, Pack = 1)]
-    public struct Float80
+    public readonly struct Float80
     {
         [FieldOffset(0x0)]
-        public ulong Mantissa;
+        public readonly ulong Mantissa;
 
         [FieldOffset(0x8)]
-        public ushort Exponent;
+        public readonly ushort Exponent;
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/src/Implementation/AllocationContext.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Implementation/AllocationContext.cs
@@ -4,7 +4,7 @@
 
 namespace Microsoft.Diagnostics.Runtime.Implementation
 {
-    public struct AllocationContext
+    public readonly struct AllocationContext
     {
         public ulong Pointer { get; }
         public ulong Limit { get; }

--- a/src/Microsoft.Diagnostics.Runtime/src/Implementation/FinalizerQueueSegment.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Implementation/FinalizerQueueSegment.cs
@@ -4,7 +4,7 @@
 
 namespace Microsoft.Diagnostics.Runtime.Implementation
 {
-    public struct FinalizerQueueSegment
+    public readonly struct FinalizerQueueSegment
     {
         public ulong Start { get; }
         public ulong End { get; }

--- a/src/Microsoft.Diagnostics.Runtime/src/Implementation/SymbolServerLocator.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Implementation/SymbolServerLocator.cs
@@ -320,7 +320,7 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
         }
 #pragma warning restore CA1308 // Normalize strings to uppercase
 
-        private struct SymbolPathEntry
+        private readonly struct SymbolPathEntry
         {
             public string? Cache { get; }
             public string Location { get; }

--- a/src/Microsoft.Diagnostics.Runtime/src/Linux/Structs/ElfAuxv32.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Linux/Structs/ElfAuxv32.cs
@@ -7,7 +7,7 @@ using System.Runtime.InteropServices;
 namespace Microsoft.Diagnostics.Runtime.Linux
 {
     [StructLayout(LayoutKind.Sequential, Pack = 1)]
-    internal struct ElfAuxv32
+    internal readonly struct ElfAuxv32
     {
         public readonly uint Type;
         public readonly uint Value;

--- a/src/Microsoft.Diagnostics.Runtime/src/Linux/Structs/ElfAuxv64.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Linux/Structs/ElfAuxv64.cs
@@ -7,7 +7,7 @@ using System.Runtime.InteropServices;
 namespace Microsoft.Diagnostics.Runtime.Linux
 {
     [StructLayout(LayoutKind.Sequential, Pack = 1)]
-    internal struct ElfAuxv64
+    internal readonly struct ElfAuxv64
     {
         public readonly ulong Type;
         public readonly ulong Value;

--- a/src/Microsoft.Diagnostics.Runtime/src/Linux/Structs/ElfHeader32.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Linux/Structs/ElfHeader32.cs
@@ -7,7 +7,7 @@ using System.Runtime.InteropServices;
 namespace Microsoft.Diagnostics.Runtime.Linux
 {
     [StructLayout(LayoutKind.Sequential, Pack = 1)]
-    internal struct ElfHeader32 : IElfHeader
+    internal readonly struct ElfHeader32 : IElfHeader
     {
         private readonly ElfHeaderCommon _common;
 

--- a/src/Microsoft.Diagnostics.Runtime/src/Linux/Structs/ElfHeader64.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Linux/Structs/ElfHeader64.cs
@@ -7,7 +7,7 @@ using System.Runtime.InteropServices;
 namespace Microsoft.Diagnostics.Runtime.Linux
 {
     [StructLayout(LayoutKind.Sequential, Pack = 1)]
-    internal struct ElfHeader64 : IElfHeader
+    internal readonly struct ElfHeader64 : IElfHeader
     {
         private readonly ElfHeaderCommon _common;
 

--- a/src/Microsoft.Diagnostics.Runtime/src/Linux/Structs/ElfHeaderCommon.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Linux/Structs/ElfHeaderCommon.cs
@@ -7,7 +7,7 @@ using System.Runtime.InteropServices;
 namespace Microsoft.Diagnostics.Runtime.Linux
 {
     [StructLayout(LayoutKind.Sequential, Pack = 1)]
-    internal struct ElfHeaderCommon
+    internal readonly struct ElfHeaderCommon
     {
         private const int EI_NIDENT = 16;
 

--- a/src/Microsoft.Diagnostics.Runtime/src/Utilities/PEImage/CorHeader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Utilities/PEImage/CorHeader.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
     /// </summary>
     public class CorHeader
     {
-        private IMAGE_COR20_HEADER _header;
+        private readonly IMAGE_COR20_HEADER _header;
 
         internal CorHeader(ref IMAGE_COR20_HEADER header)
         {

--- a/src/Microsoft.Diagnostics.Runtime/src/Utilities/PEImage/IMAGE_COR20_HEADER_ENTRYPOINT.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Utilities/PEImage/IMAGE_COR20_HEADER_ENTRYPOINT.cs
@@ -7,7 +7,7 @@ using System.Runtime.InteropServices;
 namespace Microsoft.Diagnostics.Runtime.Utilities
 {
     [StructLayout(LayoutKind.Explicit)]
-    public struct IMAGE_COR20_HEADER_ENTRYPOINT
+    public readonly struct IMAGE_COR20_HEADER_ENTRYPOINT
     {
         [FieldOffset(0)]
         public readonly uint Token;

--- a/src/Microsoft.Diagnostics.Runtime/src/Utilities/PEImage/ImageFileHeader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Utilities/PEImage/ImageFileHeader.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
     /// </summary>
     public class ImageFileHeader
     {
-        private IMAGE_FILE_HEADER _header;
+        private readonly IMAGE_FILE_HEADER _header;
 
         internal ImageFileHeader(ref IMAGE_FILE_HEADER header)
         {


### PR DESCRIPTION
- Make structs `readonly` where possible in the `Microsoft.Diagnostics.Runtime` assembly
- Remove some redundant `readonly` member modifiers
- Mark some members of `ClrArray` as `readonly`