### PR TITLE
Add IExportSymbols support to PEImage modules

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/PEImagePdbTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/PEImagePdbTests.cs
@@ -38,5 +38,17 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             Assert.NotNull(imgPdb);
             Assert.NotNull(imgPdb.Path);
         }
+
+        [Fact]
+        public void ExportSymbolTest()
+        {
+            // Load Windows' ntdll.dll
+            var dllFileName = Path.Combine(Environment.SystemDirectory, "ntdll.dll");
+            using PEImage img = new PEImage(new FileStream(dllFileName, FileMode.Open, FileAccess.Read));
+            Assert.NotNull(img);
+
+            Assert.True(img.TryGetExportSymbol("DbgBreakPoint", out ulong offset));
+            Assert.NotEqual(0UL, offset);
+        }
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/PublicAPI/net461/PublicAPI.Shipped.txt
+++ b/src/Microsoft.Diagnostics.Runtime/PublicAPI/net461/PublicAPI.Shipped.txt
@@ -740,7 +740,7 @@ Microsoft.Diagnostics.Runtime.ILToNativeMap.ILOffset -> int
 Microsoft.Diagnostics.Runtime.ILToNativeMap.ILToNativeMap() -> void
 Microsoft.Diagnostics.Runtime.ILToNativeMap.StartAddress -> ulong
 Microsoft.Diagnostics.Runtime.IExportReader
-Microsoft.Diagnostics.Runtime.IExportReader.TryGetSymbolAddress(ulong baseAddress, string! name, out ulong offset) -> bool
+Microsoft.Diagnostics.Runtime.IExportReader.TryGetSymbolAddress(ulong baseAddress, string! name, out ulong address) -> bool
 Microsoft.Diagnostics.Runtime.IMemoryReader
 Microsoft.Diagnostics.Runtime.IMemoryReader.PointerSize.get -> int
 Microsoft.Diagnostics.Runtime.IMemoryReader.Read(ulong address, System.Span<byte> buffer) -> int
@@ -1017,12 +1017,14 @@ Microsoft.Diagnostics.Runtime.Utilities.ElfCoreFile.Dispose() -> void
 Microsoft.Diagnostics.Runtime.Utilities.ElfCoreFile.ElfCoreFile(System.IO.Stream! stream, bool leaveOpen = false) -> void
 Microsoft.Diagnostics.Runtime.Utilities.ElfCoreFile.ElfCoreFile(string! coredump) -> void
 Microsoft.Diagnostics.Runtime.Utilities.ElfFile.Dispose() -> void
-Microsoft.Diagnostics.Runtime.Utilities.ElfFile.ElfFile(System.IO.Stream! stream, bool leaveOpen = false) -> void
 Microsoft.Diagnostics.Runtime.Utilities.ElfFile.ElfFile(string! filename) -> void
+Microsoft.Diagnostics.Runtime.Utilities.ElfFile.ElfFile(System.IO.Stream! stream, bool leaveOpen = false) -> void
+Microsoft.Diagnostics.Runtime.Utilities.ElfFile.ElfFile(System.IO.Stream! stream, ulong position, bool leaveOpen, bool isVirtual) -> void
 Microsoft.Diagnostics.Runtime.Utilities.ElfFile.BuildId.get -> System.Collections.Immutable.ImmutableArray<byte>
 Microsoft.Diagnostics.Runtime.Utilities.ElfFile.Header.get -> Microsoft.Diagnostics.Runtime.Utilities.IElfHeader!
 Microsoft.Diagnostics.Runtime.Utilities.ElfFile.Notes.get -> System.Collections.Immutable.ImmutableArray<Microsoft.Diagnostics.Runtime.Utilities.ElfNote!>
 Microsoft.Diagnostics.Runtime.Utilities.ElfFile.ProgramHeaders.get -> System.Collections.Immutable.ImmutableArray<Microsoft.Diagnostics.Runtime.Utilities.ElfProgramHeader!>
+Microsoft.Diagnostics.Runtime.Utilities.ElfFile.TryGetExportSymbol(string! symbolName, out ulong offset) -> bool
 Microsoft.Diagnostics.Runtime.Utilities.ElfHeaderType
 Microsoft.Diagnostics.Runtime.Utilities.ElfHeaderType.Core = 4 -> Microsoft.Diagnostics.Runtime.Utilities.ElfHeaderType
 Microsoft.Diagnostics.Runtime.Utilities.ElfHeaderType.Executable = 2 -> Microsoft.Diagnostics.Runtime.Utilities.ElfHeaderType
@@ -1269,6 +1271,7 @@ Microsoft.Diagnostics.Runtime.Utilities.PEImage.Reader.get -> System.Reflection.
 Microsoft.Diagnostics.Runtime.Utilities.PEImage.Resources.get -> Microsoft.Diagnostics.Runtime.Utilities.ResourceEntry!
 Microsoft.Diagnostics.Runtime.Utilities.PEImage.RvaToOffset(int virtualAddress) -> int
 Microsoft.Diagnostics.Runtime.Utilities.PEImage.Sections.get -> System.Collections.Immutable.ImmutableArray<System.Reflection.PortableExecutable.SectionHeader>
+Microsoft.Diagnostics.Runtime.Utilities.PEImage.TryGetExportSymbol(string! symbolName, out ulong offset) -> bool
 Microsoft.Diagnostics.Runtime.Utilities.ResourceEntry
 Microsoft.Diagnostics.Runtime.Utilities.ResourceEntry.ChildCount.get -> int
 Microsoft.Diagnostics.Runtime.Utilities.ResourceEntry.Children.get -> System.Collections.Immutable.ImmutableArray<Microsoft.Diagnostics.Runtime.Utilities.ResourceEntry!>

--- a/src/Microsoft.Diagnostics.Runtime/PublicAPI/net5.0/PublicAPI.Shipped.txt
+++ b/src/Microsoft.Diagnostics.Runtime/PublicAPI/net5.0/PublicAPI.Shipped.txt
@@ -740,7 +740,7 @@ Microsoft.Diagnostics.Runtime.ILToNativeMap.ILOffset -> int
 Microsoft.Diagnostics.Runtime.ILToNativeMap.ILToNativeMap() -> void
 Microsoft.Diagnostics.Runtime.ILToNativeMap.StartAddress -> ulong
 Microsoft.Diagnostics.Runtime.IExportReader
-Microsoft.Diagnostics.Runtime.IExportReader.TryGetSymbolAddress(ulong baseAddress, string! name, out ulong offset) -> bool
+Microsoft.Diagnostics.Runtime.IExportReader.TryGetSymbolAddress(ulong baseAddress, string! name, out ulong address) -> bool
 Microsoft.Diagnostics.Runtime.IMemoryReader
 Microsoft.Diagnostics.Runtime.IMemoryReader.PointerSize.get -> int
 Microsoft.Diagnostics.Runtime.IMemoryReader.Read(ulong address, System.Span<byte> buffer) -> int
@@ -1017,12 +1017,14 @@ Microsoft.Diagnostics.Runtime.Utilities.ElfCoreFile.Dispose() -> void
 Microsoft.Diagnostics.Runtime.Utilities.ElfCoreFile.ElfCoreFile(System.IO.Stream! stream, bool leaveOpen = false) -> void
 Microsoft.Diagnostics.Runtime.Utilities.ElfCoreFile.ElfCoreFile(string! coredump) -> void
 Microsoft.Diagnostics.Runtime.Utilities.ElfFile.Dispose() -> void
-Microsoft.Diagnostics.Runtime.Utilities.ElfFile.ElfFile(System.IO.Stream! stream, bool leaveOpen = false) -> void
 Microsoft.Diagnostics.Runtime.Utilities.ElfFile.ElfFile(string! filename) -> void
+Microsoft.Diagnostics.Runtime.Utilities.ElfFile.ElfFile(System.IO.Stream! stream, bool leaveOpen = false) -> void
+Microsoft.Diagnostics.Runtime.Utilities.ElfFile.ElfFile(System.IO.Stream! stream, ulong position, bool leaveOpen, bool isVirtual) -> void
 Microsoft.Diagnostics.Runtime.Utilities.ElfFile.BuildId.get -> System.Collections.Immutable.ImmutableArray<byte>
 Microsoft.Diagnostics.Runtime.Utilities.ElfFile.Header.get -> Microsoft.Diagnostics.Runtime.Utilities.IElfHeader!
 Microsoft.Diagnostics.Runtime.Utilities.ElfFile.Notes.get -> System.Collections.Immutable.ImmutableArray<Microsoft.Diagnostics.Runtime.Utilities.ElfNote!>
 Microsoft.Diagnostics.Runtime.Utilities.ElfFile.ProgramHeaders.get -> System.Collections.Immutable.ImmutableArray<Microsoft.Diagnostics.Runtime.Utilities.ElfProgramHeader!>
+Microsoft.Diagnostics.Runtime.Utilities.ElfFile.TryGetExportSymbol(string! symbolName, out ulong offset) -> bool
 Microsoft.Diagnostics.Runtime.Utilities.ElfHeaderType
 Microsoft.Diagnostics.Runtime.Utilities.ElfHeaderType.Core = 4 -> Microsoft.Diagnostics.Runtime.Utilities.ElfHeaderType
 Microsoft.Diagnostics.Runtime.Utilities.ElfHeaderType.Executable = 2 -> Microsoft.Diagnostics.Runtime.Utilities.ElfHeaderType
@@ -1269,6 +1271,7 @@ Microsoft.Diagnostics.Runtime.Utilities.PEImage.Reader.get -> System.Reflection.
 Microsoft.Diagnostics.Runtime.Utilities.PEImage.Resources.get -> Microsoft.Diagnostics.Runtime.Utilities.ResourceEntry!
 Microsoft.Diagnostics.Runtime.Utilities.PEImage.RvaToOffset(int virtualAddress) -> int
 Microsoft.Diagnostics.Runtime.Utilities.PEImage.Sections.get -> System.Collections.Immutable.ImmutableArray<System.Reflection.PortableExecutable.SectionHeader>
+Microsoft.Diagnostics.Runtime.Utilities.PEImage.TryGetExportSymbol(string! symbolName, out ulong offset) -> bool
 Microsoft.Diagnostics.Runtime.Utilities.ResourceEntry
 Microsoft.Diagnostics.Runtime.Utilities.ResourceEntry.ChildCount.get -> int
 Microsoft.Diagnostics.Runtime.Utilities.ResourceEntry.Children.get -> System.Collections.Immutable.ImmutableArray<Microsoft.Diagnostics.Runtime.Utilities.ResourceEntry!>

--- a/src/Microsoft.Diagnostics.Runtime/PublicAPI/netcoreapp3.1/PublicAPI.Shipped.txt
+++ b/src/Microsoft.Diagnostics.Runtime/PublicAPI/netcoreapp3.1/PublicAPI.Shipped.txt
@@ -740,7 +740,7 @@ Microsoft.Diagnostics.Runtime.ILToNativeMap.ILOffset -> int
 Microsoft.Diagnostics.Runtime.ILToNativeMap.ILToNativeMap() -> void
 Microsoft.Diagnostics.Runtime.ILToNativeMap.StartAddress -> ulong
 Microsoft.Diagnostics.Runtime.IExportReader
-Microsoft.Diagnostics.Runtime.IExportReader.TryGetSymbolAddress(ulong baseAddress, string! name, out ulong offset) -> bool
+Microsoft.Diagnostics.Runtime.IExportReader.TryGetSymbolAddress(ulong baseAddress, string! name, out ulong address) -> bool
 Microsoft.Diagnostics.Runtime.IMemoryReader
 Microsoft.Diagnostics.Runtime.IMemoryReader.PointerSize.get -> int
 Microsoft.Diagnostics.Runtime.IMemoryReader.Read(ulong address, System.Span<byte> buffer) -> int
@@ -1017,12 +1017,14 @@ Microsoft.Diagnostics.Runtime.Utilities.ElfCoreFile.Dispose() -> void
 Microsoft.Diagnostics.Runtime.Utilities.ElfCoreFile.ElfCoreFile(System.IO.Stream! stream, bool leaveOpen = false) -> void
 Microsoft.Diagnostics.Runtime.Utilities.ElfCoreFile.ElfCoreFile(string! coredump) -> void
 Microsoft.Diagnostics.Runtime.Utilities.ElfFile.Dispose() -> void
-Microsoft.Diagnostics.Runtime.Utilities.ElfFile.ElfFile(System.IO.Stream! stream, bool leaveOpen = false) -> void
 Microsoft.Diagnostics.Runtime.Utilities.ElfFile.ElfFile(string! filename) -> void
+Microsoft.Diagnostics.Runtime.Utilities.ElfFile.ElfFile(System.IO.Stream! stream, bool leaveOpen = false) -> void
+Microsoft.Diagnostics.Runtime.Utilities.ElfFile.ElfFile(System.IO.Stream! stream, ulong position, bool leaveOpen, bool isVirtual) -> void
 Microsoft.Diagnostics.Runtime.Utilities.ElfFile.BuildId.get -> System.Collections.Immutable.ImmutableArray<byte>
 Microsoft.Diagnostics.Runtime.Utilities.ElfFile.Header.get -> Microsoft.Diagnostics.Runtime.Utilities.IElfHeader!
 Microsoft.Diagnostics.Runtime.Utilities.ElfFile.Notes.get -> System.Collections.Immutable.ImmutableArray<Microsoft.Diagnostics.Runtime.Utilities.ElfNote!>
 Microsoft.Diagnostics.Runtime.Utilities.ElfFile.ProgramHeaders.get -> System.Collections.Immutable.ImmutableArray<Microsoft.Diagnostics.Runtime.Utilities.ElfProgramHeader!>
+Microsoft.Diagnostics.Runtime.Utilities.ElfFile.TryGetExportSymbol(string! symbolName, out ulong offset) -> bool
 Microsoft.Diagnostics.Runtime.Utilities.ElfHeaderType
 Microsoft.Diagnostics.Runtime.Utilities.ElfHeaderType.Core = 4 -> Microsoft.Diagnostics.Runtime.Utilities.ElfHeaderType
 Microsoft.Diagnostics.Runtime.Utilities.ElfHeaderType.Executable = 2 -> Microsoft.Diagnostics.Runtime.Utilities.ElfHeaderType
@@ -1269,6 +1271,7 @@ Microsoft.Diagnostics.Runtime.Utilities.PEImage.Reader.get -> System.Reflection.
 Microsoft.Diagnostics.Runtime.Utilities.PEImage.Resources.get -> Microsoft.Diagnostics.Runtime.Utilities.ResourceEntry!
 Microsoft.Diagnostics.Runtime.Utilities.PEImage.RvaToOffset(int virtualAddress) -> int
 Microsoft.Diagnostics.Runtime.Utilities.PEImage.Sections.get -> System.Collections.Immutable.ImmutableArray<System.Reflection.PortableExecutable.SectionHeader>
+Microsoft.Diagnostics.Runtime.Utilities.PEImage.TryGetExportSymbol(string! symbolName, out ulong offset) -> bool
 Microsoft.Diagnostics.Runtime.Utilities.ResourceEntry
 Microsoft.Diagnostics.Runtime.Utilities.ResourceEntry.ChildCount.get -> int
 Microsoft.Diagnostics.Runtime.Utilities.ResourceEntry.Children.get -> System.Collections.Immutable.ImmutableArray<Microsoft.Diagnostics.Runtime.Utilities.ResourceEntry!>

--- a/src/Microsoft.Diagnostics.Runtime/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
+++ b/src/Microsoft.Diagnostics.Runtime/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
@@ -740,7 +740,7 @@ Microsoft.Diagnostics.Runtime.ILToNativeMap.ILOffset -> int
 Microsoft.Diagnostics.Runtime.ILToNativeMap.ILToNativeMap() -> void
 Microsoft.Diagnostics.Runtime.ILToNativeMap.StartAddress -> ulong
 Microsoft.Diagnostics.Runtime.IExportReader
-Microsoft.Diagnostics.Runtime.IExportReader.TryGetSymbolAddress(ulong baseAddress, string! name, out ulong offset) -> bool
+Microsoft.Diagnostics.Runtime.IExportReader.TryGetSymbolAddress(ulong baseAddress, string! name, out ulong address) -> bool
 Microsoft.Diagnostics.Runtime.IMemoryReader
 Microsoft.Diagnostics.Runtime.IMemoryReader.PointerSize.get -> int
 Microsoft.Diagnostics.Runtime.IMemoryReader.Read(ulong address, System.Span<byte> buffer) -> int
@@ -1017,12 +1017,14 @@ Microsoft.Diagnostics.Runtime.Utilities.ElfCoreFile.Dispose() -> void
 Microsoft.Diagnostics.Runtime.Utilities.ElfCoreFile.ElfCoreFile(System.IO.Stream! stream, bool leaveOpen = false) -> void
 Microsoft.Diagnostics.Runtime.Utilities.ElfCoreFile.ElfCoreFile(string! coredump) -> void
 Microsoft.Diagnostics.Runtime.Utilities.ElfFile.Dispose() -> void
-Microsoft.Diagnostics.Runtime.Utilities.ElfFile.ElfFile(System.IO.Stream! stream, bool leaveOpen = false) -> void
 Microsoft.Diagnostics.Runtime.Utilities.ElfFile.ElfFile(string! filename) -> void
+Microsoft.Diagnostics.Runtime.Utilities.ElfFile.ElfFile(System.IO.Stream! stream, bool leaveOpen = false) -> void
+Microsoft.Diagnostics.Runtime.Utilities.ElfFile.ElfFile(System.IO.Stream! stream, ulong position, bool leaveOpen, bool isVirtual) -> void
 Microsoft.Diagnostics.Runtime.Utilities.ElfFile.BuildId.get -> System.Collections.Immutable.ImmutableArray<byte>
 Microsoft.Diagnostics.Runtime.Utilities.ElfFile.Header.get -> Microsoft.Diagnostics.Runtime.Utilities.IElfHeader!
 Microsoft.Diagnostics.Runtime.Utilities.ElfFile.Notes.get -> System.Collections.Immutable.ImmutableArray<Microsoft.Diagnostics.Runtime.Utilities.ElfNote!>
 Microsoft.Diagnostics.Runtime.Utilities.ElfFile.ProgramHeaders.get -> System.Collections.Immutable.ImmutableArray<Microsoft.Diagnostics.Runtime.Utilities.ElfProgramHeader!>
+Microsoft.Diagnostics.Runtime.Utilities.ElfFile.TryGetExportSymbol(string! symbolName, out ulong offset) -> bool
 Microsoft.Diagnostics.Runtime.Utilities.ElfHeaderType
 Microsoft.Diagnostics.Runtime.Utilities.ElfHeaderType.Core = 4 -> Microsoft.Diagnostics.Runtime.Utilities.ElfHeaderType
 Microsoft.Diagnostics.Runtime.Utilities.ElfHeaderType.Executable = 2 -> Microsoft.Diagnostics.Runtime.Utilities.ElfHeaderType
@@ -1269,6 +1271,7 @@ Microsoft.Diagnostics.Runtime.Utilities.PEImage.Reader.get -> System.Reflection.
 Microsoft.Diagnostics.Runtime.Utilities.PEImage.Resources.get -> Microsoft.Diagnostics.Runtime.Utilities.ResourceEntry!
 Microsoft.Diagnostics.Runtime.Utilities.PEImage.RvaToOffset(int virtualAddress) -> int
 Microsoft.Diagnostics.Runtime.Utilities.PEImage.Sections.get -> System.Collections.Immutable.ImmutableArray<System.Reflection.PortableExecutable.SectionHeader>
+Microsoft.Diagnostics.Runtime.Utilities.PEImage.TryGetExportSymbol(string! symbolName, out ulong offset) -> bool
 Microsoft.Diagnostics.Runtime.Utilities.ResourceEntry
 Microsoft.Diagnostics.Runtime.Utilities.ResourceEntry.ChildCount.get -> int
 Microsoft.Diagnostics.Runtime.Utilities.ResourceEntry.Children.get -> System.Collections.Immutable.ImmutableArray<Microsoft.Diagnostics.Runtime.Utilities.ResourceEntry!>

--- a/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Core/CoreDumpReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataReaders/Core/CoreDumpReader.cs
@@ -168,26 +168,17 @@ namespace Microsoft.Diagnostics.Runtime
         /// </summary>
         /// <param name="baseAddress">module base address</param>
         /// <param name="name">symbol name (without the module name prepended)</param>
-        /// <param name="offset">address returned</param>
+        /// <param name="address">address returned</param>
         /// <returns>true if found</returns>
-        public bool TryGetSymbolAddress(ulong baseAddress, string name, out ulong offset)
+        bool IExportReader.TryGetSymbolAddress(ulong baseAddress, string name, out ulong address)
         {
             using ElfFile? elfFile = GetElfFile(baseAddress);
-            try
+            if (elfFile is not null && elfFile.TryGetExportSymbol(name, out ulong offset))
             {
-                ElfDynamicSection? dynamicSection = elfFile?.DynamicSection;
-
-                if (dynamicSection is not null && dynamicSection.TryLookupSymbol(name, out ElfSymbol? symbol) && symbol is not null)
-                {
-                    offset = baseAddress + (ulong)symbol.Value;
-                    return true;
-                }
+                address = baseAddress + offset;
+                return true;
             }
-            catch (Exception ex) when (ex is IOException || ex is InvalidDataException)
-            {
-            }
-
-            offset = 0;
+            address = 0;
             return false;
         }
 

--- a/src/Microsoft.Diagnostics.Runtime/src/DataReaders/IExportReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataReaders/IExportReader.cs
@@ -16,8 +16,8 @@ namespace Microsoft.Diagnostics.Runtime
         /// </summary>
         /// <param name="baseAddress">module base address</param>
         /// <param name="name">symbol name (without the module name prepended)</param>
-        /// <param name="offset">address returned</param>
+        /// <param name="address">symbol address returned</param>
         /// <returns>true if found</returns>
-        bool TryGetSymbolAddress(ulong baseAddress, string name, out ulong offset);
+        bool TryGetSymbolAddress(ulong baseAddress, string name, out ulong address);
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/src/Linux/RelativeAddressSpace.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Linux/RelativeAddressSpace.cs
@@ -32,6 +32,9 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
 
         public int Read(ulong position, Span<byte> buffer)
         {
+            if ((long)position < _baseToRelativeShift)
+                return 0;
+
             ulong basePosition = (ulong)((long)position - _baseToRelativeShift);
             if (basePosition < _baseStart)
                 return 0;

--- a/src/Microsoft.Diagnostics.Runtime/src/MacOS/MachOCoreDump.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/MacOS/MachOCoreDump.cs
@@ -258,7 +258,6 @@ namespace Microsoft.Diagnostics.Runtime.MacOS
             return _modules = new Dictionary<ulong, MachOModule>();
         }
 
-
         private bool FindSegmentContaining(ulong address, out MachOSegment seg)
         {
             int lower = 0;
@@ -287,7 +286,6 @@ namespace Microsoft.Diagnostics.Runtime.MacOS
             seg = new MachOSegment();
             return false;
         }
-
 
         public void Dispose()
         {

--- a/src/Microsoft.Diagnostics.Runtime/src/Utilities/PEImage/ImageExportDirectory.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Utilities/PEImage/ImageExportDirectory.cs
@@ -1,0 +1,21 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.Diagnostics.Runtime.Utilities
+{
+    internal struct IMAGE_EXPORT_DIRECTORY
+    {
+        public int Characteristics;
+        public int TimeDateStamp;
+        public short MajorVersion;
+        public short MinorVersion;
+        public int Name;
+        public int Base;
+        public int NumberOfFunctions;
+        public int NumberOfNames;
+        public int AddressOfFunctions;     // RVA from base of image
+        public int AddressOfNames;         // RVA from base of image
+        public int AddressOfNameOrdinals;  // RVA from base of image
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/src/Utilities/PEImage/PEImage.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Utilities/PEImage/PEImage.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Reflection.PortableExecutable;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Text;
 
 namespace Microsoft.Diagnostics.Runtime.Utilities
 {
@@ -33,6 +34,7 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
         private ImmutableArray<SectionHeader> _sections;
         private ImmutableArray<PdbInfo> _pdbs;
         private ResourceEntry? _resources;
+        private IMAGE_EXPORT_DIRECTORY? _exportDirectory;
 
         private bool _disposed;
 
@@ -257,6 +259,77 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
             }
         }
 
+        /// <summary>
+        /// Returns the address of a module export symbol if found
+        /// </summary>
+        /// <param name="symbolName">symbol name (without the module name prepended)</param>
+        /// <param name="offset">symbol offset returned</param>
+        /// <returns>true if found</returns>
+        public bool TryGetExportSymbol(string symbolName, out ulong offset)
+        {
+            try
+            {
+                if (_exportDirectory is null)
+                {
+                    if (PEHeader is not null)
+                    {
+                        DirectoryEntry exportTableDirectory = PEHeader.ExportTableDirectory;
+                        if (exportTableDirectory.RelativeVirtualAddress != 0 && exportTableDirectory.Size != 0)
+                        {
+                            _exportDirectory = Read<IMAGE_EXPORT_DIRECTORY>(RvaToOffset(exportTableDirectory.RelativeVirtualAddress));
+                        }
+                    }
+                }
+                if (_exportDirectory is not null)
+                {
+                    IMAGE_EXPORT_DIRECTORY exportDirectory = _exportDirectory.Value;
+
+                    for (int nameIndex = 0; nameIndex < exportDirectory.NumberOfNames; nameIndex++)
+                    {
+                        int namePointerRVA = Read<int>(RvaToOffset(exportDirectory.AddressOfNames + (sizeof(uint) * nameIndex)));
+                        if (namePointerRVA != 0)
+                        {
+                            string name = ReadNullTerminatedAscii(namePointerRVA);
+                            if (name == symbolName)
+                            {
+                                ushort ordinalForNamedExport = Read<ushort>(RvaToOffset(exportDirectory.AddressOfNameOrdinals + (sizeof(ushort) * nameIndex)));
+                                int exportRVA = Read<int>(RvaToOffset(exportDirectory.AddressOfFunctions + (sizeof(uint) * ordinalForNamedExport)));
+                                offset = (uint)RvaToOffset(exportRVA);
+                                return true;
+                            }
+                        }
+                    }
+                }
+            }
+            catch (Exception ex) when (ex is IOException || ex is InvalidDataException)
+            {
+            }
+            offset = 0;
+            return false;
+        }
+
+        private string ReadNullTerminatedAscii(int rva)
+        {
+            StringBuilder builder = new(64);
+            Span<byte> bytes = stackalloc byte[64];
+
+            bool done = false;
+            int read;
+            while (!done && (read = Read(rva, bytes)) != 0)
+            {
+                rva += read;
+                for (int i = 0; !done && i < read; i++)
+                {
+                    if (bytes[i] != 0)
+                        builder.Append((char)bytes[i]);
+                    else
+                        done = true;
+                }
+            }
+
+            return builder.ToString();
+        }
+
         private ResourceEntry CreateResourceRoot()
         {
             return new ResourceEntry(this, null, "root", false, RvaToOffset(ResourceVirtualAddress));
@@ -344,7 +417,7 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
 
                 return result.MoveOrCopyToImmutable();
             }
-            catch (IOException)
+            catch (Exception ex) when (ex is IOException || ex is InvalidDataException)
             {
                 return ImmutableArray<PdbInfo>.Empty;
             }


### PR DESCRIPTION
Added PEImage.TryGetExportSymbol public method.

Clean up and refactor of ELF symbol export lookup. Added ElfFile.TryGetExportSymbol public method.

Added ElfFile constructor that allows a memory stream to be passed.

Added IExportReader implementation to MinidumpReader and DbgEngDataReader.