### PR TITLE
Ensure DacDataTargetWrapper is flushed

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/src/DataTargets/DacLibrary.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataTargets/DacLibrary.cs
@@ -136,6 +136,8 @@ namespace Microsoft.Diagnostics.Runtime
             InternalDacPrivateInterface = new ClrDataProcess(this, iUnk);
         }
 
+        internal void Flush() => DacDataTarget.Flush();
+
         public void Dispose()
         {
             Dispose(true);

--- a/src/Microsoft.Diagnostics.Runtime/src/Implementation/ClrmdRuntime.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Implementation/ClrmdRuntime.cs
@@ -118,6 +118,8 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
 
             _helpers.DataReader.FlushCachedData();
             _helpers.FlushCachedData();
+
+            DacLibrary.Flush();
         }
 
         public override IEnumerable<ClrModule> EnumerateModules()


### PR DESCRIPTION
DacDataTargetWrapper would cache a module list that wasn't cleared when Flush is called.  Now we allow ClrRuntime.Flush to also flush DacLibrary -> DacDataTargetWrapper.

Fixes https://github.com/microsoft/clrmd/issues/856.