### PR TITLE
Fix the architecture bit in the arm64/x86 context flags

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Registers/Arm64Context.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Registers/Arm64Context.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Diagnostics.Runtime
     [StructLayout(LayoutKind.Explicit, Pack = 1)]
     public struct Arm64Context
     {
-        public const uint Context = 0x00200000;
+        public const uint Context = 0x00400000;
         public const uint ContextControl = Context | 0x1;
         public const uint ContextInteger = Context | 0x2;
         public const uint ContextFloatingPoint = Context | 0x4;

--- a/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Registers/X86Context.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Registers/X86Context.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Diagnostics.Runtime
     [StructLayout(LayoutKind.Explicit, Pack = 1)]
     public struct X86Context
     {
-        public const uint Context = 0x00100000;
+        public const uint Context = 0x00010000;
         public const uint ContextControl = Context | 0x1;
         public const uint ContextInteger = Context | 0x2;
         public const uint ContextSegments = Context | 0x4;


### PR DESCRIPTION
This is important because if the context is returned back to DBI/DAC like it is in dotnet-dump, the context isn't internally copied correctly causing the SOS `clrstack -i` commands to fail.  

DAC/DBI code does this:

  if ((dstFlags & srcFlags & DT_CONTEXT_CONTROL) == DT_CONTEXT_CONTROL)