### PR TITLE
Eliminate memory mapped file in array pool cache entry

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/src/Windows/ArrayPoolBasedCacheEntryFactory.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Windows/ArrayPoolBasedCacheEntryFactory.cs
@@ -3,30 +3,24 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.IO;
 using System.IO.MemoryMappedFiles;
 
 namespace Microsoft.Diagnostics.Runtime.Windows
 {
-    internal sealed class ArrayPoolBasedCacheEntryFactory : SegmentCacheEntryFactory, IDisposable
+    internal sealed class ArrayPoolBasedCacheEntryFactory : SegmentCacheEntryFactory
     {
         private readonly MemoryMappedFile _mappedFile;
 
-        internal ArrayPoolBasedCacheEntryFactory(FileStream stream, bool leaveOpen)
+        private string _dumpPath;
+
+        internal ArrayPoolBasedCacheEntryFactory(string dumpPath)
         {
-            _mappedFile = MemoryMappedFile.CreateFromFile(stream,
-                                                          mapName: null,
-                                                          capacity: 0,
-                                                          MemoryMappedFileAccess.Read,
-                                                          HandleInheritability.None,
-                                                          leaveOpen);
+            _dumpPath = dumpPath;
         }
 
         public override SegmentCacheEntry CreateEntryForSegment(MinidumpSegment segmentData, Action<uint> updateOwningCacheForSizeChangeCallback)
         {
-            return new ArrayPoolBasedCacheEntry(_mappedFile, segmentData, updateOwningCacheForSizeChangeCallback);
+            return new ArrayPoolBasedCacheEntry(_dumpPath, segmentData, updateOwningCacheForSizeChangeCallback);
         }
-
-        public void Dispose() => _mappedFile.Dispose();
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/src/Windows/ArrayPoolBasedCacheEntryFactory.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Windows/ArrayPoolBasedCacheEntryFactory.cs
@@ -3,14 +3,11 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.IO.MemoryMappedFiles;
 
 namespace Microsoft.Diagnostics.Runtime.Windows
 {
     internal sealed class ArrayPoolBasedCacheEntryFactory : SegmentCacheEntryFactory
     {
-        private readonly MemoryMappedFile _mappedFile;
-
         private string _dumpPath;
 
         internal ArrayPoolBasedCacheEntryFactory(string dumpPath)

--- a/src/Microsoft.Diagnostics.Runtime/src/Windows/CacheNativeMethods.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Windows/CacheNativeMethods.cs
@@ -6,6 +6,7 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
 
 namespace Microsoft.Diagnostics.Runtime.Windows
 {
@@ -41,6 +42,11 @@ namespace Microsoft.Diagnostics.Runtime.Windows
             [return: MarshalAs(UnmanagedType.Bool)]
             internal static extern bool CloseHandle(IntPtr handle);
 
+            internal static bool ReadFile(SafeFileHandle file, IntPtr buffer, uint numberOfBytesToRead, out uint numberOfBytesRead)
+            {
+                return ReadFile(file.DangerousGetHandle(), buffer, numberOfBytesToRead, out numberOfBytesRead, lpOverlapped: IntPtr.Zero);
+            }
+
             internal static bool ReadFile(IntPtr hFile, IntPtr buffer, uint numberOfBytesToRead, out uint numberOfBytesRead)
             {
                 return ReadFile(hFile, buffer, numberOfBytesToRead, out numberOfBytesRead, lpOverlapped: IntPtr.Zero);
@@ -56,6 +62,11 @@ namespace Microsoft.Diagnostics.Runtime.Windows
 
             [DllImport("kernel32.dll", SetLastError = true)]
             private static extern bool ReadFile(IntPtr hFile, UIntPtr lpBuffer, uint nNumberOfBytesToRead, out uint lpNumberOfBytesRead, IntPtr lpOverlapped);
+
+            internal static bool SetFilePointerEx(SafeFileHandle file, long distanceToMove, SeekOrigin seekOrigin)
+            {
+                return SetFilePointerEx(file.DangerousGetHandle(), distanceToMove, lpNewFilePointer: IntPtr.Zero, seekOrigin);
+            }
 
             internal static bool SetFilePointerEx(IntPtr file, long distanceToMove, SeekOrigin seekOrigin)
             {

--- a/src/Microsoft.Diagnostics.Runtime/src/Windows/CachedMemoryReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Windows/CachedMemoryReader.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Diagnostics.Runtime.Windows
             else
             {
                 // We can't add the lock memory privilege, so just fall back on our ArrayPool/MemoryMappedFile based cache 
-                _cachedMemorySegments = new HeapSegmentDataCache(new ArrayPoolBasedCacheEntryFactory(stream, leaveOpen), entryCountWhenFull: (uint)_segments.Length, cacheIsFullyPopulatedBeforeUse: true, MaxCacheSize);
+                _cachedMemorySegments = new HeapSegmentDataCache(new ArrayPoolBasedCacheEntryFactory(dumpPath), entryCountWhenFull: (uint)_segments.Length, cacheIsFullyPopulatedBeforeUse: true, MaxCacheSize);
 
                 // Force creation of emtpy entries for each segment, this won't map the data in from disk but it WILL prevent us from needing to take any locks at the first level of the cache
                 // (the individual entries, when asked for data requiring page-in or when evicting data in page-out will still take locks for consistency).


### PR DESCRIPTION
In favor of simpler CreateFile/SetFilePointer/ReadFile calls