### PR TITLE
Fix heap walking issue when the marking bit is set

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/src/Builders/RuntimeBuilder.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Builders/RuntimeBuilder.cs
@@ -1019,6 +1019,9 @@ namespace Microsoft.Diagnostics.Runtime.Builders
             if (mt == 0)
                 return null;
 
+            // Remove marking bit.
+            mt &= ~1ul;
+
             {
                 ClrType? result = TryGetType(mt);
                 if (result != null)


### PR DESCRIPTION
The GC sets the low bit on method tables when marking objects.  We need to ignore this bit, but the code that masked the bit off was lost in rewrite.