### PR TITLE
Don't read gcdesc pointers one at a time

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/src/Extensions/SpanExtensions.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Extensions/SpanExtensions.cs
@@ -47,8 +47,11 @@ namespace Microsoft.Diagnostics.Runtime
         }
 #endif
 
-        public static unsafe ulong AsPointer(this Span<byte> span)
+        public static unsafe ulong AsPointer(this Span<byte> span, int offset = 0)
         {
+            if (offset > 0)
+                span = span.Slice(offset);
+
             DebugOnly.Assert(span.Length >= IntPtr.Size);
             DebugOnly.Assert(unchecked((int)Unsafe.AsPointer(ref MemoryMarshal.GetReference(span))) % IntPtr.Size == 0);
             return IntPtr.Size == 4


### PR DESCRIPTION
The previous code would individually read one pointer at a time as we walked objects for references.  Now read in the entire object into one buffer before walking the object.