### PR TITLE
Fix a bug related to generation bounds for regions

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/HeapTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/HeapTests.cs
@@ -214,6 +214,11 @@ namespace Microsoft.Diagnostics.Runtime.Tests
                 if (seg.Generation2.Length > 0)
                     Assert.True(seg.ObjectRange.Contains(seg.Generation2));
 
+                Assert.True(seg.Generation2.Start == seg.Start);
+                Assert.True(seg.Generation2.Start + seg.Generation2.Length == seg.Generation1.Start);
+                Assert.True(seg.Generation1.Start + seg.Generation1.Length == seg.Generation0.Start);
+                Assert.True(seg.Generation0.Start + seg.Generation0.Length == seg.End);
+
                 if (seg.Length == 0)
                 {
                     continue;

--- a/src/Microsoft.Diagnostics.Runtime/src/Builders/SegmentBuilder.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Builders/SegmentBuilder.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Diagnostics.Runtime.Builders
             {
                 if (_regions)
                 {
-                    return (_generation == 1) ? Start : End;
+                    return (_generation <= 1) ? Start : End;
                 }
                 else
                 {
@@ -99,7 +99,7 @@ namespace Microsoft.Diagnostics.Runtime.Builders
             {
                 if (_regions)
                 {
-                    return End - Gen1Start;
+                    return (_generation == 1) ? End - Start : 0;
                 }
                 else
                 {
@@ -112,14 +112,7 @@ namespace Microsoft.Diagnostics.Runtime.Builders
         {
             get
             {
-                if (_regions)
-                {
-                    return (_generation >= 2) ? Start : End;
-                }
-                else
-                {
-                    return Start;
-                }
+                return Start;
             }
         }
 
@@ -129,7 +122,7 @@ namespace Microsoft.Diagnostics.Runtime.Builders
             {
                 if (_regions)
                 {
-                    return End - Gen2Start;
+                    return (_generation >= 2) ? End - Start : 0;
                 }
                 else
                 {


### PR DESCRIPTION
@Maoni0 reported that generational aware analysis in PerfView is not working for full core dumps. After debugging for a while, I have found a few bugs related to generation detection. This PR fixes some of them, the remaining ones are in PerfView and are fixed [there](https://github.com/microsoft/perfview/pull/1674).

With this change, we have these new invariants for regions, which used to hold for segments.

```
Gen2Start == Start
Gen2Start + Gen2Length == Gen1Start
Gen1Start + Gen1Length == Gen0Start
Gen1Start + Gen0Length == End
```

The old code is not *technically* wrong, the ranges are empty anyway, but this is more convenient for PerfView to consume, and we don't know if there are other tools replicated the way PerfView did things, so might as well get it fixed.