### PR TITLE
Remove ClrModule.SimpleName

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/ModuleTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/ModuleTests.cs
@@ -104,7 +104,6 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             {
                 Assert.True(File.Exists(module.Name));
                 Assert.True(File.Exists(module.AssemblyName));
-                Assert.Equal(Path.GetFileNameWithoutExtension(module.Name), module.SimpleName);
             }
         }
 

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/ClrModule.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/ClrModule.cs
@@ -46,11 +46,6 @@ namespace Microsoft.Diagnostics.Runtime
         public abstract string? Name { get; }
 
         /// <summary>
-        /// Gets the simple name of the module.
-        /// </summary>
-        public abstract string? SimpleName { get; }
-
-        /// <summary>
         /// Gets a value indicating whether this module was created through <c>System.Reflection.Emit</c> (and thus has no associated
         /// file).
         /// </summary>

--- a/src/Microsoft.Diagnostics.Runtime/src/Implementation/ClrmdModule.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Implementation/ClrmdModule.cs
@@ -27,7 +27,6 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
 
         public override ClrAppDomain AppDomain { get; }
         public override string? Name { get; }
-        public override string? SimpleName { get; }
         public override string? AssemblyName { get; }
         public override ulong AssemblyAddress { get; }
         public override ulong Address { get; }
@@ -49,7 +48,6 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
             _helpers = data.Helpers;
             AppDomain = parent;
             Name = data.Name;
-            SimpleName = data.SimpleName;
             AssemblyName = data.AssemblyName;
             AssemblyAddress = data.AssemblyAddress;
             Address = data.Address;


### PR DESCRIPTION
This is failing in some cases I don't understand, so I'm backing out the public surface area
of this feature until it's fixed.

https://github.com/microsoft/clrmd/issues/712