### PR TITLE
* Handle arithmetic overflow when dealing with large memory dump files.

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/src/Common/ObjectSet.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/ObjectSet.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Diagnostics.Runtime
                     {
                         StartAddress = start,
                         EndAddress = end,
-                        Objects = new BitArray((int)(end - start) / MinObjSize, false)
+                        Objects = new BitArray((int)((uint)(end - start) / MinObjSize), false)
                     });
                 }
             }
@@ -146,7 +146,7 @@ namespace Microsoft.Diagnostics.Runtime
         /// <returns>The index into seg.Objects.</returns>
         protected int GetOffset(ulong obj, HeapHashSegment seg)
         {
-            return checked((int)(obj - seg.StartAddress) / MinObjSize);
+            return checked((int)((uint)(obj - seg.StartAddress) / MinObjSize));
         }
 
         /// <summary>

--- a/src/Microsoft.Diagnostics.Runtime/src/Windows/AWEBasedCacheEntry.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Windows/AWEBasedCacheEntry.cs
@@ -155,7 +155,7 @@ namespace Microsoft.Diagnostics.Runtime.Windows
             // NOTE: The caller ensures this method is not called concurrently
 
             uint readSize;
-            if ((pageAlignedOffset + EntryPageSize) <= (int)_segmentData.Size)
+            if ((pageAlignedOffset + EntryPageSize) <= (uint)_segmentData.Size)
             {
                 readSize = EntryPageSize;
             }

--- a/src/Microsoft.Diagnostics.Runtime/src/Windows/CacheEntryBase.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Windows/CacheEntryBase.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Diagnostics.Runtime.Windows
             _segmentData = segmentData;
 
             int pageCount = (int)((_segmentData.End - _segmentData.VirtualAddress) / EntryPageSize);
-            if (((int)(_segmentData.End - _segmentData.VirtualAddress) % EntryPageSize) != 0)
+            if (((uint)(_segmentData.End - _segmentData.VirtualAddress) % EntryPageSize) != 0)
                 pageCount++;
 
             _pages = new CachePage<T>[pageCount];


### PR DESCRIPTION
When opening a large memory dump file (10+ GB), any segment that is larger than 2GB in size is missing.
This is because an arithmetic overflow occurs when both loading the dump and again when creating the runtime.

Loading the same dump file in ClrMd 1.1 works fine so I suspect this is a regression.

Having the segments missing means that walking the heap objects and enumerating the roots will not return the correct data.