### PR TITLE
Perf tuning on heaps segment cache 

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/src/Windows/HeapSegmentDataCache.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Windows/HeapSegmentDataCache.cs
@@ -74,8 +74,13 @@ namespace Microsoft.Diagnostics.Runtime.Windows
         {
             ThrowIfDisposed();
 
+            bool acquiredReadLock = false;
+
             if (!_cacheIsComplete)
+            {
                 _cacheLock.EnterReadLock();
+                acquiredReadLock = true;
+            }
 
             bool res = false;
 
@@ -85,7 +90,7 @@ namespace Microsoft.Diagnostics.Runtime.Windows
             }
             finally
             {
-                if (!_cacheIsComplete)
+                if (acquiredReadLock)
                     _cacheLock.ExitReadLock();
             }
 
@@ -228,8 +233,13 @@ namespace Microsoft.Diagnostics.Runtime.Windows
             IEnumerable<(KeyValuePair<ulong, SegmentCacheEntry> CacheEntry, int LastAccessTimestamp)> items = null;
             List<(KeyValuePair<ulong, SegmentCacheEntry> CacheEntry, int LastAccessTimestamp)> entries = null;
 
+            bool acquiredReadLock = false;
+
             if (!_cacheIsComplete)
+            { 
                 _cacheLock.EnterReadLock();
+                acquiredReadLock = true;
+            }
 
             // Select all cache entries which aren't at their min-size
             //
@@ -247,7 +257,7 @@ namespace Microsoft.Diagnostics.Runtime.Windows
             }
             finally
             {
-                if (!_cacheIsComplete)
+                if (acquiredReadLock)
                     _cacheLock.ExitReadLock();
             }
 

--- a/src/Microsoft.Diagnostics.Runtime/src/Windows/SegmentCacheEntry.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Windows/SegmentCacheEntry.cs
@@ -12,11 +12,11 @@ namespace Microsoft.Diagnostics.Runtime.Windows
 
         public abstract int MinSize { get; }
 
-        public abstract long LastAccessTickCount { get; }
+        public abstract int LastAccessTimestamp { get; }
 
         public abstract long PageOutData();
 
-        public abstract void UpdateLastAccessTickCount();
+        public abstract void UpdateLastAccessTimstamp();
 
         public abstract void GetDataForAddress(ulong address, uint byteCount, IntPtr buffer, out uint bytesRead);
 


### PR DESCRIPTION
Stop using longs to represent time stamps

Stop using QPC/Interlocked.Exchange to update time stamps

The timestamps are only used for comparing the access temporality of two cache entries to select the least recently accessed of the two and select the least recently amongst all entries for removal if we need to keep the cache under its cap size. To that end it doesn't matter if unprotected RMWs (Read/Modify/Write) lead to 'losing' access 'ticks' as the odds of a lost tick placing a recently accessed heap segment into the trim bucket incorrectly is essentially 0.