### PR TITLE
Add support for SyncBlocks

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/src/Common/ClrHeap.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/ClrHeap.cs
@@ -120,6 +120,13 @@ namespace Microsoft.Diagnostics.Runtime
         public abstract IEnumerable<MemoryRange> EnumerateAllocationContexts();
 
         /// <summary>
+        /// Obtains the SyncBlock data for a given object, if the object has an associated SyncBlock.
+        /// </summary>
+        /// <param name="obj">The object to get SyncBlock data for.</param>
+        /// <returns>The SyncBlock for the object, null if the object does not have one.</returns>
+        public abstract SyncBlock? GetSyncBlock(ulong obj);
+
+        /// <summary>
         /// Returns a string representation of this heap, including the size and number of segments.
         /// </summary>
         /// <returns>The string representation of this heap.</returns>
@@ -131,14 +138,17 @@ namespace Microsoft.Diagnostics.Runtime
         }
 
         /// <summary>
-        /// Use ClrObject.Size instead.
+        /// This is an implementation helper.  Use ClrObject.IsComCallWrapper and ClrObject.IsRuntimeCallWrapper instead.
         /// </summary>
-        /// <param name="objRef"></param>
-        /// <param name="type"></param>
-        /// <returns></returns>
+        public abstract SyncBlockComFlags GetComFlags(ulong obj);
+
+        /// <summary>
+        /// This is an implementation helper.  Use ClrObject.Size instead.
+        /// </summary>
         public abstract ulong GetObjectSize(ulong objRef, ClrType type);
 
         /// <summary>
+        /// This is an implementation helper.  Use <see cref="ClrObject.EnumerateReferences(bool, bool)">ClrObject.EnumerateReferences</see> instead.
         /// Enumerates all objects that the given object references.  This method is meant for internal use to
         /// implement ClrObject.EnumerateReferences, which you should use instead of calling this directly.
         /// </summary>
@@ -153,6 +163,7 @@ namespace Microsoft.Diagnostics.Runtime
 
 
         /// <summary>
+        /// This is an implementation helper.
         /// Enumerates all objects that the given object references.  This method is meant for internal use to
         /// implement ClrObject.EnumerateReferencesWithFields, which you should use instead of calling this directly.
         /// </summary>

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/ClrObject.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/ClrObject.cs
@@ -126,12 +126,32 @@ namespace Microsoft.Diagnostics.Runtime
         public ulong Size => GetTypeOrThrow().Heap.GetObjectSize(Address, GetTypeOrThrow());
 
         /// <summary>
+        /// Obtains the SyncBlock for this object.  Returns null if there is no SyncBlock associated with this object.
+        /// </summary>
+        public SyncBlock? SyncBlock => Type?.Heap.GetSyncBlock(Address);
+
+        /// <summary>
+        /// Returns true if this object is a COM class factory.
+        /// </summary>
+        public bool IsComClassFactory => (GetTypeOrThrow().Heap.GetComFlags(Address) & SyncBlockComFlags.ComClassFactory) == SyncBlockComFlags.ComClassFactory;
+
+        /// <summary>
+        /// Returns true if this object is a ComCallableWrapper.
+        /// </summary>
+        public bool IsComCallableWrapper => (GetTypeOrThrow().Heap.GetComFlags(Address) & SyncBlockComFlags.ComCallableWrapper) == SyncBlockComFlags.ComCallableWrapper;
+
+        /// <summary>
+        /// Returns true if this object is a RuntimeCallableWrapper.
+        /// </summary>
+        public bool IsRuntimeCallableWrapper => (GetTypeOrThrow().Heap.GetComFlags(Address) & SyncBlockComFlags.RuntimeCallableWrapper) == SyncBlockComFlags.RuntimeCallableWrapper;
+
+        /// <summary>
         /// Returns the ComCallableWrapper for the given object.
         /// </summary>
         /// <returns>The ComCallableWrapper associated with the object, <see langword="null"/> if obj is not a CCW.</returns>
         public ComCallableWrapper? AsComCallableWrapper()
         {
-            if (IsNull || !IsValidObject)
+            if (IsNull || !IsValidObject || !IsComCallableWrapper)
                 return null;
 
             return Helpers.Factory.CreateCCWForObject(Address);

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/SyncBlock.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/SyncBlock.cs
@@ -1,0 +1,25 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.Diagnostics.Runtime
+{
+    public class SyncBlock
+    {
+        public ulong Object { get; }
+
+        public virtual bool IsComCallWrapper => false;
+        public virtual bool IsRuntimeCallWrapper => false;
+        public virtual bool IsComClassFactory => false;
+
+        public virtual bool IsMonitorHeld => false;
+        public virtual ulong HoldingThreadAddress => 0;
+        public virtual int RecursionCount => 0;
+        public virtual int WaitingThreadCount => 0;
+
+        public SyncBlock(ulong obj)
+        {
+            Object = obj;
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/SyncBlockFlags.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/SyncBlockFlags.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Microsoft.Diagnostics.Runtime
+{
+    [Flags]
+    public enum SyncBlockComFlags : byte
+    {
+        None = 0,
+        ComCallableWrapper = 1,
+        RuntimeCallableWrapper = 2,
+        ComClassFactory = 4
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/src/Implementation/ComSyncBlock.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Implementation/ComSyncBlock.cs
@@ -1,0 +1,21 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.Diagnostics.Runtime.Implementation
+{
+    public sealed class ComSyncBlock : SyncBlock
+    {
+        public SyncBlockComFlags ComFlags { get; }
+
+        public override bool IsComCallWrapper => (ComFlags & SyncBlockComFlags.ComCallableWrapper) == SyncBlockComFlags.ComCallableWrapper;
+        public override bool IsRuntimeCallWrapper => (ComFlags & SyncBlockComFlags.ComCallableWrapper) == SyncBlockComFlags.ComCallableWrapper;
+        public override bool IsComClassFactory => (ComFlags & SyncBlockComFlags.ComClassFactory) == SyncBlockComFlags.ComClassFactory;
+
+        public ComSyncBlock(ulong obj, uint comFlags)
+            : base(obj)
+        {
+            ComFlags = (SyncBlockComFlags)comFlags;
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/src/Implementation/FullSyncBlock.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Implementation/FullSyncBlock.cs
@@ -1,0 +1,33 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Diagnostics.Runtime.DacInterface;
+
+namespace Microsoft.Diagnostics.Runtime.Implementation
+{
+    public sealed class FullSyncBlock : SyncBlock
+    {
+        public SyncBlockComFlags ComFlags { get; }
+
+        public override bool IsComCallWrapper => (ComFlags & SyncBlockComFlags.ComCallableWrapper) == SyncBlockComFlags.ComCallableWrapper;
+        public override bool IsRuntimeCallWrapper => (ComFlags & SyncBlockComFlags.ComCallableWrapper) == SyncBlockComFlags.ComCallableWrapper;
+        public override bool IsComClassFactory => (ComFlags & SyncBlockComFlags.ComClassFactory) == SyncBlockComFlags.ComClassFactory;
+
+        public override bool IsMonitorHeld { get; }
+        public override ulong HoldingThreadAddress { get; }
+        public override int RecursionCount { get; }
+        public override int WaitingThreadCount { get; }
+
+        public FullSyncBlock(in SyncBlockData syncBlk)
+            : base(syncBlk.Object)
+        {
+            ComFlags = (SyncBlockComFlags)syncBlk.COMFlags;
+
+            IsMonitorHeld = syncBlk.MonitorHeld != 0;
+            HoldingThreadAddress = syncBlk.HoldingThread;
+            RecursionCount = syncBlk.Recursion >= int.MaxValue ? int.MaxValue : (int)syncBlk.Recursion;
+            WaitingThreadCount = (int)syncBlk.AdditionalThreadCount;
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/src/Implementation/IHeapHelpers.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Implementation/IHeapHelpers.cs
@@ -15,5 +15,7 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
         IEnumerable<(ulong Source, ulong Target)> EnumerateDependentHandleLinks();
         bool CreateSegments(ClrHeap clrHeap, out ImmutableArray<ClrSegment> segemnts, out ImmutableArray<MemoryRange> allocationContexts,
                             out ImmutableArray<FinalizerQueueSegment> fqRoots, out ImmutableArray<FinalizerQueueSegment> fqObjects);
+
+        bool GetSyncBlocks(out List<ComSyncBlock> comSyncBlocks, out List<FullSyncBlock> fullSyncBlocks, out List<ulong> emptySyncBlocks);
     }
 }


### PR DESCRIPTION
- Greatly improves AsComCallableWraper and AsRuntimeCallableWrapper performance (after the first call, which warms up the cache).
- Added ClrObject.SyncBlock, ClrObject.IsComCallableWrapper, and ClrObject.IsRuntimeCallableWrapper.