### PR TITLE
Fix issues with enumerating the heap and references

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/src/Common/ClrReference.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/ClrReference.cs
@@ -8,8 +8,8 @@ namespace Microsoft.Diagnostics.Runtime
 {
     public readonly struct ClrReference
     {
-        const ulong OffsetFlag = 8000000000000000ul;
-        const ulong DependentFlag = 4000000000000000ul;
+        const ulong OffsetFlag = 0x8000000000000000ul;
+        const ulong DependentFlag = 0x4000000000000000ul;
 
         private readonly ulong _offsetOrHandle;
 

--- a/src/Microsoft.Diagnostics.Runtime/src/Implementation/ClrmdSegment.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Implementation/ClrmdSegment.cs
@@ -119,7 +119,7 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
                 {
                     uint count;
                     if (large)
-                        count = Unsafe.As<byte, uint>(ref buffer[IntPtr.Size * 2]);
+                        count = Unsafe.As<byte, uint>(ref buffer[IntPtr.Size]);
                     else
                         memoryReader.ReadDword(obj + (uint)IntPtr.Size, out count);
 


### PR DESCRIPTION
- We calculated the wrong offset for LoH object ranges.
- A missing 0x value meant values were in octal instead of hex.