### PR TITLE
Fix an infinite chain when ClrReference.InnerField fails to blame correctly

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/src/Common/ClrReference.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/ClrReference.cs
@@ -56,6 +56,11 @@ namespace Microsoft.Diagnostics.Runtime
                 if (field is null)
                     return null;
 
+                // Primitive types intentionally have a recursive definition.  In the case where we incorrectly find
+                // an object's offset as one of these fields we need to break out of the infinite loop.
+                if (field == Field && field.Name == "m_value")
+                    return null;
+
                 unchecked
                 {
                     return new ClrReference(Object, field, OffsetFlag | (uint)offset);


### PR DESCRIPTION
Primitive fields are recursively defined, which means if we incorrectly blame a ClrReference.InnerField on one, we can create infinite loops in customer code.

I'm still working on why we blame the wrong field, but this stops the loop in case we do.