### PR TITLE
Various Fixes

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/src/DacInterface/Structs/HeapDetails.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DacInterface/Structs/HeapDetails.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
 
         [MarshalAs(UnmanagedType.ByValArray, SizeConst = 4)]
         public readonly GenerationData[] GenerationTable;
-        public readonly ulong EphemeralHeapSegment;
+        public readonly ClrDataAddress EphemeralHeapSegment;
 
         [MarshalAs(UnmanagedType.ByValArray, SizeConst = 7)]
         public readonly ClrDataAddress[] FinalizationFillPointers;

--- a/src/Microsoft.Diagnostics.Runtime/src/Implementation/ClrmdSegment.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Implementation/ClrmdSegment.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
             if (!large)
                 memoryReader.EnsureRangeInCache(obj);
 
-            while (obj < CommittedEnd)
+            while (obj < End)
             {
                 ulong mt;
                 if (large)

--- a/src/Microsoft.Diagnostics.Runtime/src/Implementation/SymbolServerLocator.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Implementation/SymbolServerLocator.cs
@@ -37,9 +37,9 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
                 string location = split[split.Length - 1];
 
                 string? cache = null;
-                if (split.Length > 1)
+                if (split.Length > 2)
                 {
-                    cache = split[split.Length - 1];
+                    cache = split[split.Length - 2];
 
                     if (cache.Equals("cache", StringComparison.OrdinalIgnoreCase))
                     {


### PR DESCRIPTION
- Symbol locator was using the wrong path for its cache.
- Ephemeral segment heap data was improperly sign extended.
- We walked past the allocated range of segments when enumerating objects.
- We hit InvalidOperationExceptions in EnumerateReferencesWithFields due to the dac reporting a 0 MethodTable for certain fields.