### PR TITLE
Mini Dump segment size might be bigger than Int32 can fit

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/src/Windows/AWEBasedCacheEntry.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Windows/AWEBasedCacheEntry.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Diagnostics.Runtime.Windows
                         CachePage<UIntPtr> page = _pages[i];
                         if (page != null)
                         {
-                            uint pagesToUnMap = (uint)(page.DataExtent / SystemPageSize) + (uint)((page.DataExtent % SystemPageSize) != 0 ? 1 : 0);
+                            uint pagesToUnMap = (uint)(page.DataExtent / (ulong)SystemPageSize) + (uint)((page.DataExtent % (ulong)SystemPageSize) != 0 ? 1 : 0);
 
                             // We need to unmap the physical memory from this VM range and then free the VM range
                             bool unmapPhysicalPagesResult = CacheNativeMethods.AWE.MapUserPhysicalPages(page.Data, pagesToUnMap, pageArray: UIntPtr.Zero);
@@ -89,7 +89,7 @@ namespace Microsoft.Diagnostics.Runtime.Windows
                                 continue;
                             }
 
-                            sizeRemoved += page.DataExtent;
+                            sizeRemoved += (long)page.DataExtent;
 
                             bool virtualFreeRes = CacheNativeMethods.Memory.VirtualFree(page.Data, sizeToFree: UIntPtr.Zero, CacheNativeMethods.Memory.VirtualFreeType.Release);
                             if (!virtualFreeRes)
@@ -132,15 +132,15 @@ namespace Microsoft.Diagnostics.Runtime.Windows
             return sizeRemoved;
         }
 
-        protected unsafe override uint InvokeCallbackWithDataPtr(CachePage<UIntPtr> page, Func<UIntPtr, uint, uint> callback)
+        protected unsafe override uint InvokeCallbackWithDataPtr(CachePage<UIntPtr> page, Func<UIntPtr, ulong, uint> callback)
         {
             return callback(page.Data, page.DataExtent);
         }
 
-        protected override uint CopyDataFromPage(CachePage<UIntPtr> page, IntPtr buffer, uint inPageOffset, uint byteCount)
+        protected override uint CopyDataFromPage(CachePage<UIntPtr> page, IntPtr buffer, ulong inPageOffset, uint byteCount)
         {
             // Calculate how much of the requested read can be satisfied by the page
-            uint sizeRead = Math.Min(page.DataExtent - inPageOffset, byteCount);
+            uint sizeRead = (uint)Math.Min(page.DataExtent - inPageOffset, byteCount);
 
             unsafe
             {
@@ -150,24 +150,24 @@ namespace Microsoft.Diagnostics.Runtime.Windows
             return sizeRead;
         }
 
-        protected override (UIntPtr Data, uint DataExtent) GetPageDataAtOffset(uint pageAlignedOffset)
+        protected override (UIntPtr Data, ulong DataExtent) GetPageDataAtOffset(ulong pageAlignedOffset)
         {
             // NOTE: The caller ensures this method is not called concurrently
 
-            uint readSize;
-            if ((pageAlignedOffset + EntryPageSize) <= (uint)_segmentData.Size)
+            ulong readSize;
+            if (pageAlignedOffset + EntryPageSize <= _segmentData.Size)
             {
                 readSize = EntryPageSize;
             }
             else
             {
-                readSize = (uint)_segmentData.Size - pageAlignedOffset;
+                readSize = _segmentData.Size - pageAlignedOffset;
             }
 
             if (HeapSegmentCacheEventSource.Instance.IsEnabled())
-                HeapSegmentCacheEventSource.Instance.PageInDataStart((long)(_segmentData.VirtualAddress + pageAlignedOffset), readSize);
+                HeapSegmentCacheEventSource.Instance.PageInDataStart((long)(_segmentData.VirtualAddress + pageAlignedOffset), (long)readSize);
 
-            int startingMemoryPageNumber = (int)(pageAlignedOffset / AWEBasedCacheEntry.SystemPageSize);
+            ulong startingMemoryPageNumber = (pageAlignedOffset / (ulong)AWEBasedCacheEntry.SystemPageSize);
 
             try
             {
@@ -181,10 +181,15 @@ namespace Microsoft.Diagnostics.Runtime.Windows
                 if (vmPtr == UIntPtr.Zero)
                     throw new Win32Exception(Marshal.GetLastWin32Error());
 
-                uint numberOfPages = readSize / (uint)AWEBasedCacheEntry.SystemPageSize + (((readSize % AWEBasedCacheEntry.SystemPageSize) == 0) ? 0u : 1u);
+                ulong numberOfPages = readSize / (uint)AWEBasedCacheEntry.SystemPageSize + (((readSize % (ulong)AWEBasedCacheEntry.SystemPageSize) == 0) ? 0u : 1u);
 
                 // Map one VirtualAlloc sized page of our physical memory into the VM space, we have to adjust the pageFrameArray pointer as MapUserPhysicalPages only takes a page count and a page frame array starting point
-                bool mapPhysicalPagesResult = CacheNativeMethods.AWE.MapUserPhysicalPages(vmPtr, numberOfPages, _pageFrameArray + (startingMemoryPageNumber * UIntPtr.Size));
+                bool mapPhysicalPagesResult = CacheNativeMethods.AWE.MapUserPhysicalPages(
+                    vmPtr,
+                    numberOfPages,
+                    new UIntPtr((ulong)_pageFrameArray + (startingMemoryPageNumber * (ulong)UIntPtr.Size))
+                );
+                
                 if (!mapPhysicalPagesResult)
                     throw new Win32Exception(Marshal.GetLastWin32Error());
 
@@ -216,7 +221,7 @@ namespace Microsoft.Diagnostics.Runtime.Windows
                     {
                         // NOTE: While VirtualAllocPageSize SHOULD be a multiple of SystemPageSize there is no guarantee I can find that says that is true always and everywhere
                         // so to be safe I make sure we don't leave any straggling pages behind if that is true.
-                        uint numberOfPages = (uint)(page.DataExtent / SystemPageSize) + ((page.DataExtent % SystemPageSize) == 0 ? 0U : 1U);
+                        uint numberOfPages = (uint)(page.DataExtent / (ulong)SystemPageSize) + ((page.DataExtent % (ulong)SystemPageSize) == 0 ? 0U : 1U);
 
                         // We need to unmap the physical memory from this VM range and then free the VM range
                         bool unmapPhysicalPagesResult = CacheNativeMethods.AWE.MapUserPhysicalPages(page.Data, numberOfPages, pageArray: UIntPtr.Zero);

--- a/src/Microsoft.Diagnostics.Runtime/src/Windows/ArrayPoolBasedCacheEntry.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Windows/ArrayPoolBasedCacheEntry.cs
@@ -43,12 +43,12 @@ namespace Microsoft.Diagnostics.Runtime.Windows
             }
             while (Interlocked.CompareExchange(ref _entrySize, newCurrent, oldCurrent) != oldCurrent);
 
-            return data.DataRemoved;
+            return (long)data.DataRemoved;
         }
 
         protected override uint EntryPageSize => SystemPageSize;
 
-        protected override (byte[] Data, uint DataExtent) GetPageDataAtOffset(uint pageAlignedOffset)
+        protected override (byte[] Data, ulong DataExtent) GetPageDataAtOffset(ulong pageAlignedOffset)
         {
             // NOTE: The caller ensures this method is not called concurrently
 
@@ -56,17 +56,17 @@ namespace Microsoft.Diagnostics.Runtime.Windows
                 HeapSegmentCacheEventSource.Instance.PageInDataStart((long)(_segmentData.VirtualAddress + pageAlignedOffset), EntryPageSize);
 
             uint readSize;
-            if ((pageAlignedOffset + EntryPageSize) <= (uint)_segmentData.Size)
+            if (pageAlignedOffset + EntryPageSize <= _segmentData.Size)
             {
                 readSize = EntryPageSize;
             }
             else
             {
-                readSize = (uint)_segmentData.Size - pageAlignedOffset;
+                readSize = (uint)(_segmentData.Size - pageAlignedOffset);
             }
 
             bool pageInFailed = false;
-            using (MemoryMappedViewAccessor view = _mappedFile.CreateViewAccessor((long)_segmentData.FileOffset + pageAlignedOffset, size: (long)readSize, MemoryMappedFileAccess.Read))
+            using (MemoryMappedViewAccessor view = _mappedFile.CreateViewAccessor((long)_segmentData.FileOffset + (long)pageAlignedOffset, size: readSize, MemoryMappedFileAccess.Read))
             {
                 try
                 {
@@ -119,7 +119,7 @@ namespace Microsoft.Diagnostics.Runtime.Windows
             }
         }
 
-        protected override uint InvokeCallbackWithDataPtr(CachePage<byte[]> page, Func<UIntPtr, uint, uint> callback)
+        protected override uint InvokeCallbackWithDataPtr(CachePage<byte[]> page, Func<UIntPtr, ulong, uint> callback)
         {
             unsafe
             {
@@ -130,10 +130,10 @@ namespace Microsoft.Diagnostics.Runtime.Windows
             }
         }
 
-        protected override uint CopyDataFromPage(CachePage<byte[]> page, IntPtr buffer, uint inPageOffset, uint byteCount)
+        protected override uint CopyDataFromPage(CachePage<byte[]> page, IntPtr buffer, ulong inPageOffset, uint byteCount)
         {
             // Calculate how much of the requested read can be satisfied by the page
-            uint sizeRead = Math.Min(page.DataExtent - inPageOffset, byteCount);
+            uint sizeRead = (uint)Math.Min(page.DataExtent - inPageOffset, byteCount);
 
             unsafe
             {
@@ -157,10 +157,10 @@ namespace Microsoft.Diagnostics.Runtime.Windows
             }
         }
 
-        private (uint DataRemoved, uint ItemsSkipped) TryRemoveAllPagesFromCache(bool disposeLocks)
+        private (ulong DataRemoved, uint ItemsSkipped) TryRemoveAllPagesFromCache(bool disposeLocks)
         {
             // Assume we will be able to evict all non-null pages
-            uint dataRemoved = 0;
+            ulong dataRemoved = 0;
             uint itemsSkipped = 0;
 
             for (int i = 0; i < _pages.Length; i++)

--- a/src/Microsoft.Diagnostics.Runtime/src/Windows/CacheNativeMethods.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Windows/CacheNativeMethods.cs
@@ -177,7 +177,7 @@ namespace Microsoft.Diagnostics.Runtime.Windows
             [return: MarshalAs(UnmanagedType.Bool)]
             private static extern bool AllocateUserPhysicalPages(IntPtr processHandle, ref UIntPtr numberOfPages, UIntPtr pageArray);
 
-            internal static bool MapUserPhysicalPages(UIntPtr virtualAddress, uint numberOfPages, UIntPtr pageArray)
+            internal static bool MapUserPhysicalPages(UIntPtr virtualAddress, ulong numberOfPages, UIntPtr pageArray)
             {
                 UIntPtr numberOfPagesToMap = new UIntPtr(numberOfPages);
                 return MapUserPhysicalPages(virtualAddress, numberOfPagesToMap, pageArray);

--- a/src/Microsoft.Diagnostics.Runtime/src/Windows/CachePage.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Windows/CachePage.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Diagnostics.Runtime.Windows
 {
     internal class CachePage<T>
     {
-        internal CachePage(T data, uint dataExtent)
+        internal CachePage(T data, ulong dataExtent)
         {
             Data = data;
             DataExtent = dataExtent;
@@ -17,6 +17,6 @@ namespace Microsoft.Diagnostics.Runtime.Windows
 
         public T Data { get; }
 
-        public uint DataExtent { get; }
+        public ulong DataExtent { get; }
     }
 }


### PR DESCRIPTION
Fix for #947.
Mini Dump can have large segments. Currently, unit is used to store the size of a segment and it might be not enough in some cases. In particular, I have a dump of IIS process that has a large (more than 8Gb) segment. When I'm trying to analyze it with ClrMD it crashes with System.AccessViolationException.