### PR TITLE
Ensure threads are enumerated in the same order as dumps

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/ThreadReaderTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/ThreadReaderTests.cs
@@ -42,9 +42,9 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         public void EnumerateOSThreadIdsTest()
         {
             using DataTarget dt = TestTargets.Types.LoadFullDump();
-            IThreadReader threadReader = (IThreadReader)dt.DataReader;
             using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
 
+            IThreadReader threadReader = (IThreadReader)dt.DataReader;
             uint[] threads = threadReader.EnumerateOSThreadIds().ToArray();
             
             Assert.NotEmpty(threads);
@@ -55,6 +55,20 @@ namespace Microsoft.Diagnostics.Runtime.Tests
 
             foreach (uint threadId in runtime.Threads.Select(f => f.OSThreadId).Where(id => id != 0))
                 Assert.Contains(threadId, threads);
+        }
+
+        [Fact]
+        public void EnsureOSThreadOrdering()
+        {
+            using DataTarget dt = TestTargets.Types.LoadFullDump();
+            using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
+
+            IThreadReader threadReader = (IThreadReader)dt.DataReader;
+
+            var items = threadReader.EnumerateOSThreadIds().ToArray();
+
+            uint mainThreadId = runtime.GetMainThread().OSThreadId;
+            Assert.Equal(mainThreadId, threadReader.EnumerateOSThreadIds().First());
         }
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Core/CoreDumpReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Core/CoreDumpReader.cs
@@ -133,8 +133,8 @@ namespace Microsoft.Diagnostics.Runtime
 
         public IEnumerable<uint> EnumerateOSThreadIds()
         {
-            Dictionary<uint, IElfPRStatus> threads = LoadThreads();
-            return threads.Keys;
+            foreach (IElfPRStatus status in _core.EnumeratePRStatus())
+                yield return status.ThreadId;
         }
 
         public ulong GetThreadTeb(uint osThreadId) => 0;

--- a/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Minidump/MinidumpReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Minidump/MinidumpReader.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Diagnostics.Runtime
         {
         }
 
-        public IEnumerable<uint> EnumerateOSThreadIds() => _minidump.Tebs.Keys;
+        public IEnumerable<uint> EnumerateOSThreadIds() => _minidump.OrderedThreads;
 
         public ulong GetThreadTeb(uint osThreadId)
         {

--- a/src/Microsoft.Diagnostics.Runtime/src/Windows/Minidump.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Windows/Minidump.cs
@@ -40,6 +40,8 @@ namespace Microsoft.Diagnostics.Runtime.Windows
             }
         }
 
+        public ImmutableArray<uint> OrderedThreads => _threadTask.Result.Threads;
+
         public ImmutableDictionary<uint, ulong> Tebs => _threadTask.Result.Tebs;
 
         public ImmutableArray<MinidumpModule> Modules { get; }
@@ -195,10 +197,11 @@ namespace Microsoft.Diagnostics.Runtime.Windows
                               orderby d.StreamType ascending
                               select d;
 
+            var threadBuilder = ImmutableArray.CreateBuilder<uint>();
+
             byte[] buffer = ArrayPool<byte>.Shared.Rent(1024);
             try
             {
-
                 foreach (MinidumpDirectory directory in _directories.Where(d => d.StreamType == MinidumpStreamType.ThreadListStream || d.StreamType == MinidumpStreamType.ThreadExListStream))
                 {
                     if (directory.StreamType == MinidumpStreamType.ThreadListStream)
@@ -213,6 +216,10 @@ namespace Microsoft.Diagnostics.Runtime.Windows
                         for (int i = 0; i < read; i += SizeOf<MinidumpThread>())
                         {
                             MinidumpThread thread = Unsafe.As<byte, MinidumpThread>(ref buffer[i]);
+
+                            if (!threadContextLocations.ContainsKey(thread.ThreadId))
+                                threadBuilder.Add(thread.ThreadId);
+
                             threadContextLocations[thread.ThreadId] = (thread.ThreadContext.Rva, thread.ThreadContext.DataSize, thread.Teb);
                         }
                     }
@@ -228,6 +235,10 @@ namespace Microsoft.Diagnostics.Runtime.Windows
                         for (int i = 0; i < read; i += SizeOf<MinidumpThreadEx>())
                         {
                             MinidumpThreadEx thread = Unsafe.As<byte, MinidumpThreadEx>(ref buffer[i]);
+
+                            if (!threadContextLocations.ContainsKey(thread.ThreadId))
+                                threadBuilder.Add(thread.ThreadId);
+
                             threadContextLocations[thread.ThreadId] = (thread.ThreadContext.Rva, thread.ThreadContext.DataSize, thread.Teb);
                         }
                     }
@@ -249,7 +260,10 @@ namespace Microsoft.Diagnostics.Runtime.Windows
                         {
                             MinidumpThreadInfo thread = Unsafe.As<byte, MinidumpThreadInfo>(ref buffer[i]);
                             if (!threadContextLocations.ContainsKey(thread.ThreadId))
+                            {
                                 threadContextLocations[thread.ThreadId] = (0, 0, 0);
+                                threadBuilder.Add(thread.ThreadId);
+                            }
                         }
                     }
                 }
@@ -273,7 +287,8 @@ namespace Microsoft.Diagnostics.Runtime.Windows
             return new ThreadReadResult()
             {
                 ContextData = contextBuilder.MoveToImmutable(),
-                Tebs = tebBuilder.ToImmutable()
+                Tebs = tebBuilder.ToImmutable(),
+                Threads = threadBuilder.ToImmutable()
             };
         }
         #endregion
@@ -423,6 +438,7 @@ namespace Microsoft.Diagnostics.Runtime.Windows
         {
             public ImmutableArray<MinidumpContextData> ContextData;
             public ImmutableDictionary<uint, ulong> Tebs;
+            public ImmutableArray<uint> Threads;
         }
     }
 


### PR DESCRIPTION
This change moves 2.0 to match ClrMD 1.1 behavior, where we ensure that threads are enumerated in the order they exist in minidumps and coredumps.

Note that this does _not_ guarantee any particular ordering, such as assume the first thread is the "main" thread.  Programs that create crash and coredumps are able to set any particular ordering in the dumps.  It's valid to create crash dumps and coredumps where the first thread in the stream is not the main thread, so you should not take any dependency on ordering.