### PR TITLE
Silence PEReader exception

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/src/Utilities/PEImage/PEImage.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Utilities/PEImage/PEImage.cs
@@ -106,6 +106,9 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
             catch (BadImageFormatException)
             {
             }
+            catch (EndOfStreamException)
+            {
+            }
         }
 
         internal int ResourceVirtualAddress => PEHeader?.ResourceTableDirectory.RelativeVirtualAddress ?? 0;


### PR DESCRIPTION
When there's not enough of the PE image to fully initialize a PEReader object it can throw an EndOfStreamException.