### PR TITLE
Fix division by zero exception when segment length is <=16 bytes

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/src/Implementation/ClrmdSegment.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Implementation/ClrmdSegment.cs
@@ -150,6 +150,9 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
 
             ulong step = Length / ((uint)_markers.Length + 1);
 
+            if (step == 0)
+                return -1;
+
             ulong offset = obj - FirstObjectAddress;
             int index = (int)(offset / step) - 1;
 


### PR DESCRIPTION
When analyzing a dump for a x86 program, I faced a division by zero exception when calling ClrSegment.GetNextObjectAddress.
```
at Microsoft.Diagnostics.Runtime.Implementation.ClrmdSegment.GetMarkerIndex(UInt64 obj)
   at Microsoft.Diagnostics.Runtime.Implementation.ClrmdSegment.GetNextObjectAddress(UInt64 addr)
   at Microsoft.Diagnostic.Tools.Dump.ExtensionCommands.ClrMDHelper.<EnumerateObjectsInGeneration>d__37.MoveNext() in C:\dev\dotnet-diagnostics\src\Tools\dotnet-dump\ExtensionCommands\ClrMDHelper.cs:line 710
   at System.Linq.Enumerable.WhereEnumerableIterator`1.MoveNext()
```
It occurs because my current segment is only 16 bytes long, with a "free" ClrObject" occupying 12 out of the 16 bytes. (The exception happens the second time I call GetNextObjectAdddress, with `<segmentAdress> + 0x0c` address.

From my understanding, markers are used to avoid enumerating objects from the beginning of the segment when calling `ClrSegment.GetPreviousObjectAddress` method.
In the case of a 16 bytes segment, in my opinion it makes no sense to add markers, that's why I chose to exit quickly by returning -1.