### PR TITLE
Add a fake "SizeOfImage" on Linux

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Core/CoreDumpReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Core/CoreDumpReader.cs
@@ -109,6 +109,12 @@ namespace Microsoft.Diagnostics.Runtime
                 filesize = pe.IndexFileSize;
                 timestamp = pe.IndexTimeStamp;
             }
+            else
+            {
+                // It's true that we are setting "IndexFileSize" to be the raw size on linux for Linux modules,
+                // but this unblocks some SOS scenarios.
+                filesize = (int)image.Size;
+            }
 
             // We set buildId to "default" which means we will later lazily evaluate the buildId on demand.
             return new ModuleInfo((ulong)image.BaseAddress, image.Path, image._containsExecutable, filesize, timestamp, buildId: default);


### PR DESCRIPTION
SOS requires us to be able to know the size of an image in memory.  This unblocks some functionality by letting us use the SizeOfImage on coredumps for this purpose.