### PR TITLE
Fix symbol server path regression

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/NullBinaryLocator.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/NullBinaryLocator.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Immutable;
 using System.Threading.Tasks;
 
 namespace Microsoft.Diagnostics.Runtime.Tests
@@ -13,7 +14,17 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             return null;
         }
 
+        public string FindBinary(string fileName, ImmutableArray<byte> buildId, bool checkProperties = true)
+        {
+            return null;
+        }
+
         public Task<string> FindBinaryAsync(string fileName, int buildTimeStamp, int imageSize, bool checkProperties = true)
+        {
+            return Task.FromResult<string>(null);
+        }
+
+        public Task<string> FindBinaryAsync(string fileName, ImmutableArray<byte> buildId, bool checkProperties = true)
         {
             return Task.FromResult<string>(null);
         }

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/IBinaryLocator.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/IBinaryLocator.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Immutable;
 using System.Threading.Tasks;
 
 namespace Microsoft.Diagnostics.Runtime
@@ -37,5 +38,27 @@ namespace Microsoft.Diagnostics.Runtime
         /// <param name="checkProperties">Whether or not to validate the properties of the binary after download.</param>
         /// <returns>A full path on disk (local) of where the binary was copied to, <see langword="null"/> if it was not found.</returns>
         Task<string?> FindBinaryAsync(string fileName, int buildTimeStamp, int imageSize, bool checkProperties = true);
+
+        /// <summary>
+        /// Attempts to locate a binary via the symbol server.  This function will then copy the file
+        /// locally to the symbol cache and return the location of the local file on disk.  May be called
+        /// from multiple threads at the same time.
+        /// </summary>
+        /// <param name="fileName">The file name or path of the binary to locate.</param>
+        /// <param name="buildId">The build id that the binary is indexed under.</param>
+        /// <param name="checkProperties">Whether or not to validate the properties of the binary after download.</param>
+        /// <returns>A full path on disk (local) of where the binary was copied to, <see langword="null"/> if it was not found.</returns>
+        string? FindBinary(string fileName, ImmutableArray<byte> buildId, bool checkProperties = true);
+
+        /// <summary>
+        /// Attempts to locate a binary via the symbol server.  This function will then copy the file
+        /// locally to the symbol cache and return the location of the local file on disk.  May be called
+        /// from multiple threads at the same time.
+        /// </summary>
+        /// <param name="fileName">The file name or path of the binary to locate.</param>
+        /// <param name="buildId">The build id that the binary is indexed under.</param>
+        /// <param name="checkProperties">Whether or not to validate the properties of the binary after download.</param>
+        /// <returns>A full path on disk (local) of where the binary was copied to, <see langword="null"/> if it was not found.</returns>
+        Task<string?> FindBinaryAsync(string fileName, ImmutableArray<byte> buildId, bool checkProperties = true);
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/src/DataTargets/DataTarget.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataTargets/DataTarget.cs
@@ -58,11 +58,18 @@ namespace Microsoft.Diagnostics.Runtime
             if (locator == null)
             {
                 if (DataReader.TargetPlatform == OSPlatform.Windows)
-                    locator = new SymbolServerLocator();
+                {
+                    string sympath = Environment.GetEnvironmentVariable("_NT_SYMBOL_PATH") ?? "http://msdl.microsoft.com/download/symbols";
+                    locator = new SymbolServerLocator(sympath);
+                }
                 else if (DataReader.TargetPlatform == OSPlatform.Linux)
+                {
                     locator = new LinuxDefaultSymbolLocator(DataReader);
+                }
                 else
+                {
                     throw new PlatformNotSupportedException($"ClrMD only supports the Windows and Linux platforms.  TargetPlatform={DataReader.TargetPlatform}");
+                }
             }
 
             BinaryLocator = locator;

--- a/src/Microsoft.Diagnostics.Runtime/src/Implementation/SymbolServerLocator.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Implementation/SymbolServerLocator.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -72,6 +73,10 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
 
             Directory.CreateDirectory(_cache);
         }
+
+        public string? FindBinary(string fileName, ImmutableArray<byte> buildId, bool checkProperties = true) => null;
+
+        public Task<string?> FindBinaryAsync(string fileName, ImmutableArray<byte> buildId, bool checkProperties = true) => Task.FromResult<string?>(null);
 
         public string? FindBinary(string fileName, int buildTimeStamp, int imageSize, bool checkProperties)
             => FindBinaryAsync(fileName, buildTimeStamp, imageSize, checkProperties).Result;

--- a/src/Microsoft.Diagnostics.Runtime/src/Linux/LinuxDefaultSymbolLocator.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Linux/LinuxDefaultSymbolLocator.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -32,6 +33,10 @@ namespace Microsoft.Diagnostics.Runtime.Linux
             string? localBinary = FindLocalBinary(fileName);
             return localBinary ?? _locator?.FindBinary(fileName, buildTimeStamp, imageSize, checkProperties);
         }
+
+        public string? FindBinary(string fileName, ImmutableArray<byte> buildId, bool checkProperties = true) => null;
+
+        public Task<string?> FindBinaryAsync(string fileName, ImmutableArray<byte> buildId, bool checkProperties = true) => Task.FromResult<string?>(null);
 
         public Task<string?> FindBinaryAsync(string fileName, int buildTimeStamp, int imageSize, bool checkProperties)
         {


### PR DESCRIPTION
- Recent changes lost the code that checked _NT_SYMBOL_PATH.
- Add a method to IBinaryLocator for getting files by buildId.  This is not yet implemented.