### PR TITLE
Change ClrStatcField to require AppDomains

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/Helpers.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/Helpers.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         public static ClrObject GetStaticObjectValue(this ClrType mainType, string fieldName)
         {
             ClrStaticField field = mainType.GetStaticFieldByName(fieldName);
-            return field.ReadObject();
+            return field.ReadObject(mainType.Module.AppDomain);
         }
 
         public static ClrModule GetMainModule(this ClrRuntime runtime)
@@ -98,7 +98,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
 
         public static ClrStackFrame GetFrame(this ClrThread thread, string functionName)
         {
-            return thread.EnumerateStackTrace().Single(sf => sf.Method != null ? sf.Method.Name == functionName : false);
+            return thread.EnumerateStackTrace().Single(sf => sf.Method != null && sf.Method.Name == functionName);
         }
 
         public static string TestWorkingDirectory

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/StaticFieldTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/StaticFieldTests.cs
@@ -29,8 +29,8 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             Assert.NotNull(staticType2);
             Assert.NotEqual(staticType1, staticType2);
 
-            int value2 = staticType1.StaticFields.Single().Read<int>();
-            int value42 = staticType2.StaticFields.Single().Read<int>();
+            int value2 = staticType1.StaticFields.Single().Read<int>(staticType1.Module.AppDomain);
+            int value42 = staticType2.StaticFields.Single().Read<int>(staticType2.Module.AppDomain);
 
             if (value2 > value42)
             {

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/TypeTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/TypeTests.cs
@@ -65,12 +65,13 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             using DataTarget dt = TestTargets.Types.LoadFullDump();
             using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
             ClrHeap heap = runtime.Heap;
+            ClrAppDomain domain = runtime.AppDomains.Single();
 
             ClrModule module = runtime.GetModule(ModuleName);
             ClrType typesType = module.GetTypeByName("Types");
             ClrStaticField field = typesType.GetStaticFieldByName("s_i");
 
-            ClrObject obj = field.ReadObject();
+            ClrObject obj = field.ReadObject(domain);
             Assert.False(obj.IsNull);
 
             ClrType type = obj.Type;
@@ -435,7 +436,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             Assert.Equal(0, es.Size);
         }
 
-        [Fact(Skip = "This looks like a bug in mscordac and not ClrMD.")]
+        [Fact]
         public void StringEmptyIsObtainableTest()
         {
             using DataTarget dt = TestTargets.Types.LoadFullDump();
@@ -448,7 +449,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             ClrStaticField empty = stringType.GetStaticFieldByName("Empty");
             Assert.NotNull(empty);
 
-            string value = empty.ReadString();
+            string value = empty.ReadString(runtime.AppDomains.Single());
             Assert.Equal(string.Empty, value);
         }
 
@@ -476,7 +477,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             // this test to fail but the underlying issue would be fixed.
             Assert.Null(componentType);
 
-            ClrObject itemsObj = list.ReadObject().ReadObjectField("_items");
+            ClrObject itemsObj = list.ReadObject(runtime.AppDomains.Single()).ReadObjectField("_items");
 
             // Ensure we are looking at the same ClrType
             if (dt.CacheOptions.CacheTypes)
@@ -499,7 +500,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             ClrAppDomain domain = runtime.AppDomains.Single();
 
             ClrType fooType = runtime.GetModule("sharedlibrary.dll").GetTypeByName("Foo");
-            ClrObject obj = runtime.GetModule(ModuleName).GetTypeByName("Types").GetStaticFieldByName("s_foo").ReadObject();
+            ClrObject obj = runtime.GetModule(ModuleName).GetTypeByName("Types").GetStaticFieldByName("s_foo").ReadObject(domain);
 
             if (dt.CacheOptions.CacheTypes)
             {
@@ -650,10 +651,10 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             ClrModule typesModule = runtime.GetModule(TypeTests.ModuleName);
             ClrType type = typesModule.GetTypeByName("Types");
 
-            ClrObject s_array = type.GetStaticFieldByName("s_array").ReadObject();
-            ClrObject s_one = type.GetStaticFieldByName("s_one").ReadObject();
-            ClrObject s_two = type.GetStaticFieldByName("s_two").ReadObject();
-            ClrObject s_three = type.GetStaticFieldByName("s_three").ReadObject();
+            ClrObject s_array = type.GetStaticFieldByName("s_array").ReadObject(domain);
+            ClrObject s_one = type.GetStaticFieldByName("s_one").ReadObject(domain);
+            ClrObject s_two = type.GetStaticFieldByName("s_two").ReadObject(domain);
+            ClrObject s_three = type.GetStaticFieldByName("s_three").ReadObject(domain);
 
             ulong[] expected = { s_one, s_two, s_three };
 
@@ -681,7 +682,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             ClrModule typesModule = runtime.GetModule(TypeTests.ModuleName);
             ClrType type = typesModule.GetTypeByName("Types");
 
-            ClrObject obj = type.GetStaticFieldByName("s_array").ReadObject();
+            ClrObject obj = type.GetStaticFieldByName("s_array").ReadObject(domain);
             Assert.True(obj.IsArray);
 
             ClrArray arr = obj.AsArray();
@@ -701,10 +702,10 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             ClrModule typesModule = runtime.GetModule(TypeTests.ModuleName);
             ClrType type = typesModule.GetTypeByName("Types");
 
-            ulong s_array = type.GetStaticFieldByName("s_array").ReadObject();
-            ulong s_one = type.GetStaticFieldByName("s_one").ReadObject();
-            ulong s_two = type.GetStaticFieldByName("s_two").ReadObject();
-            ulong s_three = type.GetStaticFieldByName("s_three").ReadObject();
+            ulong s_array = type.GetStaticFieldByName("s_array").ReadObject(domain);
+            ulong s_one = type.GetStaticFieldByName("s_one").ReadObject(domain);
+            ulong s_two = type.GetStaticFieldByName("s_two").ReadObject(domain);
+            ulong s_three = type.GetStaticFieldByName("s_three").ReadObject(domain);
 
             ClrType arrayType = heap.GetObjectType(s_array);
 
@@ -724,13 +725,14 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         {
             using DataTarget dt = TestTargets.Types.LoadFullDump();
             using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
+            ClrAppDomain domain = runtime.AppDomains.Single();
 
             ClrModule typesModule = runtime.GetModule(TypeTests.ModuleName);
             ClrType type = typesModule.GetTypeByName("Types");
 
-            ClrArray s_array = type.GetStaticFieldByName("s_array").ReadObject().AsArray();
-            ClrArray s_2dArray = type.GetStaticFieldByName("s_2dArray").ReadObject().AsArray();
-            ClrArray s_5dArray = type.GetStaticFieldByName("s_5dArray").ReadObject().AsArray();
+            ClrArray s_array = type.GetStaticFieldByName("s_array").ReadObject(domain).AsArray();
+            ClrArray s_2dArray = type.GetStaticFieldByName("s_2dArray").ReadObject(domain).AsArray();
+            ClrArray s_5dArray = type.GetStaticFieldByName("s_5dArray").ReadObject(domain).AsArray();
 
             Assert.Equal(1, s_array.Rank);
             Assert.Equal(2, s_2dArray.Rank);
@@ -742,12 +744,13 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         {
             using DataTarget dt = TestTargets.Types.LoadFullDump();
             using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
+            ClrAppDomain domain = runtime.AppDomains.Single();
 
             ClrModule typesModule = runtime.GetModule(TypeTests.ModuleName);
             ClrType type = typesModule.GetTypeByName("Types");
 
-            ClrArray s_array = type.GetStaticFieldByName("s_array").ReadObject().AsArray();
-            ClrArray s_5dArray = type.GetStaticFieldByName("s_5dArray").ReadObject().AsArray();
+            ClrArray s_array = type.GetStaticFieldByName("s_array").ReadObject(domain).AsArray();
+            ClrArray s_5dArray = type.GetStaticFieldByName("s_5dArray").ReadObject(domain).AsArray();
 
             Assert.Equal(3, s_array.GetLength(0));
 
@@ -763,13 +766,14 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         {
             using DataTarget dt = TestTargets.Types.LoadFullDump();
             using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
+            ClrAppDomain domain = runtime.AppDomains.Single();
 
             ClrModule typesModule = runtime.GetModule(TypeTests.ModuleName);
             ClrType type = typesModule.GetTypeByName("Types");
 
-            ClrArray s_szObjArray = type.GetStaticFieldByName("s_szObjArray").ReadObject().AsArray();
-            ClrArray s_mdObjArray = type.GetStaticFieldByName("s_mdObjArray").ReadObject().AsArray();
-            ClrArray s_2dObjArray = type.GetStaticFieldByName("s_2dObjArray").ReadObject().AsArray();
+            ClrArray s_szObjArray = type.GetStaticFieldByName("s_szObjArray").ReadObject(domain).AsArray();
+            ClrArray s_mdObjArray = type.GetStaticFieldByName("s_mdObjArray").ReadObject(domain).AsArray();
+            ClrArray s_2dObjArray = type.GetStaticFieldByName("s_2dObjArray").ReadObject(domain).AsArray();
 
             Assert.Equal(1, s_szObjArray.Rank);
             Assert.Equal(1, s_mdObjArray.Rank);
@@ -792,13 +796,14 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         {
             using DataTarget dt = TestTargets.Types.LoadFullDump();
             using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
+            ClrAppDomain domain = runtime.AppDomains.Single();
 
             ClrModule typesModule = runtime.GetModule(TypeTests.ModuleName);
             ClrType type = typesModule.GetTypeByName("Types");
 
-            ClrArray s_szIntArray = type.GetStaticFieldByName("s_szIntArray").ReadObject().AsArray(); // System.Int32[]
-            ClrArray s_mdIntArray = type.GetStaticFieldByName("s_mdIntArray").ReadObject().AsArray(); // System.Int32[*]
-            ClrArray s_2dIntArray = type.GetStaticFieldByName("s_2dIntArray").ReadObject().AsArray(); // System.Int32[,]
+            ClrArray s_szIntArray = type.GetStaticFieldByName("s_szIntArray").ReadObject(domain).AsArray(); // System.Int32[]
+            ClrArray s_mdIntArray = type.GetStaticFieldByName("s_mdIntArray").ReadObject(domain).AsArray(); // System.Int32[*]
+            ClrArray s_2dIntArray = type.GetStaticFieldByName("s_2dIntArray").ReadObject(domain).AsArray(); // System.Int32[,]
 
             Assert.Equal(1, s_szIntArray.Rank);
             Assert.Equal(1, s_mdIntArray.Rank);

--- a/src/Microsoft.Diagnostics.Runtime/src/Builders/RuntimeBuilder.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Builders/RuntimeBuilder.cs
@@ -208,9 +208,11 @@ namespace Microsoft.Diagnostics.Runtime.Builders
                     return result;
 
                 if (_moduleBuilder.Init(addr))
-                    return _modules[addr] = new ClrmdModule(domain, _moduleBuilder);
+                    result = _modules[addr] = new ClrmdModule(domain, _moduleBuilder);
+                else
+                    result = _modules[addr] = new ClrmdModule(domain, this, addr);
 
-                return _modules[addr] = new ClrmdModule(domain, this, addr);
+                return result;
             }
         }
 

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/ClrField.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/ClrField.cs
@@ -80,9 +80,10 @@ namespace Microsoft.Diagnostics.Runtime
         public abstract bool IsProtected { get; }
 
         /// <summary>
-        /// If the field has a well defined offset from the base of the object, return it (otherwise -1).
+        /// For instance fields, this is the offset of the field within the object.
+        /// For static fields this is the offset within the block of memory allocated for the module's static fields.
         /// </summary>
-        public virtual int Offset => -1;
+        public abstract int Offset { get; }
 
         /// <summary>
         /// Returns a string representation of this object.

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/ClrInstanceField.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/ClrInstanceField.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Diagnostics.Runtime
         public abstract T Read<T>(ulong objRef, bool interior) where T : unmanaged;
 
         /// <summary>
-        /// Reads teh value of an object field.
+        /// Reads the value of an object field.
         /// </summary>
         /// <param name="objRef">The object to read the instance field from.</param>
         /// <param name="interior">Whether or not the field is interior to a struct.</param>

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/ClrStaticField.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/ClrStaticField.cs
@@ -26,31 +26,31 @@ namespace Microsoft.Diagnostics.Runtime
         /// Gets the address of the static field's value in memory.
         /// </summary>
         /// <returns>The address of the field's value.</returns>
-        public abstract ulong Address { get; }
+        public abstract ulong GetAddress(ClrAppDomain appDomain);
 
         /// <summary>
         /// Reads the value of the field as an unmanaged struct or primitive type.
         /// </summary>
         /// <typeparam name="T">An unmanaged struct or primitive type.</typeparam>
         /// <returns>The value read.</returns>
-        public abstract T Read<T>() where T : unmanaged;
+        public abstract T Read<T>(ClrAppDomain appDomain) where T : unmanaged;
 
         /// <summary>
-        /// Reads teh value of an object field.
+        /// Reads the value of an object field.
         /// </summary>
         /// <returns>The value read.</returns>
-        public abstract ClrObject ReadObject();
+        public abstract ClrObject ReadObject(ClrAppDomain appDomain);
 
         /// <summary>
         /// Reads a ValueType struct from the instance field.
         /// </summary>
         /// <returns>The value read.</returns>
-        public abstract ClrValueType ReadStruct();
+        public abstract ClrValueType ReadStruct(ClrAppDomain appDomain);
 
         /// <summary>
         /// Reads a string from the instance field.
         /// </summary>
         /// <returns>The value read.</returns>
-        public abstract string? ReadString();
+        public abstract string? ReadString(ClrAppDomain appDomain);
     }
 }


### PR DESCRIPTION
The original design of ClrStaticField was to use the AppDomain associated with its parent type.  This made it very difficult to walk the value of that static field in all AppDomains as it's difficult to have ClrMD find and construct all of the concrete ClrTypes for each domain.  Instead we'll just require the user to pass the ClrAppDomain of the value to read.  They can always use "staticField.Parent.Module.AppDomain" to get the previous behavior.