### PR TITLE
Fixes linux dumps with module that is not a ELF or PE file in module list

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/src/Utilities/PEImage/PEImage.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Utilities/PEImage/PEImage.cs
@@ -372,6 +372,9 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
         {
             Span<byte> buffer = stackalloc byte[sizeof(T)];
             int read = stream.Read(buffer);
+            if (read == 0)
+                return default;
+
             if (read < buffer.Length)
                 buffer = buffer.Slice(0, read);
 


### PR DESCRIPTION
Dumps generated on distro OpenSuse in the diagnostics repo testing have a weird module in
the image list: /usr/share/icu/52.1/icudt52l.dat. It is neither an ELF image or an PE file.

The call to PEImage.ReadIndexProperties throws an IndexOutOfRangeException exception in CoreDumpReader.CreateModuleInfo
because the buffer in PEImage.Read<T> is empty.