### PR TITLE
Fixed bug preventing the last sync block item to be considered for in…

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/src/Builders/RuntimeBuilder.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Builders/RuntimeBuilder.cs
@@ -137,7 +137,7 @@ namespace Microsoft.Diagnostics.Runtime.Builders
                 }
 
                 curr++;
-                if (curr >= max)
+                if (curr > max)
                     break;
 
                 hr = _sos.GetSyncBlockData(curr, out data);

--- a/src/Microsoft.Diagnostics.Runtime/src/Implementation/FullSyncBlock.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Implementation/FullSyncBlock.cs
@@ -27,7 +27,8 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
             IsMonitorHeld = syncBlk.MonitorHeld != 0;
             HoldingThreadAddress = syncBlk.HoldingThread;
             RecursionCount = syncBlk.Recursion >= int.MaxValue ? int.MaxValue : (int)syncBlk.Recursion;
-            WaitingThreadCount = (int)syncBlk.AdditionalThreadCount;
+            // https://stackoverflow.com/questions/2203000/windbg-sos-explanation-of-syncblk-output
+            WaitingThreadCount = IsMonitorHeld ? (int)((syncBlk.MonitorHeld - 1) / 2) : (int)syncBlk.AdditionalThreadCount;
         }
     }
 }


### PR DESCRIPTION
…clusion in one of the sync block lists.

If you run this method and count the number of items added to the three lists the total count is one less than the TotalSyncBlockCount.  That is a result of this bug.