### PR TITLE
Mark ClrField.Type and ClrValueType.Type as nullable

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/src/Common/ClrField.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/ClrField.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Diagnostics.Runtime
         /// Gets the type of the field.  Note this property may return <see langword="null"/> on error.  There is a bug in several versions
         /// of our debugging layer which causes this.  You should always null-check the return value of this field.
         /// </summary>
-        public abstract ClrType Type { get; }
+        public abstract ClrType? Type { get; }
 
         /// <summary>
         /// Gets the element type of this field.  Note that even when Type is <see langword="null"/>, this should still tell you
@@ -91,11 +91,11 @@ namespace Microsoft.Diagnostics.Runtime
         /// <returns>A string representation of this object.</returns>
         public override string? ToString()
         {
-            ClrType type = Type;
-            if (type != null)
-                return $"{type.Name} {Name}";
-
-            return Name;
+            ClrType? type = Type;
+            if (type is null)
+                return Name;
+            
+            return $"{type.Name} {Name}";
         }
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/src/Implementation/ClrmdField.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Implementation/ClrmdField.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
             }
         }
 
-        public override ClrType Type
+        public override ClrType? Type
         {
             get
             {
@@ -43,7 +43,7 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
                     return _type;
 
                 InitData();
-                return _type!;
+                return _type;
             }
         }
 
@@ -207,7 +207,7 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
             return objRef + (ulong)(Offset + IntPtr.Size);
         }
 
-        internal static int GetSize(ClrType type, ClrElementType cet)
+        internal static int GetSize(ClrType? type, ClrElementType cet)
         {
             // todo:  What if we have a struct which is not fully constructed (null MT,
             //        null type) and need to get the size of the field?


### PR DESCRIPTION
ClrField.Type and ClrValueType.Type can actually be null.  Even if the 99% case is that they are non-null we need to mark them appropriately for error handling.