### PR TITLE
Load memory regions after process suspend in MacOSProcessDataReader

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/src/DataReaders/MacOS/MacOSProcessDataReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataReaders/MacOS/MacOSProcessDataReader.cs
@@ -40,8 +40,6 @@ namespace Microsoft.Diagnostics.Runtime.MacOS
 
             _task = task;
 
-            _memoryRegions = LoadMemoryRegions();
-
             if (suspend)
             {
                 status = Native.ptrace(Native.PT_ATTACH, processId);
@@ -57,6 +55,8 @@ namespace Microsoft.Diagnostics.Runtime.MacOS
 
                 _suspended = true;
             }
+
+            _memoryRegions = LoadMemoryRegions();
 
             Architecture = RuntimeInformation.ProcessArchitecture switch
             {


### PR DESCRIPTION
Load memory regions after process suspend in MacOSProcessDataReader

Fixes a race condition when the target process's memory regions are modified before the process suspended.