### PR TITLE
More single-file fixes

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/PublicAPI/net461/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Diagnostics.Runtime/PublicAPI/net461/PublicAPI.Unshipped.txt
@@ -441,6 +441,7 @@ Microsoft.Diagnostics.Runtime.DacInterface.ClrDataMethod.ClrDataMethod(Microsoft
 Microsoft.Diagnostics.Runtime.DacInterface.ClrDataMethod.GetILToNativeMap() -> Microsoft.Diagnostics.Runtime.ILToNativeMap[]?
 Microsoft.Diagnostics.Runtime.DacInterface.ClrDataModule
 Microsoft.Diagnostics.Runtime.DacInterface.ClrDataModule.ClrDataModule(Microsoft.Diagnostics.Runtime.DacLibrary! library, System.IntPtr pUnknown) -> void
+Microsoft.Diagnostics.Runtime.DacInterface.ClrDataModule.GetFileName() -> string?
 Microsoft.Diagnostics.Runtime.DacInterface.ClrDataModule.GetModuleData(out Microsoft.Diagnostics.Runtime.DacInterface.ExtendedModuleData data) -> Microsoft.Diagnostics.Runtime.Utilities.HResult
 Microsoft.Diagnostics.Runtime.DacInterface.ClrDataModule.GetName() -> string?
 Microsoft.Diagnostics.Runtime.DacInterface.ClrDataProcess
@@ -885,8 +886,10 @@ Microsoft.Diagnostics.Runtime.Implementation.IModuleData
 Microsoft.Diagnostics.Runtime.Implementation.IModuleData.Address.get -> ulong
 Microsoft.Diagnostics.Runtime.Implementation.IModuleData.AssemblyAddress.get -> ulong
 Microsoft.Diagnostics.Runtime.Implementation.IModuleData.AssemblyName.get -> string?
+Microsoft.Diagnostics.Runtime.Implementation.IModuleData.FileName.get -> string?
 Microsoft.Diagnostics.Runtime.Implementation.IModuleData.Helpers.get -> Microsoft.Diagnostics.Runtime.Implementation.IModuleHelpers!
 Microsoft.Diagnostics.Runtime.Implementation.IModuleData.ILImageBase.get -> ulong
+Microsoft.Diagnostics.Runtime.Implementation.IModuleData.IsDynamic.get -> bool
 Microsoft.Diagnostics.Runtime.Implementation.IModuleData.IsFlatLayout.get -> bool
 Microsoft.Diagnostics.Runtime.Implementation.IModuleData.IsPEFile.get -> bool
 Microsoft.Diagnostics.Runtime.Implementation.IModuleData.IsReflection.get -> bool

--- a/src/Microsoft.Diagnostics.Runtime/PublicAPI/net461/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Diagnostics.Runtime/PublicAPI/net461/PublicAPI.Unshipped.txt
@@ -646,6 +646,7 @@ Microsoft.Diagnostics.Runtime.DacInterface.WorkRequestData.WorkRequestData() -> 
 Microsoft.Diagnostics.Runtime.DacLibrary
 Microsoft.Diagnostics.Runtime.DacLibrary.DacLibrary(Microsoft.Diagnostics.Runtime.DataTarget! dataTarget, System.IntPtr pClrDataProcess) -> void
 Microsoft.Diagnostics.Runtime.DacLibrary.DacLibrary(Microsoft.Diagnostics.Runtime.DataTarget! dataTarget, string! dacPath) -> void
+Microsoft.Diagnostics.Runtime.DacLibrary.DacLibrary(Microsoft.Diagnostics.Runtime.DataTarget! dataTarget, string! dacPath, ulong runtimeBaseAddress) -> void
 Microsoft.Diagnostics.Runtime.DacLibrary.DacPrivateInterface.get -> Microsoft.Diagnostics.Runtime.DacInterface.ClrDataProcess!
 Microsoft.Diagnostics.Runtime.DacLibrary.Dispose() -> void
 Microsoft.Diagnostics.Runtime.DacLibrary.GetInterface<T>(in System.Guid riid) -> T?

--- a/src/Microsoft.Diagnostics.Runtime/PublicAPI/net5.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Diagnostics.Runtime/PublicAPI/net5.0/PublicAPI.Unshipped.txt
@@ -441,6 +441,7 @@ Microsoft.Diagnostics.Runtime.DacInterface.ClrDataMethod.ClrDataMethod(Microsoft
 Microsoft.Diagnostics.Runtime.DacInterface.ClrDataMethod.GetILToNativeMap() -> Microsoft.Diagnostics.Runtime.ILToNativeMap[]?
 Microsoft.Diagnostics.Runtime.DacInterface.ClrDataModule
 Microsoft.Diagnostics.Runtime.DacInterface.ClrDataModule.ClrDataModule(Microsoft.Diagnostics.Runtime.DacLibrary! library, System.IntPtr pUnknown) -> void
+Microsoft.Diagnostics.Runtime.DacInterface.ClrDataModule.GetFileName() -> string?
 Microsoft.Diagnostics.Runtime.DacInterface.ClrDataModule.GetModuleData(out Microsoft.Diagnostics.Runtime.DacInterface.ExtendedModuleData data) -> Microsoft.Diagnostics.Runtime.Utilities.HResult
 Microsoft.Diagnostics.Runtime.DacInterface.ClrDataModule.GetName() -> string?
 Microsoft.Diagnostics.Runtime.DacInterface.ClrDataProcess
@@ -885,8 +886,10 @@ Microsoft.Diagnostics.Runtime.Implementation.IModuleData
 Microsoft.Diagnostics.Runtime.Implementation.IModuleData.Address.get -> ulong
 Microsoft.Diagnostics.Runtime.Implementation.IModuleData.AssemblyAddress.get -> ulong
 Microsoft.Diagnostics.Runtime.Implementation.IModuleData.AssemblyName.get -> string?
+Microsoft.Diagnostics.Runtime.Implementation.IModuleData.FileName.get -> string?
 Microsoft.Diagnostics.Runtime.Implementation.IModuleData.Helpers.get -> Microsoft.Diagnostics.Runtime.Implementation.IModuleHelpers!
 Microsoft.Diagnostics.Runtime.Implementation.IModuleData.ILImageBase.get -> ulong
+Microsoft.Diagnostics.Runtime.Implementation.IModuleData.IsDynamic.get -> bool
 Microsoft.Diagnostics.Runtime.Implementation.IModuleData.IsFlatLayout.get -> bool
 Microsoft.Diagnostics.Runtime.Implementation.IModuleData.IsPEFile.get -> bool
 Microsoft.Diagnostics.Runtime.Implementation.IModuleData.IsReflection.get -> bool

--- a/src/Microsoft.Diagnostics.Runtime/PublicAPI/net5.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Diagnostics.Runtime/PublicAPI/net5.0/PublicAPI.Unshipped.txt
@@ -646,6 +646,7 @@ Microsoft.Diagnostics.Runtime.DacInterface.WorkRequestData.WorkRequestData() -> 
 Microsoft.Diagnostics.Runtime.DacLibrary
 Microsoft.Diagnostics.Runtime.DacLibrary.DacLibrary(Microsoft.Diagnostics.Runtime.DataTarget! dataTarget, System.IntPtr pClrDataProcess) -> void
 Microsoft.Diagnostics.Runtime.DacLibrary.DacLibrary(Microsoft.Diagnostics.Runtime.DataTarget! dataTarget, string! dacPath) -> void
+Microsoft.Diagnostics.Runtime.DacLibrary.DacLibrary(Microsoft.Diagnostics.Runtime.DataTarget! dataTarget, string! dacPath, ulong runtimeBaseAddress) -> void
 Microsoft.Diagnostics.Runtime.DacLibrary.DacPrivateInterface.get -> Microsoft.Diagnostics.Runtime.DacInterface.ClrDataProcess!
 Microsoft.Diagnostics.Runtime.DacLibrary.Dispose() -> void
 Microsoft.Diagnostics.Runtime.DacLibrary.GetInterface<T>(in System.Guid riid) -> T?

--- a/src/Microsoft.Diagnostics.Runtime/PublicAPI/netcoreapp3.1/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Diagnostics.Runtime/PublicAPI/netcoreapp3.1/PublicAPI.Unshipped.txt
@@ -441,6 +441,7 @@ Microsoft.Diagnostics.Runtime.DacInterface.ClrDataMethod.ClrDataMethod(Microsoft
 Microsoft.Diagnostics.Runtime.DacInterface.ClrDataMethod.GetILToNativeMap() -> Microsoft.Diagnostics.Runtime.ILToNativeMap[]?
 Microsoft.Diagnostics.Runtime.DacInterface.ClrDataModule
 Microsoft.Diagnostics.Runtime.DacInterface.ClrDataModule.ClrDataModule(Microsoft.Diagnostics.Runtime.DacLibrary! library, System.IntPtr pUnknown) -> void
+Microsoft.Diagnostics.Runtime.DacInterface.ClrDataModule.GetFileName() -> string?
 Microsoft.Diagnostics.Runtime.DacInterface.ClrDataModule.GetModuleData(out Microsoft.Diagnostics.Runtime.DacInterface.ExtendedModuleData data) -> Microsoft.Diagnostics.Runtime.Utilities.HResult
 Microsoft.Diagnostics.Runtime.DacInterface.ClrDataModule.GetName() -> string?
 Microsoft.Diagnostics.Runtime.DacInterface.ClrDataProcess
@@ -885,8 +886,10 @@ Microsoft.Diagnostics.Runtime.Implementation.IModuleData
 Microsoft.Diagnostics.Runtime.Implementation.IModuleData.Address.get -> ulong
 Microsoft.Diagnostics.Runtime.Implementation.IModuleData.AssemblyAddress.get -> ulong
 Microsoft.Diagnostics.Runtime.Implementation.IModuleData.AssemblyName.get -> string?
+Microsoft.Diagnostics.Runtime.Implementation.IModuleData.FileName.get -> string?
 Microsoft.Diagnostics.Runtime.Implementation.IModuleData.Helpers.get -> Microsoft.Diagnostics.Runtime.Implementation.IModuleHelpers!
 Microsoft.Diagnostics.Runtime.Implementation.IModuleData.ILImageBase.get -> ulong
+Microsoft.Diagnostics.Runtime.Implementation.IModuleData.IsDynamic.get -> bool
 Microsoft.Diagnostics.Runtime.Implementation.IModuleData.IsFlatLayout.get -> bool
 Microsoft.Diagnostics.Runtime.Implementation.IModuleData.IsPEFile.get -> bool
 Microsoft.Diagnostics.Runtime.Implementation.IModuleData.IsReflection.get -> bool

--- a/src/Microsoft.Diagnostics.Runtime/PublicAPI/netcoreapp3.1/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Diagnostics.Runtime/PublicAPI/netcoreapp3.1/PublicAPI.Unshipped.txt
@@ -646,6 +646,7 @@ Microsoft.Diagnostics.Runtime.DacInterface.WorkRequestData.WorkRequestData() -> 
 Microsoft.Diagnostics.Runtime.DacLibrary
 Microsoft.Diagnostics.Runtime.DacLibrary.DacLibrary(Microsoft.Diagnostics.Runtime.DataTarget! dataTarget, System.IntPtr pClrDataProcess) -> void
 Microsoft.Diagnostics.Runtime.DacLibrary.DacLibrary(Microsoft.Diagnostics.Runtime.DataTarget! dataTarget, string! dacPath) -> void
+Microsoft.Diagnostics.Runtime.DacLibrary.DacLibrary(Microsoft.Diagnostics.Runtime.DataTarget! dataTarget, string! dacPath, ulong runtimeBaseAddress) -> void
 Microsoft.Diagnostics.Runtime.DacLibrary.DacPrivateInterface.get -> Microsoft.Diagnostics.Runtime.DacInterface.ClrDataProcess!
 Microsoft.Diagnostics.Runtime.DacLibrary.Dispose() -> void
 Microsoft.Diagnostics.Runtime.DacLibrary.GetInterface<T>(in System.Guid riid) -> T?

--- a/src/Microsoft.Diagnostics.Runtime/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Diagnostics.Runtime/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -441,6 +441,7 @@ Microsoft.Diagnostics.Runtime.DacInterface.ClrDataMethod.ClrDataMethod(Microsoft
 Microsoft.Diagnostics.Runtime.DacInterface.ClrDataMethod.GetILToNativeMap() -> Microsoft.Diagnostics.Runtime.ILToNativeMap[]?
 Microsoft.Diagnostics.Runtime.DacInterface.ClrDataModule
 Microsoft.Diagnostics.Runtime.DacInterface.ClrDataModule.ClrDataModule(Microsoft.Diagnostics.Runtime.DacLibrary! library, System.IntPtr pUnknown) -> void
+Microsoft.Diagnostics.Runtime.DacInterface.ClrDataModule.GetFileName() -> string?
 Microsoft.Diagnostics.Runtime.DacInterface.ClrDataModule.GetModuleData(out Microsoft.Diagnostics.Runtime.DacInterface.ExtendedModuleData data) -> Microsoft.Diagnostics.Runtime.Utilities.HResult
 Microsoft.Diagnostics.Runtime.DacInterface.ClrDataModule.GetName() -> string?
 Microsoft.Diagnostics.Runtime.DacInterface.ClrDataProcess
@@ -885,8 +886,10 @@ Microsoft.Diagnostics.Runtime.Implementation.IModuleData
 Microsoft.Diagnostics.Runtime.Implementation.IModuleData.Address.get -> ulong
 Microsoft.Diagnostics.Runtime.Implementation.IModuleData.AssemblyAddress.get -> ulong
 Microsoft.Diagnostics.Runtime.Implementation.IModuleData.AssemblyName.get -> string?
+Microsoft.Diagnostics.Runtime.Implementation.IModuleData.FileName.get -> string?
 Microsoft.Diagnostics.Runtime.Implementation.IModuleData.Helpers.get -> Microsoft.Diagnostics.Runtime.Implementation.IModuleHelpers!
 Microsoft.Diagnostics.Runtime.Implementation.IModuleData.ILImageBase.get -> ulong
+Microsoft.Diagnostics.Runtime.Implementation.IModuleData.IsDynamic.get -> bool
 Microsoft.Diagnostics.Runtime.Implementation.IModuleData.IsFlatLayout.get -> bool
 Microsoft.Diagnostics.Runtime.Implementation.IModuleData.IsPEFile.get -> bool
 Microsoft.Diagnostics.Runtime.Implementation.IModuleData.IsReflection.get -> bool

--- a/src/Microsoft.Diagnostics.Runtime/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Diagnostics.Runtime/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -646,6 +646,7 @@ Microsoft.Diagnostics.Runtime.DacInterface.WorkRequestData.WorkRequestData() -> 
 Microsoft.Diagnostics.Runtime.DacLibrary
 Microsoft.Diagnostics.Runtime.DacLibrary.DacLibrary(Microsoft.Diagnostics.Runtime.DataTarget! dataTarget, System.IntPtr pClrDataProcess) -> void
 Microsoft.Diagnostics.Runtime.DacLibrary.DacLibrary(Microsoft.Diagnostics.Runtime.DataTarget! dataTarget, string! dacPath) -> void
+Microsoft.Diagnostics.Runtime.DacLibrary.DacLibrary(Microsoft.Diagnostics.Runtime.DataTarget! dataTarget, string! dacPath, ulong runtimeBaseAddress) -> void
 Microsoft.Diagnostics.Runtime.DacLibrary.DacPrivateInterface.get -> Microsoft.Diagnostics.Runtime.DacInterface.ClrDataProcess!
 Microsoft.Diagnostics.Runtime.DacLibrary.Dispose() -> void
 Microsoft.Diagnostics.Runtime.DacLibrary.GetInterface<T>(in System.Guid riid) -> T?

--- a/src/Microsoft.Diagnostics.Runtime/src/Builders/ModuleBuilder.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Builders/ModuleBuilder.cs
@@ -29,6 +29,7 @@ namespace Microsoft.Diagnostics.Runtime.Builders
         public ulong MetadataLength => _moduleData.MetadataSize;
 
         public bool IsFlatLayout { get; private set; }
+        public bool IsDynamic { get; private set; }
         public ulong Size { get; private set; }
 
         public string? Name
@@ -49,6 +50,8 @@ namespace Microsoft.Diagnostics.Runtime.Builders
         }
 
         public string? SimpleName { get; private set; }
+
+        public string? FileName { get; private set; }
 
         public string? AssemblyName
         {
@@ -81,22 +84,18 @@ namespace Microsoft.Diagnostics.Runtime.Builders
             if (dataModule != null && dataModule.GetModuleData(out ExtendedModuleData data))
             {
                 IsFlatLayout = data.IsFlatLayout != 0;
+                IsDynamic = data.IsDynamic != 0;
                 Size = data.LoadedPESize;
             }
             else
             {
                 IsFlatLayout = false;
+                IsDynamic = false;
                 Size = 0;
             }
 
-            if (dataModule != null)
-            {
-                SimpleName = dataModule.GetName();
-            }
-            else
-            {
-                SimpleName = null;
-            }
+            SimpleName = dataModule?.GetName();
+            FileName = dataModule?.GetFileName();
 
             return true;
         }

--- a/src/Microsoft.Diagnostics.Runtime/src/DacInterface/ClrDataModule.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DacInterface/ClrDataModule.cs
@@ -48,6 +48,17 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             return hr ? name : null;
         }
 
+        public string? GetFileName()
+        {
+            // GetFileName will fault if buffer pointer is null. Use fixed size buffer.
+            char[] buffer = new char[1024];
+            fixed (char* bufferPtr = buffer)
+            {
+                HResult hr = VTable.GetFileName(Self, 1024, out int nameLength, bufferPtr);
+                return hr && nameLength > 0 ? new string(buffer, 0, nameLength - 1) : null;
+            }
+        }
+
         [StructLayout(LayoutKind.Sequential)]
         private readonly unsafe struct IClrDataModuleVTable
         {
@@ -78,7 +89,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             private readonly IntPtr EnumDataByName;
             private readonly IntPtr EndEnumDataByName;
             public readonly delegate* unmanaged[Stdcall]<IntPtr, int, out int, char*, HResult> GetName;
-            private readonly IntPtr GetFileName;
+            public readonly delegate* unmanaged[Stdcall]<IntPtr, int, out int, char*, HResult> GetFileName;
             private readonly IntPtr GetFlags;
             private readonly IntPtr IsSameObject;
             private readonly IntPtr StartEnumExtents;

--- a/src/Microsoft.Diagnostics.Runtime/src/DacInterface/DacDataTargetWrapper.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DacInterface/DacDataTargetWrapper.cs
@@ -55,9 +55,12 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             builder.AddMethod(new GetMetadataDelegate(GetMetadata));
             builder.Complete();
 
-            builder = AddInterface(IID_ICLRRuntimeLocator, false);
-            builder.AddMethod(new GetRuntimeBaseDelegate(GetRuntimeBase));
-            builder.Complete();
+            if (runtimeBaseAddress != 0)
+            {
+                builder = AddInterface(IID_ICLRRuntimeLocator, false);
+                builder.AddMethod(new GetRuntimeBaseDelegate(GetRuntimeBase));
+                builder.Complete();
+            }
         }
 
         public void EnterMagicCallbackContext() => Interlocked.Increment(ref _callbackContext);
@@ -306,8 +309,9 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             IntPtr self,
             out ulong address)
         {
+            Debug.Assert(_runtimeBaseAddress != 0);
             address = _runtimeBaseAddress;
-            return _runtimeBaseAddress != 0 ? HResult.S_OK : HResult.E_FAIL;
+            return HResult.S_OK;
         }
 
         private delegate HResult GetMetadataDelegate(IntPtr self, [In][MarshalAs(UnmanagedType.LPWStr)] string fileName, int imageTimestamp, int imageSize,

--- a/src/Microsoft.Diagnostics.Runtime/src/DacInterface/DacDataTargetWrapper.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DacInterface/DacDataTargetWrapper.cs
@@ -20,9 +20,11 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
 
         private static readonly Guid IID_IDacDataTarget = new("3E11CCEE-D08B-43e5-AF01-32717A64DA03");
         private static readonly Guid IID_IMetadataLocator = new("aa8fa804-bc05-4642-b2c5-c353ed22fc63");
+        private static readonly Guid IID_ICLRRuntimeLocator = new Guid("b760bf44-9377-4597-8be7-58083bdc5146");
 
         private readonly DataTarget _dataTarget;
         private readonly IDataReader _dataReader;
+        private readonly ulong _runtimeBaseAddress;
         private volatile ModuleInfo[]? _modules;
 
         private Action? _callback;
@@ -30,10 +32,11 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
 
         public IntPtr IDacDataTarget { get; }
 
-        public DacDataTargetWrapper(DataTarget dataTarget)
+        public DacDataTargetWrapper(DataTarget dataTarget, ulong runtimeBaseAddress = 0)
         {
             _dataTarget = dataTarget;
             _dataReader = _dataTarget.DataReader;
+            _runtimeBaseAddress = runtimeBaseAddress;
 
             VTableBuilder builder = AddInterface(IID_IDacDataTarget, false);
             builder.AddMethod(new GetMachineTypeDelegate(GetMachineType));
@@ -50,6 +53,10 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
 
             builder = AddInterface(IID_IMetadataLocator, false);
             builder.AddMethod(new GetMetadataDelegate(GetMetadata));
+            builder.Complete();
+
+            builder = AddInterface(IID_ICLRRuntimeLocator, false);
+            builder.AddMethod(new GetRuntimeBaseDelegate(GetRuntimeBase));
             builder.Complete();
         }
 
@@ -295,6 +302,14 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             return HResult.S_OK;
         }
 
+        private HResult GetRuntimeBase(
+            IntPtr self,
+            out ulong address)
+        {
+            address = _runtimeBaseAddress;
+            return _runtimeBaseAddress != 0 ? HResult.S_OK : HResult.E_FAIL;
+        }
+
         private delegate HResult GetMetadataDelegate(IntPtr self, [In][MarshalAs(UnmanagedType.LPWStr)] string fileName, int imageTimestamp, int imageSize,
                                                      IntPtr mvid, uint mdRva, uint flags, uint bufferSize, IntPtr buffer, int* dataSize);
         private delegate HResult GetMachineTypeDelegate(IntPtr self, out IMAGE_FILE_MACHINE machineType);
@@ -308,5 +323,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
         private delegate HResult GetThreadContextDelegate(IntPtr self, uint threadID, uint contextFlags, int contextSize, IntPtr context);
         private delegate HResult SetThreadContextDelegate(IntPtr self, uint threadID, uint contextSize, IntPtr context);
         private delegate HResult RequestDelegate(IntPtr self, uint reqCode, uint inBufferSize, IntPtr inBuffer, IntPtr outBufferSize, out IntPtr outBuffer);
+
+        private delegate HResult GetRuntimeBaseDelegate([In] IntPtr self, [Out] out ulong address);
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/src/DataTargets/ClrInfo.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataTargets/ClrInfo.cs
@@ -102,7 +102,7 @@ namespace Microsoft.Diagnostics.Runtime
             if (IntPtr.Size != DataTarget.DataReader.PointerSize)
                 throw new InvalidOperationException("Mismatched pointer size between this process and the dac.");
 
-            DacLibrary dacLibrary = new DacLibrary(DataTarget, dac);
+            DacLibrary dacLibrary = new DacLibrary(DataTarget, dac, ModuleInfo.ImageBase);
             DacInterface.SOSDac? sos = dacLibrary.SOSDacInterface;
             if (sos is null)
                 throw new InvalidOperationException($"Could not create a ISOSDac pointer from this dac library: {dac}");

--- a/src/Microsoft.Diagnostics.Runtime/src/DataTargets/DacLibrary.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataTargets/DacLibrary.cs
@@ -86,7 +86,12 @@ namespace Microsoft.Diagnostics.Runtime
             DacDataTarget = new DacDataTargetWrapper(dataTarget);
         }
 
-        public unsafe DacLibrary(DataTarget dataTarget, string dacPath)
+        public DacLibrary(DataTarget dataTarget, string dacPath)
+            : this(dataTarget, dacPath, runtimeBaseAddress: 0)
+        {
+        }
+
+        internal unsafe DacLibrary(DataTarget dataTarget, string dacPath, ulong runtimeBaseAddress)
         {
             if (dataTarget is null)
                 throw new ArgumentNullException(nameof(dataTarget));
@@ -124,7 +129,7 @@ namespace Microsoft.Diagnostics.Runtime
             if (addr == IntPtr.Zero)
                 throw new ClrDiagnosticsException("Failed to obtain Dac CLRDataCreateInstance");
 
-            DacDataTarget = new DacDataTargetWrapper(dataTarget);
+            DacDataTarget = new DacDataTargetWrapper(dataTarget, runtimeBaseAddress);
 
             var func = (delegate* unmanaged[Stdcall]<in Guid, IntPtr, out IntPtr, int>)addr;
             Guid guid = new Guid("5c552ab6-fc09-4cb3-8e36-22fa03c798b7");

--- a/src/Microsoft.Diagnostics.Runtime/src/DataTargets/DacLibrary.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataTargets/DacLibrary.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Diagnostics.Runtime
         {
         }
 
-        internal unsafe DacLibrary(DataTarget dataTarget, string dacPath, ulong runtimeBaseAddress)
+        public unsafe DacLibrary(DataTarget dataTarget, string dacPath, ulong runtimeBaseAddress)
         {
             if (dataTarget is null)
                 throw new ArgumentNullException(nameof(dataTarget));

--- a/src/Microsoft.Diagnostics.Runtime/src/Implementation/ClrmdModule.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Implementation/ClrmdModule.cs
@@ -47,8 +47,8 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
             _data = data;
             _helpers = data.Helpers;
             AppDomain = parent;
-            Name = data.Name;
-            AssemblyName = data.AssemblyName;
+            Name = data.Name ?? data.FileName;
+            AssemblyName = data.AssemblyName ?? data.FileName;
             AssemblyAddress = data.AssemblyAddress;
             Address = data.Address;
             IsPEFile = data.IsPEFile;
@@ -57,7 +57,7 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
             Size = data.Size;
             MetadataAddress = data.MetadataStart;
             MetadataLength = data.MetadataLength;
-            IsDynamic = data.IsReflection || string.IsNullOrWhiteSpace(Name);
+            IsDynamic = data.IsReflection || data.IsDynamic;
         }
 
         public ClrmdModule(ClrAppDomain parent, IModuleHelpers helpers, ulong addr)

--- a/src/Microsoft.Diagnostics.Runtime/src/Implementation/IModuleData.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Implementation/IModuleData.cs
@@ -13,9 +13,11 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
         ulong PEImageBase { get; }
         ulong ILImageBase { get; }
         bool IsFlatLayout { get; }
+        bool IsDynamic { get; }
         ulong Size { get; }
         ulong MetadataStart { get; }
         string? Name { get; }
+        string? FileName { get; }
         string? SimpleName { get; }
         string? AssemblyName { get; }
         ulong MetadataLength { get; }


### PR DESCRIPTION
Add a ICLRRuntimeLocator impl to DAC data target so single-file runtime can be found.

Fix single-file module names. The DAC GetPEFileName() GetAssemblyName() don't return a module/assembly file path for single file apps. 