### PR TITLE
Better type signature parsing

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/TypeTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/TypeTests.cs
@@ -567,7 +567,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
 
             ClrType genericType = runtime.GetModule("sharedlibrary.dll").GetTypeByName("GenericClass`5");
 
-            ImmutableArray<ClrGenericParameter> genericParameters = genericType.GenericParameters;
+            ClrGenericParameter[] genericParameters = genericType.EnumerateGenericParameters().ToArray();
             Assert.Equal(5, genericParameters.Length);
 
             VerifyGenericParameter(genericParameters, 0, "T1");
@@ -576,7 +576,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             VerifyGenericParameter(genericParameters, 3, "T4");
             VerifyGenericParameter(genericParameters, 4, "T5");
 
-            static void VerifyGenericParameter(ImmutableArray<ClrGenericParameter> genericParameters, int index, string name)
+            static void VerifyGenericParameter(ClrGenericParameter[] genericParameters, int index, string name)
             {
                 ClrGenericParameter genericParameter = genericParameters[index];
 

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/TypeTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/TypeTests.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -566,7 +567,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
 
             ClrType genericType = runtime.GetModule("sharedlibrary.dll").GetTypeByName("GenericClass`5");
 
-            ClrGenericParameter[] genericParameters = genericType.EnumerateGenericParameters().ToArray();
+            ImmutableArray<ClrGenericParameter> genericParameters = genericType.GenericParameters;
             Assert.Equal(5, genericParameters.Length);
 
             VerifyGenericParameter(genericParameters, 0, "T1");
@@ -575,7 +576,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             VerifyGenericParameter(genericParameters, 3, "T4");
             VerifyGenericParameter(genericParameters, 4, "T5");
 
-            static void VerifyGenericParameter(ClrGenericParameter[] genericParameters, int index, string name)
+            static void VerifyGenericParameter(ImmutableArray<ClrGenericParameter> genericParameters, int index, string name)
             {
                 ClrGenericParameter genericParameter = genericParameters[index];
 

--- a/src/Microsoft.Diagnostics.Runtime/src/Builders/RuntimeBuilder.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Builders/RuntimeBuilder.cs
@@ -1088,15 +1088,9 @@ namespace Microsoft.Diagnostics.Runtime.Builders
                 if (!parser.GetData(out int count))
                     return null;
 
-                var builder = ImmutableArray.CreateBuilder<ClrType>(count);
+                // Even though we don't make use of these types we need to move past them in the parser.
                 for (int i = 0; i < count; i++)
-                {
-                    ClrType? entry = GetOrCreateTypeFromSignature(module, parser, typeParameters, methodParameters);
-
-                    // If we fail to load the type we have to have a placeholder.
-                    entry ??= GetOrCreateBasicType(ClrElementType.Void);
-                    builder.Add(entry);
-                }
+                    GetOrCreateTypeFromSignature(module, parser, typeParameters, methodParameters);
 
                 ClrType? result = module?.ResolveToken(token);
                 return result;

--- a/src/Microsoft.Diagnostics.Runtime/src/Builders/RuntimeBuilder.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Builders/RuntimeBuilder.cs
@@ -1013,7 +1013,7 @@ namespace Microsoft.Diagnostics.Runtime.Builders
         }
 
 
-        public ClrType? GetOrCreateTypeFromSignature(ClrModule? module, SigParser parser, ImmutableArray<ClrGenericParameter> typeParameters, ImmutableArray<ClrGenericParameter> methodParameters)
+        public ClrType? GetOrCreateTypeFromSignature(ClrModule? module, SigParser parser, IEnumerable<ClrGenericParameter> typeParameters, IEnumerable<ClrGenericParameter> methodParameters)
         {
             // ECMA 335 - II.23.2.12 - Type
 
@@ -1101,8 +1101,8 @@ namespace Microsoft.Diagnostics.Runtime.Builders
                 if (!parser.GetData(out int index))
                     return null;
 
-                ImmutableArray<ClrGenericParameter> param = etype == ClrElementType.Var ? typeParameters : methodParameters;
-                if (param.IsDefault || index < 0 || index >= param.Length)
+                ClrGenericParameter[] param = (etype == ClrElementType.Var ? typeParameters : methodParameters).ToArray();
+                if (index < 0 || index >= param.Length)
                     return null;
 
                 return new ClrmdGenericType(this, GetOrCreateHeap(), module, param[index]);

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/ClrElementType.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/ClrElementType.cs
@@ -16,6 +16,11 @@ namespace Microsoft.Diagnostics.Runtime
         Unknown = 0x0,
 
         /// <summary>
+        /// Void type.
+        /// </summary>
+        Void = 0x1,
+
+        /// <summary>
         /// ELEMENT_TYPE_BOOLEAN
         /// </summary>
         Boolean = 0x2,
@@ -96,9 +101,19 @@ namespace Microsoft.Diagnostics.Runtime
         Class = 0x12,
 
         /// <summary>
+        /// ELEMENT_TYPE_VAR
+        /// </summary>
+        Var = 0x13,
+
+        /// <summary>
         /// ELEMENT_TYPE_ARRAY
         /// </summary>
         Array = 0x14,
+
+        /// <summary>
+        /// ELEMENT_TYPE_GENERICINST
+        /// </summary>
+        GenericInstantiation = 0x15,
 
         /// <summary>
         /// ELEMENT_TYPE_I
@@ -119,6 +134,11 @@ namespace Microsoft.Diagnostics.Runtime
         /// ELEMENT_TYPE_OBJECT
         /// </summary>
         Object = 0x1C,
+
+        /// <summary>
+        /// ELEMENT_TYPE_MVAR
+        /// </summary>
+        MVar = 0x1e,
 
         /// <summary>
         /// ELEMENT_TYPE_SZARRAY

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/ClrEnum.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/ClrEnum.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Diagnostics.Runtime
                     {
                         SigParser parser = new SigParser(ppvSigBlob, pcbSigBlob);
                         parser.GetCallingConvInfo(out _);
-                        parser.GetElemType(out _);
+                        parser.GetElemType(out int _);
 
                         Type? underlying = ((ClrElementType)pdwCPlusTypeFlag).GetTypeForElementType();
                         if (underlying != null)

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/ClrType.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/ClrType.cs
@@ -86,8 +86,10 @@ namespace Microsoft.Diagnostics.Runtime
         /// <returns>True if this type is an object reference, false otherwise.</returns>
         public virtual bool IsObjectReference => ElementType.IsObjectReference();
 
-
-        public virtual ImmutableArray<ClrGenericParameter> GenericParameters => ImmutableArray<ClrGenericParameter>.Empty;
+        /// <summary>
+        /// Enumerates the generic parameters of this type.
+        /// </summary>
+        public virtual IEnumerable<ClrGenericParameter> EnumerateGenericParameters() => Array.Empty<ClrGenericParameter>();
 
         /// <summary>
         /// Returns the list of interfaces this type implements.

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/ClrType.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/ClrType.cs
@@ -86,7 +86,8 @@ namespace Microsoft.Diagnostics.Runtime
         /// <returns>True if this type is an object reference, false otherwise.</returns>
         public virtual bool IsObjectReference => ElementType.IsObjectReference();
 
-        public abstract IEnumerable<ClrGenericParameter> EnumerateGenericParameters();
+
+        public virtual ImmutableArray<ClrGenericParameter> GenericParameters => ImmutableArray<ClrGenericParameter>.Empty;
 
         /// <summary>
         /// Returns the list of interfaces this type implements.

--- a/src/Microsoft.Diagnostics.Runtime/src/DacInterface/MetadataImport.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DacInterface/MetadataImport.cs
@@ -214,6 +214,17 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             return true;
         }
 
+        public SigParser GetSigFromToken(int token)
+        {
+            InitDelegate(ref _getSigFromToken, VTable.GetSigFromToken);
+
+            HResult hr = _getSigFromToken(Self, token, out IntPtr sig, out int len);
+            if (hr)
+                return new SigParser(sig, len);
+
+            return default;
+        }
+
 
         private EnumInterfaceImplsDelegate? _enumInterfaceImpls;
         private CloseEnumDelegate? _closeEnum;
@@ -228,7 +239,9 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
         private GetCustomAttributeByNameDelegate? _getCustomAttributeByName;
         private EnumGenericParamsDelegate? _enumGenericParams;
         private GetGenericParamPropsDelegate? _getGenericParamProps;
+        private GetSigFromTokenDelegate? _getSigFromToken;
 
+        private delegate HResult GetSigFromTokenDelegate(IntPtr self, int token, out IntPtr sig, out int len);
         private delegate HResult CloseEnumDelegate(IntPtr self, IntPtr e);
         private delegate HResult EnumInterfaceImplsDelegate(IntPtr self, ref IntPtr phEnum, int td, [Out] int[] rImpls, int cMax, out int pCount);
         private delegate HResult GetInterfaceImplPropsDelegate(IntPtr self, int mdImpl, out int mdClass, out int mdIFace);
@@ -315,7 +328,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
         private readonly IntPtr GetFieldMarshal;
         public readonly IntPtr GetRVA;
         private readonly IntPtr GetPermissionSetProps;
-        private readonly IntPtr GetSigFromToken;
+        public readonly IntPtr GetSigFromToken;
         private readonly IntPtr GetModuleRefProps;
         private readonly IntPtr EnumModuleRefs;
         private readonly IntPtr GetTypeSpecFromToken;

--- a/src/Microsoft.Diagnostics.Runtime/src/DataTargets/ClrInfo.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataTargets/ClrInfo.cs
@@ -82,11 +82,11 @@ namespace Microsoft.Diagnostics.Runtime
             if (DacInfo.PlatformSpecificFileName != null)
                 dac ??= DataTarget.BinaryLocator?.FindBinary(DacInfo.PlatformSpecificFileName, DacInfo.IndexTimeStamp, DacInfo.IndexFileSize, checkProperties: false);
 
+            if (IntPtr.Size != DataTarget.DataReader.PointerSize)
+                throw new InvalidOperationException("Mismatched pointer size between this process and the dac.");
+
             if (!File.Exists(dac))
                 throw new FileNotFoundException("Could not find matching DAC for this runtime.", DacInfo.PlatformSpecificFileName);
-
-            if (IntPtr.Size != DataTarget.DataReader.PointerSize)
-                throw new InvalidOperationException("Mismatched architecture between this process and the dac.");
 
             return ConstructRuntime(dac!);
         }
@@ -95,7 +95,7 @@ namespace Microsoft.Diagnostics.Runtime
         private ClrRuntime ConstructRuntime(string dac)
         {
             if (IntPtr.Size != DataTarget.DataReader.PointerSize)
-                throw new InvalidOperationException("Mismatched architecture between this process and the dac.");
+                throw new InvalidOperationException("Mismatched pointer size between this process and the dac.");
 
             DacLibrary dacLibrary = new DacLibrary(DataTarget, dac);
             DacInterface.SOSDac? sos = dacLibrary.SOSDacInterface;

--- a/src/Microsoft.Diagnostics.Runtime/src/Implementation/ClrmdConstructedType.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Implementation/ClrmdConstructedType.cs
@@ -59,11 +59,10 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
         public override ClrElementType ElementType { get; }
         public override ulong MethodTable => 0;
         public override bool IsFinalizeSuppressed(ulong obj) => false;
-        public override bool IsPointer => true;
+        public override bool IsPointer => ElementType != ClrElementType.SZArray && ElementType != ClrElementType.Array;
         public override ImmutableArray<ClrInstanceField> Fields => ImmutableArray<ClrInstanceField>.Empty;
         public override ImmutableArray<ClrStaticField> StaticFields => ImmutableArray<ClrStaticField>.Empty;
         public override ImmutableArray<ClrMethod> Methods => ImmutableArray<ClrMethod>.Empty;
-        public override IEnumerable<ClrGenericParameter> EnumerateGenericParameters() => Enumerable.Empty<ClrGenericParameter>();
         public override IEnumerable<ClrInterface> EnumerateInterfaces() => Enumerable.Empty<ClrInterface>();
         public override bool IsFinalizable => false;
         public override bool IsPublic => true;

--- a/src/Microsoft.Diagnostics.Runtime/src/Implementation/ClrmdField.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Implementation/ClrmdField.cs
@@ -148,7 +148,7 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
                 if (sigParser.GetCallingConvInfo(out int sigType) && sigType == SigParser.IMAGE_CEE_CS_CALLCONV_FIELD)
                 {
                     sigParser.SkipCustomModifiers();
-                    _type = _helpers.Factory.GetOrCreateTypeFromSignature(Parent.Module, sigParser, Parent.GenericParameters, ImmutableArray<ClrGenericParameter>.Empty);
+                    _type = _helpers.Factory.GetOrCreateTypeFromSignature(Parent.Module, sigParser, Parent.EnumerateGenericParameters(), Array.Empty<ClrGenericParameter>());
                 }
             }
 

--- a/src/Microsoft.Diagnostics.Runtime/src/Implementation/ClrmdField.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Implementation/ClrmdField.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using Microsoft.Diagnostics.Runtime.Utilities;
 
 namespace Microsoft.Diagnostics.Runtime.Implementation
@@ -142,140 +143,16 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
             }
 
             // We may have to try to construct a type from the sigParser if the method table was a bust in the constructor
-            if (_type != null)
-                return name;
+            if (_type == null)
+            {
+                if (sigParser.GetCallingConvInfo(out int sigType) && sigType == SigParser.IMAGE_CEE_CS_CALLCONV_FIELD)
+                {
+                    sigParser.SkipCustomModifiers();
+                    _type = _helpers.Factory.GetOrCreateTypeFromSignature(Parent.Module, sigParser, Parent.GenericParameters, ImmutableArray<ClrGenericParameter>.Empty);
+                }
+            }
 
-            _type = GetTypeForFieldSig(_helpers.Factory, sigParser, Parent.Heap, Parent.Module);
             return name;
-        }
-
-        internal static ClrType? GetTypeForFieldSig(ITypeFactory factory, SigParser sigParser, ClrHeap heap, ClrModule? module)
-        {
-            ClrType? result = null;
-            bool res;
-            int etype = 0;
-
-            if (res = sigParser.GetCallingConvInfo(out int sigType))
-                DebugOnly.Assert(sigType == SigParser.IMAGE_CEE_CS_CALLCONV_FIELD);
-
-            res = res && sigParser.SkipCustomModifiers();
-            res = res && sigParser.GetElemType(out etype);
-
-            // Generic instantiation
-            if (etype == 0x15)
-                res = res && sigParser.GetElemType(out etype);
-
-            if (res)
-            {
-                ClrElementType type = (ClrElementType)etype;
-
-                if (type == ClrElementType.Array)
-                {
-                    res = sigParser.PeekElemType(out etype);
-                    res = res && sigParser.SkipExactlyOne();
-
-                    int ranks = 0;
-                    res = res && sigParser.GetData(out ranks);
-
-                    if (res)
-                    {
-                        ClrType inner = factory.GetOrCreateBasicType((ClrElementType)etype);
-                        result = factory.GetOrCreateArrayType(inner, ranks);
-                    }
-                }
-                else if (type == ClrElementType.SZArray)
-                {
-                    sigParser.PeekElemType(out etype);
-                    type = (ClrElementType)etype;
-
-                    if (type.IsObjectReference())
-                    {
-                        result = factory.GetOrCreateBasicType(ClrElementType.SZArray);
-                    }
-                    else
-                    {
-                        ClrType inner = factory.GetOrCreateBasicType((ClrElementType)etype);
-                        result = factory.GetOrCreateArrayType(inner, 1);
-                    }
-                }
-                else if (type == ClrElementType.Pointer)
-                {
-                    // Only deal with single pointers for now and types that have already been constructed
-                    sigParser.GetElemType(out etype);
-                    type = (ClrElementType)etype;
-
-                    sigParser.GetToken(out int token);
-
-                    if (module != null)
-                    {
-                        ClrType? innerType;
-                        if (type.IsPrimitive())
-                        {
-                            innerType = factory.GetOrCreateBasicType(type);
-                        }
-                        else
-                        {
-                            innerType = factory.GetOrCreateTypeFromToken(module, token);
-
-                            // Fallback just in case 
-                            if (innerType is null)
-                                innerType = factory.GetOrCreateBasicType(type);
-                        }
-                        
-
-                        result = factory.GetOrCreatePointerType(innerType, 1);
-                    }
-                }
-                else if (type == ClrElementType.Object || type == ClrElementType.Class)
-                {
-                    result = heap.ObjectType;
-                }
-                else
-                {
-                    // struct, then try to get the token
-                    int token = 0;
-                    if (etype == 0x11 || etype == 0x12)
-                        sigParser.GetToken(out token);
-
-                    if (token != 0 && module != null)
-                        result = factory.GetOrCreateTypeFromToken(module, token);
-
-                    if (result is null)
-                        result = factory.GetOrCreateBasicType((ClrElementType)etype);
-                }
-            }
-
-            if (result is null)
-                return result;
-
-            if (result.IsArray && result.ComponentType is null && result is ClrmdArrayType clrmdType)
-            {
-                etype = 0;
-
-                if (res = sigParser.GetCallingConvInfo(out sigType))
-                    DebugOnly.Assert(sigType == SigParser.IMAGE_CEE_CS_CALLCONV_FIELD);
-
-                res = res && sigParser.SkipCustomModifiers();
-                res = res && sigParser.GetElemType(out etype);
-
-                _ = res && sigParser.GetElemType(out etype);
-
-                // Generic instantiation
-                if (etype == 0x15)
-                    sigParser.GetElemType(out etype);
-
-                // If it's a class or struct, then try to get the token
-                int token = 0;
-                if (etype == 0x11 || etype == 0x12)
-                    sigParser.GetToken(out token);
-
-                if (token != 0 && module != null)
-                    clrmdType.SetComponentType(factory.GetOrCreateTypeFromToken(module, token));
-                else
-                    clrmdType.SetComponentType(factory.GetOrCreateBasicType((ClrElementType)etype));
-            }
-
-            return result;
         }
 
         public override T Read<T>(ulong objRef, bool interior)

--- a/src/Microsoft.Diagnostics.Runtime/src/Implementation/ClrmdGenericType.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Implementation/ClrmdGenericType.cs
@@ -1,0 +1,94 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+
+namespace Microsoft.Diagnostics.Runtime.Implementation
+{
+    /// <summary>
+    /// This represents a ClrType for which we cannot get information from the dac.  In theory we shouldn't need this
+    /// type, but in practice there are fields which do not report a type.  This allows us to provide a non-null, semi
+    /// meaningful type even though it's not as accurate or specific as we wish it would be.
+    /// </summary>
+    public sealed class ClrmdGenericType : ClrType
+    {
+        public ClrGenericParameter GenericParameter { get; }
+
+        public ClrmdGenericType(IClrObjectHelpers helpers, ClrHeap heap, ClrModule? module, ClrGenericParameter clrGenericParameter)
+        {
+            ClrObjectHelpers = helpers ?? throw new ArgumentNullException(nameof(helpers));
+            Heap = heap ?? throw new ArgumentNullException(nameof(heap));
+            Module = module;
+            GenericParameter = clrGenericParameter;
+        }
+
+        public override GCDesc GCDesc => default;
+
+        public override ulong MethodTable => 0;
+
+        public override int MetadataToken => GenericParameter.MetadataToken;
+
+        public override string? Name => GenericParameter.Name;
+
+        public override ClrHeap Heap { get; }
+
+        public override ClrModule? Module { get; }
+
+        public override ClrElementType ElementType => ClrElementType.Var;
+
+        public override bool IsFinalizable => false;
+
+        public override bool IsPublic => false;
+
+        public override bool IsPrivate => false;
+
+        public override bool IsInternal => false;
+
+        public override bool IsProtected => false;
+
+        public override bool IsAbstract => false;
+
+        public override bool IsSealed => false;
+
+        public override bool IsInterface => false;
+
+        public override ImmutableArray<ClrInstanceField> Fields => ImmutableArray<ClrInstanceField>.Empty;
+
+        public override ImmutableArray<ClrStaticField> StaticFields => ImmutableArray<ClrStaticField>.Empty;
+
+        public override ImmutableArray<ClrMethod> Methods => ImmutableArray<ClrMethod>.Empty;
+
+        public override ClrType? BaseType => null;
+
+        public override ClrType? ComponentType => null;
+
+        public override bool IsArray => false;
+
+        public override int StaticSize => 0;
+
+        public override int ComponentSize => 0;
+
+        public override bool IsEnum => false;
+
+        public override bool IsShared => false;
+
+        public override IClrObjectHelpers ClrObjectHelpers { get; }
+
+        public override ClrEnum AsEnum() => throw new InvalidOperationException();
+
+        public override IEnumerable<ClrInterface> EnumerateInterfaces() { yield break; }
+
+        public override ulong GetArrayElementAddress(ulong objRef, int index) => throw new InvalidOperationException();
+
+        public override ClrInstanceField? GetInstanceFieldByName(string name) => null;
+
+        public override ClrStaticField? GetStaticFieldByName(string name) => null;
+
+        public override bool IsFinalizeSuppressed(ulong obj) => false;
+
+        public override T[]? ReadArrayElements<T>(ulong objRef, int start, int count) => null;
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/src/Implementation/ClrmdPrimitiveType.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Implementation/ClrmdPrimitiveType.cs
@@ -31,7 +31,6 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
         public override int StaticSize => ClrmdField.GetSize(this, ElementType);
         public override ClrType? BaseType => null; // todo;
         public override ClrHeap Heap { get; }
-        public override IEnumerable<ClrGenericParameter> EnumerateGenericParameters() => Enumerable.Empty<ClrGenericParameter>();
         public override IEnumerable<ClrInterface> EnumerateInterfaces() => Enumerable.Empty<ClrInterface>();
         public override bool IsAbstract => false;
         public override bool IsFinalizable => false;

--- a/src/Microsoft.Diagnostics.Runtime/src/Implementation/ClrmdStaticField.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Implementation/ClrmdStaticField.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Immutable;
 using System.Reflection;
 using Microsoft.Diagnostics.Runtime.Utilities;
 
@@ -93,10 +94,15 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
             }
 
             // We may have to try to construct a type from the sigParser if the method table was a bust in the constructor
-            if (_type != null)
-                return name;
+            if (_type == null)
+            {
+                if (sigParser.GetCallingConvInfo(out int sigType) && sigType == SigParser.IMAGE_CEE_CS_CALLCONV_FIELD)
+                {
+                    sigParser.SkipCustomModifiers();
+                    _type = _helpers.Factory.GetOrCreateTypeFromSignature(Parent.Module, sigParser, Parent.GenericParameters, ImmutableArray<ClrGenericParameter>.Empty);
+                }
+            }
 
-            _type = ClrmdField.GetTypeForFieldSig(_helpers.Factory, sigParser, Parent.Heap, Parent.Module);
             return name;
         }
 

--- a/src/Microsoft.Diagnostics.Runtime/src/Implementation/ClrmdStaticField.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Implementation/ClrmdStaticField.cs
@@ -99,7 +99,7 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
                 if (sigParser.GetCallingConvInfo(out int sigType) && sigType == SigParser.IMAGE_CEE_CS_CALLCONV_FIELD)
                 {
                     sigParser.SkipCustomModifiers();
-                    _type = _helpers.Factory.GetOrCreateTypeFromSignature(Parent.Module, sigParser, Parent.GenericParameters, ImmutableArray<ClrGenericParameter>.Empty);
+                    _type = _helpers.Factory.GetOrCreateTypeFromSignature(Parent.Module, sigParser, Parent.EnumerateGenericParameters(), Array.Empty<ClrGenericParameter>());
                 }
             }
 

--- a/src/Microsoft.Diagnostics.Runtime/src/Implementation/ITypeFactory.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Implementation/ITypeFactory.cs
@@ -4,6 +4,7 @@
 
 using Microsoft.Diagnostics.Runtime.Utilities;
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 
 namespace Microsoft.Diagnostics.Runtime.Implementation
@@ -25,7 +26,7 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
         ClrType GetOrCreateBasicType(ClrElementType basicType);
         ClrType? GetOrCreateArrayType(ClrType inner, int ranks);
         ClrType? GetOrCreateTypeFromToken(ClrModule module, int token);
-        ClrType? GetOrCreateTypeFromSignature(ClrModule? module, SigParser parser, ImmutableArray<ClrGenericParameter> typeParameters, ImmutableArray<ClrGenericParameter> methodParameters);
+        ClrType? GetOrCreateTypeFromSignature(ClrModule? module, SigParser parser, IEnumerable<ClrGenericParameter> typeParameters, IEnumerable<ClrGenericParameter> methodParameters);
         ClrType? GetOrCreatePointerType(ClrType innerType, int depth);
         ClrMethod? CreateMethodFromHandle(ulong methodHandle);
     }

--- a/src/Microsoft.Diagnostics.Runtime/src/Implementation/ITypeFactory.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Implementation/ITypeFactory.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.Diagnostics.Runtime.Utilities;
 using System;
 using System.Collections.Immutable;
 
@@ -24,6 +25,7 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
         ClrType GetOrCreateBasicType(ClrElementType basicType);
         ClrType? GetOrCreateArrayType(ClrType inner, int ranks);
         ClrType? GetOrCreateTypeFromToken(ClrModule module, int token);
+        ClrType? GetOrCreateTypeFromSignature(ClrModule? module, SigParser parser, ImmutableArray<ClrGenericParameter> typeParameters, ImmutableArray<ClrGenericParameter> methodParameters);
         ClrType? GetOrCreatePointerType(ClrType innerType, int depth);
         ClrMethod? CreateMethodFromHandle(ulong methodHandle);
     }

--- a/src/Microsoft.Diagnostics.Runtime/src/Utilities/SigParser/SigParser.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Utilities/SigParser/SigParser.cs
@@ -111,6 +111,18 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
             return false;
         }
 
+        public bool GetElemType(out ClrElementType etype)
+        {
+            if (GetElemType(out int e))
+            {
+                etype = (ClrElementType)e;
+                return true;
+            }
+
+            etype = ClrElementType.Unknown;
+            return false;
+        }
+
         public bool GetElemType(out int etype)
         {
             if (_len > 0)
@@ -166,6 +178,18 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
         {
             SigParser sigTemp = new SigParser(this);
             return sigTemp.GetElemType(out etype);
+        }
+
+        public bool PeekElemType(out ClrElementType etype)
+        {
+            if (PeekElemType(out int e))
+            {
+                etype = (ClrElementType)e;
+                return true;
+            }
+
+            etype = ClrElementType.Unknown;
+            return false;
         }
 
         public bool PeekElemType(out int etype)


### PR DESCRIPTION
This change essentially rewrites ClrmdField.GetTypeForFieldSig and instead implements that function as a real type signature parser.

- Move ClrmdField.GetTypeForFieldSig -> ITypeFactor.GetOrCreateTypeFromSignature.
- Implement most of ECMA 355 II.23.2.12 (type signature parsing) instead of the hacky version I wrote originally.
- Promote EnumerateGenericParameters to be a property instead of enum.
- Add ClrmdGenericType which is a "fake" constructed type for when we cannot properly look up a type.

During this change I promoted EnumerateGenericParameters from an enumeration to a property with a backing field.  This was a bad choice that I will revert before checkin, the original code was better.

Most types don't need that field, and we only need to go through GetOrCreateTypeFromSignature when the dac doesn't give us a real MethodTable for a legitimate field.  Marking this a draft until that's fixed.