### PR TITLE
Refactor cache entries

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/src/Windows/AWEBasedCacheEntry.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Windows/AWEBasedCacheEntry.cs
@@ -3,12 +3,10 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Threading;
-
 
 // TODO:  This code wasn't written to consider nullable.
 #nullable disable
@@ -16,262 +14,46 @@ using System.Threading;
 #pragma warning disable CA1810 // Initialize reference type static fields inline
 namespace Microsoft.Diagnostics.Runtime.Windows
 {
-    internal sealed class AWEBasedCacheEntry : SegmentCacheEntry, IDisposable
+    /// <summary>
+    /// Represents heap segment cache entries backed by AWE (Address Windowing Extensions). This technology allows us to read the entirety of the heap data out of the dump (which is very fast disk
+    /// access wise) up front, keep it in physical memory, but only maps those physical memory pages into our VM space as needed, allowing us to control how much memory we use and making 'mapping in'
+    /// very fast(some page table entry work in Windows instead of physically reading the data off of disk). The downside is it requires the user have special privileges as well as it maps data 
+    /// in 64k chunks(the VirtualAlloc allocation granularity).
+    /// </summary>
+    internal sealed class AWEBasedCacheEntry : CacheEntryBase<UIntPtr>
     {
         private readonly static uint VirtualAllocPageSize; // set in static ctor
         private readonly static int SystemPageSize = Environment.SystemPageSize;
 
-        private readonly Action<ulong, uint> _updateOwningCacheForSizeChangeCallback;
-        private readonly MinidumpSegment _segmentData;
         private UIntPtr _pageFrameArray;
-        private readonly int _pageFrameArrayItemCount;
-        private readonly ReaderWriterLockSlim[] _pageLocks;
-        private CachePage[] _pages;
-        private long _lastAccessTickCount;
-        private int _accessCount;
-        private volatile int _entrySize;
+        private int _pageFrameArrayItemCount;
 
         static AWEBasedCacheEntry()
         {
             CacheNativeMethods.Util.SYSTEM_INFO sysInfo = new CacheNativeMethods.Util.SYSTEM_INFO();
             CacheNativeMethods.Util.GetSystemInfo(ref sysInfo);
 
-            VirtualAllocPageSize = sysInfo.dwAllocationGranularity;
+            AWEBasedCacheEntry.VirtualAllocPageSize = sysInfo.dwAllocationGranularity;
         }
 
-        internal AWEBasedCacheEntry(MinidumpSegment segmentData, Action<ulong, uint> updateOwningCacheForSizeChangeCallback, UIntPtr pageFrameArray, int pageFrameArrayItemCount)
+        internal AWEBasedCacheEntry(MinidumpSegment segmentData, Action<uint> updateOwningCacheForSizeChangeCallback, UIntPtr pageFrameArray, int pageFrameArrayItemCount) : base(segmentData, derivedMinSize: UIntPtr.Size + (pageFrameArrayItemCount * UIntPtr.Size) + sizeof(int), updateOwningCacheForSizeChangeCallback)
         {
-            int pagesSize = (int)(segmentData.Size / VirtualAllocPageSize);
-            if ((segmentData.Size % VirtualAllocPageSize) != 0)
-                pagesSize++;
-
-            _pages = new CachePage[pagesSize];
-            _pageLocks = new ReaderWriterLockSlim[pagesSize];
-            for (int i = 0; i < _pageLocks.Length; i++)
-            {
-                _pageLocks[i] = new ReaderWriterLockSlim();
-            }
-
-            MinSize = (_pages.Length * UIntPtr.Size) + /*size of pages array*/
-                      (_pageLocks.Length * UIntPtr.Size) + /*size of pageLocks array*/
-                      (_pageFrameArrayItemCount * UIntPtr.Size) +  /*size of pageFrameArray*/
-                      (5 * IntPtr.Size) + /*size of reference type fields (updateOwningCacheForSizeChangeCallback, segmentData, pageFrameArray, pageLocks, pages)*/
-                      (2 * sizeof(int)) + /*size of int fields (pageFrameArrayItemCount, accessSize)*/
-                      sizeof(uint) +  /*size of uint field (accessCount)*/
-                      sizeof(long); /*size of long field (lasAccessTickCount)*/
-
-            _segmentData = segmentData;
-            _updateOwningCacheForSizeChangeCallback = updateOwningCacheForSizeChangeCallback;
             _pageFrameArray = pageFrameArray;
             _pageFrameArrayItemCount = pageFrameArrayItemCount;
-
-            _entrySize = MinSize;
-
-            IncrementAccessCount();
-            UpdateLastAccessTickCount();
         }
 
-        public override long LastAccessTickCount => Interlocked.Read(ref _lastAccessTickCount);
-
-        public override int AccessCount => _accessCount;
-
-        public override int CurrentSize => _entrySize;
-
-        public override void IncrementAccessCount()
-        {
-            Interlocked.Increment(ref _accessCount);
-        }
-
-        public override void GetDataForAddress(ulong address, uint byteCount, IntPtr buffer, out uint bytesRead)
-        {
-            uint offset = (uint)(address - _segmentData.VirtualAddress);
-            uint pageAlignedOffset = AlignOffsetToPageBoundary(offset);
-
-            int dataIndex = (int)(pageAlignedOffset / VirtualAllocPageSize);
-
-            ReaderWriterLockSlim targetLock = _pageLocks[dataIndex];
-
-            // THREADING: Once we have acquired the read lock we need to hold it, in some fashion, through the entirity of this method, that prevents the PageOut code from
-            // evicting this page data while we are using it.
-            targetLock.EnterReadLock();
-
-            List<(ReaderWriterLockSlim Lock, bool IsHeldAsUpgradeableReadLock)> acquiredLocks = EnsurePageRangeAtOffset(offset, targetLock, byteCount);
-
-            try
-            {
-                if (IsSinglePageRead(offset, byteCount))
-                {
-                    uint inPageOffset = MapOffsetToPageOffset(offset);
-
-                    CacheNativeMethods.Memory.memcpy(buffer, UIntPtr.Add(_pages[dataIndex].Data, (int)inPageOffset), new UIntPtr(byteCount));
-
-                    bytesRead = byteCount;
-                    return;
-                }
-                else // This is a read that spans at least one page boundary.
-                {
-                    IntPtr pInsertionPoint = buffer;
-
-                    uint inPageOffset = MapOffsetToPageOffset(offset);
-
-                    int remainingBytesToRead = (int)byteCount;
-                    do
-                    {
-                        if (dataIndex == _pages.Length)
-                        {
-                            // Out of data in this segment, report how many bytes we read
-                            bytesRead = byteCount - (uint)remainingBytesToRead;
-                            return;
-                        }
-
-                        uint bytesInCurrentPage = Math.Min((_pages[dataIndex].DataExtent - inPageOffset), (uint)remainingBytesToRead);
-
-                        UIntPtr targetData = _pages[dataIndex++].Data;
-
-                        CacheNativeMethods.Memory.memcpy(pInsertionPoint, UIntPtr.Add(targetData, (int)inPageOffset), new UIntPtr(bytesInCurrentPage));
-
-                        pInsertionPoint += (int)bytesInCurrentPage;
-                        inPageOffset = 0;
-
-                        remainingBytesToRead -= (int)bytesInCurrentPage;
-                    } while (remainingBytesToRead > 0);
-
-                    // If we get here we completed the read across multiple pages, so report we read all that was required
-                    bytesRead = byteCount;
-                }
-            }
-            finally
-            {
-                bool sawOriginalLockInLockCollection = false;
-                foreach (var (Lock, IsHeldAsUpgradeableReadLock) in acquiredLocks)
-                {
-                    if (Lock == targetLock)
-                        sawOriginalLockInLockCollection = true;
-
-                    if (IsHeldAsUpgradeableReadLock)
-                        Lock.ExitUpgradeableReadLock();
-                    else
-                        Lock.ExitReadLock();
-                }
-
-                // Exit our originally acquire read lock if, in the process of mapping in cache pages, we didn't have to upgrade it to an upgradeable read lock (in which
-                // case it would have been released by the loop above).
-                if (!sawOriginalLockInLockCollection)
-                    targetLock.ExitReadLock();
-            }
-        }
-
-        public override bool GetDataFromAddressUntil(ulong address, byte[] terminatingSequence, out byte[] result)
-        {
-            uint offset = (uint)(address - _segmentData.VirtualAddress);
-
-            uint pageAlignedOffset = AlignOffsetToPageBoundary(offset);
-            int dataIndex = (int)(pageAlignedOffset / VirtualAllocPageSize);
-
-            List<ReaderWriterLockSlim> locallyAcquiredLocks = new List<ReaderWriterLockSlim>
-            {
-                _pageLocks[dataIndex]
-            };
-
-            locallyAcquiredLocks[0].EnterReadLock();
-
-            List<(ReaderWriterLockSlim Lock, bool IsHeldAsUpgradeableReadLock)> acquiredLocks = EnsurePageAtOffset(offset, locallyAcquiredLocks[0]);
-
-            uint pageAdjustedOffset = MapOffsetToPageOffset(offset);
-
-            List<byte> res = new List<byte>();
-
-            try
-            {
-                CachePage curPage = _pages[dataIndex];
-                UIntPtr curPageData = _pages[dataIndex].Data;
-                while (true)
-                {
-                    for (uint i = pageAdjustedOffset; i < curPage.DataExtent;)
-                    {
-                        bool wasTerminatorMatch = true;
-                        for (int j = 0; j < terminatingSequence.Length; j++)
-                        {
-                            unsafe
-                            {
-                                if (*(((byte*)(curPageData.ToPointer()) + (i + j))) != terminatingSequence[j])
-                                {
-                                    wasTerminatorMatch = false;
-                                    break;
-                                }
-                            }
-                        }
-
-                        // We found our terminating sequence, so don't copy it over to the output array
-                        if (wasTerminatorMatch)
-                        {
-                            result = res.ToArray();
-                            return true;
-                        }
-
-                        // copy over the non-matching bytes
-                        for (int j = 0; j < terminatingSequence.Length; j++)
-                        {
-                            unsafe
-                            {
-                                res.Add(*((byte*)(curPageData.ToPointer()) + (i + j)));
-                            }
-                        }
-
-                        i += (uint)terminatingSequence.Length;
-                    }
-
-                    // Ran out of data in this segment before we found the end of the sequence
-                    if ((dataIndex + 1) == _pages.Length)
-                    {
-                        result = res.ToArray();
-                        return false;
-                    }
-
-                    // no offsets when we jump to the next page of data
-                    pageAdjustedOffset = 0;
-
-                    offset += curPage.DataExtent;
-
-                    locallyAcquiredLocks.Add(_pageLocks[dataIndex + 1]);
-                    locallyAcquiredLocks[locallyAcquiredLocks.Count - 1].EnterReadLock();
-
-                    acquiredLocks.AddRange(EnsurePageAtOffset(offset, locallyAcquiredLocks[locallyAcquiredLocks.Count - 1]));
-
-                    curPage = _pages[++dataIndex];
-                    if (curPage == null)
-                    {
-                        throw new InvalidOperationException($"CachePage at index {dataIndex} was null. EnsurePageAtOffset didn't work.");
-                    }
-
-                    curPageData = curPage.Data;
-                }
-            }
-            finally
-            {
-                foreach (var (Lock, IsHeldAsUpgradeableReadLock) in acquiredLocks)
-                {
-                    locallyAcquiredLocks.Remove(Lock);
-
-                    if (IsHeldAsUpgradeableReadLock)
-                        Lock.ExitUpgradeableReadLock();
-                    else
-                        Lock.ExitReadLock();
-                }
-
-                foreach (ReaderWriterLockSlim remainingLock in locallyAcquiredLocks)
-                    remainingLock.ExitReadLock();
-            }
-        }
+        protected override uint EntryPageSize => AWEBasedCacheEntry.VirtualAllocPageSize;
 
         public override long PageOutData()
         {
+            ThrowIfDisposed();
+
             if (HeapSegmentCacheEventSource.Instance.IsEnabled())
                 HeapSegmentCacheEventSource.Instance.PageOutDataStart();
 
             long sizeRemoved = 0;
 
-            int maxLoopCount = 10;
+            int maxLoopCount = 5;
             int pass = 0;
             for (; pass < maxLoopCount; pass++)
             {
@@ -285,17 +67,20 @@ namespace Microsoft.Diagnostics.Runtime.Windows
                     {
                         // Someone holds the writelock on this page, skip it and try to get it in another pass, this prevent us from blocking page out
                         // on someone currently reading a page, they will likely be done by our next pass
+
                         encounteredBusyPage = true;
                         continue;
                     }
 
                     try
                     {
-                        CachePage page = _pages[i];
+                        CachePage<UIntPtr> page = _pages[i];
                         if (page != null)
                         {
+                            uint pagesToUnMap = (uint)(page.DataExtent / SystemPageSize) + (uint)((page.DataExtent % SystemPageSize) != 0 ? 1 : 0);
+
                             // We need to unmap the physical memory from this VM range and then free the VM range
-                            bool unmapPhysicalPagesResult = CacheNativeMethods.AWE.MapUserPhysicalPages(page.Data, numberOfPages: (uint)(VirtualAllocPageSize / SystemPageSize), pageArray: UIntPtr.Zero);
+                            bool unmapPhysicalPagesResult = CacheNativeMethods.AWE.MapUserPhysicalPages(page.Data, pagesToUnMap, pageArray: UIntPtr.Zero);
                             if (!unmapPhysicalPagesResult)
                             {
                                 Debug.Fail("MapUserPhysicalPage failed to unmap a phsyical page");
@@ -303,6 +88,8 @@ namespace Microsoft.Diagnostics.Runtime.Windows
                                 // this is an error but we don't want to remove the ptr entry since we apparently didn't unmap the physical memory
                                 continue;
                             }
+
+                            sizeRemoved += page.DataExtent;
 
                             bool virtualFreeRes = CacheNativeMethods.Memory.VirtualFree(page.Data, sizeToFree: UIntPtr.Zero, CacheNativeMethods.Memory.VirtualFreeType.Release);
                             if (!virtualFreeRes)
@@ -315,8 +102,6 @@ namespace Microsoft.Diagnostics.Runtime.Windows
                                 continue;
                             }
 
-                            sizeRemoved += page.DataExtent;
-
                             // Done, throw away our VM pointer
                             _pages[i] = null;
                         }
@@ -327,7 +112,7 @@ namespace Microsoft.Diagnostics.Runtime.Windows
                     }
                 }
 
-                // We are done if we didn't encounter any busy pages during our attempt
+                // We are done if we didn't encounter any busy (locked) pages
                 if (!encounteredBusyPage)
                     break;
             }
@@ -339,9 +124,7 @@ namespace Microsoft.Diagnostics.Runtime.Windows
             {
                 oldCurrent = _entrySize;
                 newCurrent = Math.Max(MinSize, oldCurrent - (int)sizeRemoved);
-            }
-            while (Interlocked.CompareExchange(ref _entrySize, newCurrent, oldCurrent) != oldCurrent);
-
+            } while (Interlocked.CompareExchange(ref _entrySize, newCurrent, oldCurrent) != oldCurrent);
 
             if (HeapSegmentCacheEventSource.Instance.IsEnabled())
                 HeapSegmentCacheEventSource.Instance.PageOutDataEnd(sizeRemoved);
@@ -349,212 +132,53 @@ namespace Microsoft.Diagnostics.Runtime.Windows
             return sizeRemoved;
         }
 
-        public override void UpdateLastAccessTickCount()
+        protected override void InvokeCallbackWithDataPtr(CachePage<UIntPtr> page, Action<UIntPtr, uint> callback)
         {
-            long originalTickCountValue = Interlocked.Read(ref _lastAccessTickCount);
-
-            while (true)
-            {
-                CacheNativeMethods.Util.QueryPerformanceCounter(out long currentTickCount);
-                if (Interlocked.CompareExchange(ref _lastAccessTickCount, currentTickCount, originalTickCountValue) == originalTickCountValue)
-                {
-                    break;
-                }
-
-                originalTickCountValue = Interlocked.Read(ref _lastAccessTickCount);
-            }
+            callback(page.Data, page.DataExtent);
         }
 
-        private static uint AlignOffsetToPageBoundary(uint offset)
+        protected override (UIntPtr Data, uint DataExtent) GetPageDataAtOffset(uint pageAlignedOffset)
         {
-            if ((offset % VirtualAllocPageSize) != 0)
-                return offset - offset % VirtualAllocPageSize;
+            // NOTE: The caller ensures this method is not called concurrently
 
-            return offset;
-        }
-
-        private static uint MapOffsetToPageOffset(uint offset)
-        {
-            uint pageAlignedOffset = AlignOffsetToPageBoundary(offset);
-            int pageIndex = (int)(pageAlignedOffset / VirtualAllocPageSize);
-            return offset - ((uint)pageIndex * VirtualAllocPageSize);
-        }
-
-        private List<(ReaderWriterLockSlim Lock, bool IsHeldAsUpgradeableReadLock)> EnsurePageAtOffset(uint offset, ReaderWriterLockSlim acquiredReadLock)
-        {
-            return EnsurePageRangeAtOffset(offset, acquiredReadLock, VirtualAllocPageSize);
-        }
-
-        private List<(ReaderWriterLockSlim Lock, bool IsHeldAsUpgradeableReadLock)> EnsurePageRangeAtOffset(uint offset, ReaderWriterLockSlim originalReadLock, uint bytesNeeded)
-        {
-            List<(ReaderWriterLockSlim Lock, bool IsHeldAsUpgradeableReadLock)> acquiredLocks = new List<(ReaderWriterLockSlim Lock, bool IsHeldAsUpgradeableReadLock)>();
-
-            uint pageAlignedOffset = AlignOffsetToPageBoundary(offset);
-
-            int dataIndex = (int)(pageAlignedOffset / VirtualAllocPageSize);
-
-            if (_pages[dataIndex] == null)
-            {
-                // THREADING: Our contract is the caller must have acquired the read lock at least for this first page, this is because the caller needs
-                // to ensure the page cannot be evicted even after we return (presumably they want to read data from it). However, before we page in a
-                // currently null page, we have to acquire the write lock. So we acquire an upgradeable read lock on this index, and then double check if
-                // the page entry hasn't been set by someone who beat us to the write lock. We will also return this upgraded lock in the collection of
-                // upgraded locks we have acquired so the caller can release it when they are done reading the page(s)
-                originalReadLock.ExitReadLock();
-                originalReadLock.EnterUpgradeableReadLock();
-                originalReadLock.EnterWriteLock();
-
-                try
-                {
-                    if (_pages[dataIndex] == null)
-                    {
-                        UIntPtr pData = GetPageAtOffset(pageAlignedOffset, out uint dataRange);
-
-                        _pages[dataIndex] = new CachePage(pData, dataRange);
-                    }
-                }
-                catch (Exception)
-                {
-                    // THREADING: If we see an exception here we are going to rethrow, which means or caller won't be able to release the upgraded read lock, so do it here
-                    // as to not leave this page permanently locked out
-                    originalReadLock.ExitWriteLock();
-                    originalReadLock.ExitUpgradeableReadLock();
-                    throw;
-                }
-
-                // THREADING: Note the read lock held by our call to EnterUpgradeableReadLock is still in effect, so we need to return this lock as one that the
-                // caller must release when they are done
-                acquiredLocks.Add((originalReadLock, IsHeldAsUpgradeableReadLock: true));
-
-                // THREADING: Exit our write lock as we are done writing the entry
-                originalReadLock.ExitWriteLock();
-            }
-
-            // THREADING: We still either hold the original read lock or our upgraded readlock (if we set the cache page entry above), either way we know
-            // that the entry at dataIndex is non-null
-            uint bytesAvailableOnPage = _pages[dataIndex].DataExtent - (offset - pageAlignedOffset);
-            if (bytesAvailableOnPage < bytesNeeded)
-            {
-                // if bytesAvailableOnPage < bytesNeeded it means the read will cover multiple cache pages, so we need to also fault in any following cache 
-                // pages
-                int bytesRemaining = (int)bytesNeeded - (int)bytesAvailableOnPage;
-                do
-                {
-                    // Out of data for this memory segment, it may be the case that the read crosses between memory segments, so return any info on any
-                    // upgraded locks we have acquired thus far
-                    if ((dataIndex + 1) == _pages.Length)
-                    {
-                        return acquiredLocks;
-                    }
-
-                    pageAlignedOffset += VirtualAllocPageSize;
-
-                    // Take a read lock on the next page entry
-                    originalReadLock = _pageLocks[dataIndex + 1];
-                    originalReadLock.EnterReadLock();
-
-                    if (_pages[dataIndex + 1] != null)
-                    {
-                        bytesRemaining -= (int)_pages[++dataIndex].DataExtent;
-
-                        acquiredLocks.Add((originalReadLock, IsHeldAsUpgradeableReadLock: false));
-                        continue;
-                    }
-
-                    // THREADING: We know the entry must have been null or we would have continued above, so go ahead and enter as an upgradeable lock and
-                    // acquire the write lock
-                    originalReadLock.ExitReadLock();
-                    originalReadLock.EnterUpgradeableReadLock();
-                    originalReadLock.EnterWriteLock();
-
-                    if (_pages[dataIndex + 1] == null)
-                    {
-                        // Still not set, so we will set it now
-
-                        try
-                        {
-                            UIntPtr pData = GetPageAtOffset(pageAlignedOffset, out uint dataRange);
-
-                            _pages[++dataIndex] = new CachePage(pData, dataRange);
-
-                            bytesRemaining -= (int)dataRange;
-                        }
-                        catch (Exception)
-                        {
-                            // THREADING: If we see an exception here we are going to rethrow, which means or caller won't be able to release the upgraded read lock, so do it here
-                            // as to not leave this page permanently locked out
-                            originalReadLock.ExitWriteLock();
-                            originalReadLock.ExitUpgradeableReadLock();
-
-                            // Drop any read locks we have taken up to this point as our caller won't be able to do that since we are re-throwing
-                            foreach ((ReaderWriterLockSlim Lock, bool IsHeldAsUpgradeableReadLock) in acquiredLocks)
-                            {
-                                if (IsHeldAsUpgradeableReadLock)
-                                    Lock.ExitUpgradeableReadLock();
-                                else
-                                    Lock.ExitReadLock();
-                            }
-
-                            throw;
-                        }
-                    }
-                    else // someone else beat us to filling this page in, extract the data we need
-                    {
-                        bytesRemaining -= (int)_pages[++dataIndex].DataExtent;
-                    }
-
-                    // THREADING: Exit our write lock as we either wrote the entry or someone else did, but keep our read lock so the page can't be
-                    // evicted before the caller can read it
-                    originalReadLock.ExitWriteLock();
-                    acquiredLocks.Add((originalReadLock, IsHeldAsUpgradeableReadLock: true));
-                } while (bytesRemaining > 0);
-            }
-
-            return acquiredLocks;
-        }
-
-        private UIntPtr GetPageAtOffset(uint offset, out uint dataExtent)
-        {
             uint readSize;
-            if ((offset + VirtualAllocPageSize) <= (int)_segmentData.Size)
+            if ((pageAlignedOffset + EntryPageSize) <= (int)_segmentData.Size)
             {
-                readSize = VirtualAllocPageSize;
+                readSize = EntryPageSize;
             }
             else
             {
-                readSize = (uint)_segmentData.Size - offset;
+                readSize = (uint)_segmentData.Size - pageAlignedOffset;
             }
 
             if (HeapSegmentCacheEventSource.Instance.IsEnabled())
-                HeapSegmentCacheEventSource.Instance.PageInDataStart((long)(_segmentData.VirtualAddress + offset), readSize);
+                HeapSegmentCacheEventSource.Instance.PageInDataStart((long)(_segmentData.VirtualAddress + pageAlignedOffset), readSize);
 
-            dataExtent = readSize;
-
-            int memoryPageNumber = (int)(offset / SystemPageSize);
+            int startingMemoryPageNumber = (int)(pageAlignedOffset / AWEBasedCacheEntry.SystemPageSize);
 
             try
             {
-                // Allocate a VM range to map the physical memory into
-                UIntPtr vmPtr = CacheNativeMethods.Memory.VirtualAlloc(VirtualAllocPageSize, CacheNativeMethods.Memory.VirtualAllocType.Reserve | CacheNativeMethods.Memory.VirtualAllocType.Physical, CacheNativeMethods.Memory.MemoryProtection.ReadWrite);
+                // Allocate a VM range to map the physical memory into.
+                //
+                // NOTE: VirtualAlloc ALWAYS rounds allocation requests to the VirtualAllocPageSize, which is 64k. If you ask it for less the allocation will succeed but it will have
+                // reserved 64k of memory, making that memory unsuable for anyone else. If you do this a lot (say across an entire dump heap) you easily fragment memory to the point
+                // of seeing sporadic allocation failures due to not being able to find enough contiguous memory. VMMAP (from SysInternals) is good for showing this kind of 
+                // fragmentation, it marks the excess space as 'Unusable Space'
+                UIntPtr vmPtr = CacheNativeMethods.Memory.VirtualAlloc((uint)EntryPageSize, CacheNativeMethods.Memory.VirtualAllocType.Reserve | CacheNativeMethods.Memory.VirtualAllocType.Physical, CacheNativeMethods.Memory.MemoryProtection.ReadWrite);
                 if (vmPtr == UIntPtr.Zero)
                     throw new Win32Exception(Marshal.GetLastWin32Error());
 
-                // Map pages of our physical memory into the VM space, we have to adjust the pageFrameArray pointer as MapUserPhysicalPages only takes a page count and a page frame array starting point
-                uint numberOfPages = readSize / (uint)Environment.SystemPageSize + (((readSize % Environment.SystemPageSize) == 0) ? 0u : 1u);
-                bool mapPhysicalPagesResult = CacheNativeMethods.AWE.MapUserPhysicalPages(vmPtr, numberOfPages: numberOfPages, _pageFrameArray + (memoryPageNumber * UIntPtr.Size));
+                uint numberOfPages = readSize / (uint)AWEBasedCacheEntry.SystemPageSize + (((readSize % AWEBasedCacheEntry.SystemPageSize) == 0) ? 0u : 1u);
+
+                // Map one VirtualAlloc sized page of our physical memory into the VM space, we have to adjust the pageFrameArray pointer as MapUserPhysicalPages only takes a page count and a page frame array starting point
+                bool mapPhysicalPagesResult = CacheNativeMethods.AWE.MapUserPhysicalPages(vmPtr, numberOfPages, _pageFrameArray + (startingMemoryPageNumber * UIntPtr.Size));
                 if (!mapPhysicalPagesResult)
                     throw new Win32Exception(Marshal.GetLastWin32Error());
-
-                UpdateLastAccessTickCount();
-                Interlocked.Add(ref _entrySize, (int)readSize);
-
-                // NOTE: We call back under lock, non-ideal but the callback should NOT be modifying this entry in any way
-                _updateOwningCacheForSizeChangeCallback(_segmentData.VirtualAddress, readSize);
 
                 if (HeapSegmentCacheEventSource.Instance.IsEnabled())
                     HeapSegmentCacheEventSource.Instance.PageInDataEnd((int)readSize);
 
-                return vmPtr;
+                return (vmPtr, readSize);
             }
             catch (Exception ex)
             {
@@ -565,100 +189,74 @@ namespace Microsoft.Diagnostics.Runtime.Windows
             }
         }
 
-        private bool IsSinglePageRead(uint offset, uint byteCount)
+        protected override void Dispose(bool disposing)
         {
-            uint alignedOffset = AlignOffsetToPageBoundary(offset);
-
-            int dataIndex = (int)(alignedOffset / VirtualAllocPageSize);
-
-            CachePage startingPage = _pages[dataIndex];
-            if (startingPage == null)
+            for (int i = 0; i < _pages.Length; i++)
             {
-                throw new InvalidOperationException($"Inside IsSinglePageRead but the page at index {dataIndex} is null. You need to call EnsurePageAtOffset or EnsurePageRangeAtOffset before calling this method.");
-            }
+                ReaderWriterLockSlim pageLock = _pageLocks[i];
+                pageLock.EnterWriteLock();
 
-            uint inPageOffset = MapOffsetToPageOffset(offset);
-
-            return (inPageOffset + byteCount) < startingPage.DataExtent;
-        }
-
-        public void Dispose()
-        {
-            if (_pages != null)
-            {
-                for (int i = 0; i < _pages.Length; i++)
+                try
                 {
-                    ReaderWriterLockSlim pageLock = _pageLocks[i];
-                    pageLock.EnterWriteLock();
-
-                    try
+                    CachePage<UIntPtr> page = _pages[i];
+                    if (page != null)
                     {
-                        CachePage page = _pages[i];
-                        if (page != null)
+                        // NOTE: While VirtualAllocPageSize SHOULD be a mulitple of SystemPageSize there is no guarantee I can find that says that is true always and everywhere
+                        // so to be safe I make sure we don't leave any straggling pages behind if that is true.
+                        uint numberOfPages = (uint)(page.DataExtent / SystemPageSize) + ((page.DataExtent % SystemPageSize) == 0 ? 0U : 1U);
+
+                        // We need to unmap the physical memory from this VM range and then free the VM range
+                        bool unmapPhysicalPagesResult = CacheNativeMethods.AWE.MapUserPhysicalPages(page.Data, numberOfPages, pageArray: UIntPtr.Zero);
+                        if (!unmapPhysicalPagesResult)
                         {
-                            // We need to unmap the physical memory from this VM range and then free the VM range
-                            bool unmapPhysicalPagesResult = CacheNativeMethods.AWE.MapUserPhysicalPages(page.Data, numberOfPages: (uint)(VirtualAllocPageSize / Environment.SystemPageSize), pageArray: UIntPtr.Zero);
-                            if (!unmapPhysicalPagesResult)
-                            {
-                                Debug.Fail("MapUserPhysicalPage failed to unmap a phsyical page");
+                            Debug.Fail("MapUserPhysicalPage failed to unmap a phsyical page");
 
-                                // this is an error but we don't want to remove the ptr entry since we apparently didn't unmap the physical memory
-                                continue;
-                            }
-
-                            bool virtualFreeRes = CacheNativeMethods.Memory.VirtualFree(page.Data, sizeToFree: UIntPtr.Zero, CacheNativeMethods.Memory.VirtualFreeType.Release);
-                            if (!virtualFreeRes)
-                            {
-                                Debug.Fail("MapUserPhysicalPage failed to unmap a phsyical page");
-
-                                // this is an error but we already unmapped the physical memory so also throw away our VM pointer
-                                _pages[i] = null;
-
-                                continue;
-                            }
-
-                            // Done, throw away our VM pointer
-                            _pages[i] = null;
+                            // this is an error but we don't want to remove the ptr entry since we apparently didn't unmap the physical memory
+                            continue;
                         }
+
+                        // NOTE: When calling with VirtualFreeTypeRelease sizeToFree must be 0 (which indicates the entire allocation)
+                        bool virtualFreeRes = CacheNativeMethods.Memory.VirtualFree(page.Data, sizeToFree: UIntPtr.Zero, CacheNativeMethods.Memory.VirtualFreeType.Release);
+                        if (!virtualFreeRes)
+                        {
+                            Debug.Fail("MapUserPhysicalPage failed to unmap a phsyical page");
+
+                            // this is an error but we already unmapped the physical memory so also throw away our VM pointer
+                            _pages[i] = null;
+
+                            continue;
+                        }
+
+                        // Done, throw away our VM pointer
+                        _pages[i] = null;
                     }
-                    finally
+                }
+                finally
+                {
+                    pageLock.ExitWriteLock();
+
+                    if (_pages[i] == null)
                     {
-                        pageLock.ExitWriteLock();
+                        pageLock.Dispose();
                     }
                 }
-
-
-                uint numberOfPagesToFree = (uint)_pageFrameArrayItemCount;
-                bool freeUserPhyiscalPagesRes = CacheNativeMethods.AWE.FreeUserPhysicalPages(ref numberOfPagesToFree, _pageFrameArray);
-                if (!freeUserPhyiscalPagesRes)
-                {
-                    Debug.Fail("Failed tp free our physical pages");
-                }
-
-                if (numberOfPagesToFree != _pageFrameArrayItemCount)
-                {
-                    Debug.Fail("Failed to free ALL of our physical pages");
-                }
-
-                // Free our page frame array
-                CacheNativeMethods.Memory.HeapFree(_pageFrameArray);
-                _pageFrameArray = UIntPtr.Zero;
-
-                _pages = null;
             }
-        }
 
-        [DebuggerDisplay("Size: {DataExtent}")]
-        internal sealed class CachePage
-        {
-            internal CachePage(UIntPtr data, uint dataExtent)
+            uint numberOfPagesToFree = (uint)_pageFrameArrayItemCount;
+            bool freeUserPhyiscalPagesRes = CacheNativeMethods.AWE.FreeUserPhysicalPages(ref numberOfPagesToFree, _pageFrameArray);
+            if (!freeUserPhyiscalPagesRes)
             {
-                Data = data;
-                DataExtent = dataExtent;
+                Debug.Fail("Failed to free our physical pages");
             }
 
-            public UIntPtr Data { get; }
-            public uint DataExtent { get; }
+            if (numberOfPagesToFree != _pageFrameArrayItemCount)
+            {
+                Debug.Fail("Failed to free ALL of our physical pages");
+            }
+
+            // Free our page frame array
+            CacheNativeMethods.Memory.HeapFree(_pageFrameArray);
+            _pageFrameArray = UIntPtr.Zero;
         }
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/src/Windows/AWEBasedCacheEntryFactory.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Windows/AWEBasedCacheEntryFactory.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Diagnostics.Runtime.Windows
             _sharedSegment = UIntPtr.Zero;
         }
 
-        public override SegmentCacheEntry CreateEntryForSegment(MinidumpSegment segmentData, Action<ulong, uint> updateOwningCacheForSizeChangeCallback)
+        public override SegmentCacheEntry CreateEntryForSegment(MinidumpSegment segmentData, Action<uint> updateOwningCacheForSizeChangeCallback)
         {
             bool setFPRes = CacheNativeMethods.File.SetFilePointerEx(_dumpFileHandle, (long)segmentData.FileOffset, SeekOrigin.Begin);
             if (!setFPRes)

--- a/src/Microsoft.Diagnostics.Runtime/src/Windows/ArrayPoolBasedCacheEntry.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Windows/ArrayPoolBasedCacheEntry.cs
@@ -4,555 +4,157 @@
 
 using System;
 using System.Buffers;
-using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO.MemoryMappedFiles;
 using System.Runtime.CompilerServices;
 using System.Threading;
-using System.Threading.Tasks;
 
 // TODO:  This code wasn't written to consider nullable.
 #nullable disable
 
 namespace Microsoft.Diagnostics.Runtime.Windows
 {
-    internal class ArrayPoolBasedCacheEntry : SegmentCacheEntry, IDisposable
+    /// <summary>
+    /// Represents heap segment cache entries backed by arrays from ArrayPool{byte}.Shared. This technology is less efficient than the <see cref="AWEBasedCacheEntry"/> but it has upsides
+    /// around not requiring special privileges and mapping in a more granular fashion (4k pages vs 64k pages).
+    /// </summary>
+
+    internal sealed class ArrayPoolBasedCacheEntry : CacheEntryBase<byte[]>
     {
-        private readonly static uint PageSize = (uint)Environment.SystemPageSize;
+        private static readonly uint SystemPageSize = (uint)Environment.SystemPageSize;
 
-        private readonly Action<ulong, uint> _updateOwningCacheForAddedChunk;
-        private readonly MemoryMappedFile _mappedFile;
-        private readonly MinidumpSegment _segmentData;
-        private readonly ReaderWriterLockSlim[] _dataChunkLocks;
-        private readonly CachePage[] _dataChunks;
-        private int _accessCount;
-        private long _lastAccessTickCount;
-        private volatile int _entrySize;
+        private MemoryMappedFile _mappedFile;
 
-        internal ArrayPoolBasedCacheEntry(MemoryMappedFile mappedFile, MinidumpSegment segmentData, Action<ulong, uint> updateOwningCacheForAddedChunk)
+        internal ArrayPoolBasedCacheEntry(MemoryMappedFile mappedFile, MinidumpSegment segmentData, Action<uint> updateOwningCacheForAddedChunk) : base(segmentData, derivedMinSize: 2 * IntPtr.Size, updateOwningCacheForAddedChunk)
         {
             _mappedFile = mappedFile;
-            _segmentData = segmentData;
-
-            int pageCount = (int)((segmentData.End - segmentData.VirtualAddress) / PageSize);
-            if (((int)(segmentData.End - segmentData.VirtualAddress) % PageSize) != 0)
-                pageCount++;
-
-            _dataChunks = new CachePage[pageCount];
-            _dataChunkLocks = new ReaderWriterLockSlim[pageCount];
-            for (int i = 0; i < _dataChunkLocks.Length; i++)
-                _dataChunkLocks[i] = new ReaderWriterLockSlim();
-
-            MinSize = (6 * UIntPtr.Size) + /*our six fields that are reference type fields (updateOwningCacheForAddedChunk, disposeQueue, mappedFile, segmentData, dataChunkLocks, dataChunks)*/
-                      (_dataChunks.Length * UIntPtr.Size) + /*The array of data chunks (each element being a pointer)*/
-                      (_dataChunkLocks.Length * UIntPtr.Size) + /*The array of locks for our data chunks*/
-                      sizeof(int) + /*accessCount field*/
-                      sizeof(uint) + /*entrySize field*/
-                      sizeof(long) /*lastAccessTickCount field*/;
-
-            _entrySize = MinSize;
-
-            _updateOwningCacheForAddedChunk = updateOwningCacheForAddedChunk;
-
-            IncrementAccessCount();
-            UpdateLastAccessTickCount();
-        }
-
-        public override int AccessCount => _accessCount;
-
-        public override void IncrementAccessCount()
-        {
-            Interlocked.Increment(ref _accessCount);
-        }
-
-        public override long LastAccessTickCount => Interlocked.Read(ref _lastAccessTickCount);
-
-        public override int CurrentSize => _entrySize;
-
-        public override void GetDataForAddress(ulong address, uint byteCount, IntPtr buffer, out uint bytesRead)
-        {
-            uint offset = (uint)(address - _segmentData.VirtualAddress);
-
-            uint pageAlignedOffset = AlignOffsetToPageBoundary(offset);
-            int dataIndex = (int)(pageAlignedOffset / PageSize);
-
-            ReaderWriterLockSlim targetLock = _dataChunkLocks[dataIndex];
-
-            // THREADING: Once we have acquired the read lock we need to hold it, in some fashion, through the entirity of this method, that prevents the cache eviction code from
-            // evicting this entry while we are using it.
-            targetLock.EnterReadLock();
-
-            List<(ReaderWriterLockSlim Lock, bool IsHeldAsUpgradeableReadLock)> acquiredLocks = EnsurePageRangeAtOffset(offset, targetLock, byteCount);
-
-            try
-            {
-                if (IsSinglePageRead(offset, byteCount))
-                {
-                    uint inPageOffset = MapOffsetToPageOffset(offset);
-
-                    byte[] targetData = _dataChunks[dataIndex].Data;
-                    unsafe
-                    {
-                        fixed (byte* pSource = &targetData[inPageOffset])
-                        {
-                            CacheNativeMethods.Memory.memcpy(buffer, new UIntPtr(pSource), new UIntPtr(byteCount));
-                        }
-                    }
-
-                    bytesRead = byteCount;
-                    return;
-                }
-                else // This is a read that spans at least one page boundary.
-                {
-                    IntPtr pInsertionPoint = buffer;
-
-                    uint inPageOffset = MapOffsetToPageOffset(offset);
-
-                    int remainingBytesToRead = (int)byteCount;
-                    do
-                    {
-                        if (dataIndex == _dataChunks.Length)
-                        {
-                            // Out of data in this segment, report how many bytes we read
-                            bytesRead = byteCount - (uint)remainingBytesToRead;
-                            return;
-                        }
-
-                        uint bytesInCurrentPage = Math.Min((_dataChunks[dataIndex].DataExtent - inPageOffset), (uint)remainingBytesToRead);
-
-                        byte[] targetData = _dataChunks[dataIndex++].Data;
-
-                        unsafe
-                        {
-                            fixed (byte* pSource = &targetData[inPageOffset])
-                            {
-                                CacheNativeMethods.Memory.memcpy(pInsertionPoint, new UIntPtr(pSource), new UIntPtr(bytesInCurrentPage));
-                            }
-                        }
-
-                        pInsertionPoint += (int)bytesInCurrentPage;
-                        inPageOffset = 0;
-
-                        remainingBytesToRead -= (int)bytesInCurrentPage;
-                    } while (remainingBytesToRead > 0);
-
-                    // If we get here we completed the read across multiple pages, so report we read all that was required
-                    bytesRead = byteCount;
-                }
-            }
-            finally
-            {
-                bool sawOriginalLockInLockCollection = false;
-                foreach (var (Lock, IsHeldAsUpgradeableReadLock) in acquiredLocks)
-                {
-                    if (Lock == targetLock)
-                        sawOriginalLockInLockCollection = true;
-
-                    if (IsHeldAsUpgradeableReadLock)
-                        Lock.ExitUpgradeableReadLock();
-                    else
-                        Lock.ExitReadLock();
-                }
-
-                // Exit our originally acquire read lock if, in the process of mapping in cache pages, we didn't have to upgrade it to an upgradeable read lock (in which
-                // case it would have been released by the loop above).
-                if (!sawOriginalLockInLockCollection)
-                    targetLock.ExitReadLock();
-            }
-        }
-
-        public override bool GetDataFromAddressUntil(ulong address, byte[] terminatingSequence, out byte[] result)
-        {
-            uint offset = (uint)(address - _segmentData.VirtualAddress);
-
-            uint pageAlignedOffset = AlignOffsetToPageBoundary(offset);
-            int dataIndex = (int)(pageAlignedOffset / PageSize);
-
-            List<ReaderWriterLockSlim> locallyAcquiredLocks = new List<ReaderWriterLockSlim>
-            {
-                _dataChunkLocks[dataIndex]
-            };
-
-            locallyAcquiredLocks[0].EnterReadLock();
-
-            List<(ReaderWriterLockSlim Lock, bool IsHeldAsUpgradeableReadLock)> acquiredLocks = EnsurePageAtOffset(offset, locallyAcquiredLocks[0]);
-
-            uint pageAdjustedOffset = MapOffsetToPageOffset(offset);
-
-            List<byte> res = new List<byte>();
-
-            try
-            {
-                CachePage curPage = _dataChunks[dataIndex];
-                while (true)
-                {
-                    for (uint i = pageAdjustedOffset; i < curPage.DataExtent;)
-                    {
-                        bool wasTerminatorMatch = true;
-                        for (int j = 0; j < terminatingSequence.Length; j++)
-                        {
-                            if (curPage.Data[i + j] != terminatingSequence[j])
-                            {
-                                wasTerminatorMatch = false;
-                                break;
-                            }
-                        }
-
-                        // We found our terminating sequence, so don't copy it over to the output array
-                        if (wasTerminatorMatch)
-                        {
-                            result = res.ToArray();
-                            return true;
-                        }
-
-                        // copy over the non-matching bytes
-                        for (int j = 0; j < terminatingSequence.Length; j++)
-                        {
-                            res.Add(curPage.Data[i + j]);
-                        }
-
-                        i += (uint)terminatingSequence.Length;
-                    }
-
-                    // Ran out of data in this segment before we found the end of the sequence
-                    if ((dataIndex + 1) == _dataChunks.Length)
-                    {
-                        result = res.ToArray();
-                        return false;
-                    }
-
-                    // no offsets when we jump to the next page of data
-                    pageAdjustedOffset = 0;
-
-                    offset += curPage.DataExtent;
-
-                    locallyAcquiredLocks.Add(_dataChunkLocks[dataIndex + 1]);
-                    locallyAcquiredLocks[locallyAcquiredLocks.Count - 1].EnterReadLock();
-
-                    acquiredLocks.AddRange(EnsurePageAtOffset(offset, locallyAcquiredLocks[locallyAcquiredLocks.Count - 1]));
-
-                    curPage = _dataChunks[++dataIndex];
-                    if (curPage == null)
-                    {
-                        throw new InvalidOperationException($"Expected a CachePage to exist at {dataIndex} but it was null! EnsurePageAtOffset didn't work.");
-                    }
-                }
-            }
-            finally
-            {
-                foreach (var (Lock, IsHeldAsUpgradeableReadLock) in acquiredLocks)
-                {
-                    locallyAcquiredLocks.Remove(Lock);
-
-                    if (IsHeldAsUpgradeableReadLock)
-                        Lock.ExitUpgradeableReadLock();
-                    else
-                        Lock.ExitReadLock();
-                }
-
-                foreach (ReaderWriterLockSlim remainingLock in locallyAcquiredLocks)
-                    remainingLock.ExitReadLock();
-            }
         }
 
         public override long PageOutData()
         {
-            var data = TryRemoveAllPagesFromCache();
+            ThrowIfDisposed();
+
+            var data = TryRemoveAllPagesFromCache(disposeLocks: false);
 
             int oldCurrent;
             int newCurrent;
             do
             {
-                oldCurrent = _entrySize;
-                newCurrent = Math.Max((int)this.MinSize, oldCurrent - (int)data.DataRemoved);
+                oldCurrent = (int)_entrySize;
+                newCurrent = Math.Max((int)MinSize, oldCurrent - (int)data.DataRemoved);
             }
-            while(Interlocked.CompareExchange(ref _entrySize, newCurrent, oldCurrent) != oldCurrent);
+            while (Interlocked.CompareExchange(ref _entrySize, newCurrent, oldCurrent) != oldCurrent);
 
             return data.DataRemoved;
         }
 
-        public override void UpdateLastAccessTickCount()
+        protected override uint EntryPageSize => SystemPageSize;
+
+        protected override (byte[] Data, uint DataExtent) GetPageDataAtOffset(uint pageAlignedOffset)
         {
-            long originalTickCountValue = Interlocked.Read(ref _lastAccessTickCount);
+            // NOTE: The caller ensures this method is not called concurrently
 
-            while (true)
-            {
-                CacheNativeMethods.Util.QueryPerformanceCounter(out long currentTickCount);
-                if (Interlocked.CompareExchange(ref _lastAccessTickCount, currentTickCount, originalTickCountValue) == originalTickCountValue)
-                {
-                    break;
-                }
-
-                originalTickCountValue = Interlocked.Read(ref _lastAccessTickCount);
-            }
-        }
-
-        public void Dispose()
-        {
-            // TODO:  Need to figure out why we can't free all items.
-            for (int i = 0; i < 3; i++)
-            {
-                while (TryRemoveAllPagesFromCache().ItemsSkipped != 0)
-                {
-
-                }
-            }
-        }
-
-        private static uint MapOffsetToPageOffset(uint offset)
-        {
-            uint pageAlignedOffset = AlignOffsetToPageBoundary(offset);
-
-            int pageIndex = (int)(pageAlignedOffset / PageSize);
-
-            return offset - ((uint)pageIndex * PageSize);
-        }
-
-        private static uint AlignOffsetToPageBoundary(uint offset)
-        {
-            if ((offset % PageSize) != 0)
-                return offset - offset % PageSize;
-
-            return offset;
-        }
-
-        private List<(ReaderWriterLockSlim Lock, bool IsHeldAsUpgradeableReadLock)> EnsurePageAtOffset(uint offset, ReaderWriterLockSlim originalReadLock)
-        {
-            return EnsurePageRangeAtOffset(offset, originalReadLock, PageSize);
-        }
-
-        private List<(ReaderWriterLockSlim Lock, bool IsHeldAsUpgradeableReadLock)> EnsurePageRangeAtOffset(uint offset, ReaderWriterLockSlim originalReadLock, uint bytesNeeded)
-        {
-            List<(ReaderWriterLockSlim Lock, bool IsHeldAsUpgradeableReadLock)> acquiredLocks = new List<(ReaderWriterLockSlim Lock, bool IsHeldAsUpgradeableReadLock)>();
-
-            uint pageAlignedOffset = AlignOffsetToPageBoundary(offset);
-
-            int dataIndex = (int)(pageAlignedOffset / PageSize);
-
-            if (_dataChunks[dataIndex] is null)
-            {
-                // THREADING: Our contract is the caller must have acquired the read lock at least for this first page, this is because the caller needs
-                // to ensure the page cannot be evicted even after we return (presumably they want to read data from it). However, before we page in a
-                // currently null page, we have to acquire the write lock. So we acquire an upgradeable read lock on this index, and then double check if
-                // the page entry hasn't been set by someone who beat us to the write lock. We will also return this upgraded lock in the collection of
-                // upgraded locks we have acquired so the caller can release it when they are done reading the page(s)
-                originalReadLock.ExitReadLock();
-                originalReadLock.EnterUpgradeableReadLock();
-                originalReadLock.EnterWriteLock();
-                try
-                {
-                    if (_dataChunks[dataIndex] is null)
-                    {
-                        byte[] data = GetPageAtOffset(pageAlignedOffset, out uint dataRange);
-                        _dataChunks[dataIndex] = new CachePage(data, dataRange);
-
-                        UpdateLastAccessTickCount();
-                        Interlocked.Add(ref _entrySize, (int)dataRange);
-
-                        _updateOwningCacheForAddedChunk(_segmentData.VirtualAddress, dataRange);
-                    }
-                }
-                catch (Exception)
-                {
-                    // THREADING: If we see an exception here we are going to rethrow, which means or caller won't be able to release the upgraded read lock, so do it here
-                    // as to not leave this page permanently locked out
-                    originalReadLock.ExitWriteLock();
-                    originalReadLock.ExitUpgradeableReadLock();
-                    throw;
-                }
-
-                // THREADING: Note the read lock held by our call to EnterUpgradeableReadLock is still in effect, so we need to return this lock as one that the
-                // caller must release when they are done
-                acquiredLocks.Add((originalReadLock, IsHeldAsUpgradeableReadLock: true));
-
-                // THREADING: Exit our write lock as we are done writing the entry
-                originalReadLock.ExitWriteLock();
-            }
-
-            // THREADING: We still either hold the original read lock or our upgraded readlock (if we set the cache page entry above), either way we know
-            // that the entry at dataIndex is non-null
-            uint bytesAvailableOnPage = _dataChunks[dataIndex].DataExtent - (offset - pageAlignedOffset);
-            if (bytesAvailableOnPage < bytesNeeded)
-            {
-                int bytesRemaining = (int)bytesNeeded - (int)bytesAvailableOnPage;
-                do
-                {
-                    // Out of data for this memory segment, it may be the case that the read crosses between memory segments
-                    if ((dataIndex + 1) == _dataChunks.Length)
-                    {
-                        return acquiredLocks;
-                    }
-
-                    pageAlignedOffset += PageSize;
-
-                    // Take a read lock on the next page entry
-                    originalReadLock = _dataChunkLocks[dataIndex + 1];
-                    originalReadLock.EnterReadLock();
-
-                    if (_dataChunks[dataIndex + 1] != null)
-                    {
-                        bytesRemaining -= (int)_dataChunks[++dataIndex].DataExtent;
-
-                        acquiredLocks.Add((originalReadLock, IsHeldAsUpgradeableReadLock: false));
-                        continue;
-                    }
-
-                    // THREADING: We know the entry must have been null or we would have continued above, so go ahead and enter as an upgradeable lock and
-                    // acquire the write lock
-                    originalReadLock.ExitReadLock();
-                    originalReadLock.EnterUpgradeableReadLock();
-                    originalReadLock.EnterWriteLock();
-
-                    if (_dataChunks[dataIndex + 1] == null)
-                    {
-                        // Still not set, so we will set it now
-                        try
-                        {
-                            byte[] data = GetPageAtOffset(pageAlignedOffset, out uint dataRange);
-
-                            _dataChunks[++dataIndex] = new CachePage(data, dataRange);
-
-                            UpdateLastAccessTickCount();
-                            Interlocked.Add(ref _entrySize, (int)dataRange);
-
-                            _updateOwningCacheForAddedChunk(_segmentData.VirtualAddress, dataRange);
-
-                            bytesRemaining -= (int)dataRange;
-                        }
-                        catch (Exception)
-                        {
-                            // THREADING: If we see an exception here we are going to rethrow, which means or caller won't be able to release the upgraded read lock, so do it here
-                            // as to not leave this page permanently locked out
-                            originalReadLock.ExitWriteLock();
-                            originalReadLock.ExitUpgradeableReadLock();
-
-                            // Drop any read locks we have taken up to this point as our caller won't be able to do that since we are re-throwing
-                            foreach (var (Lock, IsHeldAsUpgradeableReadLock) in acquiredLocks)
-                            {
-                                if (IsHeldAsUpgradeableReadLock)
-                                    Lock.ExitUpgradeableReadLock();
-                                else
-                                    Lock.ExitReadLock();
-                            }
-
-                            throw;
-                        }
-                    }
-                    else // someone else beat us to filling this page in, extract the data we need
-                    {
-                        bytesRemaining -= (int)_dataChunks[++dataIndex].DataExtent;
-                    }
-
-                    // THREADING: Exit our write lock as we either wrote the entry or someone else did, but keep our read lock so the page can't be
-                    // evicted before the caller can read it
-                    originalReadLock.ExitWriteLock();
-                    acquiredLocks.Add((originalReadLock, IsHeldAsUpgradeableReadLock: true));
-                } while (bytesRemaining > 0);
-            }
-
-            return acquiredLocks;
-        }
-
-        private byte[] GetPageAtOffset(uint offset, out uint dataExtent)
-        {
             if (HeapSegmentCacheEventSource.Instance.IsEnabled())
-                HeapSegmentCacheEventSource.Instance.PageInDataStart((long)(_segmentData.VirtualAddress + offset), PageSize);
+                HeapSegmentCacheEventSource.Instance.PageInDataStart((long)(_segmentData.VirtualAddress + pageAlignedOffset), EntryPageSize);
 
             uint readSize;
-            if ((offset + PageSize) <= (int)_segmentData.Size)
+            if ((pageAlignedOffset + EntryPageSize) <= (int)_segmentData.Size)
             {
-                readSize = PageSize;
+                readSize = EntryPageSize;
             }
             else
             {
-                readSize = (uint)_segmentData.Size - offset;
+                readSize = (uint)_segmentData.Size - pageAlignedOffset;
             }
-
-            dataExtent = readSize;
 
             bool pageInFailed = false;
-            using MemoryMappedViewAccessor view = _mappedFile.CreateViewAccessor((long)_segmentData.FileOffset + offset, size: readSize, MemoryMappedFileAccess.Read);
-            try
+            using (MemoryMappedViewAccessor view = _mappedFile.CreateViewAccessor((long)_segmentData.FileOffset + pageAlignedOffset, size: (long)readSize, MemoryMappedFileAccess.Read))
             {
-                ulong viewOffset = (ulong)view.PointerOffset;
-
-                unsafe
+                try
                 {
-                    byte* pViewLoc = null;
-                    RuntimeHelpers.PrepareConstrainedRegions();
-                    try
+                    ulong viewOffset = (ulong)view.PointerOffset;
+
+                    unsafe
                     {
-                        view.SafeMemoryMappedViewHandle.AcquirePointer(ref pViewLoc);
-                        if (pViewLoc == null)
-                            throw new InvalidOperationException("Failed to acquire the underlying memory mapped view pointer. This is unexpected");
-
-                        pViewLoc += viewOffset;
-
-                        // Grab a shared buffer to use if there is one, or create one for the pool
-                        byte[] data = ArrayPool<byte>.Shared.Rent((int)readSize);
-
-                        // NOTE: This looks sightly ridiculous but view.ReadArray<T> is TERRIBLE for primitive types like byte, it calls Marshal.PtrToStructure for EVERY item in the 
-                        // array, the overhead of that call SWAMPS all access costs to the memory, and it is called N times (where N here is 4k), whereas memcpy just blasts the bits
-                        // from one location to the other, it is literally a couple of orders of magnitude faster.
-                        fixed (byte* pData = data)
+                        byte* pViewLoc = null;
+                        RuntimeHelpers.PrepareConstrainedRegions();
+                        try
                         {
-                            CacheNativeMethods.Memory.memcpy(new UIntPtr(pData), new UIntPtr(pViewLoc), new UIntPtr(readSize));
-                        }
+                            view.SafeMemoryMappedViewHandle.AcquirePointer(ref pViewLoc);
+                            if (pViewLoc == null)
+                                throw new InvalidOperationException("Failed to acquire the underlying memory mapped view pointer. This is unexpected");
 
-                        return data;
-                    }
-                    finally
-                    {
-                        if (pViewLoc != null)
-                            view.SafeMemoryMappedViewHandle.ReleasePointer();
+                            pViewLoc += viewOffset;
+
+                            // Grab a shared buffer to use if there is one, or create one for the pool
+                            byte[] data = ArrayPool<byte>.Shared.Rent((int)readSize);
+
+                            // NOTE: This looks sightly ridiculous but view.ReadArray<T> is TERRIBLE for primitive types like byte, it calls Marshal.PtrToStructure for EVERY item in the 
+                            // array, the overhead of that call SWAMPS all access costs to the memory, and it is called N times (where N here is 4k), whereas memcpy just blasts the bits
+                            // from one location to the other, it is literally a couple of orders of magnitude faster.
+                            fixed (byte* pData = data)
+                            {
+                                CacheNativeMethods.Memory.memcpy(new UIntPtr(pData), new UIntPtr(pViewLoc), new UIntPtr(readSize));
+                            }
+
+                            return (data, readSize);
+                        }
+                        finally
+                        {
+                            if (pViewLoc != null)
+                                view.SafeMemoryMappedViewHandle.ReleasePointer();
+                        }
                     }
                 }
-            }
-            catch (Exception ex)
-            {
-                if (HeapSegmentCacheEventSource.Instance.IsEnabled())
-                    HeapSegmentCacheEventSource.Instance.PageInDataFailed(ex.Message);
+                catch (Exception ex)
+                {
+                    if (HeapSegmentCacheEventSource.Instance.IsEnabled())
+                        HeapSegmentCacheEventSource.Instance.PageInDataFailed(ex.Message);
 
-                pageInFailed = true;
-                throw;
-            }
-            finally
-            {
-                if (!pageInFailed && HeapSegmentCacheEventSource.Instance.IsEnabled())
-                    HeapSegmentCacheEventSource.Instance.PageInDataEnd((int)readSize);
+                    pageInFailed = true;
+                    throw;
+                }
+                finally
+                {
+                    if (!pageInFailed && HeapSegmentCacheEventSource.Instance.IsEnabled())
+                        HeapSegmentCacheEventSource.Instance.PageInDataEnd((int)readSize);
+                }
             }
         }
 
-        private bool IsSinglePageRead(uint offset, uint byteCount)
+        protected unsafe override void InvokeCallbackWithDataPtr(CachePage<byte[]> page, Action<UIntPtr, uint> callback)
         {
-            // It is a simple read if the data lies entirely within a single page
-            uint alignedOffset = AlignOffsetToPageBoundary(offset);
-
-            int dataIndex = (int)(alignedOffset / PageSize);
-
-            CachePage startingPage = _dataChunks[dataIndex];
-            if (startingPage is null)
-                throw new InvalidOperationException($"Inside IsSinglePageRead but the page at index {dataIndex} is null. You need to call EnsurePageAtOffset or EnsurePageRangeAtOffset before calling this method.");
-
-            uint inPageOffset = MapOffsetToPageOffset(offset);
-            return (inPageOffset + byteCount) < startingPage.DataExtent;
+            fixed (byte* pBuffer = page.Data)
+            {
+                callback(new UIntPtr(pBuffer), page.DataExtent);
+            }
         }
 
-        private (uint DataRemoved, uint ItemsSkipped) TryRemoveAllPagesFromCache()
+        protected override void Dispose(bool disposing)
+        {
+            for (int i = 0; i < 3; i++)
+            {
+                if (TryRemoveAllPagesFromCache(disposeLocks: true).ItemsSkipped == 0)
+                {
+                    break;
+                }
+            }
+        }
+
+        private (uint DataRemoved, uint ItemsSkipped) TryRemoveAllPagesFromCache(bool disposeLocks)
         {
             // Assume we will be able to evict all non-null pages
             uint dataRemoved = 0;
             uint itemsSkipped = 0;
 
-            for (int i = 0; i < _dataChunks.Length; i++)
+            for (int i = 0; i < _pages.Length; i++)
             {
-                CachePage page = _dataChunks[i];
+                CachePage<byte[]> page = _pages[i];
                 if (page != null)
                 {
-                    ReaderWriterLockSlim dataChunkLock = _dataChunkLocks[i];
+                    ReaderWriterLockSlim dataChunkLock = _pageLocks[i];
                     if (!dataChunkLock.TryEnterWriteLock(timeout: TimeSpan.Zero))
                     {
-                        // Someone holds a read or write lock on this page, skip it and record that we skipped it
+                        // Someone holds a read or write lock on this page, skip it
                         itemsSkipped++;
                         continue;
                     }
@@ -560,35 +162,27 @@ namespace Microsoft.Diagnostics.Runtime.Windows
                     try
                     {
                         // double check that no other thread already scavenged this entry
-                        page = _dataChunks[i];
+                        page = _pages[i];
                         if (page != null)
                         {
                             ArrayPool<byte>.Shared.Return(page.Data);
-                            _dataChunks[i] = null;
                             dataRemoved += page.DataExtent;
+                            _pages[i] = null;
                         }
                     }
                     finally
                     {
                         dataChunkLock.ExitWriteLock();
+                        if (disposeLocks)
+                        {
+                            dataChunkLock.Dispose();
+                            _pageLocks[i] = null;
+                        }
                     }
                 }
             }
 
             return (dataRemoved, itemsSkipped);
-        }
-
-        [DebuggerDisplay("Size: {DataExtent}")]
-        internal sealed class CachePage
-        {
-            internal CachePage(byte[] data, uint dataExtent)
-            {
-                Data = data;
-                DataExtent = dataExtent;
-            }
-
-            public byte[] Data { get; }
-            public uint DataExtent { get; }
         }
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/src/Windows/ArrayPoolBasedCacheEntryFactory.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Windows/ArrayPoolBasedCacheEntryFactory.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Diagnostics.Runtime.Windows
                                                           leaveOpen);
         }
 
-        public override SegmentCacheEntry CreateEntryForSegment(MinidumpSegment segmentData, Action<ulong, uint> updateOwningCacheForSizeChangeCallback)
+        public override SegmentCacheEntry CreateEntryForSegment(MinidumpSegment segmentData, Action<uint> updateOwningCacheForSizeChangeCallback)
         {
             return new ArrayPoolBasedCacheEntry(_mappedFile, segmentData, updateOwningCacheForSizeChangeCallback);
         }

--- a/src/Microsoft.Diagnostics.Runtime/src/Windows/CachePage.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Windows/CachePage.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// TODO:  This code wasn't written to consider nullable.
+#nullable disable
+
+namespace Microsoft.Diagnostics.Runtime.Windows
+{
+    internal class CachePage<T>
+    {
+        internal CachePage(T data, uint dataExtent)
+        {
+            Data = data;
+            DataExtent = dataExtent;
+        }
+
+        public T Data { get; }
+
+        public uint DataExtent { get; }
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/src/Windows/CachedMemoryReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Windows/CachedMemoryReader.cs
@@ -83,13 +83,12 @@ namespace Microsoft.Diagnostics.Runtime.Windows
             else
             {
                 // We can't add the lock memory privilege, so just fall back on our ArrayPool/MemoryMappedFile based cache 
+                _cachedMemorySegments = new HeapSegmentDataCache(new ArrayPoolBasedCacheEntryFactory(stream, leaveOpen), entryCountWhenFull: (uint)_segments.Length, cacheIsFullyPopulatedBeforeUse: true, MaxCacheSize);
 
                 // Force creation of emtpy entries for each segment, this won't map the data in from disk but it WILL prevent us from needing to take any locks at the first level of the cache
                 // (the individual entries, when asked for data requiring page-in or when evicting data in page-out will still take locks for consistency).
                 foreach (MinidumpSegment segment in _segments)
                     _cachedMemorySegments.CreateAndAddEntry(segment);
-
-                _cachedMemorySegments = new HeapSegmentDataCache(new ArrayPoolBasedCacheEntryFactory(stream, leaveOpen), entryCountWhenFull: (uint)_segments.Length, cacheIsFullyPopulatedBeforeUse: true, MaxCacheSize);
             }
         }
 

--- a/src/Microsoft.Diagnostics.Runtime/src/Windows/CachedMemoryReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Windows/CachedMemoryReader.cs
@@ -51,13 +51,11 @@ namespace Microsoft.Diagnostics.Runtime.Windows
                 CacheNativeMethods.Util.GetSystemInfo(ref sysInfo);
 
                 // The AWE cache allocates on VirtualAlloc sized pages, which are 64k, if the majority of heap segments in the dump are < 64k this can be wasteful
-                // of memory (in the extreme we can end using 64k of VM to store < 100 bytes), in this case we will force the cache technology to be the array pool
-                // one which allocates on system page size (4k), which is still wasteful but FAR less so.
+                // of memory (in the extreme we can end using 64k of VM to store < 100 bytes), in this case we will force the cache technology to be the array pool.
                 int segmentsBelow64K = _segments.Sum((hs) => hs.Size < sysInfo.dwAllocationGranularity ? 1 : 0);
                 if (segmentsBelow64K > (int)(_segments.Length * 0.80))
                     CacheTechnology = CacheTechnology.ArrayPool;
             }
-
 
             if ((CacheTechnology == CacheTechnology.AWE) &&
                 CacheNativeMethods.Util.EnableDisablePrivilege("SeLockMemoryPrivilege", enable: true))
@@ -72,10 +70,10 @@ namespace Microsoft.Diagnostics.Runtime.Windows
                 AWEBasedCacheEntryFactory cacheEntryFactory = new AWEBasedCacheEntryFactory(stream.SafeFileHandle.DangerousGetHandle());
                 cacheEntryFactory.CreateSharedSegment(largestSegment);
 
-                _cachedMemorySegments = new HeapSegmentDataCache(cacheEntryFactory, MaxCacheSize);
+                _cachedMemorySegments = new HeapSegmentDataCache(cacheEntryFactory, entryCountWhenFull: (uint)_segments.Length, cacheIsFullyPopulatedBeforeUse: true, MaxCacheSize);
 
                 // Force the cache entry creation, this is because the AWE factory will read the heap segment data from the file into physical memory, it is FAR
-                // better for perf if we read it all in one contiunous go instead of piece-meal as needed.
+                // better for perf if we read it all in one contiunous go instead of piece-meal as needed and it allows us to elide locks on the first level of the cache.
                 foreach (MinidumpSegment segment in _segments)
                     _cachedMemorySegments.CreateAndAddEntry(segment);
 
@@ -85,7 +83,13 @@ namespace Microsoft.Diagnostics.Runtime.Windows
             else
             {
                 // We can't add the lock memory privilege, so just fall back on our ArrayPool/MemoryMappedFile based cache 
-                _cachedMemorySegments = new HeapSegmentDataCache(new ArrayPoolBasedCacheEntryFactory(stream, leaveOpen), MaxCacheSize);
+
+                // Force creation of emtpy entries for each segment, this won't map the data in from disk but it WILL prevent us from needing to take any locks at the first level of the cache
+                // (the individual entries, when asked for data requiring page-in or when evicting data in page-out will still take locks for consistency).
+                foreach (MinidumpSegment segment in _segments)
+                    _cachedMemorySegments.CreateAndAddEntry(segment);
+
+                _cachedMemorySegments = new HeapSegmentDataCache(new ArrayPoolBasedCacheEntryFactory(stream, leaveOpen), entryCountWhenFull: (uint)_segments.Length, cacheIsFullyPopulatedBeforeUse: true, MaxCacheSize);
             }
         }
 

--- a/src/Microsoft.Diagnostics.Runtime/src/Windows/HeapSegmentDataCache.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Windows/HeapSegmentDataCache.cs
@@ -7,6 +7,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 
+// TODO:  This code wasn't written to consider nullable.
+#nullable disable
+
 namespace Microsoft.Diagnostics.Runtime.Windows
 {
     internal sealed class HeapSegmentDataCache : IDisposable
@@ -45,7 +48,7 @@ namespace Microsoft.Diagnostics.Runtime.Windows
             try
             {
                 // Check the cache again now that we have acquired the write lock
-                if (_cache.TryGetValue(segment.VirtualAddress, out SegmentCacheEntry? existingEntry))
+                if (_cache.TryGetValue(segment.VirtualAddress, out SegmentCacheEntry existingEntry))
                 {
                     // Someone else beat us to adding this entry, clean up the entry we created and return the existing one
                     using (entry as IDisposable)
@@ -67,7 +70,7 @@ namespace Microsoft.Diagnostics.Runtime.Windows
             return entry;
         }
 
-        public bool TryGetCacheEntry(ulong baseAddress, out SegmentCacheEntry? entry)
+        public bool TryGetCacheEntry(ulong baseAddress, out SegmentCacheEntry entry)
         {
             ThrowIfDisposed();
 

--- a/src/Microsoft.Diagnostics.Runtime/src/Windows/SegmentCacheEntry.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Windows/SegmentCacheEntry.cs
@@ -10,17 +10,13 @@ namespace Microsoft.Diagnostics.Runtime.Windows
     {
         public abstract int CurrentSize { get; }
 
-        public int MinSize { get; protected set; }
+        public abstract int MinSize { get; }
 
         public abstract long LastAccessTickCount { get; }
-
-        public abstract int AccessCount { get; }
 
         public abstract long PageOutData();
 
         public abstract void UpdateLastAccessTickCount();
-
-        public abstract void IncrementAccessCount();
 
         public abstract void GetDataForAddress(ulong address, uint byteCount, IntPtr buffer, out uint bytesRead);
 

--- a/src/Microsoft.Diagnostics.Runtime/src/Windows/SegmentCacheEntryFactory.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Windows/SegmentCacheEntryFactory.cs
@@ -8,6 +8,6 @@ namespace Microsoft.Diagnostics.Runtime.Windows
 {
     internal abstract class SegmentCacheEntryFactory
     {
-        public abstract SegmentCacheEntry CreateEntryForSegment(MinidumpSegment segmentData, Action<ulong, uint> updateOwningCacheForSizeChangeCallback);
+        public abstract SegmentCacheEntry CreateEntryForSegment(MinidumpSegment segmentData, Action<uint> updateOwningCacheForSizeChangeCallback);
     }
 }


### PR DESCRIPTION
This change refactors and (I hope) drastically simplifies the cache entries and locking story around them as well as fixing a few bugs I found along the way.

The specific high-level changes:

Make a common base class (CacheEntryBase<T>) that represents most of the complexity that is shared between the ArrayPool and AWE cache entries. Most significantly, lock management.

Greatly simplify the locking scheme. Previously if you made a read that required accessing N pages of data I would require locking all N pages of data and ensuring they were all paged in before continuing with the read. I now stream the reads so we lock/page-in/read one page of the request at a time. This allows better granularity of concurrent reads as well as drastically simplifying lock management. It also allows us to trim a cache entry we are currently reading from as I don't announce a page-in completed (that could trigger a trim) until AFTER I have read the data.

Elide locks entirely in the HeapSegmentDataCache layer if the cache is pre-populated with all entries it could ever contain (and pre-populate for both AWE and ArrayPool caches). The entries are 'placeholders' so pre-populating doesn't mean we make the data VM resident, it just means the first layer dictionary has an entry for every MinidumpSegment in the dump. This means when mapping from segment start address -> cache entry we never need to take a lock as the cache will not change (i.e. grow) in the middle of the search.

Fix a few bugs I found along the way around accurate cache entry size tracking and the cache trimming logic.