### PR TITLE
Roll version back to 4.6.1

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/Microsoft.Diagnostics.Runtime.csproj
+++ b/src/Microsoft.Diagnostics.Runtime/Microsoft.Diagnostics.Runtime.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;netstandard2.0;net471</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;netstandard2.0;net461</TargetFrameworks>
     <NoWarn>1591;1701</NoWarn>
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>


### PR DESCRIPTION
In the future (such as ClrMD 2.1 or 2.2) we will likely move the version back forward to 4.7.1.  This change is to enable some usage of ClrMD where 4.6.1 is used.