### PR TITLE
Add IThreadReader

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/ThreadReaderTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/ThreadReaderTests.cs
@@ -1,0 +1,60 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Diagnostics.Runtime.DacInterface;
+using Microsoft.Diagnostics.Runtime.DataReaders.Implementation;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Xunit;
+
+namespace Microsoft.Diagnostics.Runtime.Tests
+{
+    public class ThreadReaderTests
+    {
+        [WindowsFact]
+        public void GetThreadTebTest()
+        {
+            using DataTarget dt = TestTargets.AppDomains.LoadFullDumpWithDbgEng();
+            IThreadReader threadReader = (IThreadReader)dt.DataReader;
+            using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
+            using SOSDac dac = runtime.DacLibrary.SOSDacInterface;
+
+
+            foreach (ClrThread thread in runtime.Threads)
+            {
+                if (!thread.IsAlive)
+                    continue;
+
+                Assert.NotEqual(0u, thread.OSThreadId);
+
+                ulong teb = threadReader.GetThreadTeb(thread.OSThreadId);
+                Assert.NotEqual(0ul, teb);
+
+                if (dac.GetThreadData(thread.Address, out ThreadData threadData))
+                    Assert.Equal((ulong)threadData.Teb, teb);
+            }
+        }
+
+        [Fact]
+        public void EnumerateOSThreadIdsTest()
+        {
+            using DataTarget dt = TestTargets.Types.LoadFullDump();
+            IThreadReader threadReader = (IThreadReader)dt.DataReader;
+            using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
+
+            uint[] threads = threadReader.EnumerateOSThreadIds().ToArray();
+            
+            Assert.NotEmpty(threads);
+            Assert.DoesNotContain(0u, threads);
+
+            // no duplicates
+            Assert.Equal(threads.Length, new HashSet<uint>(threads).Count);
+
+            foreach (uint threadId in runtime.Threads.Select(f => f.OSThreadId).Where(id => id != 0))
+                Assert.Contains(threadId, threads);
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/src/DataReaders/DbgEng/DbgEngDataReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataReaders/DbgEng/DbgEngDataReader.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
+using Microsoft.Diagnostics.Runtime.DataReaders.Implementation;
 using Microsoft.Diagnostics.Runtime.DbgEng;
 using Microsoft.Diagnostics.Runtime.Utilities;
 
@@ -16,7 +17,7 @@ using Microsoft.Diagnostics.Runtime.Utilities;
 
 namespace Microsoft.Diagnostics.Runtime
 {
-    internal sealed class DbgEngDataReader : CommonMemoryReader, IDataReader, IDisposable
+    internal sealed class DbgEngDataReader : CommonMemoryReader, IDataReader, IDisposable, IThreadReader
     {
         private static int s_totalInstanceCount;
 
@@ -299,6 +300,10 @@ namespace Microsoft.Diagnostics.Runtime
                 nextIndex = index + 1;
             }
         }
+
+
+        public IEnumerable<uint> EnumerateOSThreadIds() => _systemObjects.GetThreadIds();
+        public ulong GetThreadTeb(uint osThreadId) => _systemObjects.GetThreadTeb(osThreadId);
 
         public void Dispose()
         {

--- a/src/Microsoft.Diagnostics.Runtime/src/DataReaders/IThreadReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataReaders/IThreadReader.cs
@@ -1,0 +1,36 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.Diagnostics.Runtime.DataReaders.Implementation
+{
+    /// <summary>
+    /// This interface is implemented by all ClrMD provided implementations of <see cref="IDataReader"/>.
+    /// This interface is not used by the ClrMD library itself, but is here to maintain functionality
+    /// for previous uses of these functions in ClrMD 1.1's <see cref="IDataReader"/>.
+    /// 
+    /// This inteface must always be requested and not assumed to be there:
+    /// 
+    ///     IDataReader reader = ...;
+    /// 
+    ///     if (reader is IThreadReader threadReader)
+    ///         ...
+    /// </summary>
+    public interface IThreadReader
+    {
+        /// <summary>
+        /// Enumerates the thread ids of all live threads in the target process.
+        /// </summary>
+        /// <returns></returns>
+        public IEnumerable<uint> EnumerateOSThreadIds();
+
+        /// <summary>
+        /// Obtains the Windows specific Thread Execution Block.
+        /// </summary>
+        /// <param name="osThreadId"></param>
+        /// <returns></returns>
+        public ulong GetThreadTeb(uint osThreadId);
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Minidump/MinidumpReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Minidump/MinidumpReader.cs
@@ -8,11 +8,12 @@ using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
+using Microsoft.Diagnostics.Runtime.DataReaders.Implementation;
 using Microsoft.Diagnostics.Runtime.Windows;
 
 namespace Microsoft.Diagnostics.Runtime
 {
-    internal sealed class MinidumpReader : IDataReader, IDisposable
+    internal sealed class MinidumpReader : IDataReader, IDisposable, IThreadReader
     {
         private readonly Minidump _minidump;
         private IMemoryReader? _readerCached;
@@ -71,6 +72,14 @@ namespace Microsoft.Diagnostics.Runtime
 
         public void FlushCachedData()
         {
+        }
+
+        public IEnumerable<uint> EnumerateOSThreadIds() => _minidump.Tebs.Keys;
+
+        public ulong GetThreadTeb(uint osThreadId)
+        {
+            _minidump.Tebs.TryGetValue(osThreadId, out ulong teb);
+            return teb;
         }
 
         public bool GetThreadContext(uint threadID, uint contextFlags, Span<byte> context)

--- a/src/Microsoft.Diagnostics.Runtime/src/Linux/LinuxLiveDataReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Linux/LinuxLiveDataReader.cs
@@ -10,6 +10,7 @@ using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using Microsoft.Diagnostics.Runtime.DataReaders.Implementation;
 using Microsoft.Diagnostics.Runtime.Utilities;
 using ProcessArchitecture = System.Runtime.InteropServices.Architecture;
 
@@ -19,7 +20,7 @@ namespace Microsoft.Diagnostics.Runtime.Linux
     /// A data reader that targets a Linux process.
     /// The current process must have ptrace access to the target process.
     /// </summary>
-    internal sealed class LinuxLiveDataReader : CommonMemoryReader, IDataReader, IDisposable
+    internal sealed class LinuxLiveDataReader : CommonMemoryReader, IDataReader, IDisposable, IThreadReader
     {
         private List<MemoryMapEntry> _memoryMapEntries;
         private readonly List<uint> _threadIDs = new List<uint>();
@@ -202,6 +203,14 @@ namespace Microsoft.Diagnostics.Runtime.Linux
                 return read;
             }
         }
+
+        public IEnumerable<uint> EnumerateOSThreadIds()
+        {
+            LoadThreads();
+            return _threadIDs;
+        }
+
+        public ulong GetThreadTeb(uint _) => 0;
 
         public unsafe bool GetThreadContext(uint threadID, uint contextFlags, Span<byte> context)
         {


### PR DESCRIPTION
- Added an optional interface for IDataReaders which preserves some ClrMD 1.1 functionality.
- WindowsLiveDataTarget doesn't currently implement this.