### PR TITLE
Add ClrObject.EnumerateReferenceAddresses

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/PublicAPI/net461/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Diagnostics.Runtime/PublicAPI/net461/PublicAPI.Unshipped.txt
@@ -1,10 +1,12 @@
 #nullable enable
+abstract Microsoft.Diagnostics.Runtime.ClrHeap.EnumerateReferenceAddresses(ulong obj, Microsoft.Diagnostics.Runtime.ClrType! type, bool carefully, bool considerDependantHandles) -> System.Collections.Generic.IEnumerable<ulong>!
 Microsoft.Diagnostics.Runtime.ClrInfo.BuildId.get -> System.Collections.Immutable.ImmutableArray<byte>
 Microsoft.Diagnostics.Runtime.ClrInfo.DebuggingLibraries.get -> System.Collections.Immutable.ImmutableArray<Microsoft.Diagnostics.Runtime.DebugLibraryInfo!>
 Microsoft.Diagnostics.Runtime.ClrInfo.IndexFileSize.get -> int
 Microsoft.Diagnostics.Runtime.ClrInfo.IndexTimeStamp.get -> int
 Microsoft.Diagnostics.Runtime.ClrInfo.IsSingleFile.get -> bool
 Microsoft.Diagnostics.Runtime.ClrInfo.Version.get -> System.Version!
+Microsoft.Diagnostics.Runtime.ClrObject.EnumerateReferenceAddresses(bool carefully = false, bool considerDependantHandles = true) -> System.Collections.Generic.IEnumerable<ulong>!
 Microsoft.Diagnostics.Runtime.DacInterface.ClrDataProcess.GetSOSDacInterface12() -> Microsoft.Diagnostics.Runtime.DacInterface.SOSDac12?
 Microsoft.Diagnostics.Runtime.DacInterface.SOSDac12
 Microsoft.Diagnostics.Runtime.DacInterface.SOSDac12.GetGlobalAllocationContext(out ulong allocPtr, out ulong allocLimit) -> Microsoft.Diagnostics.Runtime.Utilities.HResult

--- a/src/Microsoft.Diagnostics.Runtime/PublicAPI/net5.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Diagnostics.Runtime/PublicAPI/net5.0/PublicAPI.Unshipped.txt
@@ -1,10 +1,12 @@
 #nullable enable
+abstract Microsoft.Diagnostics.Runtime.ClrHeap.EnumerateReferenceAddresses(ulong obj, Microsoft.Diagnostics.Runtime.ClrType! type, bool carefully, bool considerDependantHandles) -> System.Collections.Generic.IEnumerable<ulong>!
 Microsoft.Diagnostics.Runtime.ClrInfo.BuildId.get -> System.Collections.Immutable.ImmutableArray<byte>
 Microsoft.Diagnostics.Runtime.ClrInfo.DebuggingLibraries.get -> System.Collections.Immutable.ImmutableArray<Microsoft.Diagnostics.Runtime.DebugLibraryInfo!>
 Microsoft.Diagnostics.Runtime.ClrInfo.IndexFileSize.get -> int
 Microsoft.Diagnostics.Runtime.ClrInfo.IndexTimeStamp.get -> int
 Microsoft.Diagnostics.Runtime.ClrInfo.IsSingleFile.get -> bool
 Microsoft.Diagnostics.Runtime.ClrInfo.Version.get -> System.Version!
+Microsoft.Diagnostics.Runtime.ClrObject.EnumerateReferenceAddresses(bool carefully = false, bool considerDependantHandles = true) -> System.Collections.Generic.IEnumerable<ulong>!
 Microsoft.Diagnostics.Runtime.DacInterface.ClrDataProcess.GetSOSDacInterface12() -> Microsoft.Diagnostics.Runtime.DacInterface.SOSDac12?
 Microsoft.Diagnostics.Runtime.DacInterface.SOSDac12
 Microsoft.Diagnostics.Runtime.DacInterface.SOSDac12.GetGlobalAllocationContext(out ulong allocPtr, out ulong allocLimit) -> Microsoft.Diagnostics.Runtime.Utilities.HResult

--- a/src/Microsoft.Diagnostics.Runtime/PublicAPI/netcoreapp3.1/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Diagnostics.Runtime/PublicAPI/netcoreapp3.1/PublicAPI.Unshipped.txt
@@ -1,10 +1,12 @@
 #nullable enable
+abstract Microsoft.Diagnostics.Runtime.ClrHeap.EnumerateReferenceAddresses(ulong obj, Microsoft.Diagnostics.Runtime.ClrType! type, bool carefully, bool considerDependantHandles) -> System.Collections.Generic.IEnumerable<ulong>!
 Microsoft.Diagnostics.Runtime.ClrInfo.BuildId.get -> System.Collections.Immutable.ImmutableArray<byte>
 Microsoft.Diagnostics.Runtime.ClrInfo.DebuggingLibraries.get -> System.Collections.Immutable.ImmutableArray<Microsoft.Diagnostics.Runtime.DebugLibraryInfo!>
 Microsoft.Diagnostics.Runtime.ClrInfo.IndexFileSize.get -> int
 Microsoft.Diagnostics.Runtime.ClrInfo.IndexTimeStamp.get -> int
 Microsoft.Diagnostics.Runtime.ClrInfo.IsSingleFile.get -> bool
 Microsoft.Diagnostics.Runtime.ClrInfo.Version.get -> System.Version!
+Microsoft.Diagnostics.Runtime.ClrObject.EnumerateReferenceAddresses(bool carefully = false, bool considerDependantHandles = true) -> System.Collections.Generic.IEnumerable<ulong>!
 Microsoft.Diagnostics.Runtime.DacInterface.ClrDataProcess.GetSOSDacInterface12() -> Microsoft.Diagnostics.Runtime.DacInterface.SOSDac12?
 Microsoft.Diagnostics.Runtime.DacInterface.SOSDac12
 Microsoft.Diagnostics.Runtime.DacInterface.SOSDac12.GetGlobalAllocationContext(out ulong allocPtr, out ulong allocLimit) -> Microsoft.Diagnostics.Runtime.Utilities.HResult

--- a/src/Microsoft.Diagnostics.Runtime/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Diagnostics.Runtime/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,10 +1,12 @@
 #nullable enable
+abstract Microsoft.Diagnostics.Runtime.ClrHeap.EnumerateReferenceAddresses(ulong obj, Microsoft.Diagnostics.Runtime.ClrType! type, bool carefully, bool considerDependantHandles) -> System.Collections.Generic.IEnumerable<ulong>!
 Microsoft.Diagnostics.Runtime.ClrInfo.BuildId.get -> System.Collections.Immutable.ImmutableArray<byte>
 Microsoft.Diagnostics.Runtime.ClrInfo.DebuggingLibraries.get -> System.Collections.Immutable.ImmutableArray<Microsoft.Diagnostics.Runtime.DebugLibraryInfo!>
 Microsoft.Diagnostics.Runtime.ClrInfo.IndexFileSize.get -> int
 Microsoft.Diagnostics.Runtime.ClrInfo.IndexTimeStamp.get -> int
 Microsoft.Diagnostics.Runtime.ClrInfo.IsSingleFile.get -> bool
 Microsoft.Diagnostics.Runtime.ClrInfo.Version.get -> System.Version!
+Microsoft.Diagnostics.Runtime.ClrObject.EnumerateReferenceAddresses(bool carefully = false, bool considerDependantHandles = true) -> System.Collections.Generic.IEnumerable<ulong>!
 Microsoft.Diagnostics.Runtime.DacInterface.ClrDataProcess.GetSOSDacInterface12() -> Microsoft.Diagnostics.Runtime.DacInterface.SOSDac12?
 Microsoft.Diagnostics.Runtime.DacInterface.SOSDac12
 Microsoft.Diagnostics.Runtime.DacInterface.SOSDac12.GetGlobalAllocationContext(out ulong allocPtr, out ulong allocLimit) -> Microsoft.Diagnostics.Runtime.Utilities.HResult

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/ClrHeap.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/ClrHeap.cs
@@ -174,5 +174,19 @@ namespace Microsoft.Diagnostics.Runtime
         /// the heap may be in an inconsistent state.)
         /// </param>
         public abstract IEnumerable<ClrReference> EnumerateReferencesWithFields(ulong obj, ClrType type, bool carefully, bool considerDependantHandles);
+
+        /// <summary>
+        /// This is an implementation helper.
+        /// Enumerates all objects that the given object references.  This method is meant for internal use to
+        /// implement ClrObject.EnumerateReferenceAddresses which you should use instead of calling this directly.
+        /// </summary>
+        /// <param name="obj">The object in question.</param>
+        /// <param name="type">The type of the object.</param>
+        /// <param name="considerDependantHandles">Whether to consider dependant handle mappings.</param>
+        /// <param name="carefully">
+        /// Whether to bounds check along the way (useful in cases where
+        /// the heap may be in an inconsistent state.)
+        /// </param>
+        public abstract IEnumerable<ulong> EnumerateReferenceAddresses(ulong obj, ClrType type, bool carefully, bool considerDependantHandles);
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/ClrObject.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/ClrObject.cs
@@ -72,6 +72,25 @@ namespace Microsoft.Diagnostics.Runtime
         }
 
         /// <summary>
+        /// Enumerates all objects that this object references.
+        /// </summary>
+        /// <param name="carefully">Only returns pointers which lie on the managed heap.  In very rare cases it's possible to
+        /// create a crash dump where the GC was in the middle of updating data structures, or to create a crash dump of a process
+        /// with heap corruption.  In those cases, setting carefully=true would ensure we would not enumerate those bad references.
+        /// Note that setting carefully=true will cause a small performance penalty.</param>
+        /// <param name="considerDependantHandles">Setting this to true will have ClrMD check for dependent handle references.
+        /// Checking dependent handles does come at a performance penalty but will give you the true reference chain as the
+        /// GC sees it.</param>
+        /// <returns>An enumeration of object references.</returns>
+        public IEnumerable<ulong> EnumerateReferenceAddresses(bool carefully = false, bool considerDependantHandles = true)
+        {
+            if (Type is null)
+                return Enumerable.Empty<ulong>();
+
+            return Type.Heap.EnumerateReferenceAddresses(Address, Type, carefully, considerDependantHandles);
+        }
+
+        /// <summary>
         /// Returns true if this object is a boxed struct or primitive type that 
         /// </summary>
         public bool IsBoxedValue => Type != null && (Type.IsPrimitive || Type.IsValueType);


### PR DESCRIPTION
A faster version of EnumerateReferences, if you don't need the type.