### PR TITLE
Add a way to enumerate native heaps

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <!-- This repo version -->
-    <VersionPrefix>2.3.0</VersionPrefix>
+    <VersionPrefix>2.4.0</VersionPrefix>
     <DotNetUseShippingVersions>true</DotNetUseShippingVersions>
     <AutoGenerateAssemblyVersion>true</AutoGenerateAssemblyVersion>
     <UsingToolNetFrameworkReferenceAssemblies>true</UsingToolNetFrameworkReferenceAssemblies>

--- a/src/Microsoft.Diagnostics.Runtime/PublicAPI/net6.0/PublicAPI.Shipped.txt
+++ b/src/Microsoft.Diagnostics.Runtime/PublicAPI/net6.0/PublicAPI.Shipped.txt
@@ -582,7 +582,6 @@ Microsoft.Diagnostics.Runtime.DacInterface.SOSDac.SOSDac(Microsoft.Diagnostics.R
 Microsoft.Diagnostics.Runtime.DacInterface.SOSDac.SOSDac(Microsoft.Diagnostics.Runtime.DacLibrary? library, System.IntPtr ptr) -> void
 Microsoft.Diagnostics.Runtime.DacInterface.SOSDac.TraverseLoaderHeap(ulong heap, Microsoft.Diagnostics.Runtime.DacInterface.SOSDac.LoaderHeapTraverse! callback) -> Microsoft.Diagnostics.Runtime.Utilities.HResult
 Microsoft.Diagnostics.Runtime.DacInterface.SOSDac.TraverseModuleMap(Microsoft.Diagnostics.Runtime.DacInterface.SOSDac.ModuleMapTraverseKind mt, ulong module, Microsoft.Diagnostics.Runtime.DacInterface.SOSDac.ModuleMapTraverse! traverse) -> Microsoft.Diagnostics.Runtime.Utilities.HResult
-Microsoft.Diagnostics.Runtime.DacInterface.SOSDac.TraverseStubHeap(ulong heap, int type, Microsoft.Diagnostics.Runtime.DacInterface.SOSDac.LoaderHeapTraverse! callback) -> Microsoft.Diagnostics.Runtime.Utilities.HResult
 Microsoft.Diagnostics.Runtime.DacInterface.SOSDac6
 Microsoft.Diagnostics.Runtime.DacInterface.SOSDac6.GetMethodTableCollectibleData(ulong mt, out Microsoft.Diagnostics.Runtime.DacInterface.MethodTableCollectibleData data) -> Microsoft.Diagnostics.Runtime.Utilities.HResult
 Microsoft.Diagnostics.Runtime.DacInterface.SOSDac6.SOSDac6(Microsoft.Diagnostics.Runtime.DacLibrary! library, System.IntPtr ptr) -> void
@@ -1634,3 +1633,45 @@ Microsoft.Diagnostics.Runtime.ModuleKind.MachO = 4 -> Microsoft.Diagnostics.Runt
 Microsoft.Diagnostics.Runtime.ModuleKind.Other = 1 -> Microsoft.Diagnostics.Runtime.ModuleKind
 Microsoft.Diagnostics.Runtime.ModuleKind.PortableExecutable = 2 -> Microsoft.Diagnostics.Runtime.ModuleKind
 Microsoft.Diagnostics.Runtime.ModuleKind.Unknown = 0 -> Microsoft.Diagnostics.Runtime.ModuleKind
+abstract Microsoft.Diagnostics.Runtime.ClrRuntime.EnumerateClrNativeHeaps() -> System.Collections.Generic.IEnumerable<Microsoft.Diagnostics.Runtime.ClrNativeHeapInfo>!
+Microsoft.Diagnostics.Runtime.ClrInfo.CreateRuntime(Microsoft.Diagnostics.Runtime.DacLibrary! dacLibrary) -> Microsoft.Diagnostics.Runtime.ClrRuntime!
+Microsoft.Diagnostics.Runtime.DacInterface.ClrDataProcess.GetSOSDacInterface13() -> Microsoft.Diagnostics.Runtime.DacInterface.SOSDac13?
+Microsoft.Diagnostics.Runtime.DacInterface.SOSDac.TraverseStubHeap(ulong heap, Microsoft.Diagnostics.Runtime.DacInterface.SOSDac.VCSHeapType type, Microsoft.Diagnostics.Runtime.DacInterface.SOSDac.LoaderHeapTraverse! callback) -> Microsoft.Diagnostics.Runtime.Utilities.HResult
+Microsoft.Diagnostics.Runtime.DacInterface.SOSDac.VCSHeapType
+Microsoft.Diagnostics.Runtime.DacInterface.SOSDac.VCSHeapType.CacheEntryHeap = 4 -> Microsoft.Diagnostics.Runtime.DacInterface.SOSDac.VCSHeapType
+Microsoft.Diagnostics.Runtime.DacInterface.SOSDac.VCSHeapType.DispatchHeap = 3 -> Microsoft.Diagnostics.Runtime.DacInterface.SOSDac.VCSHeapType
+Microsoft.Diagnostics.Runtime.DacInterface.SOSDac.VCSHeapType.IndcellHeap = 0 -> Microsoft.Diagnostics.Runtime.DacInterface.SOSDac.VCSHeapType
+Microsoft.Diagnostics.Runtime.DacInterface.SOSDac.VCSHeapType.LookupHeap = 1 -> Microsoft.Diagnostics.Runtime.DacInterface.SOSDac.VCSHeapType
+Microsoft.Diagnostics.Runtime.DacInterface.SOSDac.VCSHeapType.ResolveHeap = 2 -> Microsoft.Diagnostics.Runtime.DacInterface.SOSDac.VCSHeapType
+Microsoft.Diagnostics.Runtime.DacInterface.SOSDac.VCSHeapType.VtableHeap = 5 -> Microsoft.Diagnostics.Runtime.DacInterface.SOSDac.VCSHeapType
+Microsoft.Diagnostics.Runtime.DacInterface.SOSDac13.LoaderHeapKind
+Microsoft.Diagnostics.Runtime.DacInterface.SOSDac13.LoaderHeapKind.LoaderHeapKindExplicitControl = 1 -> Microsoft.Diagnostics.Runtime.DacInterface.SOSDac13.LoaderHeapKind
+Microsoft.Diagnostics.Runtime.DacInterface.SOSDac13.LoaderHeapKind.LoaderHeapKindNormal = 0 -> Microsoft.Diagnostics.Runtime.DacInterface.SOSDac13.LoaderHeapKind
+Microsoft.Diagnostics.Runtime.DacInterface.SOSDac13.TraverseLoaderHeap(ulong heap, Microsoft.Diagnostics.Runtime.DacInterface.SOSDac13.LoaderHeapKind kind, Microsoft.Diagnostics.Runtime.DacInterface.SOSDac.LoaderHeapTraverse! callback) -> Microsoft.Diagnostics.Runtime.Utilities.HResult
+Microsoft.Diagnostics.Runtime.DacLibrary.SOSDacInterface13.get -> Microsoft.Diagnostics.Runtime.DacInterface.SOSDac13?
+Microsoft.Diagnostics.Runtime.IDumpInfoProvider
+Microsoft.Diagnostics.Runtime.IDumpInfoProvider.IsMiniOrTriage.get -> bool
+Microsoft.Diagnostics.Runtime.ClrNativeHeapInfo
+Microsoft.Diagnostics.Runtime.ClrNativeHeapInfo.Address.get -> ulong
+Microsoft.Diagnostics.Runtime.ClrNativeHeapInfo.ClrNativeHeapInfo() -> void
+Microsoft.Diagnostics.Runtime.ClrNativeHeapInfo.ClrNativeHeapInfo(ulong address, ulong? size, Microsoft.Diagnostics.Runtime.NativeHeapKind kind) -> void
+Microsoft.Diagnostics.Runtime.ClrNativeHeapInfo.Kind.get -> Microsoft.Diagnostics.Runtime.NativeHeapKind
+Microsoft.Diagnostics.Runtime.ClrNativeHeapInfo.Size.get -> ulong?
+Microsoft.Diagnostics.Runtime.NativeHeapKind
+Microsoft.Diagnostics.Runtime.NativeHeapKind.CacheEntryHeap = 5 -> Microsoft.Diagnostics.Runtime.NativeHeapKind
+Microsoft.Diagnostics.Runtime.NativeHeapKind.DispatchHeap = 4 -> Microsoft.Diagnostics.Runtime.NativeHeapKind
+Microsoft.Diagnostics.Runtime.NativeHeapKind.HighFrequencyHeap = 10 -> Microsoft.Diagnostics.Runtime.NativeHeapKind
+Microsoft.Diagnostics.Runtime.NativeHeapKind.HostCodeHeap = 8 -> Microsoft.Diagnostics.Runtime.NativeHeapKind
+Microsoft.Diagnostics.Runtime.NativeHeapKind.IndirectionCellHeap = 1 -> Microsoft.Diagnostics.Runtime.NativeHeapKind
+Microsoft.Diagnostics.Runtime.NativeHeapKind.LoaderCodeHeap = 7 -> Microsoft.Diagnostics.Runtime.NativeHeapKind
+Microsoft.Diagnostics.Runtime.NativeHeapKind.LookupHeap = 2 -> Microsoft.Diagnostics.Runtime.NativeHeapKind
+Microsoft.Diagnostics.Runtime.NativeHeapKind.LowFrequencyHeap = 11 -> Microsoft.Diagnostics.Runtime.NativeHeapKind
+Microsoft.Diagnostics.Runtime.NativeHeapKind.ResolveHeap = 3 -> Microsoft.Diagnostics.Runtime.NativeHeapKind
+Microsoft.Diagnostics.Runtime.NativeHeapKind.StubHeap = 9 -> Microsoft.Diagnostics.Runtime.NativeHeapKind
+Microsoft.Diagnostics.Runtime.NativeHeapKind.Unknown = 0 -> Microsoft.Diagnostics.Runtime.NativeHeapKind
+Microsoft.Diagnostics.Runtime.NativeHeapKind.VtableHeap = 6 -> Microsoft.Diagnostics.Runtime.NativeHeapKind
+Microsoft.Diagnostics.Runtime.DacInterface.SOSDac13
+Microsoft.Diagnostics.Runtime.DacInterface.SOSDac13.SOSDac13(Microsoft.Diagnostics.Runtime.DacLibrary! library, System.IntPtr ptr) -> void
+override Microsoft.Diagnostics.Runtime.ClrNativeHeapInfo.ToString() -> string!
+static Microsoft.Diagnostics.Runtime.ModuleInfo.TryCreate(Microsoft.Diagnostics.Runtime.IDataReader! reader, ulong baseAddress, string! name, int indexFileSize, int indexTimeStamp, System.Version? version) -> Microsoft.Diagnostics.Runtime.ModuleInfo?
+virtual Microsoft.Diagnostics.Runtime.ModuleInfo.TrySetProperties(int indexFileSize, int indexTimeStamp, System.Version? version) -> void

--- a/src/Microsoft.Diagnostics.Runtime/PublicAPI/net6.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Diagnostics.Runtime/PublicAPI/net6.0/PublicAPI.Unshipped.txt
@@ -1,6 +1,1 @@
 #nullable enable
-Microsoft.Diagnostics.Runtime.ClrInfo.CreateRuntime(Microsoft.Diagnostics.Runtime.DacLibrary! dacLibrary) -> Microsoft.Diagnostics.Runtime.ClrRuntime!
-Microsoft.Diagnostics.Runtime.IDumpInfoProvider
-Microsoft.Diagnostics.Runtime.IDumpInfoProvider.IsMiniOrTriage.get -> bool
-static Microsoft.Diagnostics.Runtime.ModuleInfo.TryCreate(Microsoft.Diagnostics.Runtime.IDataReader! reader, ulong baseAddress, string! name, int indexFileSize, int indexTimeStamp, System.Version? version) -> Microsoft.Diagnostics.Runtime.ModuleInfo?
-virtual Microsoft.Diagnostics.Runtime.ModuleInfo.TrySetProperties(int indexFileSize, int indexTimeStamp, System.Version? version) -> void

--- a/src/Microsoft.Diagnostics.Runtime/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
+++ b/src/Microsoft.Diagnostics.Runtime/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
@@ -1634,3 +1634,45 @@ Microsoft.Diagnostics.Runtime.ModuleKind.MachO = 4 -> Microsoft.Diagnostics.Runt
 Microsoft.Diagnostics.Runtime.ModuleKind.Other = 1 -> Microsoft.Diagnostics.Runtime.ModuleKind
 Microsoft.Diagnostics.Runtime.ModuleKind.PortableExecutable = 2 -> Microsoft.Diagnostics.Runtime.ModuleKind
 Microsoft.Diagnostics.Runtime.ModuleKind.Unknown = 0 -> Microsoft.Diagnostics.Runtime.ModuleKind
+abstract Microsoft.Diagnostics.Runtime.ClrRuntime.EnumerateClrNativeHeaps() -> System.Collections.Generic.IEnumerable<Microsoft.Diagnostics.Runtime.ClrNativeHeapInfo>!
+Microsoft.Diagnostics.Runtime.ClrInfo.CreateRuntime(Microsoft.Diagnostics.Runtime.DacLibrary! dacLibrary) -> Microsoft.Diagnostics.Runtime.ClrRuntime!
+Microsoft.Diagnostics.Runtime.DacInterface.ClrDataProcess.GetSOSDacInterface13() -> Microsoft.Diagnostics.Runtime.DacInterface.SOSDac13?
+Microsoft.Diagnostics.Runtime.DacInterface.SOSDac.TraverseStubHeap(ulong heap, Microsoft.Diagnostics.Runtime.DacInterface.SOSDac.VCSHeapType type, Microsoft.Diagnostics.Runtime.DacInterface.SOSDac.LoaderHeapTraverse! callback) -> Microsoft.Diagnostics.Runtime.Utilities.HResult
+Microsoft.Diagnostics.Runtime.DacInterface.SOSDac.VCSHeapType
+Microsoft.Diagnostics.Runtime.DacInterface.SOSDac.VCSHeapType.CacheEntryHeap = 4 -> Microsoft.Diagnostics.Runtime.DacInterface.SOSDac.VCSHeapType
+Microsoft.Diagnostics.Runtime.DacInterface.SOSDac.VCSHeapType.DispatchHeap = 3 -> Microsoft.Diagnostics.Runtime.DacInterface.SOSDac.VCSHeapType
+Microsoft.Diagnostics.Runtime.DacInterface.SOSDac.VCSHeapType.IndcellHeap = 0 -> Microsoft.Diagnostics.Runtime.DacInterface.SOSDac.VCSHeapType
+Microsoft.Diagnostics.Runtime.DacInterface.SOSDac.VCSHeapType.LookupHeap = 1 -> Microsoft.Diagnostics.Runtime.DacInterface.SOSDac.VCSHeapType
+Microsoft.Diagnostics.Runtime.DacInterface.SOSDac.VCSHeapType.ResolveHeap = 2 -> Microsoft.Diagnostics.Runtime.DacInterface.SOSDac.VCSHeapType
+Microsoft.Diagnostics.Runtime.DacInterface.SOSDac.VCSHeapType.VtableHeap = 5 -> Microsoft.Diagnostics.Runtime.DacInterface.SOSDac.VCSHeapType
+Microsoft.Diagnostics.Runtime.DacInterface.SOSDac13.LoaderHeapKind
+Microsoft.Diagnostics.Runtime.DacInterface.SOSDac13.LoaderHeapKind.LoaderHeapKindExplicitControl = 1 -> Microsoft.Diagnostics.Runtime.DacInterface.SOSDac13.LoaderHeapKind
+Microsoft.Diagnostics.Runtime.DacInterface.SOSDac13.LoaderHeapKind.LoaderHeapKindNormal = 0 -> Microsoft.Diagnostics.Runtime.DacInterface.SOSDac13.LoaderHeapKind
+Microsoft.Diagnostics.Runtime.DacInterface.SOSDac13.TraverseLoaderHeap(ulong heap, Microsoft.Diagnostics.Runtime.DacInterface.SOSDac13.LoaderHeapKind kind, Microsoft.Diagnostics.Runtime.DacInterface.SOSDac.LoaderHeapTraverse! callback) -> Microsoft.Diagnostics.Runtime.Utilities.HResult
+Microsoft.Diagnostics.Runtime.DacLibrary.SOSDacInterface13.get -> Microsoft.Diagnostics.Runtime.DacInterface.SOSDac13?
+Microsoft.Diagnostics.Runtime.IDumpInfoProvider
+Microsoft.Diagnostics.Runtime.IDumpInfoProvider.IsMiniOrTriage.get -> bool
+Microsoft.Diagnostics.Runtime.ClrNativeHeapInfo
+Microsoft.Diagnostics.Runtime.ClrNativeHeapInfo.Address.get -> ulong
+Microsoft.Diagnostics.Runtime.ClrNativeHeapInfo.ClrNativeHeapInfo() -> void
+Microsoft.Diagnostics.Runtime.ClrNativeHeapInfo.ClrNativeHeapInfo(ulong address, ulong? size, Microsoft.Diagnostics.Runtime.NativeHeapKind kind) -> void
+Microsoft.Diagnostics.Runtime.ClrNativeHeapInfo.Kind.get -> Microsoft.Diagnostics.Runtime.NativeHeapKind
+Microsoft.Diagnostics.Runtime.ClrNativeHeapInfo.Size.get -> ulong?
+Microsoft.Diagnostics.Runtime.NativeHeapKind
+Microsoft.Diagnostics.Runtime.NativeHeapKind.CacheEntryHeap = 5 -> Microsoft.Diagnostics.Runtime.NativeHeapKind
+Microsoft.Diagnostics.Runtime.NativeHeapKind.DispatchHeap = 4 -> Microsoft.Diagnostics.Runtime.NativeHeapKind
+Microsoft.Diagnostics.Runtime.NativeHeapKind.HighFrequencyHeap = 10 -> Microsoft.Diagnostics.Runtime.NativeHeapKind
+Microsoft.Diagnostics.Runtime.NativeHeapKind.HostCodeHeap = 8 -> Microsoft.Diagnostics.Runtime.NativeHeapKind
+Microsoft.Diagnostics.Runtime.NativeHeapKind.IndirectionCellHeap = 1 -> Microsoft.Diagnostics.Runtime.NativeHeapKind
+Microsoft.Diagnostics.Runtime.NativeHeapKind.LoaderCodeHeap = 7 -> Microsoft.Diagnostics.Runtime.NativeHeapKind
+Microsoft.Diagnostics.Runtime.NativeHeapKind.LookupHeap = 2 -> Microsoft.Diagnostics.Runtime.NativeHeapKind
+Microsoft.Diagnostics.Runtime.NativeHeapKind.LowFrequencyHeap = 11 -> Microsoft.Diagnostics.Runtime.NativeHeapKind
+Microsoft.Diagnostics.Runtime.NativeHeapKind.ResolveHeap = 3 -> Microsoft.Diagnostics.Runtime.NativeHeapKind
+Microsoft.Diagnostics.Runtime.NativeHeapKind.StubHeap = 9 -> Microsoft.Diagnostics.Runtime.NativeHeapKind
+Microsoft.Diagnostics.Runtime.NativeHeapKind.Unknown = 0 -> Microsoft.Diagnostics.Runtime.NativeHeapKind
+Microsoft.Diagnostics.Runtime.NativeHeapKind.VtableHeap = 6 -> Microsoft.Diagnostics.Runtime.NativeHeapKind
+Microsoft.Diagnostics.Runtime.DacInterface.SOSDac13
+Microsoft.Diagnostics.Runtime.DacInterface.SOSDac13.SOSDac13(Microsoft.Diagnostics.Runtime.DacLibrary! library, System.IntPtr ptr) -> void
+override Microsoft.Diagnostics.Runtime.ClrNativeHeapInfo.ToString() -> string!
+static Microsoft.Diagnostics.Runtime.ModuleInfo.TryCreate(Microsoft.Diagnostics.Runtime.IDataReader! reader, ulong baseAddress, string! name, int indexFileSize, int indexTimeStamp, System.Version? version) -> Microsoft.Diagnostics.Runtime.ModuleInfo?
+virtual Microsoft.Diagnostics.Runtime.ModuleInfo.TrySetProperties(int indexFileSize, int indexTimeStamp, System.Version? version) -> void

--- a/src/Microsoft.Diagnostics.Runtime/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
+++ b/src/Microsoft.Diagnostics.Runtime/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
@@ -582,7 +582,6 @@ Microsoft.Diagnostics.Runtime.DacInterface.SOSDac.SOSDac(Microsoft.Diagnostics.R
 Microsoft.Diagnostics.Runtime.DacInterface.SOSDac.SOSDac(Microsoft.Diagnostics.Runtime.DacLibrary? library, System.IntPtr ptr) -> void
 Microsoft.Diagnostics.Runtime.DacInterface.SOSDac.TraverseLoaderHeap(ulong heap, Microsoft.Diagnostics.Runtime.DacInterface.SOSDac.LoaderHeapTraverse! callback) -> Microsoft.Diagnostics.Runtime.Utilities.HResult
 Microsoft.Diagnostics.Runtime.DacInterface.SOSDac.TraverseModuleMap(Microsoft.Diagnostics.Runtime.DacInterface.SOSDac.ModuleMapTraverseKind mt, ulong module, Microsoft.Diagnostics.Runtime.DacInterface.SOSDac.ModuleMapTraverse! traverse) -> Microsoft.Diagnostics.Runtime.Utilities.HResult
-Microsoft.Diagnostics.Runtime.DacInterface.SOSDac.TraverseStubHeap(ulong heap, int type, Microsoft.Diagnostics.Runtime.DacInterface.SOSDac.LoaderHeapTraverse! callback) -> Microsoft.Diagnostics.Runtime.Utilities.HResult
 Microsoft.Diagnostics.Runtime.DacInterface.SOSDac6
 Microsoft.Diagnostics.Runtime.DacInterface.SOSDac6.GetMethodTableCollectibleData(ulong mt, out Microsoft.Diagnostics.Runtime.DacInterface.MethodTableCollectibleData data) -> Microsoft.Diagnostics.Runtime.Utilities.HResult
 Microsoft.Diagnostics.Runtime.DacInterface.SOSDac6.SOSDac6(Microsoft.Diagnostics.Runtime.DacLibrary! library, System.IntPtr ptr) -> void

--- a/src/Microsoft.Diagnostics.Runtime/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Diagnostics.Runtime/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,7 +1,1 @@
 #nullable enable
-Microsoft.Diagnostics.Runtime.ClrInfo.CreateRuntime(Microsoft.Diagnostics.Runtime.DacLibrary! dacLibrary) -> Microsoft.Diagnostics.Runtime.ClrRuntime!
-Microsoft.Diagnostics.Runtime.IDumpInfoProvider
-Microsoft.Diagnostics.Runtime.IDumpInfoProvider.IsMiniOrTriage.get -> bool
-static Microsoft.Diagnostics.Runtime.ModuleInfo.TryCreate(Microsoft.Diagnostics.Runtime.IDataReader! reader, ulong baseAddress, string! name, int indexFileSize, int indexTimeStamp, System.Version? version) -> Microsoft.Diagnostics.Runtime.ModuleInfo?
-virtual Microsoft.Diagnostics.Runtime.ModuleInfo.TrySetProperties(int indexFileSize, int indexTimeStamp, System.Version? version) -> void
-

--- a/src/Microsoft.Diagnostics.Runtime/src/Builders/RuntimeBuilder.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Builders/RuntimeBuilder.cs
@@ -763,7 +763,7 @@ namespace Microsoft.Diagnostics.Runtime.Builders
 
                 hr = _sos13.TraverseLoaderHeap(address, kind, callback);
             }
-            else if (_clrInfo.Flavor == ClrFlavor.Core && _clrInfo.Version.Major != 7)
+            else if (_clrInfo.Flavor == ClrFlavor.Desktop || (_clrInfo.Flavor == ClrFlavor.Core && _clrInfo.Version.Major != 7))
             {
                 // The basic ISOSDacInterface doesn't understand the difference between the different kinds of runtime
                 // loader heaps.  If the heap is an ExplicitControlLoaderHeap then it doesn't have a vtable but it will

--- a/src/Microsoft.Diagnostics.Runtime/src/Builders/RuntimeBuilder.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Builders/RuntimeBuilder.cs
@@ -29,6 +29,7 @@ namespace Microsoft.Diagnostics.Runtime.Builders
         private readonly SOSDac6? _sos6;
         private readonly SOSDac8? _sos8;
         private readonly SOSDac12? _sos12;
+        private readonly SOSDac13? _sos13;
         private readonly int _threads;
         private readonly ulong _finalizer;
         private readonly ulong _firstThread;
@@ -66,6 +67,7 @@ namespace Microsoft.Diagnostics.Runtime.Builders
             _sos6 = _library.SOSDacInterface6;
             _sos8 = _library.SOSDacInterface8;
             _sos12 = library.SOSDacInterface12;
+            _sos13 = library.SOSDacInterface13;
 
             DataReader = _clrInfo.DataTarget.DataReader;
 
@@ -654,6 +656,140 @@ namespace Microsoft.Diagnostics.Runtime.Builders
                 }
             }
         }
+
+        IEnumerable<ClrNativeHeapInfo> IRuntimeHelpers.EnumerateClrNativeHeaps(ulong systemDomainAddress, ulong sharedDomainAddress)
+        {
+            List<ClrNativeHeapInfo> heaps = new();
+
+            // Enumerate JIT code heaps.
+            foreach (JitManagerInfo jitMgr in _sos.GetJitManagers())
+            {
+                foreach (var mem in _sos.GetCodeHeapList(jitMgr.Address))
+                {
+                    if (mem.Type == CodeHeapType.Loader)
+                    {
+                        if (TraverseLoaderHeap(mem.Address, SOSDac13.LoaderHeapKind.LoaderHeapKindExplicitControl, (address, size, _) => heaps.Add(new ClrNativeHeapInfo(address, SanitizeSize(size), NativeHeapKind.LoaderCodeHeap))))
+                            foreach (ClrNativeHeapInfo result in heaps)
+                                yield return result;
+
+                        heaps.Clear();
+                    }
+                    else if (mem.Type == CodeHeapType.Host)
+                    {
+                        ulong? size = mem.CurrentAddress >= mem.Address ? mem.CurrentAddress - mem.Address : null;
+                        yield return new ClrNativeHeapInfo(mem.Address, size, NativeHeapKind.HostCodeHeap);
+                    }
+                    else
+                    {
+                        yield return new ClrNativeHeapInfo(mem.Address, null, NativeHeapKind.Unknown);
+                    }
+                }
+            }
+
+            // Enumerate AppDomain heaps
+            if (systemDomainAddress != 0)
+                AddAppDomainHeaps(systemDomainAddress, heaps);
+
+            if (sharedDomainAddress != 0 && sharedDomainAddress != systemDomainAddress)
+                AddAppDomainHeaps(sharedDomainAddress, heaps);
+
+            // Shouldn't be needed, but just some defensive coding to not enumerate the same heaps
+            HashSet<ulong> seen = new();
+            foreach (var heap in heaps)
+                if (seen.Add(heap.Address))
+                    yield return heap;
+
+            foreach (ClrDataAddress appDomainAddress in _sos.GetAppDomainList())
+            {
+                heaps.Clear();
+                AddAppDomainHeaps(appDomainAddress, heaps);
+                foreach (var heap in heaps)
+                    if (seen.Add(heap.Address))
+                        yield return heap;
+            }
+        }
+
+        private void AddAppDomainHeaps(ClrDataAddress appDomainAddress, List<ClrNativeHeapInfo> heaps)
+        {
+            if (_sos.GetAppDomainData(appDomainAddress, out AppDomainData domain))
+            {
+                TraverseWithCleanup(heaps, () => TraverseLoaderHeap(domain.StubHeap, SOSDac13.LoaderHeapKind.LoaderHeapKindNormal, (address, size, isCurrent) => heaps.Add(new(address, SanitizeSize(size), NativeHeapKind.StubHeap))));
+                TraverseWithCleanup(heaps, () => TraverseLoaderHeap(domain.HighFrequencyHeap, SOSDac13.LoaderHeapKind.LoaderHeapKindNormal, (address, size, isCurrent) => heaps.Add(new(address, SanitizeSize(size), NativeHeapKind.HighFrequencyHeap))));
+                TraverseWithCleanup(heaps, () => TraverseLoaderHeap(domain.LowFrequencyHeap, SOSDac13.LoaderHeapKind.LoaderHeapKindNormal, (address, size, isCurrent) => heaps.Add(new(address, SanitizeSize(size), NativeHeapKind.LowFrequencyHeap))));
+
+                TraverseWithCleanup(heaps, () => _sos.TraverseStubHeap(appDomainAddress, SOSDac.VCSHeapType.IndcellHeap, (address, size, isCurrent) => heaps.Add(new(address, SanitizeSize(size), NativeHeapKind.IndirectionCellHeap))));
+                TraverseWithCleanup(heaps, () => _sos.TraverseStubHeap(appDomainAddress, SOSDac.VCSHeapType.LookupHeap, (address, size, isCurrent) => heaps.Add(new(address, SanitizeSize(size), NativeHeapKind.LookupHeap))));
+                TraverseWithCleanup(heaps, () => _sos.TraverseStubHeap(appDomainAddress, SOSDac.VCSHeapType.ResolveHeap, (address, size, isCurrent) => heaps.Add(new(address, SanitizeSize(size), NativeHeapKind.ResolveHeap))));
+                TraverseWithCleanup(heaps, () => _sos.TraverseStubHeap(appDomainAddress, SOSDac.VCSHeapType.DispatchHeap, (address, size, isCurrent) => heaps.Add(new(address, SanitizeSize(size), NativeHeapKind.DispatchHeap))));
+                TraverseWithCleanup(heaps, () => _sos.TraverseStubHeap(appDomainAddress, SOSDac.VCSHeapType.CacheEntryHeap, (address, size, isCurrent) => heaps.Add(new(address, SanitizeSize(size), NativeHeapKind.CacheEntryHeap))));
+                TraverseWithCleanup(heaps, () => _sos.TraverseStubHeap(appDomainAddress, SOSDac.VCSHeapType.VtableHeap, (address, size, isCurrent) => heaps.Add(new(address, SanitizeSize(size), NativeHeapKind.VtableHeap))));
+            }
+        }
+
+        private static ulong? SanitizeSize(nint size)
+        {
+            // If TraverseHeap returns a negative size or a size that's too large, we'll treat
+            // this as not having size info.  This shouldn't happen in practice.
+            if (size < 0 || size > int.MaxValue)
+                return null;
+
+            return (ulong)size;
+        }
+
+        private void TraverseWithCleanup(List<ClrNativeHeapInfo> heaps, Func<HResult> traverseAction)
+        {
+            // TraverseLoaderHeap can fail, even after making some callbacks.  This happens if we have a bad address
+            // or corrupted LoaderHeap/corrupted dump. If this happens, remove all entries we added to the list of
+            // heaps we found.
+            int count = heaps.Count;
+            if (!traverseAction())
+            {
+                int added = heaps.Count - count;
+                if (added > 0)
+                    heaps.RemoveRange(count, added);
+            }
+        }
+
+        private HResult TraverseLoaderHeap(ulong address, SOSDac13.LoaderHeapKind kind, SOSDac.LoaderHeapTraverse callback)
+        {
+            if (address == 0)
+                return HResult.E_INVALIDARG;
+
+            HResult hr;
+            if (_sos13 is not null)
+            {
+                // ISOSDacInterface13 understands how to walk LoaderHeaps properly, but it's only implemented in
+                // .Net 8 and beyond.
+
+                hr = _sos13.TraverseLoaderHeap(address, kind, callback);
+            }
+            else if (_clrInfo.Flavor == ClrFlavor.Core && _clrInfo.Version.Major != 7)
+            {
+                // The basic ISOSDacInterface doesn't understand the difference between the different kinds of runtime
+                // loader heaps.  If the heap is an ExplicitControlLoaderHeap then it doesn't have a vtable but it will
+                // be treated as a LoaderHeap, which has the same layout aside from the fact that it DOES have a vtable.
+                // So, if we are enumerating an ExplictControl we need to move the address back by one pointer so that
+                // the enumeration code will work properly.
+
+                if (kind == SOSDac13.LoaderHeapKind.LoaderHeapKindExplicitControl)
+                    address -= (uint)DataReader.PointerSize;
+
+                hr = _sos.TraverseLoaderHeap(address, callback);
+            }
+            else
+            {
+                // Except on .NET 7 where we inverted that behavior.
+
+                if (kind == SOSDac13.LoaderHeapKind.LoaderHeapKindNormal)
+                    address += (uint)DataReader.PointerSize;
+
+                hr = _sos.TraverseLoaderHeap(address, callback);
+            }
+
+            GC.KeepAlive(callback);
+            return hr;
+        }
+
 
         void IRuntimeHelpers.FlushCachedData()
         {

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/ClrNativeHeapInfo.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/ClrNativeHeapInfo.cs
@@ -1,0 +1,43 @@
+﻿namespace Microsoft.Diagnostics.Runtime
+{
+    /// <summary>
+    /// A region of native memory allocated by CLR.
+    /// </summary>
+    public readonly struct ClrNativeHeapInfo
+    {
+        /// <summary>
+        /// The base address of this heap.
+        /// </summary>
+        public ulong Address { get; }
+
+        /// <summary>
+        /// The size of this heap.  Note that Size may be null when we do not know the size of
+        /// the heap.
+        /// </summary>
+        public ulong? Size { get; }
+
+        /// <summary>
+        /// The kind of heap this is.
+        /// </summary>
+        public NativeHeapKind Kind { get; }
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        public ClrNativeHeapInfo(ulong address, ulong? size, NativeHeapKind kind)
+        {
+            Address = address;
+            Size = size;
+            Kind = kind;
+        }
+
+        /// <inheritdoc/>
+        public override string ToString()
+        {
+            if (Size is ulong size)
+                return $"[{Address:x},{Address+size:x}] - {Kind}";
+
+            return $"{Address:x} - {Kind}";
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/ClrRuntime.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/ClrRuntime.cs
@@ -96,6 +96,14 @@ namespace Microsoft.Diagnostics.Runtime
         public abstract IEnumerable<ClrModule> EnumerateModules();
 
         /// <summary>
+        /// Enumerates native heaps that CLR has allocated.  This method is used to give insights into
+        /// what native memory ranges are owned by CLR.  For example, this is the information enumerated
+        /// by SOS's !eeheap and "!ext maddress".
+        /// </summary>
+        /// <returns>An enumeration of heaps.</returns>
+        public abstract IEnumerable<ClrNativeHeapInfo> EnumerateClrNativeHeaps();
+
+        /// <summary>
         /// Flushes the DAC cache.  This function MUST be called any time you expect to call the same function
         /// but expect different results.  For example, after walking the heap, you need to call Flush before
         /// attempting to walk the heap again.  After calling this function, you must discard ALL ClrMD objects

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/NativeHeapKind.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/NativeHeapKind.cs
@@ -1,0 +1,69 @@
+﻿namespace Microsoft.Diagnostics.Runtime
+{
+    /// <summary>
+    /// The kind of native heap.
+    /// </summary>
+    public enum NativeHeapKind
+    {
+        /// <summary>
+        /// This region of memory is a heap that was allocated by CLR, but we didn't have
+        /// enough information to tell which kind of heap.
+        /// </summary>
+        Unknown,
+
+        /// <summary>
+        /// Indirection cells.
+        /// </summary>
+        IndirectionCellHeap,
+
+        /// <summary>
+        /// Lookup stubs.
+        /// </summary>
+        LookupHeap,
+
+        /// <summary>
+        /// Resolve stubs.
+        /// </summary>
+        ResolveHeap,
+
+        /// <summary>
+        /// Dispatch stubs.
+        /// </summary>
+        DispatchHeap,
+
+        /// <summary>
+        /// Resolve cache element entries.
+        /// </summary>
+        CacheEntryHeap,
+
+        /// <summary>
+        /// Vtable-based jump stubs.
+        /// </summary>
+        VtableHeap,
+
+        /// <summary>
+        /// Loader Codeheaps.
+        /// </summary>
+        LoaderCodeHeap,
+
+        /// <summary>
+        /// Host Codeheaps.
+        /// </summary>
+        HostCodeHeap,
+
+        /// <summary>
+        /// Stub heap.
+        /// </summary>
+        StubHeap,
+
+        /// <summary>
+        /// High frequency heap.
+        /// </summary>
+        HighFrequencyHeap,
+
+        /// <summary>
+        /// Low frequency heap.
+        /// </summary>
+        LowFrequencyHeap,
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/src/DacInterface/ClrDataProcess.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DacInterface/ClrDataProcess.cs
@@ -98,6 +98,22 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             }
         }
 
+        public SOSDac13? GetSOSDacInterface13()
+        {
+            IntPtr result = QueryInterface(SOSDac13.IID_ISOSDac13);
+            if (result == IntPtr.Zero)
+                return null;
+
+            try
+            {
+                return new SOSDac13(_library, result);
+            }
+            catch (InvalidOperationException)
+            {
+                return null;
+            }
+        }
+
         public void Flush()
         {
             VTable.Flush(Self);

--- a/src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac.cs
@@ -591,7 +591,17 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             return hr;
         }
 
-        public HResult TraverseStubHeap(ulong heap, int type, LoaderHeapTraverse callback)
+        public enum VCSHeapType
+        {
+            IndcellHeap,
+            LookupHeap,
+            ResolveHeap,
+            DispatchHeap,
+            CacheEntryHeap,
+            VtableHeap
+        }
+
+        public HResult TraverseStubHeap(ulong heap, VCSHeapType type, LoaderHeapTraverse callback)
         {
             HResult hr = VTable.TraverseVirtCallStubHeap(Self, heap, type, Marshal.GetFunctionPointerForDelegate(callback));
             GC.KeepAlive(callback);
@@ -776,7 +786,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
         // Heaps
         public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, IntPtr, int> TraverseLoaderHeap;
         public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, int, JitCodeHeapInfo*, out int, int> GetCodeHeapList;
-        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, int, IntPtr, int> TraverseVirtCallStubHeap;
+        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, SOSDac.VCSHeapType, IntPtr, int> TraverseVirtCallStubHeap;
 
         // Other
         public readonly delegate* unmanaged[Stdcall]<IntPtr, out CommonMethodTables, int> GetUsefulGlobals;

--- a/src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac13.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac13.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using Microsoft.Diagnostics.Runtime.Utilities;
+using static Microsoft.Diagnostics.Runtime.DacInterface.SOSDac;
+
+namespace Microsoft.Diagnostics.Runtime.DacInterface
+{
+    /// <summary>
+    /// This is an undocumented, untested, and unsupported interface.  Do not use directly.
+    /// </summary>
+    public sealed unsafe class SOSDac13 : CallableCOMWrapper
+    {
+        internal static readonly Guid IID_ISOSDac13 = new("3176a8ed-597b-4f54-a71f-83695c6a8c5d");
+
+        public SOSDac13(DacLibrary library, IntPtr ptr)
+            : base(library?.OwningLibrary, IID_ISOSDac13, ptr)
+        {
+        }
+
+        private ref readonly ISOSDac13VTable VTable => ref Unsafe.AsRef<ISOSDac13VTable>(_vtable);
+
+        public HResult TraverseLoaderHeap(ulong heap, LoaderHeapKind kind, LoaderHeapTraverse callback)
+        {
+            HResult hr = VTable.TraverseLoaderHeap(Self, heap, kind, Marshal.GetFunctionPointerForDelegate(callback));
+            GC.KeepAlive(callback);
+            return hr;
+        }
+
+        /// <summary>
+        /// The type of the underlying loader heap.
+        /// </summary>
+        public enum LoaderHeapKind
+        {
+            /// <summary>
+            /// A LoaderHeap in the CLR codebase.
+            /// </summary>
+            LoaderHeapKindNormal = 0,
+
+            /// <summary>
+            /// An ExplicitControlLoaderHeap in the CLR codebase.
+            /// </summary>
+            LoaderHeapKindExplicitControl = 1
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private readonly unsafe struct ISOSDac13VTable
+        {
+            public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, LoaderHeapKind, IntPtr, int> TraverseLoaderHeap;
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/src/DataTargets/DacLibrary.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataTargets/DacLibrary.cs
@@ -45,6 +45,7 @@ namespace Microsoft.Diagnostics.Runtime
         public SOSDac6? SOSDacInterface6 => InternalDacPrivateInterface.GetSOSDacInterface6();
         public SOSDac8? SOSDacInterface8 => InternalDacPrivateInterface.GetSOSDacInterface8();
         public SOSDac12? SOSDacInterface12 => InternalDacPrivateInterface.GetSOSDacInterface12();
+        public SOSDac13? SOSDacInterface13 => InternalDacPrivateInterface.GetSOSDacInterface13();
 
         public DacLibrary(DataTarget dataTarget, IntPtr pClrDataProcess)
         {

--- a/src/Microsoft.Diagnostics.Runtime/src/Implementation/ClrmdRuntime.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Implementation/ClrmdRuntime.cs
@@ -154,6 +154,8 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
 
         public override ClrMethod? GetMethodByHandle(ulong methodHandle) => _helpers.Factory.CreateMethodFromHandle(methodHandle);
 
+        public override IEnumerable<ClrNativeHeapInfo> EnumerateClrNativeHeaps() => _helpers.EnumerateClrNativeHeaps(SystemDomain?.Address ?? 0, SharedDomain?.Address ?? 0);
+
         public override ClrMethod? GetMethodByInstructionPointer(ulong ip)
         {
             ulong md = _helpers.GetMethodDesc(ip);

--- a/src/Microsoft.Diagnostics.Runtime/src/Implementation/IRuntimeHelpers.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Implementation/IRuntimeHelpers.cs
@@ -19,5 +19,6 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
         ulong GetMethodDesc(ulong ip);
         string? GetJitHelperFunctionName(ulong ip);
         ClrModule? GetBaseClassLibrary(ClrRuntime runtime);
+        IEnumerable<ClrNativeHeapInfo> EnumerateClrNativeHeaps(ulong systemDomainAddress, ulong sharedDomainAddress);
     }
 }

--- a/src/Samples/DbgEngExtension/MAddress.cs
+++ b/src/Samples/DbgEngExtension/MAddress.cs
@@ -5,6 +5,7 @@ using System.Buffers;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Text;
+using static Microsoft.Diagnostics.Runtime.DacInterface.SOSDac;
 
 namespace DbgEngExtension
 {
@@ -465,7 +466,7 @@ namespace DbgEngExtension
                                 CodeHeapType.Loader => ClrMemoryKind.LoaderHeap,
                                 CodeHeapType.Host => ClrMemoryKind.Host,
                                 _ => ClrMemoryKind.UnknownCodeHeap
-                            }
+                            } 
                         };
 
                     foreach (var seg in runtime.Heap.Segments)
@@ -532,27 +533,27 @@ namespace DbgEngExtension
                 }));
 
 
-                sos.TraverseStubHeap(address, (int)VCSHeapType.LookupHeap, (address, size, isCurrent) => heaps.Add(new ClrMemoryPointer()
+                sos.TraverseStubHeap(address, VCSHeapType.LookupHeap, (address, size, isCurrent) => heaps.Add(new ClrMemoryPointer()
                 {
                     Address = address,
                     Kind = ClrMemoryKind.LookupHeap
                 }));
 
 
-                sos.TraverseStubHeap(address, (int)VCSHeapType.ResolveHeap, (address, size, isCurrent) => heaps.Add(new ClrMemoryPointer()
+                sos.TraverseStubHeap(address, VCSHeapType.ResolveHeap, (address, size, isCurrent) => heaps.Add(new ClrMemoryPointer()
                 {
                     Address = address,
                     Kind = ClrMemoryKind.ResolveHeap
                 }));
 
 
-                sos.TraverseStubHeap(address, (int)VCSHeapType.DispatchHeap, (address, size, isCurrent) => heaps.Add(new ClrMemoryPointer()
+                sos.TraverseStubHeap(address, VCSHeapType.DispatchHeap, (address, size, isCurrent) => heaps.Add(new ClrMemoryPointer()
                 {
                     Address = address,
                     Kind = ClrMemoryKind.DispatchHeap
                 }));
 
-                sos.TraverseStubHeap(address, (int)VCSHeapType.CacheEntryHeap, (address, size, isCurrent) => heaps.Add(new ClrMemoryPointer()
+                sos.TraverseStubHeap(address, VCSHeapType.CacheEntryHeap, (address, size, isCurrent) => heaps.Add(new ClrMemoryPointer()
                 {
                     Address = address,
                     Kind = ClrMemoryKind.CacheEntryHeap
@@ -713,14 +714,6 @@ namespace DbgEngExtension
             HandleTable,
         }
 
-        enum VCSHeapType
-        {
-            IndcellHeap,
-            LookupHeap,
-            ResolveHeap,
-            DispatchHeap,
-            CacheEntryHeap
-        }
 
         [Flags]
         public enum MemProtect


### PR DESCRIPTION
Added ClrRuntime.EnumerateClrNativeHeaps.  This function will enumerate the native heaps/memory that CLR has allocated.  This is intended to be used in functions similar to SOS's !eeheap.

Added ISOSDacInterface13 to implement this and related functions.

Worked around an issue in .Net 7.