### PR TITLE
Fix LegacyRuntime.EnumerateJitHeaps

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/src/Desktop/LegacyRuntime.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Desktop/LegacyRuntime.cs
@@ -354,10 +354,10 @@ namespace Microsoft.Diagnostics.Runtime.Desktop
                     if (Request(DacRequests.MANAGER_LIST, null, output))
                     {
                         MutableJitCodeHeapInfo heapInfo = new MutableJitCodeHeapInfo();
-                        int CodeHeapTypeOffset = Marshal.OffsetOf(typeof(JitCodeHeapInfo), "codeHeapType").ToInt32();
-                        int AddressOffset = Marshal.OffsetOf(typeof(JitCodeHeapInfo), "address").ToInt32();
-                        int CurrAddrOffset = Marshal.OffsetOf(typeof(JitCodeHeapInfo), "currentAddr").ToInt32();
-                        int JitCodeHeapInfoSize = Marshal.SizeOf(typeof(JitCodeHeapInfo));
+                        int CodeHeapTypeOffset = Marshal.OffsetOf(typeof(MutableJitCodeHeapInfo), nameof(MutableJitCodeHeapInfo.Type)).ToInt32();
+                        int AddressOffset = Marshal.OffsetOf(typeof(MutableJitCodeHeapInfo), nameof(MutableJitCodeHeapInfo.Address)).ToInt32();
+                        int CurrAddrOffset = Marshal.OffsetOf(typeof(MutableJitCodeHeapInfo), nameof(MutableJitCodeHeapInfo.CurrentAddress)).ToInt32();
+                        int JitCodeHeapInfoSize = Marshal.SizeOf(typeof(MutableJitCodeHeapInfo));
 
                         for (int i = 0; i < count; ++i)
                         {


### PR DESCRIPTION
## Issue
For the code:

<details>
<summary>Details</summary>

```C#
using Microsoft.Diagnostics.Runtime;
using System;
using System.IO;
using System.Linq;

namespace ConsoleApp1
{
    class Program
    {
        static void Main(string[] args)
        {
            if (args.Length != 1) throw new ArgumentException(nameof(args));
            if (!File.Exists(args[0])) throw new FileNotFoundException(args[0]);

            var dataTarget = DataTarget.LoadCrashDump(args[0]);
            var runtime = dataTarget.ClrVersions?.Select(x => x.CreateRuntime()).FirstOrDefault();
            if (runtime == null) throw new NullReferenceException(nameof(runtime));
            var @throw = runtime.EnumerateMemoryRegions().ToList();
        }
        // ConsoleApp1.exe "C:\tmp\ConsoleApp.DMP"
    }
}
```

</details>

Application throws:

<details>
<summary>Details</summary>

```
Unhandled Exception: System.ArgumentException: Field passed in is not a marshaled member of the type 'Microsoft.Diagnostics.Runtime.DacInterface.JitCodeHeapInfo'.
Parameter name: fieldName
   at System.Runtime.InteropServices.Marshal.OffsetOf(Type t, String fieldName)
   at Microsoft.Diagnostics.Runtime.Desktop.LegacyRuntime.<EnumerateJitHeaps>d__36.MoveNext()
   at Microsoft.Diagnostics.Runtime.Desktop.DesktopRuntimeBase.<EnumerateMemoryRegions>d__58.MoveNext()
   at System.Collections.Generic.List`1..ctor(IEnumerable`1 collection)
   at System.Linq.Enumerable.ToList[TSource](IEnumerable`1 source)
   at ConsoleApp1.Program.Main(String[] args) in C:\tmp\ConsoleApp1\Program.cs:line 18
```

</details>

## Memory dump details:
* **Platform**: X64
* **Target framework**: .NET Framework 2.0
* **WinVer**: Windows 10, 1909
* **Application code:**

<details>
<summary>Details</summary>

```C#
using System;

namespace ConsoleApp
{
    class Program
    {
        static void Main()
        {
            Console.WriteLine("Memory dump");
            throw new Exception();
        }
    }
}
```

</details>