### PR TITLE
Minor cleanups for 2.2

### DIFF
--- a/src/Benchmarks/AweHelpers.cs
+++ b/src/Benchmarks/AweHelpers.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 using System.Security.Principal;
 using System.Text;
 
@@ -9,9 +10,10 @@ namespace Benchmarks
 {
     internal static class AweHelpers
     {
+        [SupportedOSPlatform("windows")]
         public static bool IsAweEnabled => EnableDisablePrivilege("SeLockMemoryPrivilege", enable: true);
 
-
+        [SupportedOSPlatform("windows")]
         private static bool EnableDisablePrivilege(string PrivilegeName, bool enable)
         {
             if (!OpenProcessToken(Process.GetCurrentProcess().Handle, TokenAccessLevels.AdjustPrivileges | TokenAccessLevels.Query, out IntPtr processToken))

--- a/src/Benchmarks/Benchmarks.csproj
+++ b/src/Benchmarks/Benchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/Microsoft.Diagnostics.Runtime/PublicAPI/net6.0/PublicAPI.Shipped.txt
+++ b/src/Microsoft.Diagnostics.Runtime/PublicAPI/net6.0/PublicAPI.Shipped.txt
@@ -1627,3 +1627,11 @@ virtual Microsoft.Diagnostics.Runtime.ModuleInfo.ResourceRoot.get -> Microsoft.D
 virtual Microsoft.Diagnostics.Runtime.ModuleInfo.ImageSize.get -> long
 virtual Microsoft.Diagnostics.Runtime.ModuleInfo.Version.get -> System.Version!
 virtual Microsoft.Diagnostics.Runtime.PlatformFunctions.IsEqualFileVersion(string! file, System.Version! version) -> bool
+abstract Microsoft.Diagnostics.Runtime.ModuleInfo.Kind.get -> Microsoft.Diagnostics.Runtime.ModuleKind
+Microsoft.Diagnostics.Runtime.DataTarget.SetSymbolPath(string! symbolPath) -> void
+Microsoft.Diagnostics.Runtime.ModuleKind
+Microsoft.Diagnostics.Runtime.ModuleKind.Elf = 3 -> Microsoft.Diagnostics.Runtime.ModuleKind
+Microsoft.Diagnostics.Runtime.ModuleKind.MachO = 4 -> Microsoft.Diagnostics.Runtime.ModuleKind
+Microsoft.Diagnostics.Runtime.ModuleKind.Other = 1 -> Microsoft.Diagnostics.Runtime.ModuleKind
+Microsoft.Diagnostics.Runtime.ModuleKind.PortableExecutable = 2 -> Microsoft.Diagnostics.Runtime.ModuleKind
+Microsoft.Diagnostics.Runtime.ModuleKind.Unknown = 0 -> Microsoft.Diagnostics.Runtime.ModuleKind

--- a/src/Microsoft.Diagnostics.Runtime/PublicAPI/net6.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Diagnostics.Runtime/PublicAPI/net6.0/PublicAPI.Unshipped.txt
@@ -1,9 +1,1 @@
 #nullable enable
-abstract Microsoft.Diagnostics.Runtime.ModuleInfo.Kind.get -> Microsoft.Diagnostics.Runtime.ModuleKind
-Microsoft.Diagnostics.Runtime.DataTarget.SetSymbolPath(string! symbolPath) -> void
-Microsoft.Diagnostics.Runtime.ModuleKind
-Microsoft.Diagnostics.Runtime.ModuleKind.Elf = 3 -> Microsoft.Diagnostics.Runtime.ModuleKind
-Microsoft.Diagnostics.Runtime.ModuleKind.MachO = 4 -> Microsoft.Diagnostics.Runtime.ModuleKind
-Microsoft.Diagnostics.Runtime.ModuleKind.Other = 1 -> Microsoft.Diagnostics.Runtime.ModuleKind
-Microsoft.Diagnostics.Runtime.ModuleKind.PortableExecutable = 2 -> Microsoft.Diagnostics.Runtime.ModuleKind
-Microsoft.Diagnostics.Runtime.ModuleKind.Unknown = 0 -> Microsoft.Diagnostics.Runtime.ModuleKind

--- a/src/Microsoft.Diagnostics.Runtime/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
+++ b/src/Microsoft.Diagnostics.Runtime/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
@@ -1627,3 +1627,11 @@ virtual Microsoft.Diagnostics.Runtime.ModuleInfo.ResourceRoot.get -> Microsoft.D
 virtual Microsoft.Diagnostics.Runtime.ModuleInfo.ImageSize.get -> long
 virtual Microsoft.Diagnostics.Runtime.ModuleInfo.Version.get -> System.Version!
 virtual Microsoft.Diagnostics.Runtime.PlatformFunctions.IsEqualFileVersion(string! file, System.Version! version) -> bool
+abstract Microsoft.Diagnostics.Runtime.ModuleInfo.Kind.get -> Microsoft.Diagnostics.Runtime.ModuleKind
+Microsoft.Diagnostics.Runtime.DataTarget.SetSymbolPath(string! symbolPath) -> void
+Microsoft.Diagnostics.Runtime.ModuleKind
+Microsoft.Diagnostics.Runtime.ModuleKind.Elf = 3 -> Microsoft.Diagnostics.Runtime.ModuleKind
+Microsoft.Diagnostics.Runtime.ModuleKind.MachO = 4 -> Microsoft.Diagnostics.Runtime.ModuleKind
+Microsoft.Diagnostics.Runtime.ModuleKind.Other = 1 -> Microsoft.Diagnostics.Runtime.ModuleKind
+Microsoft.Diagnostics.Runtime.ModuleKind.PortableExecutable = 2 -> Microsoft.Diagnostics.Runtime.ModuleKind
+Microsoft.Diagnostics.Runtime.ModuleKind.Unknown = 0 -> Microsoft.Diagnostics.Runtime.ModuleKind

--- a/src/Microsoft.Diagnostics.Runtime/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Diagnostics.Runtime/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,9 +1,1 @@
 #nullable enable
-abstract Microsoft.Diagnostics.Runtime.ModuleInfo.Kind.get -> Microsoft.Diagnostics.Runtime.ModuleKind
-Microsoft.Diagnostics.Runtime.DataTarget.SetSymbolPath(string! symbolPath) -> void
-Microsoft.Diagnostics.Runtime.ModuleKind
-Microsoft.Diagnostics.Runtime.ModuleKind.Elf = 3 -> Microsoft.Diagnostics.Runtime.ModuleKind
-Microsoft.Diagnostics.Runtime.ModuleKind.MachO = 4 -> Microsoft.Diagnostics.Runtime.ModuleKind
-Microsoft.Diagnostics.Runtime.ModuleKind.Other = 1 -> Microsoft.Diagnostics.Runtime.ModuleKind
-Microsoft.Diagnostics.Runtime.ModuleKind.PortableExecutable = 2 -> Microsoft.Diagnostics.Runtime.ModuleKind
-Microsoft.Diagnostics.Runtime.ModuleKind.Unknown = 0 -> Microsoft.Diagnostics.Runtime.ModuleKind


### PR DESCRIPTION
- Move benchmarks to .Net 6.
- Update Shipped/Unshipped api surface now that we are on 2.2.
- Fix SupportedOSPlatform warning.