### PR TITLE
Mark ModuleInfo.DataReader obsolete

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/DataTargetTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/DataTargetTests.cs
@@ -40,5 +40,15 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             string path = Path.GetTempFileName();
             _ = Assert.Throws<InvalidDataException>(() => DataTarget.LoadDump(path));
         }
+
+        [Fact]
+        public void ModuleInfoNonNullDataTarget()
+        {
+            // Regression test for https://github.com/microsoft/clrmd/issues/754
+
+            using DataTarget dt = TestTargets.Types.LoadFullDump();
+            foreach (ModuleInfo module in dt.DataReader.EnumerateModules())
+                Assert.Equal(dt.DataReader, module.DataReader);
+        }
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Core/CoreDumpReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Core/CoreDumpReader.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Microsoft.Diagnostics.Runtime.Linux;
 using Microsoft.Diagnostics.Runtime.Utilities;
@@ -96,7 +97,7 @@ namespace Microsoft.Diagnostics.Runtime
             return _modules;
         }
 
-        private static ModuleInfo CreateModuleInfo(ElfLoadedImage image)
+        private ModuleInfo CreateModuleInfo(ElfLoadedImage image)
         {
             ElfFile? file = image.Open();
 
@@ -111,7 +112,7 @@ namespace Microsoft.Diagnostics.Runtime
             }
 
             // We set buildId to "default" which means we will later lazily evaluate the buildId on demand.
-            return new ModuleInfo((ulong)image.BaseAddress, image.Path, image._containsExecutable, filesize, timestamp, buildId: default);
+            return new ModuleInfo(this, (ulong)image.BaseAddress, image.Path, image._containsExecutable, filesize, timestamp, buildId: default);
         }
 
         public void FlushCachedData()

--- a/src/Microsoft.Diagnostics.Runtime/src/DataReaders/DbgEng/DbgEngDataReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataReaders/DbgEng/DbgEngDataReader.cs
@@ -219,7 +219,7 @@ namespace Microsoft.Diagnostics.Runtime
                 for (int i = 0; i < bases.Length; ++i)
                 {
                     string? fn = _symbols.GetModuleNameStringWide(DebugModuleName.Image, i, bases[i]);
-                    ModuleInfo info = new ModuleInfo(bases[i], fn, true, mods[i].Size, mods[i].TimeDateStamp, ImmutableArray<byte>.Empty);
+                    ModuleInfo info = new ModuleInfo(this, bases[i], fn, true, mods[i].Size, mods[i].TimeDateStamp, ImmutableArray<byte>.Empty);
                     modules.Add(info);
                 }
             }

--- a/src/Microsoft.Diagnostics.Runtime/src/DataReaders/MacOS/MacOSProcessDataReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataReaders/MacOS/MacOSProcessDataReader.cs
@@ -107,7 +107,7 @@ namespace Microsoft.Diagnostics.Runtime.MacOS
                 Native.dyld_image_info info = Read<Native.dyld_image_info>(infos.infoArray, i);
                 ulong imageAddress = info.imageLoadAddress;
                 string imageFilePath = ReadNullTerminatedAscii(info.imageFilePath);
-                yield return new ModuleInfo(imageAddress, imageFilePath, true, 0, 0, ImmutableArray<byte>.Empty);
+                yield return new ModuleInfo(this, imageAddress, imageFilePath, true, 0, 0, ImmutableArray<byte>.Empty);
             }
 
             unsafe T Read<T>(ulong address, uint index = 0)

--- a/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Minidump/MinidumpReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Minidump/MinidumpReader.cs
@@ -65,8 +65,7 @@ namespace Microsoft.Diagnostics.Runtime
             // We set buildId to "Empty" since only PEImages exist where minidumps are created, and we do not
             // want to try to lazily evaluate the buildId later
             return from module in _minidump.EnumerateModuleInfo()
-                   select new ModuleInfo(module.BaseOfImage, module.ModuleName, true, module.SizeOfImage,
-                                         module.DateTimeStamp, ImmutableArray<byte>.Empty);
+                   select new ModuleInfo(this, module.BaseOfImage, module.ModuleName, true, module.SizeOfImage, module.DateTimeStamp, ImmutableArray<byte>.Empty);
         }
 
         public void FlushCachedData()

--- a/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Windows/WindowsProcessDataReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Windows/WindowsProcessDataReader.cs
@@ -147,7 +147,7 @@ namespace Microsoft.Diagnostics.Runtime
                 GetFileProperties(baseAddr, out int filesize, out int timestamp);
 
                 string fileName = sb.ToString();
-                ModuleInfo module = new ModuleInfo(baseAddr, fileName, true, filesize, timestamp, ImmutableArray<byte>.Empty);
+                ModuleInfo module = new ModuleInfo(this, baseAddr, fileName, true, filesize, timestamp, ImmutableArray<byte>.Empty);
                 result.Add(module);
             }
 

--- a/src/Microsoft.Diagnostics.Runtime/src/DataTargets/DataTarget.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataTargets/DataTarget.cs
@@ -222,8 +222,10 @@ namespace Microsoft.Diagnostics.Runtime
             ModuleInfo[] modules = DataReader.EnumerateModules().Where(m => m.FileName != null && m.FileName.IndexOfAny(invalid) < 0).ToArray();
             Array.Sort(modules, (a, b) => a.ImageBase.CompareTo(b.ImageBase));
 
+#pragma warning disable CS0618 // Type or member is obsolete
             foreach (ModuleInfo module in modules)
                 module.DataTarget = this;
+#pragma warning restore CS0618 // Type or member is obsolete
 
             return _modules = modules;
         }

--- a/src/Microsoft.Diagnostics.Runtime/src/Linux/LinuxLiveDataReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Linux/LinuxLiveDataReader.cs
@@ -113,7 +113,7 @@ namespace Microsoft.Diagnostics.Runtime.Linux
             let containsExecutable = image.Any(entry => entry.IsExecutable)
             let beginAddress = image.Min(entry => entry.BeginAddress)
             let props = GetPEImageProperties(filePath)
-            select new ModuleInfo(beginAddress, filePath, containsExecutable, props.Filesize, props.Timestamp, buildId: default);
+            select new ModuleInfo(this, beginAddress, filePath, containsExecutable, props.Filesize, props.Timestamp, buildId: default);
 
         private static (int Filesize, int Timestamp) GetPEImageProperties(string filePath)
         {


### PR DESCRIPTION
This property should never have been exposed.  The real 'parent' of a ModuleInfo is an IDataReader, which is what this property should have been.  For now I'm marking the old property obsolete until a major release.

Fixes https://github.com/microsoft/clrmd/issues/754.