### PR TITLE
Use memory mapped files for minidump

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Minidump/MinidumpReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Minidump/MinidumpReader.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Diagnostics.Runtime
 
         public IMemoryReader MemoryReader => _readerCached ??= _minidump.MemoryReader;
 
-        public MinidumpReader(string crashDump, Stream stream)
+        public MinidumpReader(string crashDump, FileStream stream)
         {
             if (crashDump is null)
                 throw new ArgumentNullException(nameof(crashDump));
@@ -36,9 +36,8 @@ namespace Microsoft.Diagnostics.Runtime
 
             DisplayName = crashDump;
 
-            stream.Dispose();
-            _file = MemoryMappedFile.CreateFromFile(crashDump, FileMode.Open);
-            _stream = _file.CreateViewStream();
+            _file = MemoryMappedFile.CreateFromFile(stream, null, 0, MemoryMappedFileAccess.Read, HandleInheritability.None, leaveOpen: false);
+            _stream = _file.CreateViewStream(0, 0, MemoryMappedFileAccess.Read);
             _minidump = new Minidump(crashDump, _stream);
 
             Architecture = _minidump.Architecture switch

--- a/src/Microsoft.Diagnostics.Runtime/src/DataTargets/DataTarget.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataTargets/DataTarget.cs
@@ -235,7 +235,7 @@ namespace Microsoft.Diagnostics.Runtime
             else if (!File.Exists(filePath))
                 throw new FileNotFoundException($"Could not open dump file '{filePath}'.", filePath);
 
-            (Stream stream, DumpFileFormat format) = OpenDump(filePath);
+            (FileStream stream, DumpFileFormat format) = OpenDump(filePath);
             try
             {
 #pragma warning disable CA2000 // Dispose objects before losing scope
@@ -264,9 +264,9 @@ namespace Microsoft.Diagnostics.Runtime
             }
         }
 
-        private static (Stream stream, DumpFileFormat format) OpenDump(string path)
+        private static (FileStream stream, DumpFileFormat format) OpenDump(string path)
         {
-            Stream stream = File.OpenRead(path);
+            FileStream stream = File.OpenRead(path);
             try
             {
                 Span<byte> span = stackalloc byte[8];


### PR DESCRIPTION
Contributes to #660 

Interestingly enough, the simplest use of MMF increases performance significantly for my test case.

The MMF doesn't allow any file sharing by default so there can only be one stream at the same time. (Why do we need two streams?) I made `MinidumpReader` the `IDataReader` responsible for the disposal.