### PR TITLE
Add a fallback for exception/string offsets

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/ExceptionTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/ExceptionTests.cs
@@ -28,7 +28,8 @@ namespace Microsoft.Diagnostics.Runtime.Tests
 
             ExceptionTestData testData = TestTargets.NestedExceptionData;
             Assert.Equal(testData.OuterExceptionMessage, ex.Message);
-            Assert.Equal(testData.OuterExceptionType, ex.Type.Name);
+            if (ex.Type.Name != null)
+                Assert.Equal(testData.OuterExceptionType, ex.Type.Name);
             Assert.NotNull(ex.Inner);
         }
 

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/MinidumpTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/MinidumpTests.cs
@@ -49,5 +49,16 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
             ExceptionTests.TestProperties(runtime);
         }
+
+
+
+        [Fact]
+        public void MinidumpExceptionPropertiesNoSymbolsTest()
+        {
+            using DataTarget dt = TestTargets.NestedException.LoadMiniDump();
+            dt.BinaryLocator = new NullBinaryLocator();
+            using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
+            ExceptionTests.TestProperties(runtime);
+        }
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/NullBinaryLocator.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/NullBinaryLocator.cs
@@ -1,0 +1,21 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading.Tasks;
+
+namespace Microsoft.Diagnostics.Runtime.Tests
+{
+    class NullBinaryLocator : IBinaryLocator
+    {
+        public string FindBinary(string fileName, int buildTimeStamp, int imageSize, bool checkProperties = true)
+        {
+            return null;
+        }
+
+        public Task<string> FindBinaryAsync(string fileName, int buildTimeStamp, int imageSize, bool checkProperties = true)
+        {
+            return Task.FromResult<string>(null);
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/src/Implementation/ClrmdArrayType.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Implementation/ClrmdArrayType.cs
@@ -15,8 +15,8 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
         public override int ComponentSize { get; }
         public override ClrType? ComponentType => _componentType;
 
-        public ClrmdArrayType(ClrHeap heap, ClrType? baseType, ClrModule? module, ITypeData data)
-            : base(heap, baseType, module, data)
+        public ClrmdArrayType(ClrHeap heap, ClrType? baseType, ClrModule? module, ITypeData data, string? name = null)
+            : base(heap, baseType, module, data, name)
         {
             if (data is null)
                 throw new ArgumentNullException(nameof(data));

--- a/src/Microsoft.Diagnostics.Runtime/src/Implementation/ClrmdType.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Implementation/ClrmdType.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
         public override bool ContainsPointers { get; }
         public override bool IsShared { get; }
 
-        public ClrmdType(ClrHeap heap, ClrType? baseType, ClrModule? module, ITypeData data)
+        public ClrmdType(ClrHeap heap, ClrType? baseType, ClrModule? module, ITypeData data, string? name = null)
         {
             if (data is null)
                 throw new ArgumentNullException(nameof(data));
@@ -86,6 +86,7 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
             StaticSize = data.BaseSize;
             ContainsPointers = data.ContainsPointers;
             IsShared = data.IsShared;
+            _name = name;
 
             // If there are no methods, preempt the expensive work to create methods
             if (data.MethodCount == 0)

--- a/src/Microsoft.Diagnostics.Runtime/src/Implementation/IExceptionHelpers.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Implementation/IExceptionHelpers.cs
@@ -8,6 +8,10 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
 {
     public interface IExceptionHelpers
     {
+        IDataReader DataReader { get; }
         ImmutableArray<ClrStackFrame> GetExceptionStackTrace(ClrThread? thread, ClrObject obj);
+        uint GetInnerExceptionOffset(ClrType type);
+        uint GetHResultOffset(ClrType type);
+        uint GetMessageOffset(ClrType type);
     }
 }


### PR DESCRIPTION
- Added a fallback for exception offsets in case we cannot locate the module the original data came from.
- Hardcoded string offsets because the only versions of the runtime we support contains the same length/data offsets.  We would need to revisit this scenario if that changes in the future.

Fixes https://github.com/microsoft/clrmd/issues/406.