### PR TITLE
Switch to new CI version 3.0 build/publish

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -140,7 +140,7 @@ stages:
         # as well as NuGet, SourceLink, and signing validation.
         # The variables get imported from group dotnet-diagnostics-sdl-params
         publishingInfraVersion: 3
-        enableSourceLinkValidation: true
+        enableSourceLinkValidation: false
         enableSigningValidation: true
         enableSymbolValidation: false
         enableNugetValidation: true


### PR DESCRIPTION
These changes allows the clrmd binaries to be published to be properly the "dotnet-tools" feed so that the diagnostics repo's DARC subscription can receive the updates from this repo.