### PR TITLE
Locate file directly

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/src/Implementation/FileSymbolCache.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Implementation/FileSymbolCache.cs
@@ -104,7 +104,16 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
                 return null;
 
             string fullPath = Path.Combine(Location, key);
-            return File.Exists(fullPath) ? fullPath : null;
+            if (File.Exists(fullPath))
+            {
+                return fullPath;
+            }
+            else
+            {
+                string fileName = Path.GetFileName(fullPath);
+                fullPath = Path.Combine(Location, fileName);
+                return File.Exists(fullPath) ? fullPath : null;
+            }
         }
 
         internal string Store(Stream stream, string key)


### PR DESCRIPTION
This change allows PerfView users to set the symbol path to the build folder and open Linux minidumps as follows:

`set _NT_SYMBOL_PATH = <runtime-repo-base>\artifacts\bin\coreclr\Linux.x64.Debug` 

The problem with the existing code is that it insists the crossdac must be exactly at the path generated by the `FindPEImage` method. In my example, the code checks if this file exists and fails the lookup if it isn't there.

```
<runtime-repo-base>\artifacts\bin\coreclr\Linux.x64.Debug\mscordaccore.dll\elf-buildid-coreclr-ee0b86c2c007c9cd8008ebb49c6bd22c8593ff74\mscordaccore.dll
```

I understand this is what a normal symbol cache would do, but it is so inconvenient that I prefer to have the symbol logic checking one more location.
