### PR TITLE
Update macOS pool name in azure-pipelines.yml

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -103,7 +103,7 @@ stages:
 
         - job: MacOS
           pool:
-            name: Hosted macOS
+            vmImage: macos-11
 
           strategy:
             matrix:


### PR DESCRIPTION
The old name is no longer supported.