### PR TITLE
Don't throw NRE from MemoryVirtualAddressSpace.Name, return null instead

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/src/Linux/MemoryVirtualAddressSpace.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Linux/MemoryVirtualAddressSpace.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Diagnostics.Runtime.Linux
 
         public long Length => throw new NotImplementedException();
 
-        public string Name => throw new NotImplementedException();
+        public string Name => null;
 
         public int Read(long position, Span<byte> buffer)
         {


### PR DESCRIPTION
When there are problems with loading an ELF header, a `NullReferenceException` is thrown with "The method or operation is not implemented" message as shown in the following example, making really hard to understand what's happened.

```
Unhandled Exception: System.NotImplementedException: The method or operation is not implemented.
at Microsoft.Diagnostics.Runtime.Linux.MemoryVirtualAddressSpace.get_Name()
at Microsoft.Diagnostics.Runtime.Linux.ElfFile..ctor(Reader reader, Int64 position, Boolean isVirtual)
at Microsoft.Diagnostics.Runtime.Linux.LinuxLiveDataReader.GetElfFile(UInt64 baseAddress)
at Microsoft.Diagnostics.Runtime.Linux.LinuxLiveDataReader.GetVersionInfo(UInt64 baseAddress, VersionInfo& version)
at Microsoft.Diagnostics.Runtime.ModuleInfo.get_Version()
at Microsoft.Diagnostics.Runtime.DataTarget.GetOrCreateClrVersions()
at STDump.DumpHelper.WriteDump(DataTarget target, TextWriter writer, CancellationToken cancellationToken)
at STDump.Program.DumpStackTraces(IEnumerable`1 arguments)
at Microsoft.Extensions.CommandLineUtils.CommandLineApplication.Execute(String[] args)
```

After investigating source code, I've realized the `IAddressSpace.Name` property getter is used only in the `ElfFile`'s constructor, just before throwing `InvalidOperationException` which contain much more informative message.

https://github.com/microsoft/clrmd/blob/a2c23aa4525a237d33e84fcfbfb5d02215797db4/src/Microsoft.Diagnostics.Runtime/src/Linux/ElfFile.cs#L94-L101

And since `null` value is expected there, I've changed `MemoryVirtualAddressSpace.Name` getter to return `null` instead of throwing `NullReferenceException` to avoid masking one exception by another.