### PR TITLE
Support regions

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/src/Builders/RuntimeBuilder.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Builders/RuntimeBuilder.cs
@@ -167,7 +167,7 @@ namespace Microsoft.Diagnostics.Runtime.Builders
             }
 
             bool result = false;
-            SegmentBuilder segBuilder = new SegmentBuilder(_sos);
+            SegmentBuilder segBuilder = new SegmentBuilder(_sos, DataReader.PointerSize);
             if (clrHeap.IsServer)
             {
                 ClrDataAddress[] heapList = _sos.GetHeapList(clrHeap.LogicalHeapCount);

--- a/src/Microsoft.Diagnostics.Runtime/src/Builders/SegmentBuilder.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Builders/SegmentBuilder.cs
@@ -10,22 +10,37 @@ namespace Microsoft.Diagnostics.Runtime.Builders
     internal sealed class SegmentBuilder : ISegmentData
     {
         private SegmentData _segment;
+        private bool _regions;
         private ulong _heapAllocated;
-        private ulong _ephemGen0Start;
-        private ulong _ephemGen1Start;
         private ulong _ephemAddress;
         private readonly SOSDac _sos;
+
+        // Segments only
+        private ulong _ephemGen0Start;
+        private ulong _ephemGen1Start;
+
+        // Regions only
+        private int _generation;
 
         public SegmentBuilder(SOSDac sos)
         {
             _sos = sos;
         }
 
-        public bool Initialize(ulong address, in HeapDetails heap)
+        public bool Initialize(ulong address, int generation, in HeapDetails heap)
         {
+            _regions = heap.SavedSweepEphemeralSeg.Value == -1;
+
             _heapAllocated = heap.Allocated;
-            _ephemGen0Start = heap.GenerationTable[0].AllocationStart;
-            _ephemGen1Start = heap.GenerationTable[1].AllocationStart;
+            if (_regions)
+            {
+                _generation = generation;
+            }
+            else
+            {
+                _ephemGen0Start = heap.GenerationTable[0].AllocationStart;
+                _ephemGen1Start = heap.GenerationTable[1].AllocationStart;
+            }
             _ephemAddress = heap.EphemeralHeapSegment;
 
             return _sos.GetSegmentData(address, out _segment);
@@ -33,8 +48,9 @@ namespace Microsoft.Diagnostics.Runtime.Builders
 
         #region ISegmentData
         public int LogicalHeap { get; set; }
-
-        public ulong BaseAddress => _segment.Address;
+        
+        // 0x20 is sizeof(aligned_plug_and_gap)
+        public ulong BaseAddress => _regions ? (_segment.Start - 0x20) : _segment.Address;
 
         public ulong Start => _segment.Start;
 
@@ -44,17 +60,82 @@ namespace Microsoft.Diagnostics.Runtime.Builders
 
         public ulong CommittedEnd => _segment.Committed;
 
-        public ulong Gen0Start => IsEphemeralSegment ? _ephemGen0Start : End;
+        public ulong Gen0Start
+        {
+            get
+            {
+                if (_regions)
+                {
+                    return (_generation == 0) ? Start : End;
+                }
+                else
+                {
+                    return IsEphemeralSegment ? _ephemGen0Start : End;
+                }
+            }
+        }
 
         public ulong Gen0Length => End - Gen0Start;
 
-        public ulong Gen1Start => IsEphemeralSegment ? _ephemGen1Start : End;
+        public ulong Gen1Start
+        {
+            get
+            {
+                if (_regions)
+                {
+                    return (_generation == 1) ? Start : End;
+                }
+                else
+                {
+                    return IsEphemeralSegment ? _ephemGen1Start : End;
+                }
+            }
+        }
 
-        public ulong Gen1Length => Gen0Start - Gen1Start;
+        public ulong Gen1Length
+        {
+            get
+            {
+                if (_regions)
+                {
+                    return End - Gen1Start;
+                }
+                else
+                {
+                    return Gen0Start - Gen1Start;
+                }
+            }
+        }
 
-        public ulong Gen2Start => Start;
+        public ulong Gen2Start
+        {
+            get
+            {
+                if (_regions)
+                {
+                    return (_generation >= 2) ? Start : End;
+                }
+                else
+                {
+                    return Start;
+                }
+            }
+        }
 
-        public ulong Gen2Length => Gen1Start - Start;
+        public ulong Gen2Length
+        {
+            get
+            {
+                if (_regions)
+                {
+                    return End - Gen2Start;
+                }
+                else
+                {
+                    return Gen1Start - Start;
+                }
+            }
+        }
 
         public bool IsLargeObjectSegment { get; set; }
 

--- a/src/Microsoft.Diagnostics.Runtime/src/Builders/SegmentBuilder.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Builders/SegmentBuilder.cs
@@ -21,10 +21,12 @@ namespace Microsoft.Diagnostics.Runtime.Builders
 
         // Regions only
         private int _generation;
+        private ulong _sizeofPlugAndGap;
 
-        public SegmentBuilder(SOSDac sos)
+        public SegmentBuilder(SOSDac sos, int pointerSize)
         {
             _sos = sos;
+            _sizeofPlugAndGap = (ulong)pointerSize * 4;
         }
 
         public bool Initialize(ulong address, int generation, in HeapDetails heap)
@@ -48,9 +50,8 @@ namespace Microsoft.Diagnostics.Runtime.Builders
 
         #region ISegmentData
         public int LogicalHeap { get; set; }
-        
-        // 0x20 is sizeof(aligned_plug_and_gap)
-        public ulong BaseAddress => _regions ? (_segment.Start - 0x20) : _segment.Address;
+
+        public ulong BaseAddress => _regions ? (_segment.Start - _sizeofPlugAndGap) : _segment.Address;
 
         public ulong Start => _segment.Start;
 


### PR DESCRIPTION
This PR fixes https://github.com/microsoft/clrmd/issues/936.

## Here are a few key changes in the heap data structure:

To get our terminologies straight, while we still have the `heap_segment` objects, we call them `region` objects under the context of `USE_REGIONS`. 

Under `USE_REGIONS`, the `heap_segment` object itself is stored somewhere other than the address it manages (it is part of the `seg_mapping_table` to be precise), therefore we cannot use the address of the `heap_segment` object itself to determine the base address of the region.

With `USE_REGIONS`, gen0 and gen1 are no longer restricted on `ephemeral_heap_segment`, we could have a linked list of regions for gen0 and gen1. This explains the extra calls to `AddSegments` on `ProcessHeap`.

The field `allocation_start` is no longer defined in `generation`. For backward compatibility reasons, the field is still defined on the `DacpGenerationData` structure, but it will always be 0 in .NET 6 when `USE_REGIONS` is turned on. There isn't a single start and end pointer for gen0 and gen1 anymore. Instead, each region belongs to a generation, therefore the `Gen0Start` and `Gen0Length` are simply set to the `Start` and `End-Start` of the region if it is indeed a gen0 region, otherwise it is set to `End` and `0` respectively. 

Beyond the obvious changes, here are some not so obvious changes that might break things:

1. The regions are no longer sorted, so I have to remove the check in the unit tests.
2. There could be empty regions, so I have to avoid walking them in heap enumeration.
3. By default, each region is just 4MB (LOH regions has a default size of 32MB), so one might have a lot more regions.

## Status of the PR:

Right now this fix is sufficient to get the [DumpGen](https://github.com/dotnet/diagnostics/blob/1bbeecbd0dfa6a010368b2f8b4ea867421f15600/src/Microsoft.Diagnostics.ExtensionCommands/DumpGenCommand.cs) command in SOS to work with https://github.com/dotnet/diagnostics/pull/2501. With [some hacks](https://github.com/cshung/clrmd/tree/private/TestHacks), all the unit tests passed. I might have missed other scenarios that are not covered by the tests.

## Future work:

As the change on SOS side and unit test changes indicate, even when the fix is in, it is still possible for callers to be broken by `USE_REGIONS`. While there is nothing we can do in the code to prevent that, we might be able to communicate upfront to get it fixed earlier.

Eventually, we need to publish a new version with region support enabled so that SOS (and other tools) can consume the new functionalities.