### PR TITLE
Fix: ITypeHelpers.GetObjectData should return a nullable value

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/PublicAPI/net461/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Diagnostics.Runtime/PublicAPI/net461/PublicAPI.Unshipped.txt
@@ -994,7 +994,7 @@ Microsoft.Diagnostics.Runtime.Implementation.ITypeHelpers.DataReader.get -> Micr
 Microsoft.Diagnostics.Runtime.Implementation.ITypeHelpers.Factory.get -> Microsoft.Diagnostics.Runtime.Implementation.ITypeFactory!
 Microsoft.Diagnostics.Runtime.Implementation.ITypeHelpers.GetAssemblyLoadContextAddress(ulong mt) -> ulong
 Microsoft.Diagnostics.Runtime.Implementation.ITypeHelpers.GetLoaderAllocatorHandle(ulong mt) -> ulong
-Microsoft.Diagnostics.Runtime.Implementation.ITypeHelpers.GetObjectData(ulong objRef) -> Microsoft.Diagnostics.Runtime.Implementation.IObjectData!
+Microsoft.Diagnostics.Runtime.Implementation.ITypeHelpers.GetObjectData(ulong objRef) -> Microsoft.Diagnostics.Runtime.Implementation.IObjectData?
 Microsoft.Diagnostics.Runtime.Implementation.ITypeHelpers.GetTypeName(ulong mt, out string? name) -> bool
 Microsoft.Diagnostics.Runtime.M128A
 Microsoft.Diagnostics.Runtime.M128A.Clear() -> void

--- a/src/Microsoft.Diagnostics.Runtime/PublicAPI/net5.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Diagnostics.Runtime/PublicAPI/net5.0/PublicAPI.Unshipped.txt
@@ -994,7 +994,7 @@ Microsoft.Diagnostics.Runtime.Implementation.ITypeHelpers.DataReader.get -> Micr
 Microsoft.Diagnostics.Runtime.Implementation.ITypeHelpers.Factory.get -> Microsoft.Diagnostics.Runtime.Implementation.ITypeFactory!
 Microsoft.Diagnostics.Runtime.Implementation.ITypeHelpers.GetAssemblyLoadContextAddress(ulong mt) -> ulong
 Microsoft.Diagnostics.Runtime.Implementation.ITypeHelpers.GetLoaderAllocatorHandle(ulong mt) -> ulong
-Microsoft.Diagnostics.Runtime.Implementation.ITypeHelpers.GetObjectData(ulong objRef) -> Microsoft.Diagnostics.Runtime.Implementation.IObjectData!
+Microsoft.Diagnostics.Runtime.Implementation.ITypeHelpers.GetObjectData(ulong objRef) -> Microsoft.Diagnostics.Runtime.Implementation.IObjectData?
 Microsoft.Diagnostics.Runtime.Implementation.ITypeHelpers.GetTypeName(ulong mt, out string? name) -> bool
 Microsoft.Diagnostics.Runtime.M128A
 Microsoft.Diagnostics.Runtime.M128A.Clear() -> void

--- a/src/Microsoft.Diagnostics.Runtime/PublicAPI/netcoreapp3.1/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Diagnostics.Runtime/PublicAPI/netcoreapp3.1/PublicAPI.Unshipped.txt
@@ -994,7 +994,7 @@ Microsoft.Diagnostics.Runtime.Implementation.ITypeHelpers.DataReader.get -> Micr
 Microsoft.Diagnostics.Runtime.Implementation.ITypeHelpers.Factory.get -> Microsoft.Diagnostics.Runtime.Implementation.ITypeFactory!
 Microsoft.Diagnostics.Runtime.Implementation.ITypeHelpers.GetAssemblyLoadContextAddress(ulong mt) -> ulong
 Microsoft.Diagnostics.Runtime.Implementation.ITypeHelpers.GetLoaderAllocatorHandle(ulong mt) -> ulong
-Microsoft.Diagnostics.Runtime.Implementation.ITypeHelpers.GetObjectData(ulong objRef) -> Microsoft.Diagnostics.Runtime.Implementation.IObjectData!
+Microsoft.Diagnostics.Runtime.Implementation.ITypeHelpers.GetObjectData(ulong objRef) -> Microsoft.Diagnostics.Runtime.Implementation.IObjectData?
 Microsoft.Diagnostics.Runtime.Implementation.ITypeHelpers.GetTypeName(ulong mt, out string? name) -> bool
 Microsoft.Diagnostics.Runtime.M128A
 Microsoft.Diagnostics.Runtime.M128A.Clear() -> void

--- a/src/Microsoft.Diagnostics.Runtime/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Diagnostics.Runtime/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -994,7 +994,7 @@ Microsoft.Diagnostics.Runtime.Implementation.ITypeHelpers.DataReader.get -> Micr
 Microsoft.Diagnostics.Runtime.Implementation.ITypeHelpers.Factory.get -> Microsoft.Diagnostics.Runtime.Implementation.ITypeFactory!
 Microsoft.Diagnostics.Runtime.Implementation.ITypeHelpers.GetAssemblyLoadContextAddress(ulong mt) -> ulong
 Microsoft.Diagnostics.Runtime.Implementation.ITypeHelpers.GetLoaderAllocatorHandle(ulong mt) -> ulong
-Microsoft.Diagnostics.Runtime.Implementation.ITypeHelpers.GetObjectData(ulong objRef) -> Microsoft.Diagnostics.Runtime.Implementation.IObjectData!
+Microsoft.Diagnostics.Runtime.Implementation.ITypeHelpers.GetObjectData(ulong objRef) -> Microsoft.Diagnostics.Runtime.Implementation.IObjectData?
 Microsoft.Diagnostics.Runtime.Implementation.ITypeHelpers.GetTypeName(ulong mt, out string? name) -> bool
 Microsoft.Diagnostics.Runtime.M128A
 Microsoft.Diagnostics.Runtime.M128A.Clear() -> void

--- a/src/Microsoft.Diagnostics.Runtime/src/Builders/RuntimeBuilder.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Builders/RuntimeBuilder.cs
@@ -1489,13 +1489,15 @@ namespace Microsoft.Diagnostics.Runtime.Builders
             return 0;
         }
 
-        IObjectData ITypeHelpers.GetObjectData(ulong objRef)
+        IObjectData? ITypeHelpers.GetObjectData(ulong objRef)
         {
             CheckDisposed();
 
             // todo remove
-            _sos.GetObjectData(objRef, out ObjectData data);
-            return data;
+            if (_sos.GetObjectData(objRef, out ObjectData data) == HResult.S_OK)
+                return data;
+
+            return null;
         }
 
         string? IClrObjectHelpers.ReadString(ulong addr, int maxLength)

--- a/src/Microsoft.Diagnostics.Runtime/src/Implementation/ClrmdArrayType.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Implementation/ClrmdArrayType.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
             {
                 ClrType? componentType = ComponentType;
 
-                IObjectData data = Helpers.GetObjectData(objRef);
+                IObjectData? data = Helpers.GetObjectData(objRef);
                 if (data != null)
                 {
                     _baseArrayOffset = (int)(data.DataPointer - objRef);
@@ -68,7 +68,7 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
             else
             {
                 // Slow path, we need to get the element type of the array.
-                IObjectData data = Helpers.GetObjectData(objRef);
+                IObjectData? data = Helpers.GetObjectData(objRef);
                 if (data is null)
                     return null;
 

--- a/src/Microsoft.Diagnostics.Runtime/src/Implementation/ITypeHelpers.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Implementation/ITypeHelpers.cs
@@ -22,6 +22,6 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
         ulong GetAssemblyLoadContextAddress(ulong mt);
 
         // TODO: Should not expose this:
-        IObjectData GetObjectData(ulong objRef);
+        IObjectData? GetObjectData(ulong objRef);
     }
 }


### PR DESCRIPTION
ClrmdArrayType.GetArrayElementAddress can return a wrong address.

The method calls Helpers.GetObjectData and expect it to return a nullable value but in the current implementation it's always not null. This behavior can lead to incorrect calculation of an element address. 

