### PR TITLE
Add Linux support for CreateSnapshotAndAttach

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/Microsoft.Diagnostics.Runtime.csproj
+++ b/src/Microsoft.Diagnostics.Runtime/Microsoft.Diagnostics.Runtime.csproj
@@ -25,6 +25,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.Diagnostics.NETCore.Client" Version="0.2.61701" />
     <!-- <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.113">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/src/Microsoft.Diagnostics.Runtime/src/DataReaders/LinuxSnapshot/LinuxSnapshotTarget.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataReaders/LinuxSnapshot/LinuxSnapshotTarget.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Diagnostics.Runtime
                 }
 
 #pragma warning disable CA2000 // Dispose objects before losing scope
-                LinuxSnapshotTarget result = new LinuxSnapshotTarget(new MinidumpReader(dumpPath), pid, dumpPath);
+                LinuxSnapshotTarget result = new LinuxSnapshotTarget(new CoreDumpReader(dumpPath, File.OpenRead(dumpPath)), pid, dumpPath);
                 dumpPath = null;
                 return result;
 #pragma warning restore CA2000 // Dispose objects before losing scope

--- a/src/Microsoft.Diagnostics.Runtime/src/DataReaders/LinuxSnapshot/LinuxSnapshotTarget.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataReaders/LinuxSnapshot/LinuxSnapshotTarget.cs
@@ -1,0 +1,65 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Diagnostics.NETCore.Client;
+using System;
+using System.IO;
+
+namespace Microsoft.Diagnostics.Runtime
+{
+    internal class LinuxSnapshotTarget : CustomDataTarget
+    {
+        private readonly int _pid;
+        private readonly string _filename;
+
+        public LinuxSnapshotTarget(IDataReader reader, int pid, string filename) : base(reader)
+        {
+            _pid = pid;
+            _filename = filename;
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+
+            try
+            {
+                File.Delete(_filename);
+            }
+            catch
+            {
+            }
+        }
+
+        public override string ToString() => $"{_filename} (snapshot of pid:{_pid:x})";
+
+        public static LinuxSnapshotTarget CreateSnapshotFromProcess(int pid)
+        {
+            string? dumpPath = Path.GetTempFileName();
+            try
+            {
+                try
+                {
+                    DiagnosticsClient client = new DiagnosticsClient(pid);
+                    client.WriteDump(DumpType.Full, dumpPath, logDumpGeneration: false);
+                }
+                catch (ServerErrorException sxe)
+                {
+                    throw new ArgumentException($"Unable to create a snapshot of process {pid:x}.", sxe);
+                }
+
+#pragma warning disable CA2000 // Dispose objects before losing scope
+                LinuxSnapshotTarget result = new LinuxSnapshotTarget(new MinidumpReader(dumpPath), pid, dumpPath);
+                dumpPath = null;
+                return result;
+#pragma warning restore CA2000 // Dispose objects before losing scope
+            }
+            finally
+            {
+                if (dumpPath != null)
+                    File.Delete(dumpPath);
+            }
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/src/DataTargets/DataTarget.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataTargets/DataTarget.cs
@@ -344,7 +344,7 @@ namespace Microsoft.Diagnostics.Runtime
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
-                // todo:  Before checkin use Microsoft.Diagnostics.NETCore.Client to create a local dump file to debug
+                return new DataTarget(LinuxSnapshotTarget.CreateSnapshotFromProcess(processId));
             }
 
             throw new PlatformNotSupportedException(GetPlatformMessage(nameof(AttachToProcess), RuntimeInformation.OSDescription));


### PR DESCRIPTION
(I haven't yet tested this checkin.)

Adding support for linux seemed oddly easy.  @mikem8361 do you think this would work taking a snapshot of your own process?  Have you ever tested that before?

I was reading through `DiagnosticsClient` and even though we'd pause before getting the IPC response everything _seems_ like it would work?  I'll do more testing before merging this change.

Also @NextTurn for code review, though it's a simple change.  I hate that I can't ask for reviews outside of the dotnet foundation...

I am using ArgumentException for errors attaching to a process.  That originally came from the fact that Process.GetProcessById will throw ArgumentException when the process isn't valid.  It still seems a bit odd to throw such a generic exception instead of something more meaningful, but I'm not sure what else I'd throw when we can't attach to a process for some reason.