### PR TITLE
Improve ELF reader EnumerateModules() perf

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/PEImageResourceTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/PEImageResourceTests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             Assert.NotNull(fileVersion.FileVersion);
 
             ClrInfo clrInfo = dt.ClrVersions[0];
-            Assert.True(clrInfo.Version.ToString() == fileVersion.VersionInfo.ToString());
+            Assert.Equal(clrInfo.Version, fileVersion.VersionInfo);
         }
 
         [Fact]

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/PEImageResourceTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/PEImageResourceTests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             Assert.NotNull(fileVersion.FileVersion);
 
             ClrInfo clrInfo = dt.ClrVersions[0];
-            Assert.Contains(clrInfo.Version.ToString(), fileVersion.FileVersion);
+            Assert.True(clrInfo.Version.ToString() == fileVersion.VersionInfo.ToString());
         }
 
         [Fact]

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/ModuleInfo.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/ModuleInfo.cs
@@ -104,9 +104,9 @@ namespace Microsoft.Diagnostics.Runtime
             
             try
             {
-                using (ReadVirtualStream stream = new ReadVirtualStream(_dataReader, (long)ImageBase, FileSize))
+                PEImage image = GetPEImage();
+                if (image != null && image.IsValid)
                 {
-                    PEImage image = new PEImage(stream, isVirtual: true);
                     _managed = image.OptionalHeader.ComDescriptorDirectory.VirtualAddress != 0;
                     _pdb = image.DefaultPdb;
                 }
@@ -114,6 +114,11 @@ namespace Microsoft.Diagnostics.Runtime
             catch
             {
             }
+        }
+
+        protected virtual void InitVersion(out VersionInfo version)
+        {
+            _dataReader.GetVersionInfo(ImageBase, out version);
         }
 
         /// <summary>
@@ -126,7 +131,7 @@ namespace Microsoft.Diagnostics.Runtime
                 if (_versionInit || _dataReader == null)
                     return _version;
 
-                _dataReader.GetVersionInfo(ImageBase, out _version);
+                InitVersion(out _version);
                 _versionInit = true;
                 return _version;
             }
@@ -162,9 +167,9 @@ namespace Microsoft.Diagnostics.Runtime
         }
 
         [NonSerialized]
-        private readonly IDataReader _dataReader;
+        protected readonly IDataReader _dataReader;
         private PdbInfo _pdb;
-        private bool _initialized;
+        protected bool _initialized;
         private bool _managed;
         private VersionInfo _version;
         private bool _versionInit;

--- a/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Core/CoreDumpReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Core/CoreDumpReader.cs
@@ -174,7 +174,7 @@ namespace Microsoft.Diagnostics.Runtime
                 _modules = new List<CoreModuleInfo>();
                 foreach (ElfLoadedImage image in _core.LoadedImages)
                 {
-                    if ((ulong)image.BaseAddress != interpreter && !image.Path.StartsWith("/dev"))
+                    if ((ulong)image.BaseAddress != interpreter && !image.Path.StartsWith("/dev/"))
                     {
                         _modules.Add(new CoreModuleInfo(this, image));
                     }

--- a/src/Microsoft.Diagnostics.Runtime/src/Linux/ElfLoadedImage.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Linux/ElfLoadedImage.cs
@@ -41,10 +41,13 @@ namespace Microsoft.Diagnostics.Runtime.Linux
             return new ElfFile(header, _vaReader, BaseAddress, true);
         }
 
+        /// <summary>
+        /// NOTE: This function will only work on "file" layout PE's in the core dump. 
+        /// </summary>
         public PEImage OpenAsPEImage()
         {
             Stream stream = new ReaderStream(BaseAddress, _vaReader);
-            return new PEImage(stream, isVirtual: true);
+            return new PEImage(stream, isVirtual: false);
         }
 
         internal void AddTableEntryPointers(ElfFileTableEntryPointers64 pointers)

--- a/src/Microsoft.Diagnostics.Runtime/src/Utilities/PEImage/ResourceEntry.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Utilities/PEImage/ResourceEntry.cs
@@ -11,6 +11,8 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
     /// </summary>
     public class ResourceEntry
     {
+        const int MaxPath = 1024;
+
         private static readonly ResourceEntry[] s_emptyChildren = new ResourceEntry[0];
         private ResourceEntry[] _children;
         private readonly int _offset;
@@ -138,10 +140,10 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
             {
                 IMAGE_RESOURCE_DIRECTORY_ENTRY entry = Image.Read<IMAGE_RESOURCE_DIRECTORY_ENTRY>(ref offset);
                 string name;
-                if (this == root)
-                    name = IMAGE_RESOURCE_DIRECTORY_ENTRY.GetTypeNameForTypeId(entry.Id);
-                else
+                if (entry.IsStringName)
                     name = GetName(ref entry, resourceStartFileOffset);
+                else
+                    name = IMAGE_RESOURCE_DIRECTORY_ENTRY.GetTypeNameForTypeId(entry.Id);
 
                 result[i] = new ResourceEntry(Image, this, name, entry.IsLeaf, resourceStartFileOffset + entry.DataOffset);
             }
@@ -158,7 +160,7 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
             for (int i = 0; i < len; i++)
             {
                 char c = (char)Image.Read<ushort>(ref offset);
-                if (c == 0)
+                if (c == 0 || i > MaxPath)
                     break;
 
                 sb.Append(c);


### PR DESCRIPTION
The dotnet-dump's `lm` command and any command run for the first time has a huge perf problem. The modules are enumerated to find the runtime module. Getting the Version for each PE image in the Linux core dump was taking way too long and failing.

The problem is the "layout" of managed PE modules. Some PE's are "file" layout and some are "loaded" (sections are aligned) layout in memory. The "isVirtual" flag in the PEImage constructor needs to be set based on the layout, but there is no way to determine that at the core dump data reader level. If the layout/isVirtual flag is set incorrectly, PEImage doesn't enumerate through the resources correctly, takes a long time because it is reading really long garbage strings, etc.

IDataReader.EnumerateModules() is meant to return just native modules (like libcoreclr.so, etc) but the PE's show up because it uses the NT_FILE entries in the coredump and because the PE's are memory mapped by the runtime as shared named memory,

The first part of the fix is to skip all the PE's (modules that ELFLoadedImage.Open can't open). The managed assemblies can be enumerated at a higher level (ClrRuntime.Modules) without any problems. dotnet-dump has a "clrmodules" command to do that.

The second part of the fix is to get the module's Version on demand and try both file and loaded layout of the PE images.

Fixed a problem in the ResourceEntry where resource id entries were trying to read a name string. Added check in the ResourceEntry read string code to limit strings to MaxPath (1024) characters for when the layout flag is wrong.

Fix PEImageResourceTests.FileInfoVersionTest. It wasn't comparing the same type of versions.

Issue: https://github.com/microsoft/clrmd/issues/564