### PR TITLE
Don't call FixGenerics twice

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/src/Implementation/ClrmdType.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Implementation/ClrmdType.cs
@@ -33,13 +33,21 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
         {
             get
             {
-                if (_name != null)
-                    return _name;
+                // Name can't really be string.Empty for a valid type, so we use that as a sentinal for
+                // "we tried to get the type name but it was null" to avoid calling GetTypeName over and
+                // over.
+                if (_name == null)
+                {
+                    if (Helpers.GetTypeName(MethodTable, out string? name) && name != null)
+                        _name = name;
+                    else
+                        _name = string.Empty;
+                }
 
-                if (Helpers.GetTypeName(MethodTable, out string? name))
-                    return _name = FixGenerics(name);
+                if (_name.Length == 0)
+                    return null;
 
-                return FixGenerics(name);
+                return _name;
             }
         }
 

--- a/src/Microsoft.Diagnostics.Runtime/src/Implementation/ClrmdType.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Implementation/ClrmdType.cs
@@ -38,10 +38,12 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
                 // over.
                 if (_name == null)
                 {
-                    if (Helpers.GetTypeName(MethodTable, out string? name) && name != null)
-                        _name = name;
-                    else
-                        _name = string.Empty;
+                    // GetTypeName returns whether the value should be cached or not.
+                    if (!Helpers.GetTypeName(MethodTable, out string? name))
+                        return name;
+
+                    // Cache the result or "string.Empty" for null.
+                    _name = name ?? string.Empty;
                 }
 
                 if (_name.Length == 0)

--- a/src/Microsoft.Diagnostics.Runtime/src/Implementation/ITypeHelpers.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Implementation/ITypeHelpers.cs
@@ -10,6 +10,13 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
         ITypeFactory Factory { get; }
         IClrObjectHelpers ClrObjectHelpers { get; }
 
+        /// <summary>
+        /// Gets the name for a type.
+        /// </summary>
+        /// <param name="mt">The MethodTable to request the name of.</param>
+        /// <param name="name">The name for that type, note that this has already had FixGenerics called on it.</param>
+        /// <returns>True if the value should be cached, false if the value should not be cached.  (This is controlled
+        /// by the user's string cache settings.</returns>
         bool GetTypeName(ulong mt, out string? name);
         ulong GetLoaderAllocatorHandle(ulong mt);
 


### PR DESCRIPTION
FixGenerics is called by ITypeHelpers.GetTypeName.  ClrmdType shouldn't also call it.