### PR TITLE
Fix .NET 5.0 MacOS ELF dump module list

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/src/Linux/ElfCoreFile.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Linux/ElfCoreFile.cs
@@ -211,7 +211,14 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
                 ArrayPool<byte>.Shared.Return(bytes);
             }
 
-            return lookup.Values.Where(i => i.BaseAddress != 0).ToImmutableDictionary(i => i.BaseAddress);
+            ImmutableDictionary<ulong, ElfLoadedImage>.Builder result = ImmutableDictionary.CreateBuilder<ulong, ElfLoadedImage>();
+            foreach (ElfLoadedImage image in lookup.Values)
+            {
+                image.FixBaseAddress();
+                result.Add(image.BaseAddress, image);
+            }
+
+            return result.ToImmutable();
         }
 
         public void Dispose()


### PR DESCRIPTION
This fixes what a problem with my previous single-file module fix. The hacky MacOS ELF dumps that 5.0 generates (6.0 now generates actual MachO dumps) have modules with no PageOffset == 0 file entries so my previous change doesn't add them to the list of modules.