### PR TITLE
Try both PE image layouts

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/src/Common/ModuleInfo.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/ModuleInfo.cs
@@ -62,6 +62,20 @@ namespace Microsoft.Diagnostics.Runtime
             try
             {
                 PEImage image = new PEImage(new ReadVirtualStream(DataReader, (long)ImageBase, IndexFileSize), leaveOpen: false, isVirtual: _isVirtual);
+                if (image.PEHeader == null)
+                {
+                    PEImage otherLayout = new PEImage(new ReadVirtualStream(DataReader, (long)ImageBase, IndexFileSize), leaveOpen: false, isVirtual: !_isVirtual);
+                    if (otherLayout.PEHeader != null)
+                    {
+                        image.Dispose();
+                        image = otherLayout;
+                    }
+                    else
+                    {
+                        otherLayout.Dispose();
+                    }
+                }
+
                 if (!_isManaged.HasValue)
                     _isManaged = image.IsManaged;
 


### PR DESCRIPTION
We don't actually know (or have a good way to get) the layout of images.  We'll use the "_isVirtual" flag as a first try, and if it fails we fall back to the other layout.

Fixes https://github.com/microsoft/clrmd/issues/891.