### PR TITLE
Lazily initialize ModuleInfo.BuildId

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/src/Common/ModuleInfo.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/ModuleInfo.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Diagnostics.Runtime
     public sealed class ModuleInfo
     {
         private bool? _isManaged;
+        private ImmutableArray<byte> _buildId;
         private VersionInfo? _version;
         private readonly bool _isVirtual;
 
@@ -65,7 +66,18 @@ namespace Microsoft.Diagnostics.Runtime
         /// <summary>
         /// Gets the Linux BuildId of this module.  This will be <see langword="null"/> if the module does not have a BuildId.
         /// </summary>
-        public ImmutableArray<byte> BuildId { get; }
+        public ImmutableArray<byte> BuildId
+        {
+            get
+            {
+                if (_buildId.IsDefault)
+                {
+                    return _buildId = DataTarget.DataReader.GetBuildId(ImageBase);
+                }
+
+                return _buildId;
+            }
+        }
 
         /// <summary>
         /// Gets a value indicating whether the module is managed.
@@ -143,7 +155,7 @@ namespace Microsoft.Diagnostics.Runtime
             IndexTimeStamp = timestamp;
             FileName = fileName;
             _isVirtual = isVirtual;
-            BuildId = buildId;
+            _buildId = buildId;
             _version = version;
         }
 #pragma warning restore CS8618 // Non-nullable field is uninitialized. Consider declaring as nullable.

--- a/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Core/CoreDumpReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Core/CoreDumpReader.cs
@@ -144,19 +144,21 @@ namespace Microsoft.Diagnostics.Runtime
 
         public ImmutableArray<byte> GetBuildId(ulong baseAddress)
         {
-            ElfLoadedImage image = _core.LoadedImages.First(image => (ulong)image.BaseAddress == baseAddress);
-            ElfFile? file = image.Open();
-            return file?.BuildId ?? ImmutableArray<byte>.Empty;
+            return GetElfFile(baseAddress)?.BuildId ?? ImmutableArray<byte>.Empty;
         }
 
         public void GetVersionInfo(ulong baseAddress, out VersionInfo version)
         {
-            ElfLoadedImage image = _core.LoadedImages.First(image => (ulong)image.BaseAddress == baseAddress);
-            ElfFile? file = image.Open();
+            ElfFile? file = GetElfFile(baseAddress);
             if (file is null)
                 version = default;
             else
                 LinuxFunctions.GetVersionInfo(this, baseAddress, file, out version);
+        }
+
+        private ElfFile? GetElfFile(ulong baseAddress)
+        {
+            return _core.LoadedImages.First(image => (ulong)image.BaseAddress == baseAddress).Open();
         }
 
         public bool Read(ulong address, Span<byte> buffer, out int bytesRead)

--- a/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Core/CoreDumpReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Core/CoreDumpReader.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -118,7 +119,7 @@ namespace Microsoft.Diagnostics.Runtime
                 LinuxFunctions.GetVersionInfo(this, (ulong)image.BaseAddress, file, out version);
             }
 
-            return new ModuleInfo((ulong)image.BaseAddress, filesize, timestamp, image.Path, image._containsExecutable, file?.BuildId ?? default, version);
+            return new ModuleInfo((ulong)image.BaseAddress, filesize, timestamp, image.Path, image._containsExecutable, default, version);
         }
 
         public void FlushCachedData()
@@ -139,6 +140,13 @@ namespace Microsoft.Diagnostics.Runtime
                 return status.CopyContext(contextFlags, context);
 
             return false;
+        }
+
+        public ImmutableArray<byte> GetBuildId(ulong baseAddress)
+        {
+            ElfLoadedImage image = _core.LoadedImages.First(image => (ulong)image.BaseAddress == baseAddress);
+            ElfFile? file = image.Open();
+            return file?.BuildId ?? ImmutableArray<byte>.Empty;
         }
 
         public void GetVersionInfo(ulong baseAddress, out VersionInfo version)

--- a/src/Microsoft.Diagnostics.Runtime/src/DataReaders/DbgEng/DbgEngDataReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataReaders/DbgEng/DbgEngDataReader.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -219,7 +220,7 @@ namespace Microsoft.Diagnostics.Runtime
                 for (int i = 0; i < bases.Length; ++i)
                 {
                     string? fn = _symbols.GetModuleNameStringWide(DebugModuleName.Image, i, bases[i]);
-                    ModuleInfo info = new ModuleInfo(bases[i], mods[i].Size, mods[i].TimeDateStamp, fn, isVirtual: true);
+                    ModuleInfo info = new ModuleInfo(bases[i], mods[i].Size, mods[i].TimeDateStamp, fn, isVirtual: true, buildId: ImmutableArray<byte>.Empty);
                     modules.Add(info);
                 }
             }
@@ -312,6 +313,8 @@ namespace Microsoft.Diagnostics.Runtime
             value = 0;
             return false;
         }
+
+        public ImmutableArray<byte> GetBuildId(ulong baseAddress) => ImmutableArray<byte>.Empty;
 
         public void GetVersionInfo(ulong baseAddress, out VersionInfo version)
         {

--- a/src/Microsoft.Diagnostics.Runtime/src/DataReaders/IDataReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataReaders/IDataReader.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 
 namespace Microsoft.Diagnostics.Runtime
 {
@@ -44,6 +45,8 @@ namespace Microsoft.Diagnostics.Runtime
         /// </summary>
         /// <returns>An enumerable of the modules in the target process.</returns>
         IEnumerable<ModuleInfo> EnumerateModules();
+
+        ImmutableArray<byte> GetBuildId(ulong baseAddress);
 
         /// <summary>
         /// Gets the version information for a given module (given by the base address of the module).

--- a/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Live/LiveDataReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Live/LiveDataReader.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
@@ -142,12 +143,14 @@ namespace Microsoft.Diagnostics.Runtime
                 GetFileProperties(baseAddr, out int filesize, out int timestamp);
 
                 string fileName = sb.ToString();
-                ModuleInfo module = new ModuleInfo(baseAddr, filesize, timestamp, fileName, isVirtual: true);
+                ModuleInfo module = new ModuleInfo(baseAddr, filesize, timestamp, fileName, isVirtual: true, buildId: ImmutableArray<byte>.Empty);
                 result.Add(module);
             }
 
             return result;
         }
+
+        public ImmutableArray<byte> GetBuildId(ulong baseAddress) => ImmutableArray<byte>.Empty;
 
         public void GetVersionInfo(ulong addr, out VersionInfo version)
         {

--- a/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Minidump/MinidumpReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Minidump/MinidumpReader.cs
@@ -5,6 +5,7 @@
 using Microsoft.Diagnostics.Runtime.Windows;
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 
 namespace Microsoft.Diagnostics.Runtime
@@ -55,7 +56,7 @@ namespace Microsoft.Diagnostics.Runtime
         public IEnumerable<ModuleInfo> EnumerateModules()
         {
             return from module in _minidump.EnumerateModuleInfo()
-                   select new ModuleInfo(module.BaseOfImage, module.SizeOfImage, module.DateTimeStamp, module.ModuleName, isVirtual: true, buildId: default, version: module.VersionInfo.AsVersionInfo());
+                   select new ModuleInfo(module.BaseOfImage, module.SizeOfImage, module.DateTimeStamp, module.ModuleName, isVirtual: true, buildId: ImmutableArray<byte>.Empty, version: module.VersionInfo.AsVersionInfo());
         }
 
         public void FlushCachedData()
@@ -74,6 +75,8 @@ namespace Microsoft.Diagnostics.Runtime
 
             return _minidump.MemoryReader.ReadFromRVA(ctx.ContextRva, context) == context.Length;
         }
+
+        public ImmutableArray<byte> GetBuildId(ulong baseAddress) => ImmutableArray<byte>.Empty;
 
         public void GetVersionInfo(ulong baseAddress, out VersionInfo version)
         {

--- a/src/Microsoft.Diagnostics.Runtime/src/Linux/LinuxLiveDataReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Linux/LinuxLiveDataReader.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Buffers;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -113,7 +114,7 @@ namespace Microsoft.Diagnostics.Runtime.Linux
             let containsExecutable = image.Any(entry => entry.IsExecutable)
             let beginAddress = image.Min(entry => entry.BeginAddress)
             let props = GetPEImageProperties(filePath)
-            select new ModuleInfo(beginAddress, props.Filesize, props.Timestamp, filePath, containsExecutable, buildId: default, version: props.Version);
+            select new ModuleInfo(beginAddress, props.Filesize, props.Timestamp, filePath, containsExecutable, buildId: ImmutableArray<byte>.Empty, version: props.Version);
 
         private static (int Filesize, int Timestamp, VersionInfo Version) GetPEImageProperties(string filePath)
         {
@@ -132,6 +133,8 @@ namespace Microsoft.Diagnostics.Runtime.Linux
 
             return (0, 0, default);
         }
+
+        public ImmutableArray<byte> GetBuildId(ulong baseAddress) => ImmutableArray<byte>.Empty;
 
         public unsafe void GetVersionInfo(ulong baseAddress, out VersionInfo version)
         {


### PR DESCRIPTION
Contributes to #625 

Some questions:

- `IDataReader.GetVersionInfo` is a `void` method with an `out` parameter?