### PR TITLE
Fix parsing /proc/PID/maps entries with (deleted) tag

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/src/Linux/LinuxLiveDataReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Linux/LinuxLiveDataReader.cs
@@ -309,6 +309,10 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
                 {
                     path = parts[5].StartsWith("[") ? string.Empty : parts[5];
                 }
+                else if (parts.Length == 7 && parts[6] == "(deleted)")
+                {
+                    path = string.Empty;
+                }
                 else
                 {
                     DebugOnly.Fail("Unknown data format");


### PR DESCRIPTION
The /proc/PID/maps can contain entries for file mapping / shared memory mapping that contain `(deleted)` 
after the filename. The W^X double mapping use shared memory mapping backed by the pagefile where 
the entries look like
`7fb6d722b000-7fb6d722c000 rw-s 0043c000 00:01 47618 /memfd:doublemapper (deleted)`
ClrMD was rejecting such entries as invalid in `LinuxLiveDataReader.LoadMemoryMaps.`

This change fixes it.