### PR TITLE
Change ObjectSet's fields to properties

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/src/Common/ObjectSet.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/ObjectSet.cs
@@ -19,12 +19,12 @@ namespace Microsoft.Diagnostics.Runtime
         /// <summary>
         /// The ClrHeap this is an object set over.
         /// </summary>
-        protected ClrHeap Heap { get; }
+        public ClrHeap Heap { get; }
 
         /// <summary>
         /// The minimum object size for this particular heap.
         /// </summary>
-        protected int MinObjSize => IntPtr.Size * 3;
+        public int MinObjSize => IntPtr.Size * 3;
 
         /// <summary>
         /// The collection of segments and associated objects.

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/ObjectSet.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/ObjectSet.cs
@@ -24,7 +24,9 @@ namespace Microsoft.Diagnostics.Runtime
         /// <summary>
         /// The minimum object size for this particular heap.
         /// </summary>
+#pragma warning disable CA1822 // CA1822: Mark members as static
         public int MinObjSize => IntPtr.Size * 3;
+#pragma warning restore CA1822 // CA1822: Mark members as static
 
         /// <summary>
         /// The collection of segments and associated objects.


### PR DESCRIPTION
Fixes an ancient issue.

CA1819 recommends to return a collection but it's gonna hurt the performance.