### PR TITLE
Add Destroy() override to ComCallableIUnknown

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/PublicAPI/net461/PublicAPI.Shipped.txt
+++ b/src/Microsoft.Diagnostics.Runtime/PublicAPI/net461/PublicAPI.Shipped.txt
@@ -1218,6 +1218,7 @@ Microsoft.Diagnostics.Runtime.Utilities.COMCallableIUnknown.COMCallableIUnknown(
 Microsoft.Diagnostics.Runtime.Utilities.COMCallableIUnknown.IUnknown.get -> Microsoft.Diagnostics.Runtime.Utilities.IUnknownVTable
 Microsoft.Diagnostics.Runtime.Utilities.COMCallableIUnknown.IUnknownObject.get -> System.IntPtr
 Microsoft.Diagnostics.Runtime.Utilities.COMCallableIUnknown.Release() -> int
+virtual Microsoft.Diagnostics.Runtime.Utilities.COMCallableIUnknown.Destroy() -> void
 Microsoft.Diagnostics.Runtime.Utilities.COMHelper
 Microsoft.Diagnostics.Runtime.Utilities.COMHelper.AddRefDelegate
 Microsoft.Diagnostics.Runtime.Utilities.COMHelper.COMHelper() -> void

--- a/src/Microsoft.Diagnostics.Runtime/PublicAPI/net5.0/PublicAPI.Shipped.txt
+++ b/src/Microsoft.Diagnostics.Runtime/PublicAPI/net5.0/PublicAPI.Shipped.txt
@@ -1218,6 +1218,7 @@ Microsoft.Diagnostics.Runtime.Utilities.COMCallableIUnknown.COMCallableIUnknown(
 Microsoft.Diagnostics.Runtime.Utilities.COMCallableIUnknown.IUnknown.get -> Microsoft.Diagnostics.Runtime.Utilities.IUnknownVTable
 Microsoft.Diagnostics.Runtime.Utilities.COMCallableIUnknown.IUnknownObject.get -> System.IntPtr
 Microsoft.Diagnostics.Runtime.Utilities.COMCallableIUnknown.Release() -> int
+virtual Microsoft.Diagnostics.Runtime.Utilities.COMCallableIUnknown.Destroy() -> void
 Microsoft.Diagnostics.Runtime.Utilities.COMHelper
 Microsoft.Diagnostics.Runtime.Utilities.COMHelper.AddRefDelegate
 Microsoft.Diagnostics.Runtime.Utilities.COMHelper.COMHelper() -> void

--- a/src/Microsoft.Diagnostics.Runtime/PublicAPI/netcoreapp3.1/PublicAPI.Shipped.txt
+++ b/src/Microsoft.Diagnostics.Runtime/PublicAPI/netcoreapp3.1/PublicAPI.Shipped.txt
@@ -1218,6 +1218,7 @@ Microsoft.Diagnostics.Runtime.Utilities.COMCallableIUnknown.COMCallableIUnknown(
 Microsoft.Diagnostics.Runtime.Utilities.COMCallableIUnknown.IUnknown.get -> Microsoft.Diagnostics.Runtime.Utilities.IUnknownVTable
 Microsoft.Diagnostics.Runtime.Utilities.COMCallableIUnknown.IUnknownObject.get -> System.IntPtr
 Microsoft.Diagnostics.Runtime.Utilities.COMCallableIUnknown.Release() -> int
+virtual Microsoft.Diagnostics.Runtime.Utilities.COMCallableIUnknown.Destroy() -> void
 Microsoft.Diagnostics.Runtime.Utilities.COMHelper
 Microsoft.Diagnostics.Runtime.Utilities.COMHelper.AddRefDelegate
 Microsoft.Diagnostics.Runtime.Utilities.COMHelper.COMHelper() -> void

--- a/src/Microsoft.Diagnostics.Runtime/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
+++ b/src/Microsoft.Diagnostics.Runtime/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
@@ -1218,6 +1218,7 @@ Microsoft.Diagnostics.Runtime.Utilities.COMCallableIUnknown.COMCallableIUnknown(
 Microsoft.Diagnostics.Runtime.Utilities.COMCallableIUnknown.IUnknown.get -> Microsoft.Diagnostics.Runtime.Utilities.IUnknownVTable
 Microsoft.Diagnostics.Runtime.Utilities.COMCallableIUnknown.IUnknownObject.get -> System.IntPtr
 Microsoft.Diagnostics.Runtime.Utilities.COMCallableIUnknown.Release() -> int
+virtual Microsoft.Diagnostics.Runtime.Utilities.COMCallableIUnknown.Destroy() -> void
 Microsoft.Diagnostics.Runtime.Utilities.COMHelper
 Microsoft.Diagnostics.Runtime.Utilities.COMHelper.AddRefDelegate
 Microsoft.Diagnostics.Runtime.Utilities.COMHelper.COMHelper() -> void

--- a/src/Microsoft.Diagnostics.Runtime/src/Utilities/COMInterop/ComCallableIUnknown.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Utilities/COMInterop/ComCallableIUnknown.cs
@@ -119,20 +119,19 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
                     {
                         Destroy();
                     }
-                    catch
+                    finally
                     {
-                    }
+                        foreach (IntPtr ptr in _interfaces.Values)
+                        {
+                            IntPtr* val = (IntPtr*)ptr;
+                            Marshal.FreeHGlobal(*val);
+                            Marshal.FreeHGlobal(ptr);
+                        }
 
-                    foreach (IntPtr ptr in _interfaces.Values)
-                    {
-                        IntPtr* val = (IntPtr*)ptr;
-                        Marshal.FreeHGlobal(*val);
-                        Marshal.FreeHGlobal(ptr);
+                        _handle.Free();
+                        _interfaces.Clear();
+                        _delegates.Clear();
                     }
-
-                    _handle.Free();
-                    _interfaces.Clear();
-                    _delegates.Clear();
                 }
             }
 

--- a/src/Microsoft.Diagnostics.Runtime/src/Utilities/COMInterop/ComCallableIUnknown.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Utilities/COMInterop/ComCallableIUnknown.cs
@@ -115,6 +115,14 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
                 // Only free memory the first time we reach here.
                 if (_handle.IsAllocated)
                 {
+                    try
+                    {
+                        Destroy();
+                    }
+                    catch
+                    {
+                    }
+
                     foreach (IntPtr ptr in _interfaces.Values)
                     {
                         IntPtr* val = (IntPtr*)ptr;
@@ -132,5 +140,9 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
         }
 
         private int AddRefImpl(IntPtr self) => Interlocked.Increment(ref _refCount);
+
+        protected virtual void Destroy()
+        {
+        }
     }
 }


### PR DESCRIPTION
This allows wrappers that use ComCallableIUnknown to clean up any
internal state on ref count == 0.