### PR TITLE
Rework ModuleInfo

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/BinaryLocatorTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/BinaryLocatorTests.cs
@@ -75,9 +75,9 @@ namespace Microsoft.Diagnostics.Runtime.Tests
 
             Assert.NotNull(dac);
             Assert.True(File.Exists(dac));
-            using (Stream stream = File.OpenRead(dac))
+            using (PEImage peimage = new PEImage(File.OpenRead(dac)))
             {
-                PEImage peimage = new PEImage(stream);
+                
                 Assert.True(peimage.IsValid);
             }
 

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/PEImagePdbTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/PEImagePdbTests.cs
@@ -31,8 +31,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         {
             // Load Windows' ntdll.dll
             var dllFileName = Path.Combine(Environment.SystemDirectory, "ntdll.dll");
-            using var winFileStream = new FileStream(dllFileName, FileMode.Open, FileAccess.Read);
-            PEImage img = new PEImage(winFileStream);
+            using PEImage img = new PEImage(new FileStream(dllFileName, FileMode.Open, FileAccess.Read));
             Assert.NotNull(img);
 
             PdbInfo imgPdb = img.DefaultPdb;

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/ModuleInfo.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/ModuleInfo.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Diagnostics.Runtime
         {
             try
             {
-                PEImage image = new PEImage(new ReadVirtualStream(DataTarget.DataReader, (long)ImageBase, IndexFileSize), _isVirtual);
+                PEImage image = new PEImage(new ReadVirtualStream(DataTarget.DataReader, (long)ImageBase, IndexFileSize), leaveOpen: false, isVirtual: _isVirtual);
                 if (!_isManaged.HasValue)
                     _isManaged = image.IsManaged;
 

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/ModuleInfo.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/ModuleInfo.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Immutable;
 using Microsoft.Diagnostics.Runtime.Utilities;
 
@@ -11,14 +10,16 @@ namespace Microsoft.Diagnostics.Runtime
     /// <summary>
     /// Provides information about loaded modules in a <see cref="DataTarget"/>.
     /// </summary>
-#pragma warning disable CA1001 // Types that own disposable fields should be disposable
-    public class ModuleInfo
-#pragma warning restore CA1001 // Types that own disposable fields should be disposable
+    public sealed class ModuleInfo
     {
-        private readonly IDataReader _dataReader;
         private bool? _isManaged;
         private VersionInfo? _version;
-        internal bool _isVirtual;
+        private readonly bool _isVirtual;
+
+        /// <summary>
+        /// The DataTarget which contains this module.
+        /// </summary>
+        public DataTarget DataTarget { get; internal set; }
 
         /// <summary>
         /// Gets the base address of the object.
@@ -26,14 +27,14 @@ namespace Microsoft.Diagnostics.Runtime
         public ulong ImageBase { get; }
 
         /// <summary>
-        /// Gets the file size of the image.
+        /// Gets the specific file size of the image used to index it on the symbol server.
         /// </summary>
-        public int FileSize { get; }
+        public int IndexFileSize { get; }
 
         /// <summary>
-        /// Gets the build timestamp of the image.
+        /// Gets the timestamp of the image used to index it on the symbol server.
         /// </summary>
-        public int TimeStamp { get; }
+        public int IndexTimeStamp { get; }
 
         /// <summary>
         /// Gets the file name of the module on disk.
@@ -49,7 +50,7 @@ namespace Microsoft.Diagnostics.Runtime
         {
             try
             {
-                PEImage image = new PEImage(new ReadVirtualStream(_dataReader, (long)ImageBase, FileSize), _isVirtual);
+                PEImage image = new PEImage(new ReadVirtualStream(DataTarget.DataReader, (long)ImageBase, IndexFileSize), _isVirtual);
                 if (!_isManaged.HasValue)
                     _isManaged = image.IsManaged;
 
@@ -115,40 +116,38 @@ namespace Microsoft.Diagnostics.Runtime
         {
             get
             {
-                if (_version is VersionInfo version)
+                if (_version.HasValue)
                 {
-                    return version;
+                    return _version.Value;
                 }
 
-                _dataReader.GetVersionInfo(ImageBase, out version);
+                DataTarget.DataReader.GetVersionInfo(ImageBase, out VersionInfo version);
                 _version = version;
-
                 return version;
             }
         }
+
+
+        // DataTarget is one of the few "internal set" properties, and is initialized as soon as DataTarget asks
+        // IDataReader to create ModuleInfo.  So even though we don't set it here, we will immediately set the
+        // value to non-null and never change it.
+
+#pragma warning disable CS8618 // Non-nullable field is uninitialized. Consider declaring as nullable.
 
         /// <summary>
         /// Creates a ModuleInfo object with an IDataReader instance.  This is used when
         /// lazily evaluating VersionInfo.
         /// </summary>
-        public ModuleInfo(
-            IDataReader reader,
-            ulong imgBase,
-            int filesize,
-            int timestamp,
-            string? fileName,
-            bool isVirtual,
-            ImmutableArray<byte> buildId = default,
-            VersionInfo? version = null)
+        public ModuleInfo(ulong imgBase, int filesize, int timestamp, string? fileName, bool isVirtual, ImmutableArray<byte> buildId = default, VersionInfo? version = null)
         {
-            _dataReader = reader ?? throw new ArgumentNullException(nameof(reader));
             ImageBase = imgBase;
-            FileSize = filesize;
-            TimeStamp = timestamp;
+            IndexFileSize = filesize;
+            IndexTimeStamp = timestamp;
             FileName = fileName;
             _isVirtual = isVirtual;
             BuildId = buildId;
             _version = version;
         }
+#pragma warning restore CS8618 // Non-nullable field is uninitialized. Consider declaring as nullable.
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/ModuleInfo.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/ModuleInfo.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Diagnostics.Runtime
                 if (!_isManaged.HasValue)
                     _isManaged = image.IsManaged;
 
-                return image;
+                return image.IsValid ? image : null;
             }
             catch
             {
@@ -117,9 +117,7 @@ namespace Microsoft.Diagnostics.Runtime
             get
             {
                 if (_version.HasValue)
-                {
                     return _version.Value;
-                }
 
                 DataTarget.DataReader.GetVersionInfo(ImageBase, out VersionInfo version);
                 _version = version;

--- a/src/Microsoft.Diagnostics.Runtime/src/DacInterface/DacDataTargetWrapper.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DacInterface/DacDataTargetWrapper.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
                 int i = (min + max) / 2;
                 ModuleInfo curr = _modules[i];
 
-                if (curr.ImageBase <= address && address < curr.ImageBase + (ulong)curr.FileSize)
+                if (curr.ImageBase <= address && address < curr.ImageBase + (ulong)curr.IndexFileSize)
                     return curr;
 
                 if (curr.ImageBase < address)
@@ -153,7 +153,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
                         return HResult.E_NOTIMPL;
                     }
 
-                    filePath = _dataTarget.BinaryLocator.FindBinary(info.FileName!, info.TimeStamp, info.FileSize, true);
+                    filePath = _dataTarget.BinaryLocator.FindBinary(info.FileName!, info.IndexTimeStamp, info.IndexFileSize, true);
                 }
 
                 if (filePath is null)

--- a/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Core/CoreDumpReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Core/CoreDumpReader.cs
@@ -118,7 +118,7 @@ namespace Microsoft.Diagnostics.Runtime
                 LinuxFunctions.GetVersionInfo(this, (ulong)image.BaseAddress, file, out version);
             }
 
-            return new ModuleInfo(this, (ulong)image.BaseAddress, filesize, timestamp, image.Path, image._containsExecutable, file?.BuildId ?? default, version);
+            return new ModuleInfo((ulong)image.BaseAddress, filesize, timestamp, image.Path, image._containsExecutable, file?.BuildId ?? default, version);
         }
 
         public void FlushCachedData()

--- a/src/Microsoft.Diagnostics.Runtime/src/DataReaders/DbgEng/DbgEngDataReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataReaders/DbgEng/DbgEngDataReader.cs
@@ -219,7 +219,7 @@ namespace Microsoft.Diagnostics.Runtime
                 for (int i = 0; i < bases.Length; ++i)
                 {
                     string? fn = _symbols.GetModuleNameStringWide(DebugModuleName.Image, i, bases[i]);
-                    ModuleInfo info = new ModuleInfo(this, bases[i], mods[i].Size, mods[i].TimeDateStamp, fn, isVirtual: true);
+                    ModuleInfo info = new ModuleInfo(bases[i], mods[i].Size, mods[i].TimeDateStamp, fn, isVirtual: true);
                     modules.Add(info);
                 }
             }

--- a/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Live/LiveDataReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Live/LiveDataReader.cs
@@ -142,7 +142,7 @@ namespace Microsoft.Diagnostics.Runtime
                 GetFileProperties(baseAddr, out int filesize, out int timestamp);
 
                 string fileName = sb.ToString();
-                ModuleInfo module = new ModuleInfo(this, baseAddr, filesize, timestamp, fileName, isVirtual: true);
+                ModuleInfo module = new ModuleInfo(baseAddr, filesize, timestamp, fileName, isVirtual: true);
                 result.Add(module);
             }
 

--- a/src/Microsoft.Diagnostics.Runtime/src/DataTargets/ClrInfo.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataTargets/ClrInfo.cs
@@ -86,11 +86,11 @@ namespace Microsoft.Diagnostics.Runtime
             if (dac != null && !File.Exists(dac))
                 dac = null;
 
-            if (DacInfo.FileName != null)
-                dac ??= DataTarget.BinaryLocator.FindBinary(DacInfo.FileName, DacInfo.TimeStamp, DacInfo.FileSize, checkProperties: false);
+            if (DacInfo.PlatformSpecificFileName != null)
+                dac ??= DataTarget.BinaryLocator.FindBinary(DacInfo.PlatformSpecificFileName, DacInfo.IndexTimeStamp, DacInfo.IndexFileSize, checkProperties: false);
 
             if (!File.Exists(dac))
-                throw new FileNotFoundException("Could not find matching DAC for this runtime.", DacInfo.FileName);
+                throw new FileNotFoundException("Could not find matching DAC for this runtime.", DacInfo.PlatformSpecificFileName);
 
             if (IntPtr.Size != DataTarget.DataReader.PointerSize)
                 throw new InvalidOperationException("Mismatched architecture between this process and the dac.");

--- a/src/Microsoft.Diagnostics.Runtime/src/DataTargets/DacInfo.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataTargets/DacInfo.cs
@@ -7,10 +7,16 @@ using System.Collections.Immutable;
 namespace Microsoft.Diagnostics.Runtime
 {
     /// <summary>
-    /// Represents the DAC dll.
+    /// This class provides information needed to located the correct CLR diagnostics DLL (this dll
+    /// is called the "dac").
     /// </summary>
-    public class DacInfo : ModuleInfo
+    public sealed class DacInfo
     {
+        /// <summary>
+        /// Gets the platform specific filename of the DAC dll.
+        /// </summary>
+        public string PlatformSpecificFileName { get; }
+
         /// <summary>
         /// Gets the platform-agnostic file name of the DAC dll.
         /// </summary>
@@ -22,22 +28,39 @@ namespace Microsoft.Diagnostics.Runtime
         public Architecture TargetArchitecture { get; }
 
         /// <summary>
+        /// Gets the specific file size of the image used to index it on the symbol server.
+        /// </summary>
+        public int IndexFileSize { get; }
+
+        /// <summary>
+        /// Gets the timestamp of the image used to index it on the symbol server.
+        /// </summary>
+        public int IndexTimeStamp { get; }
+
+        /// <summary>
+        /// Gets the version information for the CLR this dac matches.  The dac will have the
+        /// same version.
+        /// </summary>
+        public VersionInfo Version { get; }
+
+        /// <summary>
+        /// If CLR has a build id on this platform, this property will contain its build id.
+        /// </summary>
+        public ImmutableArray<byte> ClrBuildId { get; }
+
+        /// <summary>
         /// Constructs a DacInfo object with the appropriate properties initialized.
         /// </summary>
-        public DacInfo(
-            IDataReader reader,
-            string agnosticName,
-            Architecture targetArch,
-            ulong imgBase,
-            int filesize,
-            int timestamp,
-            string fileName,
-            VersionInfo version,
-            ImmutableArray<byte> buildId = default)
-            : base(reader, imgBase, filesize, timestamp, fileName, isVirtual: false, buildId, version)
+        public DacInfo(string specificName, string agnosticName, Architecture targetArch, int filesize, int timestamp,
+                       VersionInfo version, ImmutableArray<byte> clrBuildId)
         {
+            PlatformSpecificFileName = specificName;
             PlatformAgnosticFileName = agnosticName;
             TargetArchitecture = targetArch;
+            IndexFileSize = filesize;
+            IndexTimeStamp = timestamp;
+            Version = version;
+            ClrBuildId = clrBuildId;
         }
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/src/DataTargets/DacInfo.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataTargets/DacInfo.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Diagnostics.Runtime
 {
     /// <summary>
     /// This class provides information needed to located the correct CLR diagnostics DLL (this dll
-    /// is called the "dac").
+    /// is called the Debug Access Component (DAC)).
     /// </summary>
     public sealed class DacInfo
     {

--- a/src/Microsoft.Diagnostics.Runtime/src/DataTargets/DataTarget.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataTargets/DataTarget.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Diagnostics.Runtime
                 lock (_pefileCache)
                 {
                     foreach (PEImage? img in _pefileCache.Values)
-                        img?.Stream.Dispose();
+                        img?.Dispose();
 
                     _pefileCache.Clear();
                 }
@@ -98,14 +98,10 @@ namespace Microsoft.Diagnostics.Runtime
                     return result;
             }
 
-            Stream stream = File.OpenRead(path);
-            result = new PEImage(stream);
+            result = new PEImage(File.OpenRead(path));
 
             if (!result.IsValid)
-            {
-                stream.Dispose();
                 result = null;
-            }
 
             lock (_pefileCache)
             {

--- a/src/Microsoft.Diagnostics.Runtime/src/Implementation/ClrmdModule.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Implementation/ClrmdModule.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
                 if (_pdb is null)
                 {
                     using ReadVirtualStream stream = new ReadVirtualStream(_helpers.DataReader, (long)ImageBase, (long)(Size > 0 ? Size : int.MaxValue));
-                    using PEImage pefile = new PEImage(stream, !IsFileLayout);
+                    using PEImage pefile = new PEImage(stream, leaveOpen: true, isVirtual: !IsFileLayout);
                     if (pefile.IsValid)
                         _pdb = pefile.DefaultPdb;
                 }

--- a/src/Microsoft.Diagnostics.Runtime/src/Implementation/SymbolServerLocator.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Implementation/SymbolServerLocator.cs
@@ -277,8 +277,7 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
                 bool found = true;
                 if (checkProperties)
                 {
-                    using FileStream fs = File.Open(fullPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-                    using PEImage img = new PEImage(fs);
+                    using PEImage img = new PEImage(File.Open(fullPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite));
                     unchecked
                     {
                         found = img.IndexFileSize == imageSize && img.IndexTimeStamp == buildTimeStamp;

--- a/src/Microsoft.Diagnostics.Runtime/src/Linux/ElfLoadedImage.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Linux/ElfLoadedImage.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Diagnostics.Runtime.Linux
         public PEImage OpenAsPEImage()
         {
             Stream stream = new ReaderStream(BaseAddress, Size, _vaReader);
-            return new PEImage(stream, _containsExecutable);
+            return new PEImage(stream, leaveOpen: false, isVirtual: _containsExecutable);
         }
 
         internal void AddTableEntryPointers(ElfFileTableEntryPointers64 pointers, bool isExecutable)

--- a/src/Microsoft.Diagnostics.Runtime/src/Linux/LinuxLiveDataReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Linux/LinuxLiveDataReader.cs
@@ -136,8 +136,7 @@ namespace Microsoft.Diagnostics.Runtime.Linux
             {
                 try
                 {
-                    using FileStream stream = File.OpenRead(filePath);
-                    using PEImage pe = new PEImage(stream);
+                    using PEImage pe = new PEImage(File.OpenRead(filePath));
                     if (pe.IsValid)
                         return (pe.IndexFileSize, pe.IndexTimeStamp, pe.GetFileVersionInfo()?.VersionInfo ?? default);
                 }


### PR DESCRIPTION
ModuleInfo changes:
- Change _isVirtual to be private
- Mark the class sealed
- Keep a reference to DataTarget instead of IDataReader
- Rename FileSize/Timestamp fields

PEImage changes:
- PEImage now contains a flag for whether to leave the stream open or not
- Clean up PEImage.Dispose related methods
- Make PEImage.Stream private
- Change PEImage.Reader to be nullable

Other:
- Update LinuxLiveDataReader to not need to write to IsVirtual
- Update DacInfo to not derive from ModuleInfo