### PR TITLE
Fix tests

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/ModuleTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/ModuleTests.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
 {
     public class ModuleTests
     {
-        [Fact]
+        [WindowsFact] // ModuleInfo.Version only supports native modules at the moment
         public void FileVersionInfoVersionTest()
         {
             bool found = false;

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/TypeTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/TypeTests.cs
@@ -626,7 +626,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
 
             var query = from obj in runtime.Heap.EnumerateObjects()
-                        where obj.Type?.Name == "Types+<Async>d__0"
+                        where obj.Type?.Name?.StartsWith("Types+<Async>d__") == true
                         select obj.Type;
 
             ClrType clrType = query.Single();


### PR DESCRIPTION
The compiler-generated type is now `Types+<Async>d__16`.

/cc @Ne4to 