### PR TITLE
Clean up ClrModule.Name/FileName

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/AppDomainTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/AppDomainTests.cs
@@ -43,13 +43,13 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         private void AssertModuleDoesntContainDomains(ClrModule module, params ClrAppDomain[] domainList)
         {
             foreach (ClrAppDomain domain in domainList)
-                Assert.DoesNotContain(domain.Modules, m => m.FileName == module.FileName);
+                Assert.DoesNotContain(domain.Modules, m => m.Name == module.Name);
         }
 
         private void AssertModuleContainsDomains(ClrModule module, params ClrAppDomain[] domainList)
         {
             foreach (ClrAppDomain domain in domainList)
-                Assert.Contains(domain.Modules, m => m.FileName == module.FileName);
+                Assert.Contains(domain.Modules, m => m.Name == module.Name);
         }
 
         [FrameworkFact]
@@ -103,7 +103,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
                 Assert.Single(sharedDomain.Modules);
 
                 ClrModule mscorlib = sharedDomain.Modules.Single();
-                Assert.Equal("mscorlib.dll", Path.GetFileName(mscorlib.FileName), true);
+                Assert.Equal("mscorlib.dll", Path.GetFileName(mscorlib.Name), true);
             }
         }
 
@@ -133,7 +133,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             Assert.False(nestedExceptionModules.ContainsKey("appdomains.exe"));
 
             // Ensure that we use the same ClrModule in each AppDomain.
-            Assert.Equal(appDomainsModules["mscorlib.dll"].FileName, nestedExceptionModules["mscorlib.dll"].FileName);
+            Assert.Equal(appDomainsModules["mscorlib.dll"].Name, nestedExceptionModules["mscorlib.dll"].Name);
             Assert.NotEqual(appDomainsModules["sharedlibrary.dll"], nestedExceptionModules["sharedlibrary.dll"]);
         }
 
@@ -141,7 +141,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         {
             Dictionary<string, ClrModule> result = new Dictionary<string, ClrModule>(StringComparer.OrdinalIgnoreCase);
             foreach (ClrModule module in domain.Modules)
-                result.Add(Path.GetFileName(module.FileName), module);
+                result.Add(Path.GetFileName(module.Name), module);
 
             return result;
         }

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/Helpers.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/Helpers.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         {
             // .NET Core SDK 3.x creates an executable host by default (FDE)
             return runtime.AppDomains.SelectMany(ad => ad.Modules).Single(m => RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-                ? m.FileName.EndsWith(".exe") : File.Exists(Path.ChangeExtension(m.FileName, null)));
+                ? m.Name.EndsWith(".exe") : File.Exists(Path.ChangeExtension(m.Name, null)));
         }
 
         public static ClrMethod GetMethod(this ClrType type, string name)
@@ -85,7 +85,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         public static ClrModule GetModule(this ClrRuntime runtime, string fileName)
         {
             return (from module in runtime.AppDomains.SelectMany(ad => ad.Modules)
-                    let file = Path.GetFileName(module.FileName)
+                    let file = Path.GetFileName(module.Name)
                     where file.Equals(fileName, StringComparison.OrdinalIgnoreCase)
                     select module).FirstOrDefault();
         }

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/MethodTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/MethodTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             {
                 using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
 
-                ClrType[] types = runtime.EnumerateModules().Where(m => m.FileName.EndsWith("sharedlibrary.dll", System.StringComparison.OrdinalIgnoreCase)).Select(m => m.GetTypeByName("Foo")).Where(t => t != null).ToArray();
+                ClrType[] types = runtime.EnumerateModules().Where(m => m.Name.EndsWith("sharedlibrary.dll", System.StringComparison.OrdinalIgnoreCase)).Select(m => m.GetTypeByName("Foo")).Where(t => t != null).ToArray();
 
                 Assert.Equal(2, types.Length);
                 methodDescs = types.Select(t => t.Methods.Single(m => m.Name == "Bar")).Select(m => m.MethodDesc).ToArray();

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/RuntimeTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/RuntimeTests.cs
@@ -58,10 +58,10 @@ namespace Microsoft.Diagnostics.Runtime.Tests
                 HashSet<ClrModule> modules = new HashSet<ClrModule>();
                 foreach (ClrModule module in domain.Modules)
                 {
-                    if (Path.GetExtension(module.FileName) == ".nlp")
+                    if (Path.GetExtension(module.Name) == ".nlp")
                         continue;
 
-                    Assert.Contains(Path.GetFileName(module.FileName), expected);
+                    Assert.Contains(Path.GetFileName(module.Name), expected);
                     Assert.DoesNotContain(module, modules);
                     modules.Add(module);
                 }
@@ -100,7 +100,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             foreach (var module in oldModules)
             {
                 _ = module.Name;
-                _ = module.FileName;
+                _ = module.Name;
                 _ = module.AssemblyName;
             }
 
@@ -180,7 +180,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
 
             CheckDomainNotSame(oldModule.AppDomain, newModule.AppDomain);
 
-            AssertEqualNotSame(oldModule.FileName, newModule.FileName);
+            AssertEqualNotSame(oldModule.Name, newModule.Name);
             AssertEqualNotSame(oldModule.AssemblyName, newModule.AssemblyName);
         }
 

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/StaticFieldTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/StaticFieldTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             using DataTarget dt = TestTargets.AppDomains.LoadFullDump();
             using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
 
-            ClrModule[] sharedModules = runtime.EnumerateModules().Where(m => Path.GetFileName(m.FileName).Equals("sharedlibrary.dll", StringComparison.OrdinalIgnoreCase)).ToArray();
+            ClrModule[] sharedModules = runtime.EnumerateModules().Where(m => Path.GetFileName(m.Name).Equals("sharedlibrary.dll", StringComparison.OrdinalIgnoreCase)).ToArray();
 
             Assert.Equal(2, sharedModules.Length);
             Assert.NotEqual(sharedModules[0].AppDomain, sharedModules[1].AppDomain);

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/TypeTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/TypeTests.cs
@@ -206,7 +206,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             Assert.NotSame(types[0], types[1]);
 
             ClrType[] typesFromModule = (from module in runtime.EnumerateModules()
-                                         let name = Path.GetFileNameWithoutExtension(module.FileName)
+                                         let name = Path.GetFileNameWithoutExtension(module.Name)
                                          where name.Equals("sharedlibrary", StringComparison.OrdinalIgnoreCase)
                                          let type = module.GetTypeByName(TypeName)
                                          select type).ToArray();
@@ -230,7 +230,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             runtime.FlushCachedData();
 
             ClrType[] newTypes = (from module in runtime.EnumerateModules()
-                                  let name = Path.GetFileNameWithoutExtension(module.FileName)
+                                  let name = Path.GetFileNameWithoutExtension(module.Name)
                                   where name.Equals("sharedlibrary", StringComparison.OrdinalIgnoreCase)
                                   let type = module.GetTypeByName(TypeName)
                                   select type).ToArray();

--- a/src/Microsoft.Diagnostics.Runtime/src/Builders/ModuleBuilder.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Builders/ModuleBuilder.cs
@@ -36,7 +36,13 @@ namespace Microsoft.Diagnostics.Runtime.Builders
             get
             {
                 if (_moduleData.PEFile != 0)
-                    return _sos.GetPEFileName(_moduleData.PEFile);
+                {
+                    string? str = _sos.GetPEFileName(_moduleData.PEFile);
+                    if (string.IsNullOrWhiteSpace(str))
+                        return null;
+
+                    return str;
+                }
 
                 return null;
             }
@@ -47,7 +53,13 @@ namespace Microsoft.Diagnostics.Runtime.Builders
             get
             {
                 if (_moduleData.Assembly != 0)
-                    return _sos.GetAssemblyName(_moduleData.Assembly);
+                {
+                    string? str = _sos.GetAssemblyName(_moduleData.Assembly);
+                    if (string.IsNullOrWhiteSpace(str))
+                        return null;
+
+                    return str;
+                }
 
                 return null;
             }

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/ClrModule.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/ClrModule.cs
@@ -57,12 +57,6 @@ namespace Microsoft.Diagnostics.Runtime
         public abstract bool IsPEFile { get; }
 
         /// <summary>
-        /// Gets the file name of where the module was loaded from on disk.  Undefined results if
-        /// IsPEFile is <see langword="false"/>.
-        /// </summary>
-        public abstract string? FileName { get; }
-
-        /// <summary>
         /// Gets the base of the image loaded into memory.  This may be 0 if there is not a physical
         /// file backing it.
         /// </summary>

--- a/src/Microsoft.Diagnostics.Runtime/src/Implementation/ClrmdModule.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Implementation/ClrmdModule.cs
@@ -36,7 +36,6 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
         public override ulong MetadataAddress { get; }
         public override ulong MetadataLength { get; }
         public override bool IsDynamic { get; }
-        public override string? FileName => IsPEFile ? Name : null;
         public override MetadataImport? MetadataImport => _metadata ??= _helpers.GetMetadataImport(this);
 
         public ClrmdModule(ClrAppDomain parent, IModuleData data)


### PR DESCRIPTION
Remove ClrMD.FileName.  This property was only a mirror of .Name when IsPEImage was true.  There's no reason to have both of these.

Closes https://github.com/microsoft/clrmd/issues/529.