### PR TITLE
Ensure ModuleInfo's BuildId and VersionInfo are lazily evaluated

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/src/Common/ModuleInfo.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/ModuleInfo.cs
@@ -144,18 +144,22 @@ namespace Microsoft.Diagnostics.Runtime
 #pragma warning disable CS8618 // Non-nullable field is uninitialized. Consider declaring as nullable.
 
         /// <summary>
-        /// Creates a ModuleInfo object with an IDataReader instance.  This is used when
-        /// lazily evaluating VersionInfo.
+        /// Constructor.
         /// </summary>
-        public ModuleInfo(ulong imgBase, int filesize, int timestamp, string? fileName, bool isVirtual, ImmutableArray<byte> buildId = default, VersionInfo? version = null)
+        /// <param name="imgBase">The base of the image as loaded into the virtual address space.</param>
+        /// <param name="fileName">The full path of the file as loaded from disk (if possible), otherwise only the filename.</param>
+        /// <param name="isVirtual">Whether this image is mapped into the virtual address space.  (This is as opposed to a memmap'ed file.)</param>
+        /// <param name="indexFileSize">The index file size used by the symbol server to archive and request this binary.  Only for PEImages (not Elf or Mach-O binaries).</param>
+        /// <param name="indexTimeStamp">The index timestamp used by the symbol server to archive and request this binary.  Only for PEImages (not Elf or Mach-O binaries).</param>
+        /// <param name="buildId">The ELF buildid of this image.  Not valid for PEImages.</param>
+        public ModuleInfo(ulong imgBase, string? fileName, bool isVirtual, int indexFileSize, int indexTimeStamp, ImmutableArray<byte> buildId)
         {
             ImageBase = imgBase;
-            IndexFileSize = filesize;
-            IndexTimeStamp = timestamp;
+            IndexFileSize = indexFileSize;
+            IndexTimeStamp = indexTimeStamp;
             FileName = fileName;
             _isVirtual = isVirtual;
             _buildId = buildId;
-            _version = version;
         }
 #pragma warning restore CS8618 // Non-nullable field is uninitialized. Consider declaring as nullable.
     }

--- a/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Core/CoreDumpReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Core/CoreDumpReader.cs
@@ -98,8 +98,7 @@ namespace Microsoft.Diagnostics.Runtime
         {
             ElfFile? file = image.Open();
 
-            VersionInfo version;
-            int filesize = (int)image.Size;
+            int filesize = 0;
             int timestamp = 0;
 
             if (file is null)
@@ -107,14 +106,10 @@ namespace Microsoft.Diagnostics.Runtime
                 using PEImage pe = image.OpenAsPEImage();
                 filesize = pe.IndexFileSize;
                 timestamp = pe.IndexTimeStamp;
-                version = pe.GetFileVersionInfo()?.VersionInfo ?? default;
-            }
-            else
-            {
-                LinuxFunctions.GetVersionInfo(this, (ulong)image.BaseAddress, file, out version);
             }
 
-            return new ModuleInfo((ulong)image.BaseAddress, filesize, timestamp, image.Path, image._containsExecutable, default, version);
+            // We set buildId to "default" which means we will later lazily evaluate the buildId on demand.
+            return new ModuleInfo((ulong)image.BaseAddress, image.Path, image._containsExecutable, filesize, timestamp, buildId: default);
         }
 
         public void FlushCachedData()

--- a/src/Microsoft.Diagnostics.Runtime/src/DataReaders/DbgEng/DbgEngDataReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataReaders/DbgEng/DbgEngDataReader.cs
@@ -221,7 +221,7 @@ namespace Microsoft.Diagnostics.Runtime
                 for (int i = 0; i < bases.Length; ++i)
                 {
                     string? fn = _symbols.GetModuleNameStringWide(DebugModuleName.Image, i, bases[i]);
-                    ModuleInfo info = new ModuleInfo(bases[i], mods[i].Size, mods[i].TimeDateStamp, fn, isVirtual: true, buildId: ImmutableArray<byte>.Empty);
+                    ModuleInfo info = new ModuleInfo(bases[i], fn, true, mods[i].Size, mods[i].TimeDateStamp, ImmutableArray<byte>.Empty);
                     modules.Add(info);
                 }
             }

--- a/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Minidump/MinidumpReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Minidump/MinidumpReader.cs
@@ -68,8 +68,11 @@ namespace Microsoft.Diagnostics.Runtime
 
         public IEnumerable<ModuleInfo> EnumerateModules()
         {
+            // We set buildId to "Empty" since only PEImages exist where minidumps are created, and we do not
+            // want to try to lazily evaluate the buildId later
             return from module in _minidump.EnumerateModuleInfo()
-                   select new ModuleInfo(module.BaseOfImage, module.SizeOfImage, module.DateTimeStamp, module.ModuleName, isVirtual: true, buildId: ImmutableArray<byte>.Empty, version: module.VersionInfo.AsVersionInfo());
+                   select new ModuleInfo(module.BaseOfImage, module.ModuleName, true, module.SizeOfImage,
+                                         module.DateTimeStamp, ImmutableArray<byte>.Empty);
         }
 
         public void FlushCachedData()

--- a/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Windows/WindowsProcessDataReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Windows/WindowsProcessDataReader.cs
@@ -151,7 +151,7 @@ namespace Microsoft.Diagnostics.Runtime
                 GetFileProperties(baseAddr, out int filesize, out int timestamp);
 
                 string fileName = sb.ToString();
-                ModuleInfo module = new ModuleInfo(baseAddr, filesize, timestamp, fileName, isVirtual: true, buildId: ImmutableArray<byte>.Empty);
+                ModuleInfo module = new ModuleInfo(baseAddr, fileName, true, filesize, timestamp, ImmutableArray<byte>.Empty);
                 result.Add(module);
             }
 

--- a/src/Microsoft.Diagnostics.Runtime/src/Linux/LinuxLiveDataReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Linux/LinuxLiveDataReader.cs
@@ -115,9 +115,9 @@ namespace Microsoft.Diagnostics.Runtime.Linux
             let containsExecutable = image.Any(entry => entry.IsExecutable)
             let beginAddress = image.Min(entry => entry.BeginAddress)
             let props = GetPEImageProperties(filePath)
-            select new ModuleInfo(beginAddress, props.Filesize, props.Timestamp, filePath, containsExecutable, buildId: default, version: props.Version);
+            select new ModuleInfo(beginAddress, filePath, containsExecutable, props.Filesize, props.Timestamp, buildId: default);
 
-        private static (int Filesize, int Timestamp, VersionInfo? Version) GetPEImageProperties(string filePath)
+        private static (int Filesize, int Timestamp) GetPEImageProperties(string filePath)
         {
             if (File.Exists(filePath))
             {
@@ -125,14 +125,14 @@ namespace Microsoft.Diagnostics.Runtime.Linux
                 {
                     using PEImage pe = new PEImage(File.OpenRead(filePath));
                     if (pe.IsValid)
-                        return (pe.IndexFileSize, pe.IndexTimeStamp, pe.GetFileVersionInfo()?.VersionInfo ?? default);
+                        return (pe.IndexFileSize, pe.IndexTimeStamp);
                 }
                 catch
                 {
                 }
             }
 
-            return (0, 0, default);
+            return (0, 0);
         }
 
         public ImmutableArray<byte> GetBuildId(ulong baseAddress) => GetElfFile(baseAddress)?.BuildId ?? ImmutableArray<byte>.Empty;


### PR DESCRIPTION
It can take a long time to produce the build id and version for various modules.  This change ensures that we calculate those values on demand.