### PR TITLE
Re-implement ISOSDacInterface13

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/PublicAPI/net6.0/PublicAPI.Shipped.txt
+++ b/src/Microsoft.Diagnostics.Runtime/PublicAPI/net6.0/PublicAPI.Shipped.txt
@@ -1681,3 +1681,5 @@ Microsoft.Diagnostics.Runtime.DacInterface.SOSDac13.GetLoaderAllocatorHeaps(Micr
 Microsoft.Diagnostics.Runtime.NativeHeapKind.ExecutableHeap = 12 -> Microsoft.Diagnostics.Runtime.NativeHeapKind
 Microsoft.Diagnostics.Runtime.NativeHeapKind.FixupPrecodeHeap = 13 -> Microsoft.Diagnostics.Runtime.NativeHeapKind
 Microsoft.Diagnostics.Runtime.NativeHeapKind.NewStubPrecodeHeap = 14 -> Microsoft.Diagnostics.Runtime.NativeHeapKind
+Microsoft.Diagnostics.Runtime.NativeHeapKind.ThunkHeap = 15 -> Microsoft.Diagnostics.Runtime.NativeHeapKind
+readonly Microsoft.Diagnostics.Runtime.DacInterface.ModuleData.LoaderAllocator -> Microsoft.Diagnostics.Runtime.DacInterface.ClrDataAddress

--- a/src/Microsoft.Diagnostics.Runtime/PublicAPI/net6.0/PublicAPI.Shipped.txt
+++ b/src/Microsoft.Diagnostics.Runtime/PublicAPI/net6.0/PublicAPI.Shipped.txt
@@ -1356,7 +1356,6 @@ readonly Microsoft.Diagnostics.Runtime.DacInterface.ModuleData.FileReferencesMap
 readonly Microsoft.Diagnostics.Runtime.DacInterface.ModuleData.ILBase -> Microsoft.Diagnostics.Runtime.DacInterface.ClrDataAddress
 readonly Microsoft.Diagnostics.Runtime.DacInterface.ModuleData.IsPEFile -> uint
 readonly Microsoft.Diagnostics.Runtime.DacInterface.ModuleData.IsReflection -> uint
-readonly Microsoft.Diagnostics.Runtime.DacInterface.ModuleData.LookupTableHeap -> Microsoft.Diagnostics.Runtime.DacInterface.ClrDataAddress
 readonly Microsoft.Diagnostics.Runtime.DacInterface.ModuleData.ManifestModuleReferencesMap -> Microsoft.Diagnostics.Runtime.DacInterface.ClrDataAddress
 readonly Microsoft.Diagnostics.Runtime.DacInterface.ModuleData.MemberRefToDescMap -> Microsoft.Diagnostics.Runtime.DacInterface.ClrDataAddress
 readonly Microsoft.Diagnostics.Runtime.DacInterface.ModuleData.MetadataSize -> ulong

--- a/src/Microsoft.Diagnostics.Runtime/PublicAPI/net6.0/PublicAPI.Shipped.txt
+++ b/src/Microsoft.Diagnostics.Runtime/PublicAPI/net6.0/PublicAPI.Shipped.txt
@@ -1675,3 +1675,9 @@ Microsoft.Diagnostics.Runtime.DacInterface.SOSDac13.SOSDac13(Microsoft.Diagnosti
 override Microsoft.Diagnostics.Runtime.ClrNativeHeapInfo.ToString() -> string!
 static Microsoft.Diagnostics.Runtime.ModuleInfo.TryCreate(Microsoft.Diagnostics.Runtime.IDataReader! reader, ulong baseAddress, string! name, int indexFileSize, int indexTimeStamp, System.Version? version) -> Microsoft.Diagnostics.Runtime.ModuleInfo?
 virtual Microsoft.Diagnostics.Runtime.ModuleInfo.TrySetProperties(int indexFileSize, int indexTimeStamp, System.Version? version) -> void
+Microsoft.Diagnostics.Runtime.DacInterface.SOSDac13.GetDomainLoaderAllocator(Microsoft.Diagnostics.Runtime.DacInterface.ClrDataAddress domainAddress) -> Microsoft.Diagnostics.Runtime.DacInterface.ClrDataAddress
+Microsoft.Diagnostics.Runtime.DacInterface.SOSDac13.GetLoaderAllocatorHeapNames() -> string![]!
+Microsoft.Diagnostics.Runtime.DacInterface.SOSDac13.GetLoaderAllocatorHeaps(Microsoft.Diagnostics.Runtime.DacInterface.ClrDataAddress loaderAllocator) -> (Microsoft.Diagnostics.Runtime.DacInterface.ClrDataAddress Address, Microsoft.Diagnostics.Runtime.DacInterface.SOSDac13.LoaderHeapKind Kind)[]!
+Microsoft.Diagnostics.Runtime.NativeHeapKind.ExecutableHeap = 12 -> Microsoft.Diagnostics.Runtime.NativeHeapKind
+Microsoft.Diagnostics.Runtime.NativeHeapKind.FixupPrecodeHeap = 13 -> Microsoft.Diagnostics.Runtime.NativeHeapKind
+Microsoft.Diagnostics.Runtime.NativeHeapKind.NewStubPrecodeHeap = 14 -> Microsoft.Diagnostics.Runtime.NativeHeapKind

--- a/src/Microsoft.Diagnostics.Runtime/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
+++ b/src/Microsoft.Diagnostics.Runtime/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
@@ -1681,3 +1681,5 @@ Microsoft.Diagnostics.Runtime.DacInterface.SOSDac13.GetLoaderAllocatorHeaps(Micr
 Microsoft.Diagnostics.Runtime.NativeHeapKind.ExecutableHeap = 12 -> Microsoft.Diagnostics.Runtime.NativeHeapKind
 Microsoft.Diagnostics.Runtime.NativeHeapKind.FixupPrecodeHeap = 13 -> Microsoft.Diagnostics.Runtime.NativeHeapKind
 Microsoft.Diagnostics.Runtime.NativeHeapKind.NewStubPrecodeHeap = 14 -> Microsoft.Diagnostics.Runtime.NativeHeapKind
+Microsoft.Diagnostics.Runtime.NativeHeapKind.ThunkHeap = 15 -> Microsoft.Diagnostics.Runtime.NativeHeapKind
+readonly Microsoft.Diagnostics.Runtime.DacInterface.ModuleData.LoaderAllocator -> Microsoft.Diagnostics.Runtime.DacInterface.ClrDataAddress

--- a/src/Microsoft.Diagnostics.Runtime/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
+++ b/src/Microsoft.Diagnostics.Runtime/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
@@ -1356,7 +1356,6 @@ readonly Microsoft.Diagnostics.Runtime.DacInterface.ModuleData.FileReferencesMap
 readonly Microsoft.Diagnostics.Runtime.DacInterface.ModuleData.ILBase -> Microsoft.Diagnostics.Runtime.DacInterface.ClrDataAddress
 readonly Microsoft.Diagnostics.Runtime.DacInterface.ModuleData.IsPEFile -> uint
 readonly Microsoft.Diagnostics.Runtime.DacInterface.ModuleData.IsReflection -> uint
-readonly Microsoft.Diagnostics.Runtime.DacInterface.ModuleData.LookupTableHeap -> Microsoft.Diagnostics.Runtime.DacInterface.ClrDataAddress
 readonly Microsoft.Diagnostics.Runtime.DacInterface.ModuleData.ManifestModuleReferencesMap -> Microsoft.Diagnostics.Runtime.DacInterface.ClrDataAddress
 readonly Microsoft.Diagnostics.Runtime.DacInterface.ModuleData.MemberRefToDescMap -> Microsoft.Diagnostics.Runtime.DacInterface.ClrDataAddress
 readonly Microsoft.Diagnostics.Runtime.DacInterface.ModuleData.MetadataSize -> ulong

--- a/src/Microsoft.Diagnostics.Runtime/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
+++ b/src/Microsoft.Diagnostics.Runtime/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
@@ -1675,3 +1675,9 @@ Microsoft.Diagnostics.Runtime.DacInterface.SOSDac13.SOSDac13(Microsoft.Diagnosti
 override Microsoft.Diagnostics.Runtime.ClrNativeHeapInfo.ToString() -> string!
 static Microsoft.Diagnostics.Runtime.ModuleInfo.TryCreate(Microsoft.Diagnostics.Runtime.IDataReader! reader, ulong baseAddress, string! name, int indexFileSize, int indexTimeStamp, System.Version? version) -> Microsoft.Diagnostics.Runtime.ModuleInfo?
 virtual Microsoft.Diagnostics.Runtime.ModuleInfo.TrySetProperties(int indexFileSize, int indexTimeStamp, System.Version? version) -> void
+Microsoft.Diagnostics.Runtime.DacInterface.SOSDac13.GetDomainLoaderAllocator(Microsoft.Diagnostics.Runtime.DacInterface.ClrDataAddress domainAddress) -> Microsoft.Diagnostics.Runtime.DacInterface.ClrDataAddress
+Microsoft.Diagnostics.Runtime.DacInterface.SOSDac13.GetLoaderAllocatorHeapNames() -> string![]!
+Microsoft.Diagnostics.Runtime.DacInterface.SOSDac13.GetLoaderAllocatorHeaps(Microsoft.Diagnostics.Runtime.DacInterface.ClrDataAddress loaderAllocator) -> (Microsoft.Diagnostics.Runtime.DacInterface.ClrDataAddress Address, Microsoft.Diagnostics.Runtime.DacInterface.SOSDac13.LoaderHeapKind Kind)[]!
+Microsoft.Diagnostics.Runtime.NativeHeapKind.ExecutableHeap = 12 -> Microsoft.Diagnostics.Runtime.NativeHeapKind
+Microsoft.Diagnostics.Runtime.NativeHeapKind.FixupPrecodeHeap = 13 -> Microsoft.Diagnostics.Runtime.NativeHeapKind
+Microsoft.Diagnostics.Runtime.NativeHeapKind.NewStubPrecodeHeap = 14 -> Microsoft.Diagnostics.Runtime.NativeHeapKind

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/NativeHeapKind.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/NativeHeapKind.cs
@@ -65,5 +65,21 @@
         /// Low frequency heap.
         /// </summary>
         LowFrequencyHeap,
+
+        /// <summary>
+        /// Executable heap.
+        /// </summary>
+        ExecutableHeap,
+
+        /// <summary>
+        /// FixupPrecodeHeap
+        /// </summary>
+        FixupPrecodeHeap,
+
+        /// <summary>
+        /// NewStubPrecodeHeap
+        /// </summary>
+        NewStubPrecodeHeap,
+        ThunkHeap,
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/src/Common/NativeHeapKind.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/Common/NativeHeapKind.cs
@@ -80,6 +80,10 @@
         /// NewStubPrecodeHeap
         /// </summary>
         NewStubPrecodeHeap,
+
+        /// <summary>
+        /// ThunkHeap
+        /// </summary>
         ThunkHeap,
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac13.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DacInterface/SosDac13.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Microsoft.Diagnostics.Runtime.Utilities;
@@ -27,6 +28,66 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             return hr;
         }
 
+        public ClrDataAddress GetDomainLoaderAllocator(ClrDataAddress domainAddress)
+        {
+            if (domainAddress == 0)
+                return 0;
+
+            HResult hr = VTable.GetDomainLoaderAllocator(Self, domainAddress, out ClrDataAddress loaderAllocator);
+            return hr ? loaderAllocator : 0;
+        }
+
+        public string[] GetLoaderAllocatorHeapNames()
+        {
+            HResult hr = VTable.GetLoaderAllocatorHeapNames(Self, 0, null, out int needed);
+            if (hr && needed > 0)
+            {
+                nint[] pointers = new nint[needed];
+                fixed (nint* ptr = pointers)
+                {
+                    if (hr = VTable.GetLoaderAllocatorHeapNames(Self, needed, ptr, out _))
+                    {
+                        string[] result = new string[needed];
+                        for (int i = 0; i < needed; i++)
+                            result[i] = Marshal.PtrToStringAnsi(pointers[i]) ?? "";
+
+                        return result;
+                    }
+                }
+            }
+
+            return Array.Empty<string>();
+        }
+
+        public (ClrDataAddress Address, LoaderHeapKind Kind)[] GetLoaderAllocatorHeaps(ClrDataAddress loaderAllocator)
+        {
+            if (loaderAllocator != 0)
+            {
+                HResult hr = VTable.GetLoaderAllocatorHeaps(Self, loaderAllocator, 0, null, null, out int needed);
+
+                if (hr && needed > 0)
+                {
+                    ClrDataAddress[] addresses = new ClrDataAddress[needed];
+                    LoaderHeapKind[] kinds = new LoaderHeapKind[needed];
+
+                    fixed (ClrDataAddress* ptrAddresses = addresses)
+                    fixed (LoaderHeapKind* ptrKinds = kinds)
+                    {
+                        if (hr = VTable.GetLoaderAllocatorHeaps(Self, loaderAllocator, addresses.Length, ptrAddresses, ptrKinds, out _))
+                        {
+                            var result = new (ClrDataAddress, LoaderHeapKind)[needed];
+                            for (int i = 0; i < needed; i++)
+                                result[i] = (addresses[i], kinds[i]);
+
+                            return result;
+                        }
+                    }
+                }
+            }
+
+            return Array.Empty<(ClrDataAddress, LoaderHeapKind)>();
+        }
+
         /// <summary>
         /// The type of the underlying loader heap.
         /// </summary>
@@ -46,7 +107,10 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
         [StructLayout(LayoutKind.Sequential)]
         private readonly unsafe struct ISOSDac13VTable
         {
-            public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, LoaderHeapKind, IntPtr, int> TraverseLoaderHeap;
+            public readonly delegate* unmanaged[Stdcall]<nint, ClrDataAddress, LoaderHeapKind, nint, int> TraverseLoaderHeap;
+            public readonly delegate* unmanaged[Stdcall]<nint, ClrDataAddress, out ClrDataAddress, int> GetDomainLoaderAllocator;
+            public readonly delegate* unmanaged[Stdcall]<nint, int, nint *, out int, int> GetLoaderAllocatorHeapNames;
+            public readonly delegate* unmanaged[Stdcall]<nint, ClrDataAddress, int, ClrDataAddress*, LoaderHeapKind*, out int, int> GetLoaderAllocatorHeaps;
         }
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/src/DacInterface/Structs/ModuleData.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DacInterface/Structs/ModuleData.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
         public readonly ClrDataAddress MemberRefToDescMap;
         public readonly ClrDataAddress FileReferencesMap;
         public readonly ClrDataAddress ManifestModuleReferencesMap;
-        public readonly ClrDataAddress LookupTableHeap;
+        public readonly ClrDataAddress LoaderAllocator;
         public readonly ClrDataAddress ThunkHeap;
         public readonly ulong ModuleIndex;
     }


### PR DESCRIPTION
We found more issues with native heap reporting, so we extended ISOSDacInterface13 to account for those missing heaps and to future-proof adding and removing heaps: https://github.com/dotnet/runtime/pull/82437.

This change updates ClrMD to account for the additional interface methods.