### PR TITLE
Casting fixes

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/src/Builders/MethodBuilder.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Builders/MethodBuilder.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Diagnostics.Runtime.Builders
         private CodeHeaderData _codeHeaderData;
         private IMethodHelpers? _helpers;
 
-        public bool Init(SOSDac sos, ulong mt, int i, IMethodHelpers helpers)
+        public bool Init(SOSDac sos, ulong mt, uint i, IMethodHelpers helpers)
         {
             ulong slot = sos.GetMethodTableSlot(mt, i);
 

--- a/src/Microsoft.Diagnostics.Runtime/src/Builders/RuntimeBuilder.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Builders/RuntimeBuilder.cs
@@ -935,7 +935,7 @@ namespace Microsoft.Diagnostics.Runtime.Builders
             result.Count = result.Capacity;
 
             int curr = 0;
-            for (int i = 0; i < data.NumMethods; i++)
+            for (uint i = 0; i < data.NumMethods; i++)
             {
                 if (builder.Init(_sos, mt, i, this))
                     result[curr++] = new ClrmdMethod(type, builder);

--- a/src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac.cs
@@ -117,14 +117,14 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             }
         }
 
-        public ulong GetMethodTableSlot(ulong mt, int slot)
+        public ulong GetMethodTableSlot(ulong mt, uint slot)
         {
             if (mt == 0)
                 return 0;
 
             InitDelegate(ref _getMethodTableSlot, VTable.GetMethodTableSlot);
 
-            if (_getMethodTableSlot(Self, mt, (uint)slot, out ClrDataAddress ip))
+            if (_getMethodTableSlot(Self, mt, slot, out ClrDataAddress ip))
                 return ip;
 
             return 0;
@@ -600,7 +600,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
         {
             InitDelegate(ref _traverseModuleMap, VTable.TraverseModuleMap);
 
-            HResult hr = _traverseModuleMap(Self, (int)mt, module, Marshal.GetFunctionPointerForDelegate(traverse), IntPtr.Zero);
+            HResult hr = _traverseModuleMap(Self, mt, module, Marshal.GetFunctionPointerForDelegate(traverse), IntPtr.Zero);
             GC.KeepAlive(traverse);
             return hr;
         }
@@ -760,7 +760,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
         private delegate HResult DacGetThreadLocalModuleData(IntPtr self, ClrDataAddress addr, uint id, out ThreadLocalModuleData data);
         private delegate HResult DacTraverseLoaderHeap(IntPtr self, ClrDataAddress addr, IntPtr callback);
         private delegate HResult DacTraverseStubHeap(IntPtr self, ClrDataAddress addr, int type, IntPtr callback);
-        private delegate HResult DacTraverseModuleMap(IntPtr self, int type, ClrDataAddress addr, IntPtr callback, IntPtr param);
+        private delegate HResult DacTraverseModuleMap(IntPtr self, ModuleMapTraverseKind type, ClrDataAddress addr, IntPtr callback, IntPtr param);
         private delegate HResult DacGetJitManagers(IntPtr self, int count, [Out] JitManagerInfo[]? jitManagers, out int pNeeded);
         private delegate HResult GetModuleDelegate(IntPtr self, ClrDataAddress addr, out IntPtr iunk);
     }

--- a/src/Microsoft.Diagnostics.Runtime/src/DacInterface/Structs/MethodDescData.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DacInterface/Structs/MethodDescData.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
     {
         public readonly uint HasNativeCode;
         public readonly uint IsDynamic;
-        public readonly short SlotNumber;
+        public readonly ushort SlotNumber;
         public readonly ClrDataAddress NativeCodeAddr;
 
         // Useful for breaking when a method is jitted.


### PR DESCRIPTION
- Use unsigned integers for everything related to MethodTable slots.
- Change DacTraverseModuleMap to accept an enum instead of using an int which has to be casted.