### PR TITLE
Change IUnknownVTable.QueryInterface return type from HResult to int

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/PublicAPI/net6.0/PublicAPI.Shipped.txt
+++ b/src/Microsoft.Diagnostics.Runtime/PublicAPI/net6.0/PublicAPI.Shipped.txt
@@ -839,7 +839,7 @@ Microsoft.Diagnostics.Runtime.Utilities.HResult.Value.set -> void
 Microsoft.Diagnostics.Runtime.Utilities.IUnknownVTable
 Microsoft.Diagnostics.Runtime.Utilities.IUnknownVTable.AddRef -> delegate* unmanaged[Stdcall]<System.IntPtr, int>
 Microsoft.Diagnostics.Runtime.Utilities.IUnknownVTable.IUnknownVTable() -> void
-Microsoft.Diagnostics.Runtime.Utilities.IUnknownVTable.QueryInterface -> delegate* unmanaged[Stdcall]<System.IntPtr, in System.Guid, out System.IntPtr, Microsoft.Diagnostics.Runtime.Utilities.HResult>
+Microsoft.Diagnostics.Runtime.Utilities.IUnknownVTable.QueryInterface -> delegate* unmanaged[Stdcall]<System.IntPtr, in System.Guid, out System.IntPtr, int>
 Microsoft.Diagnostics.Runtime.Utilities.IUnknownVTable.Release -> delegate* unmanaged[Stdcall]<System.IntPtr, int>
 Microsoft.Diagnostics.Runtime.Utilities.SigParser
 Microsoft.Diagnostics.Runtime.Utilities.SigParser.GetCallingConvInfo(out int data) -> bool

--- a/src/Microsoft.Diagnostics.Runtime/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
+++ b/src/Microsoft.Diagnostics.Runtime/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
@@ -839,7 +839,7 @@ Microsoft.Diagnostics.Runtime.Utilities.HResult.Value.set -> void
 Microsoft.Diagnostics.Runtime.Utilities.IUnknownVTable
 Microsoft.Diagnostics.Runtime.Utilities.IUnknownVTable.AddRef -> delegate* unmanaged[Stdcall]<System.IntPtr, int>
 Microsoft.Diagnostics.Runtime.Utilities.IUnknownVTable.IUnknownVTable() -> void
-Microsoft.Diagnostics.Runtime.Utilities.IUnknownVTable.QueryInterface -> delegate* unmanaged[Stdcall]<System.IntPtr, in System.Guid, out System.IntPtr, Microsoft.Diagnostics.Runtime.Utilities.HResult>
+Microsoft.Diagnostics.Runtime.Utilities.IUnknownVTable.QueryInterface -> delegate* unmanaged[Stdcall]<System.IntPtr, in System.Guid, out System.IntPtr, int>
 Microsoft.Diagnostics.Runtime.Utilities.IUnknownVTable.Release -> delegate* unmanaged[Stdcall]<System.IntPtr, int>
 Microsoft.Diagnostics.Runtime.Utilities.SigParser
 Microsoft.Diagnostics.Runtime.Utilities.SigParser.GetCallingConvInfo(out int data) -> bool

--- a/src/Microsoft.Diagnostics.Runtime/src/Utilities/COMInterop/ComCallableIUnknown.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Utilities/COMInterop/ComCallableIUnknown.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
 
             IUnknownVTable* vtable = (IUnknownVTable*)Marshal.AllocHGlobal(sizeof(IUnknownVTable)).ToPointer();
             QueryInterfaceDelegate qi = QueryInterfaceImpl;
-            vtable->QueryInterface = (delegate* unmanaged[Stdcall]<IntPtr, in Guid, out IntPtr, HResult>)Marshal.GetFunctionPointerForDelegate(qi);
+            vtable->QueryInterface = (delegate* unmanaged[Stdcall]<IntPtr, in Guid, out IntPtr, int>)Marshal.GetFunctionPointerForDelegate(qi);
             _delegates.Add(qi);
 
             AddRefDelegate addRef = new AddRefDelegate(AddRefImpl);
@@ -94,7 +94,7 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
             _delegates.AddRange(keepAlive);
         }
 
-        private HResult QueryInterfaceImpl(IntPtr _, in Guid guid, out IntPtr ptr)
+        private int QueryInterfaceImpl(IntPtr _, in Guid guid, out IntPtr ptr)
         {
             if (_interfaces.TryGetValue(guid, out IntPtr value))
             {

--- a/src/Microsoft.Diagnostics.Runtime/src/Utilities/COMInterop/ComHelper.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Utilities/COMInterop/ComHelper.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
         protected delegate int ReleaseDelegate(IntPtr self);
 
         [UnmanagedFunctionPointer(CallingConvention.Winapi)]
-        protected delegate HResult QueryInterfaceDelegate(IntPtr self, in Guid guid, out IntPtr ptr);
+        protected delegate int QueryInterfaceDelegate(IntPtr self, in Guid guid, out IntPtr ptr);
 
         /// <summary>
         /// Release an IUnknown pointer.
@@ -47,7 +47,7 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
 
             IUnknownVTable* vtable = *(IUnknownVTable**)pUnk;
 
-            return vtable->QueryInterface(pUnk, riid, out result);
+            return (HResult) vtable->QueryInterface(pUnk, riid, out result);
         }
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/src/Utilities/COMInterop/UnknownVTable.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Utilities/COMInterop/UnknownVTable.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
     /// </summary>
     public unsafe struct IUnknownVTable
     {
-        public delegate* unmanaged[Stdcall]<IntPtr, in Guid, out IntPtr, HResult> QueryInterface;
+        public delegate* unmanaged[Stdcall]<IntPtr, in Guid, out IntPtr, int> QueryInterface;
         public delegate* unmanaged[Stdcall]<IntPtr, int> AddRef;
         public delegate* unmanaged[Stdcall]<IntPtr, int> Release;
     }


### PR DESCRIPTION
Partially fixes #1015

@leculver should I also change all `delegate\* unmanaged.*HResult>` entries? 
<details> <summary> `delegate\* unmanaged.*HResult>` entries </summary>

```
src/Microsoft.Diagnostics.Runtime/src/DbgEng/DebugControl.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, out uint, out DEBUG_CLASS_QUALIFIER, HResult> GetDebuggeeType;
src/Microsoft.Diagnostics.Runtime/src/DbgEng/DebugControl.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, HResult> IsPointer64Bit;
src/Microsoft.Diagnostics.Runtime/src/DbgEng/DebugControl.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, out IMAGE_FILE_MACHINE, HResult> GetEffectiveProcessorType;
src/Microsoft.Diagnostics.Runtime/src/DbgEng/DebugControl.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, int, HResult> AddEngineOptions;
src/Microsoft.Diagnostics.Runtime/src/DbgEng/DebugControl.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, int, uint, HResult> WaitForEvent;
src/Microsoft.Diagnostics.Runtime/src/DbgEng/DebugControl.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, out DEBUG_FORMAT, HResult> GetDumpFormatFlags;
src/Microsoft.Diagnostics.Runtime/src/DbgEng/DebugSymbols.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, out int, out int, HResult> GetNumberModules;
src/Microsoft.Diagnostics.Runtime/src/DbgEng/DebugSymbols.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, int, out ulong, HResult> GetModuleByIndex;
src/Microsoft.Diagnostics.Runtime/src/DbgEng/DebugSymbols.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, ulong, int, out int, out ulong, HResult> GetModuleByOffset;
src/Microsoft.Diagnostics.Runtime/src/DbgEng/DebugSymbols.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, int, ulong*, int, DEBUG_MODULE_PARAMETERS*, HResult> GetModuleParameters;
src/Microsoft.Diagnostics.Runtime/src/DbgEng/DebugSymbols.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, int, ulong, byte*, byte*, int, out int, HResult> GetModuleVersionInformation;
src/Microsoft.Diagnostics.Runtime/src/DbgEng/DebugSymbols.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, DebugModuleName, int, ulong, char*, int, out int, HResult> GetModuleNameStringWide;
src/Microsoft.Diagnostics.Runtime/src/DbgEng/DebugAdvanced.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, byte*, int, HResult> GetThreadContext;
src/Microsoft.Diagnostics.Runtime/src/DbgEng/DebugDataSpaces.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, ulong, byte*, int, out int, HResult> ReadVirtual;
src/Microsoft.Diagnostics.Runtime/src/DbgEng/DebugDataSpaces.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, ulong, out MEMORY_BASIC_INFORMATION64, HResult> QueryVirtual;
src/Microsoft.Diagnostics.Runtime/src/DbgEng/DebugSystemObjects.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, out uint, HResult> GetCurrentThreadId;
src/Microsoft.Diagnostics.Runtime/src/DbgEng/DebugSystemObjects.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, uint, HResult> SetCurrentThreadId;
src/Microsoft.Diagnostics.Runtime/src/DbgEng/DebugSystemObjects.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, out int, HResult> GetNumberThreads;
src/Microsoft.Diagnostics.Runtime/src/DbgEng/DebugSystemObjects.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, int, int, int*, uint*, HResult> GetThreadIdsByIndex;
src/Microsoft.Diagnostics.Runtime/src/DbgEng/DebugSystemObjects.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, out ulong, HResult> GetCurrentThreadTeb;
src/Microsoft.Diagnostics.Runtime/src/DbgEng/DebugSystemObjects.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, uint, out uint, HResult> GetThreadIdBySystemId;
src/Microsoft.Diagnostics.Runtime/src/DbgEng/DebugSystemObjects.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, out uint, HResult> GetCurrentProcessSystemId;
src/Microsoft.Diagnostics.Runtime/src/DbgEng/DebugSystemObjects.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, out int, HResult> GetCurrentSystemId;
src/Microsoft.Diagnostics.Runtime/src/DbgEng/DebugSystemObjects.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, int, HResult> SetCurrentSystemId;
src/Microsoft.Diagnostics.Runtime/src/DbgEng/DebugClient.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, ulong, uint, DebugAttach, HResult> AttachProcess;
src/Microsoft.Diagnostics.Runtime/src/DbgEng/DebugClient.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, string, HResult> OpenDumpFile;
src/Microsoft.Diagnostics.Runtime/src/DbgEng/DebugClient.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, HResult> DetachProcesses;
src/Microsoft.Diagnostics.Runtime/src/DbgEng/DebugClient.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, DebugEnd, HResult> EndSession;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosStackRefEnum.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, int, StackRefData*, out int, HResult> Next;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/ClrDataMethod.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, uint, out uint, ILToNativeMap*, HResult> GetILAddressMap;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac8.cs:            public readonly delegate* unmanaged[Stdcall]<IntPtr, out int, HResult> GetNumberGenerations;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac8.cs:            public readonly delegate* unmanaged[Stdcall]<IntPtr, int, GenerationData*, out int, HResult> GetGenerationTable;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac8.cs:            public readonly delegate* unmanaged[Stdcall]<IntPtr, int, ClrDataAddress*, out int, HResult> GetFinalizationFillPointers;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac8.cs:            public readonly delegate* unmanaged[Stdcall]<IntPtr, ulong, int, GenerationData*, out int, HResult> GetGenerationTableSvr;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac8.cs:            public readonly delegate* unmanaged[Stdcall]<IntPtr, ulong, int, ClrDataAddress*, out int, HResult> GetFinalizationFillPointersSvr;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac8.cs:            public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, out ClrDataAddress, HResult> GetAssemblyLoadContext;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/ClrDataProcess.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, HResult> Flush;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/ClrDataProcess.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, uint, out IntPtr, HResult> GetTaskByOSThreadID;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/ClrDataProcess.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, IntPtr, out ClrDataAddress, HResult> StartEnumMethodInstancesByAddress;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/ClrDataProcess.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, ref ClrDataAddress, out IntPtr, HResult> EnumMethodInstanceByAddress;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/ClrDataProcess.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, HResult> EndEnumMethodInstancesByAddress;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/ClrDataProcess.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, uint, int, byte*, int, byte*, HResult> Request;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/ClrDataTask.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, uint, out IntPtr, HResult> CreateStackWalk;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosHandleEnum.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, int, HandleData*, out int, HResult> Next;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/ClrDataModule.cs:            public readonly delegate* unmanaged[Stdcall]<IntPtr, int, out int, char*, HResult> GetName;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/ClrDataModule.cs:            public readonly delegate* unmanaged[Stdcall]<IntPtr, int, out int, char*, HResult> GetFileName;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/ClrDataModule.cs:            public readonly delegate* unmanaged[Stdcall]<IntPtr, uint, int, void*, int, void*, HResult> Request;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac.cs:        private string? GetString(delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, int, byte*, out int, HResult> func, ulong addr, bool skipNull = true)
src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac.cs:        private string? GetAsciiString(delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, int, byte*, out int, HResult> func, ulong addr)
src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac.cs:        private ClrDataAddress[] GetModuleOrAssembly(ulong address, int count, delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, int, ClrDataAddress*, out int, HResult> func)
src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, out ThreadStoreData, HResult> GetThreadStoreData;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, out AppDomainStoreData, HResult> GetAppDomainStoreData;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, int, ClrDataAddress*, out int, HResult> GetAppDomainList;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, out AppDomainData, HResult> GetAppDomainData;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, int, byte*, out int, HResult> GetAppDomainName;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, int, ClrDataAddress*, out int, HResult> GetAssemblyList;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, ClrDataAddress, out AssemblyData, HResult> GetAssemblyData;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, int, byte*, out int, HResult> GetAssemblyName;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, out IntPtr, HResult> GetModule;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, out ModuleData, HResult> GetModuleData;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, SOSDac.ModuleMapTraverseKind, ClrDataAddress, IntPtr, IntPtr, HResult> TraverseModuleMap;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, int, ClrDataAddress*, out int, HResult> GetAssemblyModuleList;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, uint, out ClrDataAddress, HResult> GetILForModule;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, out ThreadData, HResult> GetThreadData;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, uint, out ClrDataAddress, HResult> GetThreadFromThinlockID;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, ulong, out MethodDescData, int, RejitData[]?, out int, HResult> GetMethodDescData;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, out ClrDataAddress, HResult> GetMethodDescPtrFromIP;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, int, byte*, out int, HResult> GetMethodDescName;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, out ClrDataAddress, HResult> GetMethodDescPtrFromFrame;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, int, out ClrDataAddress, HResult> GetMethodDescFromToken;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, out CodeHeaderData, HResult> GetCodeHeaderData;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, int, JitManagerInfo*, out int, HResult> GetJitManagerList;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, int, byte*, out int, HResult> GetJitHelperFunctionName;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, out ThreadPoolData, HResult> GetThreadpoolData;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, out WorkRequestData, HResult> GetWorkRequestData;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, out ObjectData, HResult> GetObjectData;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, int, byte*, out int, HResult> GetMethodTableName;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, out MethodTableData, HResult> GetMethodTableData;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, uint, out ClrDataAddress, HResult> GetMethodTableSlot;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, out FieldInfo, HResult> GetMethodTableFieldData;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, out ClrDataAddress, HResult> GetMethodTableForEEClass;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, out FieldData, HResult> GetFieldDescData;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, int, byte*, out int, HResult> GetFrameName;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, int, byte*, out int, HResult> GetPEFileName;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, out GCInfo, HResult> GetGCHeapData;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, int, ClrDataAddress*, out int, HResult> GetGCHeapList; // svr only
src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, out HeapDetails, HResult> GetGCHeapDetails; // wks only
src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, out HeapDetails, HResult> GetGCHeapStaticData;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, out SegmentData, HResult> GetHeapSegmentData;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, int, out DomainLocalModuleData, HResult> GetDomainLocalModuleDataFromAppDomain;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, out DomainLocalModuleData, HResult> GetDomainLocalModuleDataFromModule;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, uint, out ThreadLocalModuleData, HResult> GetThreadLocalModuleData;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, int, out SyncBlockData, HResult> GetSyncBlockData;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, out IntPtr, HResult> GetHandleEnum;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrHandleKind*, int, out IntPtr, HResult> GetHandleEnumForTypes;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, IntPtr, HResult> TraverseLoaderHeap;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, int, JitCodeHeapInfo*, out int, HResult> GetCodeHeapList;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, int, IntPtr, HResult> TraverseVirtCallStubHeap;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, out CommonMethodTables, HResult> GetUsefulGlobals;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, out uint, HResult> GetTLSIndex;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, out RcwData, HResult> GetRCWData;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, int, COMInterfacePointerData*, out int, HResult> GetRCWInterfaces;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, out CcwData, HResult> GetCCWData;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, int, COMInterfacePointerData*, out int, HResult> GetCCWInterfaces;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, uint, out IntPtr, HResult> GetStackReferences;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, int, byte*, out int, HResult> GetAppDomainConfigFile;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, int, byte*, out int, HResult> GetApplicationBase;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/MetadataImport.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, IntPtr, HResult> CloseEnum;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/MetadataImport.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, ref IntPtr, int, int*, int, out int, HResult> EnumInterfaceImpls;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/MetadataImport.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, int, char*, int, out int, out TypeAttributes, out int, HResult> GetTypeDefProps;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/MetadataImport.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, int, out int, out int, HResult> GetInterfaceImplProps;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/MetadataImport.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, int, out int, char*, int, out int, HResult> GetTypeRefProps;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/MetadataImport.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, ref IntPtr, int, int*, int, out int, HResult> EnumFields;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/MetadataImport.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, int, out int, StringBuilder?, int, out int, out MethodAttributes, out IntPtr, out uint, out uint, out uint, HResult> GetMethodProps;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/MetadataImport.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, int, out uint, out uint, HResult> GetRVA;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/MetadataImport.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, int, out IntPtr, out int, HResult> GetSigFromToken;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/MetadataImport.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, int, out int, char*, int, out int, out FieldAttributes, out IntPtr, out int, out int, out IntPtr, out int, HResult> GetFieldProps;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/MetadataImport.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, int, char*, out IntPtr, out uint, HResult> GetCustomAttributeByName;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/MetadataImport.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, int, out int, HResult> GetNestedClassProps;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/MetadataImport.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, ref IntPtr, int, int*, int, out int, HResult> EnumGenericParams;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/MetadataImport.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, int, out int, out GenericParameterAttributes, out int, out int, char*, int, out int, HResult> GetGenericParamProps;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/SOSDac12.cs:            public readonly delegate* unmanaged[Stdcall]<IntPtr, out ulong, out ulong, HResult> GetGlobalAllocationContext;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/ClrStackWalk.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, uint, int, out int, byte*, HResult> GetContext;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/ClrStackWalk.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, HResult> Next;
src/Microsoft.Diagnostics.Runtime/src/DacInterface/ClrStackWalk.cs:        public readonly delegate* unmanaged[Stdcall]<IntPtr, uint, uint, byte*, uint, byte*, HResult> Request;
```
</details>
