### PR TITLE
Fix int overflow on certain large ELF modules 

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/src/Linux/ElfVirtualAddressSpace.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Linux/ElfVirtualAddressSpace.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
                     continue;
 
                 ulong offset = address - virtualAddress;
-                int toRead = Math.Min(buffer.Length - bytesRead, (int)(virtualSize - offset));
+                int toRead = (int)Math.Min((ulong)(buffer.Length - bytesRead), virtualSize - offset);
 
                 Span<byte> slice = buffer.Slice(bytesRead, toRead);
                 int read = segment.AddressSpace.Read(offset, slice);

--- a/src/Microsoft.Diagnostics.Runtime/src/Linux/RelativeAddressSpace.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Linux/RelativeAddressSpace.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
             if (basePosition < _baseStart)
                 return 0;
 
-            if ((int)_length < buffer.Length)
+            if (_length < (ulong)buffer.Length)
                 buffer = buffer.Slice(0, (int)_length);
 
             return _baseAddressSpace.Read(basePosition, buffer);


### PR DESCRIPTION
With certain linux dumps, dotnet-dump hit a problem because the ulong _length conversion to int caused the if to incorrectly Slice the buffer which threw an ArgumentOutOfRangeException.