### PR TITLE
Fix reading dumps from MacOS version 12 or greater (Monterey)

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/src/MacOS/MachOModule.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/MacOS/MachOModule.cs
@@ -121,7 +121,7 @@ namespace Microsoft.Diagnostics.Runtime.MacOS
             if (symTable is null)
                 return false;
 
-            for (uint i = 0; i < nsyms; i++)
+            for (uint i = 0; i < nsyms && start + i < symTable.Length; i++)
             {
                 string name = GetSymbolName(symTable[start + i], symbol.Length + 1);
                 if (name.Length > 0)


### PR DESCRIPTION
Change the symbol export lookup to first search the exports and then all the symbols.