### PR TITLE
Fix SOSHandleEnum memory leak

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/src/Builders/RuntimeBuilder.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Builders/RuntimeBuilder.cs
@@ -532,8 +532,10 @@ namespace Microsoft.Diagnostics.Runtime.Builders
         {
             CheckDisposed();
 
-            // Enumerating handles should be sufficiently rare as to not need to use ArrayPool
-            HandleData[] handles = new HandleData[128];
+            // Yes this is a huge array.  Older versions of ISOSHandleEnum have a memory leak when
+            // we loop below.  If we can fill the array without having to call back into
+            // SOSHandleEnum.ReadHandles then we avoid that leak entirely.
+            HandleData[] handles = new HandleData[0xc0000];
             return EnumerateHandleTable(runtime, handles);
         }
 
@@ -545,7 +547,8 @@ namespace Microsoft.Diagnostics.Runtime.Builders
             if (handleEnum is null)
                 yield break;
 
-            HandleData[] handles = new HandleData[32];
+            // See note above in EnumerateHandleTable about why this array is so large.
+            HandleData[] handles = new HandleData[0x18000];
             int fetched;
             while ((fetched = handleEnum.ReadHandles(handles)) != 0)
             {

--- a/src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac.cs
@@ -634,9 +634,18 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
         public SOSHandleEnum? EnumerateHandles(params ClrHandleKind[] types)
         {
             InitDelegate(ref _getHandleEnumForTypes, VTable.GetHandleEnumForTypes);
-
             HResult hr = _getHandleEnumForTypes(Self, types, types.Length, out IntPtr ptrEnum);
-            return hr ? new SOSHandleEnum(_library, ptrEnum) : null;
+            if (hr)
+            {
+                SOSHandleEnum result = new SOSHandleEnum(_library, ptrEnum);
+                int count = result.Release();
+                if (count == 0)
+                    throw new InvalidOperationException($"We expected to borrow a reference from GetHandleEnumForTypes, but instead fully released the object!");
+
+                return result;
+            }
+
+            return null;
         }
 
         public SOSHandleEnum? EnumerateHandles()
@@ -644,7 +653,17 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             InitDelegate(ref _getHandleEnum, VTable.GetHandleEnum);
 
             HResult hr = _getHandleEnum(Self, out IntPtr ptrEnum);
-            return hr ? new SOSHandleEnum(_library, ptrEnum) : null;
+            if (hr)
+            {
+                SOSHandleEnum result = new SOSHandleEnum(_library, ptrEnum);
+                int count = result.Release();
+                if (count == 0)
+                    throw new InvalidOperationException($"We expected to borrow a reference from GetHandleEnum, but instead fully released the object!");
+
+                return result;
+            }
+
+            return null;
         }
 
         public SOSStackRefEnum? EnumerateStackRefs(uint osThreadId)
@@ -652,7 +671,18 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             InitDelegate(ref _getStackRefEnum, VTable.GetStackReferences);
 
             HResult hr = _getStackRefEnum(Self, osThreadId, out IntPtr ptrEnum);
-            return hr ? new SOSStackRefEnum(_library, ptrEnum) : null;
+
+            if (hr)
+            {
+                SOSStackRefEnum result = new SOSStackRefEnum(_library, ptrEnum);
+                int count = result.Release();
+                if (count == 0)
+                    throw new InvalidOperationException($"We expected to borrow a reference from GetStackReferences, but instead fully released the object!");
+
+                return result;
+            }
+
+            return null;
         }
 
         public ulong GetMethodDescFromToken(ulong module, int token)


### PR DESCRIPTION
SOSHandleEnum seems to have a memory leak on Desktop CLR.  This is causing benchmarks to fail with OutOfMemoryException.

We can sometimes avoid the leak if we pass an array that's so large that it's filled on the first pass and we don't need to loop around fetching more.

Fixes https://github.com/microsoft/clrmd/issues/727.