### PR TITLE
ClrObject extension methods

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/HeapTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/HeapTests.cs
@@ -2,12 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.Diagnostics.Runtime.Utilities;
-
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using Xunit;
+using Microsoft.Diagnostics.Runtime.Utilities;
 
 namespace Microsoft.Diagnostics.Runtime.Tests
 {

--- a/src/Microsoft.Diagnostics.Runtime.Utilities/ClrObjectExtensions.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Utilities/ClrObjectExtensions.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+using Microsoft.Diagnostics.Runtime;
+
+namespace Microsoft.Diagnostics.Runtime.Utilities
+{
+    public static class ClrObjectExtensions
+    {
+        public static string GetStringValue(this ClrObject clrObject, int maxLength = int.MaxValue)
+        {
+            if (clrObject.Type.ElementType != ClrElementType.String) return null;
+            return clrObject.Type.ClrObjectHelpers.ReadString(clrObject.Address, maxLength);
+        }
+
+        public static UInt64 GetGraphSize(this ClrObject clrObject)
+        {
+            ulong size = 0;
+            var visited = new HashSet<UInt64>();
+            Accumulate(clrObject, visited, ref size);
+
+            static void Accumulate(ClrObject clrObject, HashSet<UInt64> visited, ref ulong size)
+            {
+                if (clrObject.IsNull) return;
+                if (visited.Contains(clrObject.Address)) return;
+
+                size += clrObject.Size;
+                visited.Add(clrObject.Address);
+                foreach (var childReference in clrObject.EnumerateReferencesWithFields())
+                {
+                    Accumulate(childReference.Object, visited, ref size);
+                }
+            }
+
+            return size;
+        }
+
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime.Utilities/ClrObjectExtensions.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Utilities/ClrObjectExtensions.cs
@@ -10,8 +10,7 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
     {
         public static string GetStringValue(this ClrObject clrObject, int maxLength = int.MaxValue)
         {
-            if (clrObject.Type.ElementType != ClrElementType.String) return null;
-            return clrObject.Type.ClrObjectHelpers.ReadString(clrObject.Address, maxLength);
+            return clrObject.Type.IsString ? clrObject.AsString(maxLength) : null;
         }
 
         public static UInt64 GetGraphSize(this ClrObject clrObject)


### PR DESCRIPTION
This PR contains two extension methods for ClrObject and related tests:

1. `public static string GetStringValue(this ClrObject clrObject, int maxLength = int.MaxValue)`
This is a convenient method to return the string value when the object is a string.
Null is returned when the object is not a string.
By default the string length is not limited, but can be passed as parameter

2. `public static UInt64 GetGraphSize(this ClrObject clrObject)`
This other method uses the `EnumerateReferencesWithFields` method to walk through the object graph and calculate the total size of the graph.
As an example, this is handy when you find something in the statics and need to know the amount of memory kept allocated. In general, when looking for leaks, it is a good way to evaluate the overall weight of the leak for each reference.

**Note**: The test method of `GetGraphSize` is only testing against an int[] because otherwise I don't know how to compute that same size using dotnet-dump / SOS. Any ideas on how to improve the test are welcome.

Finally, there is also a using statement reordered in HeapTests.cs