### PR TITLE
Fix MachO core dump generated on the Ventura (13.0.1)

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/src/MacOS/MachOCoreDump.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/MacOS/MachOCoreDump.cs
@@ -246,10 +246,17 @@ namespace Microsoft.Diagnostics.Runtime.MacOS
             {
                 foreach (MachOSegment seg in _segments)
                 {
-                    MachHeader64 header = ReadMemory<MachHeader64>(seg.Address);
-                    if (header.Magic == MachHeader64.Magic64 && header.FileType == MachOFileType.Dylinker)
+                    for (ulong offset = 0; offset < seg.FileSize; offset += 0x1000)
                     {
-                        _dylinker = new MachOModule(this, seg.Address, "dylinker");
+                        MachHeader64 header = ReadMemory<MachHeader64>(seg.Address + offset);
+                        if (header.Magic == MachHeader64.Magic64 && header.FileType == MachOFileType.Dylinker)
+                        {
+                            _dylinker = new MachOModule(this, seg.Address + offset, "dylinker");
+                            break;
+                        }
+                    }
+                    if (_dylinker != null)
+                    {
                         break;
                     }
                 }

--- a/src/Microsoft.Diagnostics.Runtime/src/MacOS/MachOCoreDump.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/MacOS/MachOCoreDump.cs
@@ -244,22 +244,7 @@ namespace Microsoft.Diagnostics.Runtime.MacOS
 
             if (_dylinker == null)
             {
-                foreach (MachOSegment seg in _segments)
-                {
-                    for (ulong offset = 0; offset < seg.FileSize; offset += 0x1000)
-                    {
-                        MachHeader64 header = ReadMemory<MachHeader64>(seg.Address + offset);
-                        if (header.Magic == MachHeader64.Magic64 && header.FileType == MachOFileType.Dylinker)
-                        {
-                            _dylinker = new MachOModule(this, seg.Address + offset, "dylinker");
-                            break;
-                        }
-                    }
-                    if (_dylinker != null)
-                    {
-                        break;
-                    }
-                }
+                _dylinker = FindDylinker(firstPass: true) ?? FindDylinker(firstPass: false);
             }
 
             if (_dylinker != null && _dylinker.TryLookupSymbol("dyld_all_image_infos", out ulong dyld_allImage_address))
@@ -287,6 +272,32 @@ namespace Microsoft.Diagnostics.Runtime.MacOS
             }
 
             return _modules = new Dictionary<ulong, MachOModule>();
+        }
+
+        private MachOModule? FindDylinker(bool firstPass)
+        {
+            const uint skip = 0x1000;
+            const uint firstPassAttemptCount = 8;
+            foreach (MachOSegment seg in _segments)
+            {
+                ulong start = 0;
+                ulong end = seg.FileSize;
+
+                if (firstPass)
+                    end = skip * firstPassAttemptCount;
+                else
+                    start = skip * firstPassAttemptCount;
+
+                for (ulong offset = start; offset < end; offset += skip)
+                {
+                    MachHeader64 header = ReadMemory<MachHeader64>(seg.Address + offset);
+                    if (header.Magic == MachHeader64.Magic64 && header.FileType == MachOFileType.Dylinker)
+                    {
+                        return new MachOModule(this, seg.Address + offset, "dylinker");
+                    }
+                }
+            }
+            return null;
         }
 
         private bool FindSegmentContaining(ulong address, out MachOSegment seg)

--- a/src/Microsoft.Diagnostics.Runtime/src/MacOS/MachOModule.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/MacOS/MachOModule.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Diagnostics.Runtime.MacOS
                     case LoadCommandType.Segment64:
                         Segment64LoadCommand seg64LoadCmd = DataReader.Read<Segment64LoadCommand>(cmdAddress + (uint)sizeof(LoadCommandHeader));
                         segments.Add(new MachOSegment(seg64LoadCmd));
-                        if (seg64LoadCmd.FileOffset == 0 && seg64LoadCmd.FileSize > 0)
+                        if (seg64LoadCmd.Name.Equals("__TEXT"))
                         {
                             LoadBias = BaseAddress - seg64LoadCmd.VMAddr;
                         }
@@ -140,7 +140,7 @@ namespace Microsoft.Diagnostics.Runtime.MacOS
                     }
                     if (name == symbol)
                     {
-                        address = BaseAddress + symTable[start + i].n_value;
+                        address = LoadBias + symTable[start + i].n_value;
                         return true;
                     }
                 }


### PR DESCRIPTION
On Ventura, the dylinker header isn't on a segment boundary any more. It is usually 8K into segment. There were also problems with incorrectly calculating the LoadBias and the TryLookupSymbol result.

See: https://developer.apple.com/forums/thread/720064
Runtime issue: https://github.com/dotnet/runtime/issues/79355