### PR TITLE
Change ModuleInfo._isVirtual to an enum

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/src/Common/ClrFileLayout.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/ClrFileLayout.cs
@@ -1,0 +1,29 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.Diagnostics.Runtime
+{
+    public enum ClrFileLayout
+    {
+        /// <summary>
+        /// No known mapping associated
+        /// </summary>
+        Unknown = 0,
+
+        /// <summary>
+        /// Specifies that the sections of the image were mapped to their corresponding virtual addresses, as if it was loaded with LoadLibrary (not file layout).
+        /// </summary>
+        Mapped = 1,
+
+        /// <summary>
+        /// Specifies that the image was directly mapped via a single mmap/CreateFileMapping call (file layout).
+        /// </summary>
+        Flat = 2,
+
+        /// <summary>
+        /// Windows specific: Specifies that the image was loaded using LoadLibrary (not file layout).
+        /// </summary>
+        Loaded = 4
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Core/CoreDumpReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Core/CoreDumpReader.cs
@@ -108,7 +108,7 @@ namespace Microsoft.Diagnostics.Runtime
             }
 
             // We set buildId to "default" which means we will later lazily evaluate the buildId on demand.
-            return new ModuleInfo((ulong)image.BaseAddress, image.Path, image._containsExecutable, filesize, timestamp, buildId: default);
+            return new ModuleInfo((ulong)image.BaseAddress, image.Path, image._containsExecutable ? ClrFileLayout.Mapped : ClrFileLayout.Flat, filesize, timestamp, buildId: default);
         }
 
         public void FlushCachedData()

--- a/src/Microsoft.Diagnostics.Runtime/src/DataReaders/DbgEng/DbgEngDataReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataReaders/DbgEng/DbgEngDataReader.cs
@@ -217,7 +217,7 @@ namespace Microsoft.Diagnostics.Runtime
                 for (int i = 0; i < bases.Length; ++i)
                 {
                     string? fn = _symbols.GetModuleNameStringWide(DebugModuleName.Image, i, bases[i]);
-                    ModuleInfo info = new ModuleInfo(bases[i], fn, true, mods[i].Size, mods[i].TimeDateStamp, ImmutableArray<byte>.Empty);
+                    ModuleInfo info = new ModuleInfo(bases[i], fn, ClrFileLayout.Loaded, mods[i].Size, mods[i].TimeDateStamp, ImmutableArray<byte>.Empty);
                     modules.Add(info);
                 }
             }

--- a/src/Microsoft.Diagnostics.Runtime/src/DataReaders/MacOS/MacOSProcessDataReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataReaders/MacOS/MacOSProcessDataReader.cs
@@ -107,7 +107,7 @@ namespace Microsoft.Diagnostics.Runtime.MacOS
                 Native.dyld_image_info info = Read<Native.dyld_image_info>(infos.infoArray, i);
                 ulong imageAddress = info.imageLoadAddress;
                 string imageFilePath = ReadNullTerminatedAscii(info.imageFilePath);
-                yield return new ModuleInfo(imageAddress, imageFilePath, true, 0, 0, ImmutableArray<byte>.Empty);
+                yield return new ModuleInfo(imageAddress, imageFilePath, ClrFileLayout.Mapped, 0, 0, ImmutableArray<byte>.Empty);
             }
 
             unsafe T Read<T>(ulong address, uint index = 0)

--- a/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Minidump/MinidumpReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Minidump/MinidumpReader.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Diagnostics.Runtime
             // We set buildId to "Empty" since only PEImages exist where minidumps are created, and we do not
             // want to try to lazily evaluate the buildId later
             return from module in _minidump.EnumerateModuleInfo()
-                   select new ModuleInfo(module.BaseOfImage, module.ModuleName, true, module.SizeOfImage,
+                   select new ModuleInfo(module.BaseOfImage, module.ModuleName, ClrFileLayout.Loaded, module.SizeOfImage,
                                          module.DateTimeStamp, ImmutableArray<byte>.Empty);
         }
 

--- a/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Windows/WindowsProcessDataReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Windows/WindowsProcessDataReader.cs
@@ -147,7 +147,7 @@ namespace Microsoft.Diagnostics.Runtime
                 GetFileProperties(baseAddr, out int filesize, out int timestamp);
 
                 string fileName = sb.ToString();
-                ModuleInfo module = new ModuleInfo(baseAddr, fileName, true, filesize, timestamp, ImmutableArray<byte>.Empty);
+                ModuleInfo module = new ModuleInfo(baseAddr, fileName, ClrFileLayout.Loaded, filesize, timestamp, ImmutableArray<byte>.Empty);
                 result.Add(module);
             }
 

--- a/src/Microsoft.Diagnostics.Runtime/src/Linux/LinuxLiveDataReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Linux/LinuxLiveDataReader.cs
@@ -111,9 +111,10 @@ namespace Microsoft.Diagnostics.Runtime.Linux
             group entry by entry.FilePath into image
             let filePath = image.Key
             let containsExecutable = image.Any(entry => entry.IsExecutable)
+            let mapping = containsExecutable ? ClrFileLayout.Mapped : ClrFileLayout.Flat
             let beginAddress = image.Min(entry => entry.BeginAddress)
             let props = GetPEImageProperties(filePath)
-            select new ModuleInfo(beginAddress, filePath, containsExecutable, props.Filesize, props.Timestamp, buildId: default);
+            select new ModuleInfo(beginAddress, filePath, mapping, props.Filesize, props.Timestamp, buildId: default);
 
         private static (int Filesize, int Timestamp) GetPEImageProperties(string filePath)
         {


### PR DESCRIPTION
Start tracking peimage load layout by enum in accordance with https://github.com/dotnet/runtime/blob/bd6c81a944f609b88908864827b7797c6b127c5b/src/coreclr/src/vm/peimage.h#L287.

Note that this change is NOT intended to make this work correctly for all file layouts, but instead to change the public surface area of ClrMD to support future improvments here before RTM.

Contributes to https://github.com/microsoft/clrmd/issues/475.