### PR TITLE
Use the RuntimeVersion in the new RuntimeInfo 2 for single file apps

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/src/DataTargets/ClrInfo.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataTargets/ClrInfo.cs
@@ -97,8 +97,12 @@ namespace Microsoft.Diagnostics.Runtime
                     }
                 }
 
-                // We don't actually know the version of single file CLR since the version of the module would be the user's app version
                 Version = new Version();
+                if (info.IsClrRuntimeInfo2)
+                {
+                    ClrRuntimeInfo2 info2 = DataTarget.DataReader.Read<ClrRuntimeInfo2>(runtimeInfo);
+                    Version = info2.RuntimeVersion;
+                }
             }
             else
             {
@@ -111,7 +115,6 @@ namespace Microsoft.Diagnostics.Runtime
             // Long-name dac
             if (dt.DataReader.TargetPlatform == OSPlatform.Windows && Version.Major != 0)
                 artifacts.Add(new DebugLibraryInfo(DebugLibraryKind.Dac, GetWindowsLongNameDac(flavor, currentArch, targetArch, Version), currentArch, SymbolProperties.Coreclr, IndexFileSize, IndexTimeStamp));
-
 
             // Short-name dac under CLR's properties
             if (targetPlatform == currentPlatform)

--- a/src/Microsoft.Diagnostics.Runtime/src/DataTargets/ClrInfo.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataTargets/ClrInfo.cs
@@ -55,8 +55,7 @@ namespace Microsoft.Diagnostics.Runtime
             string? dbiTargetPlatform = GetDbiFileName(flavor, targetPlatform);
             if (IsSingleFile)
             {
-                ClrRuntimeInfo info = DataTarget.DataReader.Read<ClrRuntimeInfo>(runtimeInfo);
-                if (info.IsValid)
+                if (ClrRuntimeInfo.TryReadClrRuntimeInfo(DataTarget.DataReader, runtimeInfo, out ClrRuntimeInfo info, out Version version))
                 {
                     if (dt.DataReader.TargetPlatform == OSPlatform.Windows)
                     {
@@ -96,13 +95,7 @@ namespace Microsoft.Diagnostics.Runtime
                         }
                     }
                 }
-
-                Version = new Version();
-                if (info.IsClrRuntimeInfo2)
-                {
-                    ClrRuntimeInfo2 info2 = DataTarget.DataReader.Read<ClrRuntimeInfo2>(runtimeInfo);
-                    Version = info2.RuntimeVersion;
-                }
+                Version = version;
             }
             else
             {

--- a/src/Microsoft.Diagnostics.Runtime/src/DataTargets/RuntimeInfo.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataTargets/RuntimeInfo.cs
@@ -31,6 +31,8 @@ namespace Microsoft.Diagnostics.Runtime
             }
         }
 
+        public bool IsClrRuntimeInfo2 => _version >= 2;
+
         public (int TimeStamp, int FileSize) RuntimePEProperties
         {
             get
@@ -100,5 +102,14 @@ namespace Microsoft.Diagnostics.Runtime
             Span<byte> buffer = new Span<byte>(ptr + 1, ptr[0]);
             return buffer.ToArray().ToImmutableArray();
         }
+    }
+
+    [StructLayout(LayoutKind.Sequential, Pack = 4)]
+    internal unsafe struct ClrRuntimeInfo2
+    {
+        public ClrRuntimeInfo RuntimeInfo;
+        private fixed int _runtimeVersion[4];
+
+        public Version RuntimeVersion => new Version(_runtimeVersion[0], _runtimeVersion[1], _runtimeVersion[2], _runtimeVersion[3]);
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/src/DataTargets/RuntimeInfo.cs
+++ b/src/Microsoft.Diagnostics.Runtime/src/DataTargets/RuntimeInfo.cs
@@ -22,6 +22,28 @@ namespace Microsoft.Diagnostics.Runtime
         private fixed byte _dacModuleIndex[24];
         private fixed byte _dbiModuleIndex[24];
 
+        public static unsafe bool TryReadClrRuntimeInfo(IDataReader reader, ulong address, out ClrRuntimeInfo header, out Version version)
+        {
+            header = default;
+            version = new Version();
+
+            int size = sizeof(ClrRuntimeInfo);
+            fixed (ClrRuntimeInfo* pHeader = &header)
+                if (reader.Read(address, new Span<byte>(pHeader, size)) != size || !header.IsValid)
+                    return false;
+
+            if (header._version >= 2)
+            {
+                Span<int> runtimeVersion = stackalloc int[4];
+                Span<byte> buffer = MemoryMarshal.Cast<int, byte>(runtimeVersion);
+
+                if (reader.Read(address + (uint)size, buffer) == buffer.Length)
+                    version = new Version(runtimeVersion[0], runtimeVersion[1], runtimeVersion[2], runtimeVersion[3]);
+            }
+
+            return true;
+        }
+
         public bool IsValid
         {
             get
@@ -30,8 +52,6 @@ namespace Microsoft.Diagnostics.Runtime
                     return _version > 0 && Encoding.ASCII.GetString(ptr, SymbolValue.Length) == SymbolValue;
             }
         }
-
-        public bool IsClrRuntimeInfo2 => _version >= 2;
 
         public (int TimeStamp, int FileSize) RuntimePEProperties
         {
@@ -102,14 +122,5 @@ namespace Microsoft.Diagnostics.Runtime
             Span<byte> buffer = new Span<byte>(ptr + 1, ptr[0]);
             return buffer.ToArray().ToImmutableArray();
         }
-    }
-
-    [StructLayout(LayoutKind.Sequential, Pack = 4)]
-    internal unsafe struct ClrRuntimeInfo2
-    {
-        public ClrRuntimeInfo RuntimeInfo;
-        private fixed int _runtimeVersion[4];
-
-        public Version RuntimeVersion => new Version(_runtimeVersion[0], _runtimeVersion[1], _runtimeVersion[2], _runtimeVersion[3]);
     }
 }


### PR DESCRIPTION
Checks for the new version 2 of the RuntimeInfo added in .NET 8 containing the runtime version. 

I'm not sure if this is the best approach but I didn't want to read the whole new ClrRuntimeInfo2 without checking the version just in case on < 8 runtimes it is on a page boundary. 