### PR TITLE
Fixes crash with ELF alpine arm32 dump

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/src/Linux/ElfCoreFile.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Linux/ElfCoreFile.cs
@@ -214,7 +214,6 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
             ImmutableDictionary<ulong, ElfLoadedImage>.Builder result = ImmutableDictionary.CreateBuilder<ulong, ElfLoadedImage>();
             foreach (ElfLoadedImage image in lookup.Values)
             {
-                image.FixBaseAddress();
                 result.Add(image.BaseAddress, image);
             }
 


### PR DESCRIPTION
The unhandled exception in the ELF reader happened because there is a duplicate file pointer
entry for some images in the list. Removed the unnecessary ElfLoadedImage file table list
and tracked the minimum pointer instead. This is the symstore ELF reader does and it works
great.

Issue: https://github.com/dotnet/diagnostics/issues/3003

Passes the SOS tests.