### PR TITLE
Fix memory corruption of target process in MacOSProcessDataReader.LoadThreads()

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/src/DataReaders/MacOS/MacOSProcessDataReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataReaders/MacOS/MacOSProcessDataReader.cs
@@ -313,7 +313,7 @@ namespace Microsoft.Diagnostics.Runtime.MacOS
                 }
                 finally
                 {
-                    _ = Native.mach_vm_deallocate(_task, (ulong)threads, threadsCount * sizeof(uint));
+                    _ = Native.mach_vm_deallocate(Native.mach_task_self(), (ulong)threads, threadsCount * sizeof(uint));
                 }
             }
         }


### PR DESCRIPTION
Fix memory corruption of target process in MacOSProcessDataReader.LoadThreads()

Previously it accidentally used mach_vm_deallocate() on the target process's memory
but not our own, causing EXC_BAD_ACCESS (SIGSEGV) after the process detached.