### PR TITLE
Support PE relocation

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/src/DacInterface/DacDataTargetWrapper.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DacInterface/DacDataTargetWrapper.cs
@@ -173,7 +173,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             if (info != null && info.FileName != null)
             {
                 // We do not put a using statement here to prevent needing to load/unload the binary over and over.
-                PEImage? peimage = _dataTarget.LoadPEImage(info.FileName, info.IndexTimeStamp, info.IndexFileSize, checkProperties: true);
+                PEImage? peimage = _dataTarget.LoadPEImage(info.FileName, info.IndexTimeStamp, info.IndexFileSize, checkProperties: true, info.ImageBase);
                 if (peimage != null)
                 {
                     lock (peimage)
@@ -249,7 +249,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
                 return HResult.E_INVALIDARG;
 
             // We do not put a using statement here to prevent needing to load/unload the binary over and over.
-            PEImage? peimage = _dataTarget.LoadPEImage(fileName, imageTimestamp, imageSize, checkProperties: true);
+            PEImage? peimage = _dataTarget.LoadPEImage(fileName, imageTimestamp, imageSize, checkProperties: true, imageBase: 0);
             if (peimage is null)
                 return HResult.E_FAIL;
 

--- a/src/Microsoft.Diagnostics.Runtime/src/DataTargets/DataTarget.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataTargets/DataTarget.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Diagnostics.Runtime
             }
         }
 
-        internal PEImage? LoadPEImage(string fileName, int timeStamp, int fileSize, bool checkProperties)
+        internal PEImage? LoadPEImage(string fileName, int timeStamp, int fileSize, bool checkProperties, ulong imageBase)
         {
             if (_disposed)
                 throw new ObjectDisposedException(nameof(DataTarget));
@@ -114,6 +114,7 @@ namespace Microsoft.Diagnostics.Runtime
             if (!string.IsNullOrWhiteSpace(path) && File.Exists(path))
             {
                 result = new PEImage(File.OpenRead(fileName));
+                result.Relocate(imageBase);
                 if (!result.IsValid)
                     result = null;
             }

--- a/src/Microsoft.Diagnostics.Runtime/src/DataTargets/DataTarget.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataTargets/DataTarget.cs
@@ -113,8 +113,7 @@ namespace Microsoft.Diagnostics.Runtime
 
             if (!string.IsNullOrWhiteSpace(path) && File.Exists(path))
             {
-                result = new PEImage(File.OpenRead(fileName));
-                result.Relocate(imageBase);
+                result = new PEImage(File.OpenRead(fileName), false, imageBase);
                 if (!result.IsValid)
                     result = null;
             }

--- a/src/Microsoft.Diagnostics.Runtime/src/Utilities/PEImage/ImageRelocation.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Utilities/PEImage/ImageRelocation.cs
@@ -1,0 +1,12 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.Diagnostics.Runtime.Utilities
+{
+    internal struct ImageRelocation
+    {
+        public int pageRVA;
+        public int blockSize;
+    }
+}


### PR DESCRIPTION
When a `PEImage` is loaded because we are reading from a `DataTarget`, this change will perform the necessary relocation so that subsequent `PEImage.Read` will produce correct values as if it is loaded in memory in the process.

This is apparently incomplete (e.g. not handling all relocation types), but it is good enough in the sense that it can successfully initialize the DAC when the `coreclr.dll` image is not saved (e.g. created by `createdump.exe --with-heap` on Windows). 

Tested on x64 only.