### PR TITLE
Fix refcount problem

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/TestTargets.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/TestTargets.cs
@@ -143,6 +143,8 @@ namespace Microsoft.Diagnostics.Runtime.Tests
 
             RefCountedFreeLibrary library = new RefCountedFreeLibrary(IntPtr.Zero);
 
+            Marshal.AddRef(pDebugClient);
+            Marshal.AddRef(pDebugClient);
             DebugSystemObjects sys = new DebugSystemObjects(library, pDebugClient);
             DebugClient client = new DebugClient(library, pDebugClient, sys);
             DebugControl control = new DebugControl(library, pDebugClient, sys);


### PR DESCRIPTION
The com wrappers steal references, need to AddRef them to ensure we don't over Release.