### PR TITLE
Don't throw an exception if we fail to QueryInterface IMetaDataImport

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/src/DacInterface/MetadataImport.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DacInterface/MetadataImport.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
 {
     public sealed unsafe class MetadataImport : CallableCOMWrapper
     {
-        private static readonly Guid IID_IMetaDataImport = new Guid("7DAC8207-D3AE-4c75-9B67-92801A497D44");
+        public static readonly Guid IID_IMetaDataImport = new Guid("7DAC8207-D3AE-4c75-9B67-92801A497D44");
 
         public MetadataImport(DacLibrary library, IntPtr pUnknown)
             : base(library?.OwningLibrary, IID_IMetaDataImport, pUnknown)

--- a/src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac.cs
@@ -298,14 +298,20 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             if (!_getModule(Self, module, out IntPtr iunk))
                 return null;
 
+            // Make sure we can successfully QueryInterface for IMetaDataImport.  This may fail if
+            // we do not have all of the relevant metadata mapped into memory either through the dump
+            // or via the binary locator.
+            if (QueryInterface(iunk, MetadataImport.IID_IMetaDataImport, out IntPtr pTmp))
+                Release(pTmp);
+            else
+                return null;
+
             try
             {
                 return new MetadataImport(_library, iunk);
             }
             catch (InvalidCastException)
             {
-                // QueryInterface on MetaDataImport seems to fail when we don't have full
-                // metadata available.
                 return null;
             }
         }

--- a/src/Microsoft.Diagnostics.Runtime/src/Utilities/COMInterop/ComHelper.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Utilities/COMInterop/ComHelper.cs
@@ -38,5 +38,18 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
             ReleaseDelegate release = Marshal.GetDelegateForFunctionPointer<ReleaseDelegate>(vtable->Release);
             return release(pUnk);
         }
+
+        public static unsafe HResult QueryInterface(IntPtr pUnk, in Guid riid, out IntPtr result)
+        {
+            result = IntPtr.Zero;
+
+            if (pUnk == IntPtr.Zero)
+                return HResult.E_INVALIDARG;
+
+            IUnknownVTable* vtable = *(IUnknownVTable**)pUnk;
+
+            QueryInterfaceDelegate qi = Marshal.GetDelegateForFunctionPointer<QueryInterfaceDelegate>(vtable->QueryInterface);
+            return qi(pUnk, riid, out result);
+        }
     }
 }


### PR DESCRIPTION
It's common for the QueryInterface for IMetaDataImport to fail if the dump file does not contain all of the metadata.  This is especially common in non-heap dumps and Watson dumps.  This change adds an extra QueryInterface to make sure this call will succeed before trying to create a MetadataImport instance.  This should greatly reduce the number of exceptions being thrown under normal operation.

Contributes to https://github.com/microsoft/clrmd/issues/416.