### PR TITLE
Use custom PE image reader for coredumps

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Core/CoreDumpReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Core/CoreDumpReader.cs
@@ -106,9 +106,8 @@ namespace Microsoft.Diagnostics.Runtime
 
             if (file is null)
             {
-                using PEImage pe = image.OpenAsPEImage();
-                filesize = pe.IndexFileSize;
-                timestamp = pe.IndexTimeStamp;
+                using Stream stream = image.CreateStream();
+                PEImage.ReadIndexProperties(stream, out timestamp, out filesize);
             }
             else
             {

--- a/src/Microsoft.Diagnostics.Runtime/src/Linux/ElfLoadedImage.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Linux/ElfLoadedImage.cs
@@ -42,10 +42,10 @@ namespace Microsoft.Diagnostics.Runtime.Linux
             return new ElfFile(header, _vaReader, BaseAddress, true);
         }
 
-        public PEImage OpenAsPEImage()
+        public Stream CreateStream()
         {
             Stream stream = new ReaderStream(BaseAddress, Size, _vaReader);
-            return new PEImage(stream, leaveOpen: false, isVirtual: _containsExecutable);
+            return stream;
         }
 
         internal void AddTableEntryPointers(ElfFileTableEntryPointers64 pointers, bool isExecutable)

--- a/src/Microsoft.Diagnostics.Runtime/src/Utilities/PEImage/PEImage.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Utilities/PEImage/PEImage.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection.PortableExecutable;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 namespace Microsoft.Diagnostics.Runtime.Utilities
 {
@@ -340,6 +341,70 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
             }
 
             return result.MoveOrCopyToImmutable();
+        }
+
+        internal static bool ReadIndexProperties(Stream stream, out int buildTimeStamp, out int imageSize)
+        {
+            buildTimeStamp = 0;
+            imageSize = 0;
+
+            if (Read<ushort>(stream, 0) != ExpectedDosHeaderMagic)
+                return false;
+
+            int peHeaderOffset = Read<int>(stream, PESignatureOffsetLocation);
+            ImageFileHeader header = Read<ImageFileHeader>(stream, peHeaderOffset);
+            if (header.Magic != ExpectedPESignature)
+                return false;
+
+            buildTimeStamp = header.TimeDateStamp;
+
+            int optionalHeaderOffset = peHeaderOffset + sizeof(ImageFileHeader);
+            ImageOptionalHeader optional = Read<ImageOptionalHeader>(stream, optionalHeaderOffset);
+            if (optional.Magic != 0x010b && optional.Magic != 0x020b)
+                return false;
+
+            imageSize = optional.SizeOfImage;
+
+            return true;
+        }
+
+        private static T Read<T>(Stream stream) where T: unmanaged
+        {
+            Span<byte> buffer = stackalloc byte[sizeof(T)];
+            int read = stream.Read(buffer);
+            if (read < buffer.Length)
+                buffer = buffer.Slice(0, read);
+
+            return Unsafe.As<byte, T>(ref buffer[0]);
+        }
+
+        private static T Read<T>(Stream stream, int offset) where T : unmanaged
+        {
+            stream.Seek(offset, SeekOrigin.Begin);
+            return Read<T>(stream);
+        }
+
+        [StructLayout(LayoutKind.Sequential, Pack = 1)]
+        private struct ImageFileHeader
+        {
+            public uint Magic;
+            public ushort Machine;
+            public ushort NumberOfSections;
+            public int TimeDateStamp;
+            public uint PointerToSymbolTable;
+            public uint NumberOfSymbols;
+            public ushort SizeOfOptionalHeader;
+            public ushort Characteristics;
+        }
+
+
+        [StructLayout(LayoutKind.Explicit)]
+        private struct ImageOptionalHeader
+        {
+            [FieldOffset(0)]
+            public ushort Magic;
+            [FieldOffset(56)]
+            public int SizeOfImage;
         }
     }
 }


### PR DESCRIPTION
PEReader cannot handle only reading PEImages where the barest amount of the header is in a coredump.  It expects to be able to read deeply into the header to get get sections which might not be there.  The only place where this actually matters is the coredump reader, where we might not have the PE image laying around to read.

This change implements a mini PE header reader to get the filesize/timestamp without having to use PEReader.