### PR TITLE
Fix ILOffsetMap in Minidumps

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/MethodTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/MethodTests.cs
@@ -100,5 +100,21 @@ namespace Microsoft.Diagnostics.Runtime.Tests
 
             Assert.Equal(')', methodName.Last());
         }
+
+        [Theory]
+        [InlineData(DumpType.Full)]
+        [InlineData(DumpType.Mini)]
+        public void FrameILOffsetTest(DumpType dumpType)
+        {
+            using DataTarget dt = TestTargets.NestedException.LoadDump(dumpType);
+            using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
+
+            ClrThread thread = runtime.Threads.Where(t => t.CurrentException != null).Single();
+            foreach (var frame in thread.EnumerateStackTrace().Where(f => f.Method != null))
+            {
+                var ilOffset = frame.Method.GetILOffset(frame.InstructionPointer); // cannot get correct ilOffset here
+                Assert.True(ilOffset > 0);
+            }
+        }
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/src/Builders/RuntimeBuilder.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Builders/RuntimeBuilder.cs
@@ -1653,6 +1653,10 @@ namespace Microsoft.Diagnostics.Runtime.Builders
 
             ImmutableArray<ILToNativeMap>.Builder result = ImmutableArray.CreateBuilder<ILToNativeMap>();
 
+            // EnumerateMethodByAddress will fail if we cannot read a single byte out of the instruction pointer.
+            // This holder ensures we succeed that read.
+            using IDisposable holder = _library.DacDataTarget.SucceedNextRead(1);
+
             foreach (ClrDataMethod method in _dac.EnumerateMethodInstancesByAddress(ip))
             {
                 ILToNativeMap[]? map = method.GetILToNativeMap();


### PR DESCRIPTION
The dac reads a single byte of memory out of the instruction pointer you pass to EnumerateMethodInstancesByAddress to see if it's a valid location or not.  Unfortunately in a Minidump scenario it's normal for that read to fail since we simply did not put the addres into the dump file.

This change forces that single read to succeed.