### PR TITLE
Tweak ClrArray

### DIFF
--- a/Microsoft.Diagnostics.Runtime.sln
+++ b/Microsoft.Diagnostics.Runtime.sln
@@ -11,7 +11,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Diagnostics.Runti
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Benchmarks", "src\Benchmarks\Benchmarks.csproj", "{977B7737-E082-47AE-862D-1F177C66CB8D}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".Solution Items", ".Solution Items", "{87031E7E-88BC-4646-B2C7-8810CAE33F86}"
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{87031E7E-88BC-4646-B2C7-8810CAE33F86}"
 	ProjectSection(SolutionItems) = preProject
 		doc\FAQ.md = doc\FAQ.md
 		doc\GettingStarted.md = doc\GettingStarted.md

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/BasicArrayTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/BasicArrayTests.cs
@@ -298,7 +298,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
                 .ReadObjectField(nameof(ArrayConnection.ArraysHolder.StructArray)).AsArray();
 
             // Act
-            var item = structArraySnapshot.GetStructValue(0, true);
+            var item = structArraySnapshot.GetStructValue(0);
             var intFieldValue = item.ReadField<int>("Number");
             var stringFieldValue = item.ReadField<UIntPtr>("ReferenceLoad");
             var fieldType = _heap.GetObjectType(stringFieldValue.ToUInt64());


### PR DESCRIPTION
- Reverts #787 - it did nothing.
- Deprecates `GetStructValue(int, bool)` - in ClrMD you simply can't get a non-interior struct value.
- Adds multi-dimensional `GetStructValue`.
- Fixes multi-dimensional `GetObjectValue`.
- Resolves code duplication.
- Reduces generic instantiation.