### PR TITLE
Fix escaping IOExceptions from TryLookupSymbol

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/src/Linux/ElfDynamicSection.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Linux/ElfDynamicSection.cs
@@ -75,15 +75,20 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
                 symbol = null;
                 return false;
             }
-
-            foreach (uint possibleLocation in GnuHash.GetPossibleSymbolIndex(symbolName))
+            try
             {
-                ElfSymbol s = SymbolTable.GetSymbol(possibleLocation);
-                if(s.Name == symbolName)
+                foreach (uint possibleLocation in GnuHash.GetPossibleSymbolIndex(symbolName))
                 {
-                    symbol = s;
-                    return true;
+                    ElfSymbol s = SymbolTable.GetSymbol(possibleLocation);
+                    if (s.Name == symbolName)
+                    {
+                        symbol = s;
+                        return true;
+                    }
                 }
+            }
+            catch (IOException)
+            {
             }
             symbol = null;
             return false;


### PR DESCRIPTION
Not all of memory for the export symbols existing for every module in a core dump
generated by createdump. Only the runtime module is guaranteed. These read memory
IO exceptions being thrown by GnuHash.GetPossibleSymbolIndex or SymbolTable.GetSymbol
reading the hash table or the symbol entry itself.