### PR TITLE
Reduce the overall number of benchmarks

### DIFF
--- a/src/Benchmarks/BenchmarkSwitches.cs
+++ b/src/Benchmarks/BenchmarkSwitches.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+
+namespace Benchmarks
+{
+    internal static class BenchmarkSwitches
+    {
+        public static IEnumerable<bool> OSMemoryFeatureFlags
+        {
+            get
+            {
+                yield return false;
+
+                // Currently the only time the CacheOptions.UseOSMemoryFeatures flag makes a behavioral change is
+                // on Windows and when AWE is enabled.  We will skip that part of the test if the user isn't running
+                // in that environment so that the tests don't run as long and so that the results aren't confused
+                // as having tested the AWE reader when we didn't.
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && AweHelpers.IsAweEnabled)
+                    yield return true;
+            }
+        }
+
+        public static IEnumerable<ulong> RelevantCacheSizes
+        {
+            get
+            {
+                // x86 default, 128meg
+                yield return 0x800_0000;
+
+                // 1gb
+                yield return 0x4000_0000;
+
+                // x64 default, 4gb
+                if (IntPtr.Size == 8)
+                    yield return 0x1_0000_0000;
+            }
+        }
+
+        public static IEnumerable<int> Parallelism => new int[] { 1, 4, 8 };
+    }
+}

--- a/src/Benchmarks/HeapBenchmarks.cs
+++ b/src/Benchmarks/HeapBenchmarks.cs
@@ -12,26 +12,14 @@ namespace Benchmarks
         private ClrRuntime _runtime;
         private ClrHeap _heap;
 
-        [Params(
-            32 * 1024 * 1024,
-            128 * 1024 * 1024,
-            256 * 1024 * 1024,
-            512 * 1024 * 1024,
-            1024 * 1024 * 1024)]
+        [ParamsSource(nameof(CacheSizeSource))]
         public int CacheSize { get; set; }
 
         [ParamsSource(nameof(OSMemoryFeaturesSource))]
         public bool UseOSMemoryFeatures { get; set; }
 
-        public IEnumerable<bool> OSMemoryFeaturesSource
-        {
-            get
-            {
-                yield return false;
-                if (Program.ShouldTestOSMemoryFeatures)
-                    yield return true;
-            }
-        }
+        public IEnumerable<bool> OSMemoryFeaturesSource => BenchmarkSwitches.OSMemoryFeatureFlags;
+        public IEnumerable<ulong> CacheSizeSource => BenchmarkSwitches.RelevantCacheSizes;
 
 
         [GlobalSetup]

--- a/src/Benchmarks/ParallelHeapBenchmarks.cs
+++ b/src/Benchmarks/ParallelHeapBenchmarks.cs
@@ -11,27 +11,19 @@ namespace Benchmarks
         private ClrRuntime _runtime;
         private ThreadParallelRunner<ClrSegment> _runner;
 
-        [Params(
-            32 * 1024 * 1024,
-            128 * 1024 * 1024,
-            1024 * 1024 * 1024)]
+        [ParamsSource(nameof(CacheSizeSource))]
         public int CacheSize { get; set; }
 
         [ParamsSource(nameof(OSMemoryFeaturesSource))]
         public bool UseOSMemoryFeatures { get; set; }
 
-        public IEnumerable<bool> OSMemoryFeaturesSource
-        {
-            get
-            {
-                yield return false;
-                if (Program.ShouldTestOSMemoryFeatures)
-                    yield return true;
-            }
-        }
-
-        [Params(1, 4, 8, 12)]
+        [ParamsSource(nameof(ThreadCountSource))]
         public int Threads { get; set; }
+
+        public IEnumerable<bool> OSMemoryFeaturesSource => BenchmarkSwitches.OSMemoryFeatureFlags;
+        public IEnumerable<ulong> CacheSizeSource => BenchmarkSwitches.RelevantCacheSizes;
+        public IEnumerable<int> ThreadCountSource => BenchmarkSwitches.Parallelism;
+
 
         [GlobalSetup]
         public void Setup()

--- a/src/Benchmarks/Program.cs
+++ b/src/Benchmarks/Program.cs
@@ -21,60 +21,14 @@ namespace Benchmarks
 
         public static string CrashDump => Environment.GetEnvironmentVariable(DumpFileEnv) ?? throw new InvalidOperationException("You must set the 'ClrmdBenchmarkDumpFile' environment variable before running this program.");
 
-        public static bool ShouldTestOSMemoryFeatures
-        {
-            get
-            {
-                // Currently the only time the CacheOptions.UseOSMemoryFeatures flag makes a behavioral change is
-                // on Windows and when AWE is enabled.  We will skip that part of the test if the user isn't running
-                // in that environment so that the tests don't run as long and so that the results aren't confused
-                // as having tested the AWE reader when we didn't.
-                return RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && AweHelpers.IsAweEnabled;
-            }
-        }
-
-        public static string GetDotnetPath(int pointerSize)
-        {
-            string dotnetOverride = Environment.GetEnvironmentVariable(DotnetEnv);
-            if (!string.IsNullOrWhiteSpace(dotnetOverride))
-            {
-                if (!File.Exists(dotnetOverride))
-                    throw new FileNotFoundException($"File specified by '{DotnetEnv}' not found.", dotnetOverride);
-
-                return dotnetOverride;
-            }
-
-            string programFiles = pointerSize == 4 ? Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86) : Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
-            string dotnetPath = Path.Combine(programFiles, "dotnet", "dotnet.exe");
-            if (!File.Exists(dotnetPath))
-                throw new FileNotFoundException($"Could not find `{dotnetPath}`.");
-
-            return dotnetPath;
-        }
-
-
         static void Main(string[] args)
         {
-            Assembly thisAssembly = Assembly.GetCallingAssembly();
-            List<Type> benchmarks = new List<Type>();
+            List<Type> benchmarks = GetBenchmarkTypesFromArgs(args);
+
+            // Set the argument as the crash dump.  We can't just set CrashDump here because it needs to be read from child processes.
             if (args.Length > 0)
-            {
-                // Set the argument as the crash dump.  We can't just set CrashDump here because it needs to be read from child processes.
                 Environment.SetEnvironmentVariable(DumpFileEnv, args[0]);
-
-                foreach (string benchmark in args.Skip(1))
-                {
-                    Type benchmarkType = thisAssembly.GetType($"Benchmarks.{benchmark}", throwOnError: false, ignoreCase: true);
-                    if (benchmarkType == null)
-                    {
-                        Console.WriteLine($"Benchmark '{benchmark}' not found.");
-                        Environment.Exit(2);
-                    }
-
-                    benchmarks.Add(benchmarkType);
-                }
-            }
-
+            
             // We want to run this even if we don't use the result to make sure we can successfully load 'CrashDump'.
             int targetPointerSize = GetTargetPointerSize();
 
@@ -101,21 +55,59 @@ namespace Benchmarks
             job = job.WithId(id)
                         .WithWarmupCount(1)
                         .WithIterationTime(TimeInterval.FromSeconds(1))
-                        .WithMinIterationCount(10)
-                        .WithMaxIterationCount(20)
+                        .WithMinIterationCount(5)
+                        .WithMaxIterationCount(10)
                         .DontEnforcePowerPlan(); // make sure BDN does not try to enforce High Performance power plan on Windows
 
             benchmarkConfiguration.Add(job);
 
             if (benchmarks.Count == 0)
             {
-                BenchmarkRunner.Run(thisAssembly, benchmarkConfiguration);
+                BenchmarkRunner.Run(Assembly.GetCallingAssembly(), benchmarkConfiguration);
             }
             else
             {
                 foreach (Type t in benchmarks)
                     BenchmarkRunner.Run(t, benchmarkConfiguration);
             }
+        }
+
+        private static List<Type> GetBenchmarkTypesFromArgs(string[] args)
+        {
+            Assembly thisAssembly = Assembly.GetCallingAssembly();
+            List<Type> benchmarks = new List<Type>();
+            foreach (string benchmark in args.Skip(1))
+            {
+                Type benchmarkType = thisAssembly.GetType($"Benchmarks.{benchmark}", throwOnError: false, ignoreCase: true);
+                if (benchmarkType == null)
+                {
+                    Console.WriteLine($"Benchmark '{benchmark}' not found.");
+                    Environment.Exit(2);
+                }
+
+                benchmarks.Add(benchmarkType);
+            }
+
+            return benchmarks;
+        }
+
+        public static string GetDotnetPath(int pointerSize)
+        {
+            string dotnetOverride = Environment.GetEnvironmentVariable(DotnetEnv);
+            if (!string.IsNullOrWhiteSpace(dotnetOverride))
+            {
+                if (!File.Exists(dotnetOverride))
+                    throw new FileNotFoundException($"File specified by '{DotnetEnv}' not found.", dotnetOverride);
+
+                return dotnetOverride;
+            }
+
+            string programFiles = pointerSize == 4 ? Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86) : Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
+            string dotnetPath = Path.Combine(programFiles, "dotnet", "dotnet.exe");
+            if (!File.Exists(dotnetPath))
+                throw new FileNotFoundException($"Could not find `{dotnetPath}`.");
+
+            return dotnetPath;
         }
 
         private static int GetTargetPointerSize()


### PR DESCRIPTION
Benchmarks take a very long time.  I'm going to scope down what we test just to some key values that are the defaults in clrmd.