### PR TITLE
Delegate targets

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/ClrDelegateTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/ClrDelegateTests.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Xunit;
+
+namespace Microsoft.Diagnostics.Runtime.Tests
+{
+    public class ClrDelegateTests
+    {
+        [Fact]
+        public void IsDelegateTest()
+        {
+
+            using DataTarget dt = TestTargets.Types.LoadFullDump();
+            using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
+            ClrModule typesModule = runtime.GetModule(TypeTests.ModuleName);
+            ClrType type = typesModule.GetTypeByName("Types");
+
+            ClrObject TestDelegate = type.GetStaticFieldByName("TestDelegate").ReadObject(runtime.AppDomains.Single());
+            Assert.True(TestDelegate.IsValid);
+            Assert.True(TestDelegate.IsDelegate);
+            Assert.False(TestDelegate.AsDelegate().HasMultipleTargets);
+
+            ClrObject TestEvent = type.GetStaticFieldByName("TestEvent").ReadObject(runtime.AppDomains.Single());
+            Assert.True(TestEvent.IsValid);
+            Assert.True(TestEvent.IsDelegate);
+            Assert.True(TestEvent.AsDelegate().HasMultipleTargets);
+        }
+
+
+        [Fact]
+        public void GetDelegateTest()
+        {
+            using DataTarget dt = TestTargets.Types.LoadFullDump();
+            using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
+            ClrModule typesModule = runtime.GetModule(TypeTests.ModuleName);
+            ClrType Types = typesModule.GetTypeByName("Types");
+
+            ClrDelegate TestDelegate = Types.GetStaticFieldByName("TestDelegate").ReadObject(runtime.AppDomains.Single()).AsDelegate();
+
+            ClrDelegateTarget delegateTarget = TestDelegate.GetDelegateTarget();
+            Assert.NotNull(delegateTarget);
+            CompareToInner(Types, TestDelegate, delegateTarget);
+
+            ClrDelegate TestEvent = Types.GetStaticFieldByName("TestEvent").ReadObject(runtime.AppDomains.Single()).AsDelegate();
+            ClrDelegateTarget eventTarget = TestEvent.GetDelegateTarget();
+            Assert.Null(eventTarget);
+        }
+
+        private static void CompareToInner(ClrType Types, ClrDelegate del, ClrDelegateTarget delegateTarget)
+        {
+            Assert.True(del.Object.IsDelegate); // This delegate targets a static method
+
+            Assert.NotNull(delegateTarget.Method);
+            Assert.Equal(Types, delegateTarget.Method.Type);
+            Assert.Equal("Inner", delegateTarget.Method.Name);
+        }
+
+        private static void CompareToInstanceMethod(ClrType Types, ClrDelegate del, ClrDelegateTarget delegateTarget)
+        {
+            Assert.NotEqual(del.Object.Address, delegateTarget.TargetObject.Address); // This delegate is an instance method of "Types"
+            Assert.Equal(Types, delegateTarget.TargetObject.Type);
+
+            Assert.NotNull(delegateTarget.Method);
+            Assert.Equal(Types, delegateTarget.Method.Type);
+            Assert.Equal("InstanceMethod", delegateTarget.Method.Name);
+        }
+
+        [Fact]
+        public void EnumerateDelegateTest()
+        {
+            using DataTarget dt = TestTargets.Types.LoadFullDump();
+            using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
+            ClrModule typesModule = runtime.GetModule(TypeTests.ModuleName);
+            ClrType Types = typesModule.GetTypeByName("Types");
+
+            ClrDelegate TestDelegate = Types.GetStaticFieldByName("TestDelegate").ReadObject(runtime.AppDomains.Single()).AsDelegate();
+            ClrDelegateTarget[] methods = TestDelegate.EnumerateDelegateTargets().ToArray();
+
+            Assert.Single(methods);
+            CompareToInner(Types, TestDelegate, methods[0]);
+
+
+            ClrDelegate TestEvent = Types.GetStaticFieldByName("TestEvent").ReadObject(runtime.AppDomains.Single()).AsDelegate();
+            methods = TestEvent.EnumerateDelegateTargets().ToArray();
+            
+            Assert.Equal(2, methods.Length);
+            CompareToInner(Types, TestEvent, methods[0]);
+            CompareToInstanceMethod(Types, TestEvent, methods[1]);
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/PublicAPI/net461/PublicAPI.Shipped.txt
+++ b/src/Microsoft.Diagnostics.Runtime/PublicAPI/net461/PublicAPI.Shipped.txt
@@ -1,4 +1,21 @@
 #nullable enable
+Microsoft.Diagnostics.Runtime.ClrDelegate
+Microsoft.Diagnostics.Runtime.ClrDelegate.ClrDelegate() -> void
+Microsoft.Diagnostics.Runtime.ClrDelegate.ClrDelegate(Microsoft.Diagnostics.Runtime.ClrObject obj) -> void
+Microsoft.Diagnostics.Runtime.ClrDelegate.EnumerateDelegateTargets() -> System.Collections.Generic.IEnumerable<Microsoft.Diagnostics.Runtime.ClrDelegateTarget!>!
+Microsoft.Diagnostics.Runtime.ClrDelegate.GetDelegateTarget() -> Microsoft.Diagnostics.Runtime.ClrDelegateTarget?
+Microsoft.Diagnostics.Runtime.ClrDelegate.HasMultipleTargets.get -> bool
+Microsoft.Diagnostics.Runtime.ClrDelegate.Object.get -> Microsoft.Diagnostics.Runtime.ClrObject
+Microsoft.Diagnostics.Runtime.ClrDelegateTarget
+Microsoft.Diagnostics.Runtime.ClrDelegateTarget.ClrDelegateTarget(Microsoft.Diagnostics.Runtime.ClrDelegate del, Microsoft.Diagnostics.Runtime.ClrObject target, Microsoft.Diagnostics.Runtime.ClrMethod! method) -> void
+Microsoft.Diagnostics.Runtime.ClrDelegateTarget.Method.get -> Microsoft.Diagnostics.Runtime.ClrMethod!
+Microsoft.Diagnostics.Runtime.ClrDelegateTarget.Parent.get -> Microsoft.Diagnostics.Runtime.ClrDelegate
+Microsoft.Diagnostics.Runtime.ClrDelegateTarget.TargetObject.get -> Microsoft.Diagnostics.Runtime.ClrObject
+Microsoft.Diagnostics.Runtime.ClrObject.AsDelegate() -> Microsoft.Diagnostics.Runtime.ClrDelegate
+Microsoft.Diagnostics.Runtime.ClrObject.IsDelegate.get -> bool
+Microsoft.Diagnostics.Runtime.ClrObject.TryReadField<T>(string! fieldName, out T result) -> bool
+Microsoft.Diagnostics.Runtime.ClrObject.TryReadObjectField(string! fieldName, out Microsoft.Diagnostics.Runtime.ClrObject result) -> bool
+Microsoft.Diagnostics.Runtime.ClrObject.TryReadValueTypeField(string! fieldName, out Microsoft.Diagnostics.Runtime.ClrValueType result) -> bool
 Microsoft.Diagnostics.Runtime.AMD64Context
 Microsoft.Diagnostics.Runtime.AMD64Context.AMD64Context() -> void
 Microsoft.Diagnostics.Runtime.AMD64Context.ContextFlags -> uint

--- a/src/Microsoft.Diagnostics.Runtime/PublicAPI/net5.0/PublicAPI.Shipped.txt
+++ b/src/Microsoft.Diagnostics.Runtime/PublicAPI/net5.0/PublicAPI.Shipped.txt
@@ -1,4 +1,21 @@
 #nullable enable
+Microsoft.Diagnostics.Runtime.ClrDelegate
+Microsoft.Diagnostics.Runtime.ClrDelegate.ClrDelegate() -> void
+Microsoft.Diagnostics.Runtime.ClrDelegate.ClrDelegate(Microsoft.Diagnostics.Runtime.ClrObject obj) -> void
+Microsoft.Diagnostics.Runtime.ClrDelegate.EnumerateDelegateTargets() -> System.Collections.Generic.IEnumerable<Microsoft.Diagnostics.Runtime.ClrDelegateTarget!>!
+Microsoft.Diagnostics.Runtime.ClrDelegate.GetDelegateTarget() -> Microsoft.Diagnostics.Runtime.ClrDelegateTarget?
+Microsoft.Diagnostics.Runtime.ClrDelegate.HasMultipleTargets.get -> bool
+Microsoft.Diagnostics.Runtime.ClrDelegate.Object.get -> Microsoft.Diagnostics.Runtime.ClrObject
+Microsoft.Diagnostics.Runtime.ClrDelegateTarget
+Microsoft.Diagnostics.Runtime.ClrDelegateTarget.ClrDelegateTarget(Microsoft.Diagnostics.Runtime.ClrDelegate del, Microsoft.Diagnostics.Runtime.ClrObject target, Microsoft.Diagnostics.Runtime.ClrMethod! method) -> void
+Microsoft.Diagnostics.Runtime.ClrDelegateTarget.Method.get -> Microsoft.Diagnostics.Runtime.ClrMethod!
+Microsoft.Diagnostics.Runtime.ClrDelegateTarget.Parent.get -> Microsoft.Diagnostics.Runtime.ClrDelegate
+Microsoft.Diagnostics.Runtime.ClrDelegateTarget.TargetObject.get -> Microsoft.Diagnostics.Runtime.ClrObject
+Microsoft.Diagnostics.Runtime.ClrObject.AsDelegate() -> Microsoft.Diagnostics.Runtime.ClrDelegate
+Microsoft.Diagnostics.Runtime.ClrObject.IsDelegate.get -> bool
+Microsoft.Diagnostics.Runtime.ClrObject.TryReadField<T>(string! fieldName, out T result) -> bool
+Microsoft.Diagnostics.Runtime.ClrObject.TryReadObjectField(string! fieldName, out Microsoft.Diagnostics.Runtime.ClrObject result) -> bool
+Microsoft.Diagnostics.Runtime.ClrObject.TryReadValueTypeField(string! fieldName, out Microsoft.Diagnostics.Runtime.ClrValueType result) -> bool
 Microsoft.Diagnostics.Runtime.AMD64Context
 Microsoft.Diagnostics.Runtime.AMD64Context.AMD64Context() -> void
 Microsoft.Diagnostics.Runtime.AMD64Context.ContextFlags -> uint

--- a/src/Microsoft.Diagnostics.Runtime/PublicAPI/netcoreapp3.1/PublicAPI.Shipped.txt
+++ b/src/Microsoft.Diagnostics.Runtime/PublicAPI/netcoreapp3.1/PublicAPI.Shipped.txt
@@ -1,4 +1,21 @@
 #nullable enable
+Microsoft.Diagnostics.Runtime.ClrDelegate
+Microsoft.Diagnostics.Runtime.ClrDelegate.ClrDelegate() -> void
+Microsoft.Diagnostics.Runtime.ClrDelegate.ClrDelegate(Microsoft.Diagnostics.Runtime.ClrObject obj) -> void
+Microsoft.Diagnostics.Runtime.ClrDelegate.EnumerateDelegateTargets() -> System.Collections.Generic.IEnumerable<Microsoft.Diagnostics.Runtime.ClrDelegateTarget!>!
+Microsoft.Diagnostics.Runtime.ClrDelegate.GetDelegateTarget() -> Microsoft.Diagnostics.Runtime.ClrDelegateTarget?
+Microsoft.Diagnostics.Runtime.ClrDelegate.HasMultipleTargets.get -> bool
+Microsoft.Diagnostics.Runtime.ClrDelegate.Object.get -> Microsoft.Diagnostics.Runtime.ClrObject
+Microsoft.Diagnostics.Runtime.ClrDelegateTarget
+Microsoft.Diagnostics.Runtime.ClrDelegateTarget.ClrDelegateTarget(Microsoft.Diagnostics.Runtime.ClrDelegate del, Microsoft.Diagnostics.Runtime.ClrObject target, Microsoft.Diagnostics.Runtime.ClrMethod! method) -> void
+Microsoft.Diagnostics.Runtime.ClrDelegateTarget.Method.get -> Microsoft.Diagnostics.Runtime.ClrMethod!
+Microsoft.Diagnostics.Runtime.ClrDelegateTarget.Parent.get -> Microsoft.Diagnostics.Runtime.ClrDelegate
+Microsoft.Diagnostics.Runtime.ClrDelegateTarget.TargetObject.get -> Microsoft.Diagnostics.Runtime.ClrObject
+Microsoft.Diagnostics.Runtime.ClrObject.AsDelegate() -> Microsoft.Diagnostics.Runtime.ClrDelegate
+Microsoft.Diagnostics.Runtime.ClrObject.IsDelegate.get -> bool
+Microsoft.Diagnostics.Runtime.ClrObject.TryReadField<T>(string! fieldName, out T result) -> bool
+Microsoft.Diagnostics.Runtime.ClrObject.TryReadObjectField(string! fieldName, out Microsoft.Diagnostics.Runtime.ClrObject result) -> bool
+Microsoft.Diagnostics.Runtime.ClrObject.TryReadValueTypeField(string! fieldName, out Microsoft.Diagnostics.Runtime.ClrValueType result) -> bool
 Microsoft.Diagnostics.Runtime.AMD64Context
 Microsoft.Diagnostics.Runtime.AMD64Context.AMD64Context() -> void
 Microsoft.Diagnostics.Runtime.AMD64Context.ContextFlags -> uint

--- a/src/Microsoft.Diagnostics.Runtime/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
+++ b/src/Microsoft.Diagnostics.Runtime/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
@@ -1,4 +1,21 @@
 #nullable enable
+Microsoft.Diagnostics.Runtime.ClrDelegate
+Microsoft.Diagnostics.Runtime.ClrDelegate.ClrDelegate() -> void
+Microsoft.Diagnostics.Runtime.ClrDelegate.ClrDelegate(Microsoft.Diagnostics.Runtime.ClrObject obj) -> void
+Microsoft.Diagnostics.Runtime.ClrDelegate.EnumerateDelegateTargets() -> System.Collections.Generic.IEnumerable<Microsoft.Diagnostics.Runtime.ClrDelegateTarget!>!
+Microsoft.Diagnostics.Runtime.ClrDelegate.GetDelegateTarget() -> Microsoft.Diagnostics.Runtime.ClrDelegateTarget?
+Microsoft.Diagnostics.Runtime.ClrDelegate.HasMultipleTargets.get -> bool
+Microsoft.Diagnostics.Runtime.ClrDelegate.Object.get -> Microsoft.Diagnostics.Runtime.ClrObject
+Microsoft.Diagnostics.Runtime.ClrDelegateTarget
+Microsoft.Diagnostics.Runtime.ClrDelegateTarget.ClrDelegateTarget(Microsoft.Diagnostics.Runtime.ClrDelegate del, Microsoft.Diagnostics.Runtime.ClrObject target, Microsoft.Diagnostics.Runtime.ClrMethod! method) -> void
+Microsoft.Diagnostics.Runtime.ClrDelegateTarget.Method.get -> Microsoft.Diagnostics.Runtime.ClrMethod!
+Microsoft.Diagnostics.Runtime.ClrDelegateTarget.Parent.get -> Microsoft.Diagnostics.Runtime.ClrDelegate
+Microsoft.Diagnostics.Runtime.ClrDelegateTarget.TargetObject.get -> Microsoft.Diagnostics.Runtime.ClrObject
+Microsoft.Diagnostics.Runtime.ClrObject.AsDelegate() -> Microsoft.Diagnostics.Runtime.ClrDelegate
+Microsoft.Diagnostics.Runtime.ClrObject.IsDelegate.get -> bool
+Microsoft.Diagnostics.Runtime.ClrObject.TryReadField<T>(string! fieldName, out T result) -> bool
+Microsoft.Diagnostics.Runtime.ClrObject.TryReadObjectField(string! fieldName, out Microsoft.Diagnostics.Runtime.ClrObject result) -> bool
+Microsoft.Diagnostics.Runtime.ClrObject.TryReadValueTypeField(string! fieldName, out Microsoft.Diagnostics.Runtime.ClrValueType result) -> bool
 Microsoft.Diagnostics.Runtime.AMD64Context
 Microsoft.Diagnostics.Runtime.AMD64Context.AMD64Context() -> void
 Microsoft.Diagnostics.Runtime.AMD64Context.ContextFlags -> uint

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/ClrDelegate.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/ClrDelegate.cs
@@ -1,0 +1,184 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Microsoft.Diagnostics.Runtime
+{
+    /// <summary>
+    /// Represents a delegate instance in the target process.
+    /// </summary>
+    public struct ClrDelegate
+    {
+        internal const string DelegateType = "System.Delegate";
+        /// <summary>
+        /// Constructs a <see cref="ClrDelegate"/> from a <see cref="ClrObject"/>.  Note that obj.IsDelegate
+        /// must be true.
+        /// </summary>
+        /// <param name="obj">A delegate object</param>
+        public ClrDelegate(ClrObject obj)
+        {
+            DebugOnly.Assert(obj.IsDelegate);
+
+            Object = obj;
+        }
+
+        /// <summary>
+        /// Returns whether this delegate has multiple targets or not.  If this method returns true then it is expected
+        /// that <see cref="GetDelegateTarget"/> will return <see langword="null"/> and you should use
+        /// <see cref="EnumerateDelegateTargets"/> instead.
+        /// </summary>
+        public bool HasMultipleTargets
+        {
+            get
+            {
+                if (Object.Type is null)
+                    return false;
+
+
+                return Object.TryReadField("_invocationCount", out int count) && count > 0;
+            }
+        }
+
+        /// <summary>
+        /// The actual object represented by this ClrDelegate instance.
+        /// </summary>
+        public ClrObject Object { get; }
+
+        /// <summary>
+        /// Returns a the single delegate target of the 
+        /// </summary>
+        /// <returns></returns>
+        /// <exception cref="InvalidOperationException">If this object is not a delegate we throw</exception>
+        public ClrDelegateTarget? GetDelegateTarget()
+        {
+            if (Object.Type is null)
+                throw new InvalidOperationException($"Object {this} is not a delegate.");
+
+            if (!Object.TryReadObjectField("_target", out ClrObject target))
+                return null;
+
+            bool seenOne = false;
+            ClrRuntime runtime = Object.Type.Heap.Runtime;
+
+            var methodPointerFields = Object.Type.Fields.Where(f => f.Name != null).Where(f => f.Name!.Equals("_methodPtr") || f.Name.Equals("_methodPtrAux"));
+            foreach (ClrInstanceField field in methodPointerFields)
+            {
+                if (field.ElementType == ClrElementType.NativeInt)
+                {
+                    ulong targetMethod = field.Read<UIntPtr>(Object, interior: false).ToUInt64();
+
+                    if (targetMethod != 0)
+                    {
+                        ClrMethod? result = runtime.GetMethodByInstructionPointer(targetMethod);
+                        if (result is not null)
+                            return new ClrDelegateTarget(this, target, result);
+                    }
+
+                    seenOne = true;
+                }
+            }
+
+            // If we didn't see at least one "_methodPtr*" field then actually check if this is a delegate and throw appropriately.
+            if (!seenOne && !Validate())
+                throw new InvalidOperationException($"Object {this} is not a delegate.");
+
+            return null;
+        }
+
+        private bool Validate()
+        {
+            // The overall goal here is to throw an exception when the user created a ClrDelegate class on an object that isn't
+            // a delegate.  However, we DON'T want to throw when we are failing to find the right fields due to missing metadata.
+            // Note it's ok to be slow in this method because we are down a failure path that should usually not happen in practice.
+
+            if (Object.Type is null)
+                return false;
+
+            // If we have no fields then this isn't a delegate.
+            if (Object.Type.Fields.Length == 0)
+                return false;
+
+            // Assume this is a valid
+            bool seenAny = false;
+            bool allNull = true;
+
+            foreach (var field in Object.Type.Fields)
+            {
+                seenAny |= field.Name == "_methodPtr" || field.Name == "_methodPtrAux";
+                allNull &= field.Name == null;
+            }
+
+            // If all field names were null then we cannot validate whether this was a delegate or not.  The case we are worried
+            // about here is if we have no 
+            if (allNull)
+                return true;
+
+            // If we saw fields we expected return it's valid even if we didn't understand this delegate.
+            if (seenAny)
+                return true;
+
+            ClrType? curr = Object.Type;
+
+            for (int i = 0; i < 8 && curr != null; i++, curr = curr.BaseType)
+            {
+                // If we found System.Delegate, we are done.
+                if (curr.Name == DelegateType)
+                    return true;
+
+                // If we found a blank name in mscorlib then we have a metadata problem, and we cannot validate this delegate.
+                // Don't throw an exception in this case.
+                if (curr.Name == null && curr.Module == Object.Type.Heap.Runtime.BaseClassLibrary)
+                    return true;
+            }
+
+            // We are definitely not a delegate.
+            return false;
+        }
+
+        /// <summary>
+        /// Enumerates all delegate targets of this delegate.  If called on a MulitcastDelegate, this will enumerate all
+        /// targets that will be called when this delegate is invoked.  If called on a non-MulticastDelegate, this will
+        /// enumerate the value of GetDelegateTarget.
+        /// </summary>
+        /// <returns></returns>
+        public IEnumerable<ClrDelegateTarget> EnumerateDelegateTargets()
+        {
+            ClrDelegateTarget? first = GetDelegateTarget();
+            if (first != null)
+                yield return first;
+
+            // The call to GetDelegateMethod will validate that we are a valid object and a subclass of System.Delegate
+            if (!Object.TryReadField("_invocationCount", out int count)
+                || count == 0
+                || !Object.TryReadObjectField("_invocationList", out ClrObject invocationList)
+                || !invocationList.IsArray)
+            {
+                yield break;
+            }
+
+            ClrArray invocationArray = invocationList.AsArray();
+            count = Math.Min(count, invocationArray.Length);
+
+            ClrHeap heap = Object.Type!.Heap;
+
+            UIntPtr[]? pointers = invocationArray.ReadValues<UIntPtr>(0, count);
+            if (pointers is not null)
+            {
+                foreach (UIntPtr ptr in pointers)
+                {
+                    if (ptr == UIntPtr.Zero)
+                        continue;
+
+                    ClrObject delegateObj = heap.GetObject(ptr.ToUInt64());
+                    if (delegateObj.IsDelegate)
+                    {
+                        ClrDelegateTarget? delegateTarget = new ClrDelegate(delegateObj).GetDelegateTarget();
+                        if (delegateTarget is not null)
+                            yield return delegateTarget;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/ClrDelegateTarget.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/ClrDelegateTarget.cs
@@ -1,0 +1,38 @@
+﻿namespace Microsoft.Diagnostics.Runtime
+{
+    /// <summary>
+    /// The "target" method and object that a delegate points to.
+    /// </summary>
+    public class ClrDelegateTarget
+    {
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="del">The parent delgate that this target came from.</param>
+        /// <param name="target">The "target" of this delegate.</param>
+        /// <param name="method">The method this delegate will call.</param>
+        public ClrDelegateTarget(ClrDelegate del, ClrObject target, ClrMethod method!!)
+        {
+            Parent = del;
+            TargetObject = target;
+            Method = method;
+        }
+
+        /// <summary>
+        /// The parent delegate that this target comes from.
+        /// </summary>
+        public ClrDelegate Parent { get; }
+
+        /// <summary>
+        /// The object that this delegate is targeted to.  If <see cref="Method"/> is an instance method,
+        /// this will point to the <see langword="this"/> pointer of that object.  If <see cref="Method"/>
+        /// is a static method, this will be a pointer to a delegate.
+        /// </summary>
+        public ClrObject TargetObject { get; }
+
+        /// <summary>
+        /// The method that would be called when <see cref="Parent"/> is invoked in the target process.
+        /// </summary>
+        public ClrMethod Method { get; }
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/ClrDelegateTarget.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/ClrDelegateTarget.cs
@@ -1,4 +1,6 @@
-﻿namespace Microsoft.Diagnostics.Runtime
+﻿using System;
+
+namespace Microsoft.Diagnostics.Runtime
 {
     /// <summary>
     /// The "target" method and object that a delegate points to.
@@ -11,8 +13,11 @@
         /// <param name="del">The parent delgate that this target came from.</param>
         /// <param name="target">The "target" of this delegate.</param>
         /// <param name="method">The method this delegate will call.</param>
-        public ClrDelegateTarget(ClrDelegate del, ClrObject target, ClrMethod method!!)
+        public ClrDelegateTarget(ClrDelegate del, ClrObject target, ClrMethod method)
         {
+            if (method is null)
+                throw new ArgumentNullException(nameof(method));
+
             Parent = del;
             TargetObject = target;
             Method = method;

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/ClrObject.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/ClrObject.cs
@@ -195,9 +195,7 @@ namespace Microsoft.Diagnostics.Runtime
         {
             ClrType type = GetTypeOrThrow();
             if (!type.IsArray)
-            {
                 throw new InvalidOperationException($"Object {Address:x} is not an array, type is '{type.Name}'.");
-            }
 
             return new ClrArray(Address, type);
         }
@@ -215,6 +213,40 @@ namespace Microsoft.Diagnostics.Runtime
         /// <param name="clrObject">An object to get address of.</param>
         public static implicit operator ulong(ClrObject clrObject) => clrObject.Address;
 
+
+        /// <summary>
+        /// Tries to obtain the given object field from this ClrObject.  Returns false if the field wasn't found or if
+        /// the underlying type was not an object.
+        /// </summary>
+        /// <param name="fieldName">The name of the field to retrieve.</param>
+        /// <param name="result">True if the field was found and the field's type is an object.  Returns false otherwise.</param>
+        /// <returns>A ClrObject of the given field.</returns>
+        public bool TryReadObjectField(string fieldName!!, out ClrObject result)
+        {
+            result = default;
+
+            ClrType? type = Type;
+            if (type is null)
+                return false;
+
+            ClrInstanceField? field = type.GetFieldByName(fieldName);
+            if (field is null)
+                return false;
+
+            if (!field.IsObjectReference)
+                return false;
+
+            ClrHeap heap = type.Heap;
+
+            ulong addr = field.GetAddress(Address);
+            if (!type.ClrObjectHelpers.DataReader.ReadPointer(addr, out ulong obj))
+                return false;
+
+            result = heap.GetObject(obj);
+            return true;
+        }
+
+
         /// <summary>
         /// Gets the given object reference field from this ClrObject.
         /// </summary>
@@ -222,7 +254,7 @@ namespace Microsoft.Diagnostics.Runtime
         /// <returns>A ClrObject of the given field.</returns>
         /// <exception cref="ArgumentException">The given field does not exist in the object.</exception>
         /// <exception cref="InvalidOperationException"><see cref="IsNull"/> is <see langword="true"/>.</exception>
-        public ClrObject ReadObjectField(string fieldName)
+        public ClrObject ReadObjectField(string fieldName!!)
         {
             ClrType type = GetTypeOrThrow();
             ClrInstanceField? field = type.GetFieldByName(fieldName);
@@ -241,11 +273,7 @@ namespace Microsoft.Diagnostics.Runtime
             return heap.GetObject(obj);
         }
 
-        /// <summary>
-        /// </summary>
-        /// <param name="fieldName"></param>
-        /// <returns></returns>
-        public ClrValueType ReadValueTypeField(string fieldName)
+        public ClrValueType ReadValueTypeField(string fieldName!!)
         {
             ClrType type = GetTypeOrThrow();
 
@@ -263,9 +291,31 @@ namespace Microsoft.Diagnostics.Runtime
             return new ClrValueType(addr, field.Type, true);
         }
 
+        public bool TryReadValueTypeField(string fieldName, out ClrValueType result)
+        {
+            result = default;
+
+            ClrType? type = Type;
+            if (type is null)
+                return false;
+
+            ClrInstanceField? field = type.GetFieldByName(fieldName);
+            if (field is null)
+                return false;
+
+            if (!field.IsValueType)
+                return false;
+
+            if (field.Type is null)
+                return false;
+
+            ulong addr = field.GetAddress(Address);
+            result = new ClrValueType(addr, field.Type, true);
+            return true;
+        }
+
         /// <summary>
-        /// Gets the value of a primitive field.  This will throw an InvalidCastException if the type parameter
-        /// does not match the field's type.
+        /// Gets the value of a primitive field.
         /// </summary>
         /// <typeparam name="T">The type of the field itself.</typeparam>
         /// <param name="fieldName">The name of the field.</param>
@@ -280,6 +330,32 @@ namespace Microsoft.Diagnostics.Runtime
 
             object value = field.Read<T>(Address, interior: false);
             return (T)value;
+        }
+
+
+        /// <summary>
+        /// Attempts to read the value of a primitive field.  This method does no type checking on whether T
+        /// matches the field's type.
+        /// </summary>
+        /// <typeparam name="T">The type of the field itself.</typeparam>
+        /// <param name="fieldName">The name of the field.</param>
+        /// <param name="result">The value of the missing field.</param>
+        /// <returns>True if we obtained this field and read its value, false otherwise.</returns>
+        public bool TryReadField<T>(string fieldName!!, out T result)
+            where T : unmanaged
+        {
+            result = default;
+
+            ClrType? type = Type;
+            if (type is null)
+                return false;
+
+            ClrInstanceField? field = type.GetFieldByName(fieldName);
+            if (field is null)
+                return false;
+
+            result = field.Read<T>(Address, interior: false);
+            return true;
         }
 
         public bool IsRuntimeType => Type?.Name == RuntimeType;
@@ -301,6 +377,37 @@ namespace Microsoft.Diagnostics.Runtime
                 mt = (ulong)ReadValueTypeField("m_handle").ReadField<IntPtr>("m_ptr");
 
             return type.ClrObjectHelpers.Factory.GetOrCreateType(mt, 0);
+        }
+
+        /// <summary>
+        /// Returns true if this object is a delegate, false otherwise.
+        /// </summary>
+        public bool IsDelegate
+        {
+            get
+            {
+                // Max depth = 8 should be enough to find a delegate type
+                ClrType? type = Type;
+                for (int i = 0; i < 8 && type != null; i++, type = type.BaseType)
+                    if (type.Name == ClrDelegate.DelegateType)
+                        return true;
+
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Returns this object in a <see cref="ClrDelegate"/> view.  Note it is only valid to call
+        /// <see cref="AsDelegate"/> if the underlying object is a subclass of System.Delegate.  You
+        /// can check <see cref="IsDelegate"/> before calling <see cref="AsDelegate"/>, but that is
+        /// not required as long as you are sure the object is a delegate or should be treated like
+        /// one.
+        /// </summary>
+        /// <returns>Returns this object in a <see cref="ClrDelegate"/> view.</returns>
+        public ClrDelegate AsDelegate()
+        {
+            DebugOnly.Assert(IsDelegate);
+            return new ClrDelegate(this);
         }
 
         /// <summary>

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/ClrObject.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/ClrObject.cs
@@ -221,9 +221,11 @@ namespace Microsoft.Diagnostics.Runtime
         /// <param name="fieldName">The name of the field to retrieve.</param>
         /// <param name="result">True if the field was found and the field's type is an object.  Returns false otherwise.</param>
         /// <returns>A ClrObject of the given field.</returns>
-        public bool TryReadObjectField(string fieldName!!, out ClrObject result)
+        public bool TryReadObjectField(string fieldName, out ClrObject result)
         {
             result = default;
+            if (fieldName is null)
+                return false;
 
             ClrType? type = Type;
             if (type is null)
@@ -254,7 +256,7 @@ namespace Microsoft.Diagnostics.Runtime
         /// <returns>A ClrObject of the given field.</returns>
         /// <exception cref="ArgumentException">The given field does not exist in the object.</exception>
         /// <exception cref="InvalidOperationException"><see cref="IsNull"/> is <see langword="true"/>.</exception>
-        public ClrObject ReadObjectField(string fieldName!!)
+        public ClrObject ReadObjectField(string fieldName)
         {
             ClrType type = GetTypeOrThrow();
             ClrInstanceField? field = type.GetFieldByName(fieldName);
@@ -273,7 +275,7 @@ namespace Microsoft.Diagnostics.Runtime
             return heap.GetObject(obj);
         }
 
-        public ClrValueType ReadValueTypeField(string fieldName!!)
+        public ClrValueType ReadValueTypeField(string fieldName)
         {
             ClrType type = GetTypeOrThrow();
 
@@ -341,10 +343,13 @@ namespace Microsoft.Diagnostics.Runtime
         /// <param name="fieldName">The name of the field.</param>
         /// <param name="result">The value of the missing field.</param>
         /// <returns>True if we obtained this field and read its value, false otherwise.</returns>
-        public bool TryReadField<T>(string fieldName!!, out T result)
+        public bool TryReadField<T>(string fieldName, out T result)
             where T : unmanaged
         {
             result = default;
+
+            if (fieldName is null)
+                return false;
 
             ClrType? type = Type;
             if (type is null)

--- a/src/TestTargets/Types/Types.cs
+++ b/src/TestTargets/Types/Types.cs
@@ -31,6 +31,14 @@ class Types
 
     static object s_i = 42;
 
+    delegate void TestDelegate1();
+    static event TestDelegate1 TestEvent;
+
+    delegate void TestDelegate2();
+
+    static TestDelegate2 TestDelegate = new TestDelegate2(Inner);
+
+
     public static FileAccess s_enum = FileAccess.Read;
 
     private static async Task Async()
@@ -47,6 +55,9 @@ class Types
         s_szObjArray[1] = s_szObjArray;
         s_mdObjArray.SetValue(s_mdObjArray, 2);
         s_2dObjArray[1, 2] = s_2dObjArray;
+
+        TestEvent += Inner;
+        TestEvent += new Types().InstanceMethod;
     }
 
     public static void Main()
@@ -64,5 +75,10 @@ class Types
     private static void Inner()
     {
         throw new Exception();
+    }
+
+    private void InstanceMethod()
+    {
+        TestEvent.Invoke();
     }
 }


### PR DESCRIPTION
- Added ClrObject.IsDelegate and ClrObject.AsDelegate.
- Added ClrDelegate view over a target delegate object to enumerate the methods that would be called when a delegate is invoked (along with their targets).
- Added a few ClrObject helpers for fields, "TryRead*"