### PR TITLE
Revert "Implement ModuleInfo.TryOpen"

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/PublicAPI/net6.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Diagnostics.Runtime/PublicAPI/net6.0/PublicAPI.Unshipped.txt
@@ -7,4 +7,3 @@ Microsoft.Diagnostics.Runtime.ModuleKind.MachO = 4 -> Microsoft.Diagnostics.Runt
 Microsoft.Diagnostics.Runtime.ModuleKind.Other = 1 -> Microsoft.Diagnostics.Runtime.ModuleKind
 Microsoft.Diagnostics.Runtime.ModuleKind.PortableExecutable = 2 -> Microsoft.Diagnostics.Runtime.ModuleKind
 Microsoft.Diagnostics.Runtime.ModuleKind.Unknown = 0 -> Microsoft.Diagnostics.Runtime.ModuleKind
-virtual Microsoft.Diagnostics.Runtime.ModuleInfo.TryOpen(Microsoft.Diagnostics.Runtime.IDataReader! dataReader) -> System.IO.Stream?

--- a/src/Microsoft.Diagnostics.Runtime/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Diagnostics.Runtime/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -7,4 +7,3 @@ Microsoft.Diagnostics.Runtime.ModuleKind.MachO = 4 -> Microsoft.Diagnostics.Runt
 Microsoft.Diagnostics.Runtime.ModuleKind.Other = 1 -> Microsoft.Diagnostics.Runtime.ModuleKind
 Microsoft.Diagnostics.Runtime.ModuleKind.PortableExecutable = 2 -> Microsoft.Diagnostics.Runtime.ModuleKind
 Microsoft.Diagnostics.Runtime.ModuleKind.Unknown = 0 -> Microsoft.Diagnostics.Runtime.ModuleKind
-virtual Microsoft.Diagnostics.Runtime.ModuleInfo.TryOpen(Microsoft.Diagnostics.Runtime.IDataReader! dataReader) -> System.IO.Stream?

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/ModuleInfo.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/ModuleInfo.cs
@@ -6,7 +6,6 @@ using Microsoft.Diagnostics.Runtime.Implementation;
 using Microsoft.Diagnostics.Runtime.Utilities;
 using System;
 using System.Collections.Immutable;
-using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
 
@@ -120,24 +119,6 @@ namespace Microsoft.Diagnostics.Runtime
         /// The root of the resource tree for this module if one exists, null otherwise.
         /// </summary>
         public virtual IResourceNode? ResourceRoot => null;
-
-        /// <summary>
-        /// Attempts to open this module as a Stream.  Note that this is not the same as
-        /// reading an image on disk as most images will be laid out in virtual memory.
-        /// Unfortunately, some managed code will be in on-disk layout.  There's not a great
-        /// way to find out which is correct for this module.
-        /// </summary>
-        /// <returns>A <see cref="Stream"/> or null.</returns>
-        public virtual Stream? TryOpen(IDataReader dataReader)
-        {
-            if (ImageBase > long.MaxValue)
-                return null;
-
-            if (ImageSize == 0)
-                return null;
-
-            return new ReadVirtualStream(dataReader, (long)ImageBase, ImageSize);
-        }
 
         public override string ToString() => FileName;
 


### PR DESCRIPTION
Reverts microsoft/clrmd#1023.

This simply does not work.  Even in a reasonable heap dump (not mini or triage dump) there are "holes" in memory where the file is laid out into memory.  These holes result in bad reads, so you can't use this stream for standard PE reading libraries.  I may bring this back in some other form, but for now I'm not shipping this until I can think through a better way to do it.