### PR TITLE
Fix ELF reader for MacOS generated dumps and other changes

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/src/Linux/ElfCoreFile.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Linux/ElfCoreFile.cs
@@ -166,9 +166,8 @@ namespace Microsoft.Diagnostics.Runtime.Linux
                     ulong fileStart = fileTable[i].Start;
                     ElfProgramHeader? programHeader = ElfFile.ProgramHeaders.FirstOrDefault(
                         s => (ulong)s.VirtualAddress <= fileStart && fileStart < (ulong)s.VirtualAddress + (ulong)s.VirtualSize);
-                    bool isExecutable = programHeader?.IsExecutable ?? false;
 
-                    image.AddTableEntryPointers(fileTable[i], isExecutable);
+                    image.AddTableEntryPointers(fileTable[i]);
                 }
             }
             finally

--- a/src/Microsoft.Diagnostics.Runtime/src/Linux/ElfLoadedImage.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Linux/ElfLoadedImage.cs
@@ -14,7 +14,6 @@ namespace Microsoft.Diagnostics.Runtime.Linux
         private readonly Reader _vaReader;
         private readonly bool _is64bit;
         private long _end;
-        internal bool _containsExecutable;
 
         public string Path { get; }
         public long BaseAddress { get; private set; }
@@ -48,10 +47,9 @@ namespace Microsoft.Diagnostics.Runtime.Linux
             return stream;
         }
 
-        internal void AddTableEntryPointers(ElfFileTableEntryPointers64 pointers, bool isExecutable)
+        internal void AddTableEntryPointers(ElfFileTableEntryPointers64 pointers)
         {
             _fileTable.Add(pointers);
-            _containsExecutable = _containsExecutable || isExecutable;
 
             long start = checked((long)pointers.Start);
             if (BaseAddress == 0 || start < BaseAddress)


### PR DESCRIPTION
This fixes the following issues:

1) SOS for Linux dumps generated on MacOS. The ModuleInfo ImageSize wasn't being set in this case. The ElfLoadedImage.Size is set to an appropriate value even for MachO in-memory images but when ElfLoadedImage.Open fails and PEImage.ReadIndexProperties is called the file size variable is set to 0. Rearranged the code to preserve the Size.

2) Made PEImage.ReadPdbs() more bullet proof and changed it not to return "default" which causes PEImage.DefaultPdb to hit an null ref. The try/catch added isn't as neccesary anymore because of fix #3.

3) Fixed module PDBInfo and Version for PE images in ELF coredumps. When building the module infos changed the CoreDumpReader's to always pass isVirtual to true. The _containsExecutable flag is the right value. It meant that the ELF image was an executable not the managed PE assembly. The only problem is that are still some PEs that the layout (isVirtual) is wrong and PDBInfo/Version doesn't work. This happen to be the app's DLLs. All the system BCL assemblies work.

4) Removes " (deleted)" from the ELF image path for coredumps with unloaded modules. Fixes issue https://github.com/dotnet/diagnostics/issues/1268 for dotnet-dump even though the issue was filed against dotnet-symbol. They both have the same problem.