### PR TITLE
Return null string for S_FALSE

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/src/DacInterface/MetadataImport.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DacInterface/MetadataImport.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             InitDelegate(ref _getTypeDefProps, VTable.GetTypeDefProps);
 
             HResult hr = _getTypeDefProps(Self, token, null, 0, out int needed, out attributes, out mdParent);
-            if (!hr)
+            if (!hr.IsOK)
             {
                 name = null;
                 return hr;


### PR DESCRIPTION
Fixes #671 

hr = S_FALSE
needed = 0
EnumerateInterfaces() yielded no results.

Similar fixes may be required for other methods where `needed - 1` is used.