### PR TITLE
Resolves: Add a CI pipeline with GitHub Actions

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,0 +1,102 @@
+name: CI Pipeline
+
+on: [ push, pull_request, workflow_dispatch ]
+
+jobs:
+  ci:
+    name: Continuous Integration
+    runs-on: ubuntu-latest
+    env:
+      pathToSolution: Microsoft.Diagnostics.Runtime.sln
+      testResultsFolderName: Test results
+      publishOutputFolderName: Publish output
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      # Tooling setup
+
+      - name: Install .NET SDK
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 3.1.411
+
+      - name: Install .NET SDK
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 5.0.302
+
+      # Build and test validation
+
+      - name: Restore solution
+        shell: pwsh
+        run: |
+          $pathToSolution = "${{ env.pathToSolution }}"
+
+          dotnet restore $pathToSolution
+
+      - name: Build solution
+        shell: pwsh
+        run: |
+          $pathToSolution = "${{ env.pathToSolution }}"
+          $configurationSetting = "Debug"
+
+          dotnet build $pathToSolution `
+          --configuration $configurationSetting `
+          --no-restore
+
+      - name: Run unit tests
+        continue-on-error: true
+        shell: pwsh
+        run: |
+          $pathToSolution = "${{ env.pathToSolution }}"
+          $pathToTestTargets = "src/TestTargets/TestTargets.proj"
+          $configurationSetting = "Debug"
+          $loggerAttributes = "trx;LogFilePath=TestResults.trx;verbosity=normal"
+          $testOutputFolder = "${{ env.testResultsFolderName }}"
+
+          dotnet build $pathToTestTargets `
+          --configuration $configurationSetting
+
+          dotnet test $pathToSolution `
+          --configuration $configurationSetting `
+          --logger $loggerAttributes `
+          --results-directory $testOutputFolder `
+          --no-build
+
+      # Artifact generation
+
+      - name: Publish project for each target framework
+        shell: pwsh
+        run: |
+          $pathToProject = "src/Microsoft.Diagnostics.Runtime/Microsoft.Diagnostics.Runtime.csproj"
+          $configurationSetting = "Debug"
+          $publishOutputFolder = "${{ env.publishOutputFolderName }}"
+          $targetFrameworksProperty = [String](([xml](Get-Content -Path $pathToProject)).Project.PropertyGroup.TargetFrameworks)
+          $targetFrameworks = $targetFrameworksProperty.split(';')
+
+          foreach ( $framework in $targetFrameworks ) {
+            $frameworkNum = [String]($framework -replace ' ', '')
+
+            dotnet publish $pathToProject `
+            --configuration $configurationSetting `
+            --output "$publishOutputFolder/$frameworkNum" `
+            --framework $frameworkNum `
+            --no-restore
+          }
+
+      # Artifact publish to pipeline
+
+      - name: Upload test results as pipeline artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: Test results
+          path: ${{ env.testResultsFolderName }}
+
+      - name: Upload publish output as pipeline artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: Publish output
+          path: ${{ env.publishOutputFolderName }}
+
+# Built with ❤ by [Pipeline Foundation](https://pipeline.foundation)

--- a/src/TestTargets/Types/Types.csproj
+++ b/src/TestTargets/Types/Types.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### The pipeline runs:

1. CI
- build and unit tests validation
- artifacts generation
- uploading artifacts to pipeline run (checkout the PR run of the pipeline for artifact download)

### File changes:
- Code change in `src/TestTargets/Types/Types.csproj` is because of this error:

```
/workspaces/clrmd/src/TestTargets/Types/obj/Debug/netcoreapp3.1/Types.AssemblyInfo.cs(15,12): error CS0579: Duplicate 'System.Reflection.AssemblyFileVersionAttribute' attribute [/workspaces/clrmd/src/TestTargets/Types/Types.csproj]
/workspaces/clrmd/src/TestTargets/Types/obj/Debug/netcoreapp3.1/Types.AssemblyInfo.cs(19,12): error CS0579: Duplicate 'System.Reflection.AssemblyVersionAttribute' attribute [/workspaces/clrmd/src/TestTargets/Types/Types.csproj]
```

We would like to add Continuous Deployment as well, however we know there are internal procedures often incorporated with Microsoft projects for the packaging, so we wanted to confirm first if what we have as an idea is desirable. The CD would include:
- commit-based automated versioning
- NuGet package generation and signing
- deployment to NuGet.org
- creation of GitHub Release

Please let us know if you'd like us to include that, if anything could be done better and/or if any other automation is required by the project! We would be happy to improve it to satisfactory completion 🙂  

Resolves #943 
