### PR TITLE
Add thinlock support, ObjectCorruption cleanups

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/VerifyHeapTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/VerifyHeapTests.cs
@@ -202,7 +202,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
                 Assert.True(heap.IsObjectCorrupted(obj, out ObjectCorruption result));
                 Assert.NotNull(result);
 
-                Assert.Equal(ObjectCorruptionKind.BadMethodTable, result.Kind);
+                Assert.Equal(ObjectCorruptionKind.InvalidMethodTable, result.Kind);
                 Assert.Equal(obj, result.Object);
                 Assert.Equal(0, result.Offset); // MT offset is at 0
             });

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/VerifyHeapTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/VerifyHeapTests.cs
@@ -235,7 +235,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
                     Assert.True(heap.IsObjectCorrupted(obj, out ObjectCorruption result));
                     Assert.NotNull(result);
 
-                    Assert.Equal(ObjectCorruptionKind.BadObjectReference, result.Kind);
+                    Assert.Equal(ObjectCorruptionKind.InvalidObjectReference, result.Kind);
                     Assert.Equal(obj, result.Object);
                     Assert.Equal((int)offset, result.Offset);
                 });

--- a/src/Microsoft.Diagnostics.Runtime/ClrHeap.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrHeap.cs
@@ -668,6 +668,15 @@ namespace Microsoft.Diagnostics.Runtime
             return container;
         }
 
+        internal ClrThinlock? GetThinlock(ulong address)
+        {
+            uint header = _memoryReader.Read<uint>(address - 4);
+            if (header == 0)
+                return null;
+
+            return _helpers.GetThinlock(this, header);
+        }
+
         /// <summary>
         /// Returns a string representation of this heap, including the size and number of segments.
         /// </summary>

--- a/src/Microsoft.Diagnostics.Runtime/ClrObject.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrObject.cs
@@ -158,6 +158,8 @@ namespace Microsoft.Diagnostics.Runtime
         /// </summary>
         public SyncBlock? SyncBlock => Type?.Heap.GetSyncBlock(Address);
 
+        public ClrThinlock? GetThinLock() => Type?.Heap.GetThinlock(Address);
+
         /// <summary>
         /// Returns true if this object is a COM class factory.
         /// </summary>

--- a/src/Microsoft.Diagnostics.Runtime/ClrThinlock.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrThinlock.cs
@@ -1,0 +1,24 @@
+﻿namespace Microsoft.Diagnostics.Runtime
+{
+    /// <summary>
+    /// An object's thinlock.
+    /// </summary>
+    public class ClrThinlock
+    {
+        /// <summary>
+        /// The owning thread of this thinlock.
+        /// </summary>
+        public ClrThread? Thread { get; }
+
+        /// <summary>
+        /// The recursion count of the entries for this thinlock.
+        /// </summary>
+        public int Recursion { get; }
+
+        internal ClrThinlock(ClrThread? thread, int recursion)
+        {
+            Thread = thread;
+            Recursion = recursion;
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/Implementation/ClrHeapHelpers.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Implementation/ClrHeapHelpers.cs
@@ -26,6 +26,15 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
         private readonly GCInfo _gcInfo;
         private HashSet<ulong>? _validMethodTables;
 
+        private const uint SyncBlockRecLevelMask = 0x0000FC00;
+        private const int SyncBlockRecLevelShift = 10;
+        private const uint SyncBlockThreadIdMask = 0x000003FF;
+        private const uint SyncBlockSpinLock = 0x10000000;
+        private const uint SyncBlockHashOrSyncBlockIndex = 0x08000000;
+        private const uint SyncBlockHashCodeIndex = 0x04000000;
+        private const int SyncBlockIndexBits = 26;
+        private const uint SyncBlockIndexMask = ((1u << SyncBlockIndexBits) - 1u);
+
         public bool IsServerMode => _gcInfo.ServerMode != 0;
 
         public bool AreGCStructuresValid => _gcInfo.GCStructuresValid != 0;
@@ -316,65 +325,73 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
             };
         }
 
+        public ClrThinlock? GetThinlock(ClrHeap heap, uint header)
+        {
+            if (!HasThinlock(header))
+                return null;
+
+            (uint threadId, uint recursion) = GetThinlockData(header);
+
+            ulong threadAddress = _sos.GetThreadFromThinlockId(threadId);
+            ClrThread? thread = heap.Runtime.Threads.FirstOrDefault(t => t.Address == threadAddress);
+            return new ClrThinlock(thread, (int)recursion);
+        }
+
+        private static bool HasThinlock(uint header)
+        {
+            return (header & (SyncBlockHashOrSyncBlockIndex | SyncBlockSpinLock)) == 0 && (header & SyncBlockThreadIdMask) != 0;
+        }
+
+        private (uint ThreadId, uint Recursion) GetThinlockData(uint header)
+        {
+            uint threadId = header & SyncBlockThreadIdMask;
+            uint recursion = (header & SyncBlockRecLevelMask) >> SyncBlockRecLevelShift;
+
+            return (threadId, recursion);
+        }
+
         public ObjectCorruption? VerifyObject(SyncBlockContainer syncBlocks, ClrSegment seg, ClrObject obj)
         {
+            // Is the object address pointer aligned?
             if ((obj.Address & ((uint)_memoryReader.PointerSize - 1)) != 0)
                 return new ObjectCorruption(obj, 0, ObjectCorruptionKind.ObjectNotPointerAligned);
 
             if (!obj.IsFree)
             {
+                // Can we read the method table?
                 if (!_memoryReader.Read(obj.Address, out ulong mt))
                     return new ObjectCorruption(obj, 0, ObjectCorruptionKind.CouldNotReadMethodTable);
-                
+
+                // Is the method table we read valid?
                 if (!IsValidMethodTable(mt))
-                    return new ObjectCorruption(obj, 0, ObjectCorruptionKind.BadMethodTable);
+                    return new ObjectCorruption(obj, 0, ObjectCorruptionKind.InvalidMethodTable);
 
                 // This shouldn't happen if VerifyMethodTable above returns success, but we'll make sure.
                 if (obj.Type is null)
-                    return new ObjectCorruption(obj, 0, ObjectCorruptionKind.BadMethodTable);
+                    return new ObjectCorruption(obj, 0, ObjectCorruptionKind.InvalidMethodTable);
             }
 
+            // Check object size
             int intSize = obj.Size > int.MaxValue ? int.MaxValue : (int)obj.Size;
             if (obj.Size > seg.MaxObjectSize || obj + obj.Size > seg.ObjectRange.End)
                 return new ObjectCorruption(obj, _memoryReader.PointerSize, ObjectCorruptionKind.ObjectTooLarge);
 
-            // SyncBlock
-            SyncBlock? blk = syncBlocks.TryGetSyncBlock(obj);
-            uint objHeader = _memoryReader.Read<uint>(obj - sizeof(uint));
-            if ((objHeader & HashOrSyncBlockIndex) != 0 && (objHeader & HashCodeIndex) == 0)
-            {
-                uint index = (objHeader & SyncBlockIndexMask);
-                int clrIndex = blk?.Index ?? -1;
-                
-                if (index == 0)
-                    return new ObjectCorruption(obj, -sizeof(uint), ObjectCorruptionKind.SyncBlockZero, -1, clrIndex);
-                else if (index != clrIndex)
-                    return new ObjectCorruption(obj, -sizeof(uint), ObjectCorruptionKind.SyncBlockMismatch, (int)index, clrIndex);
-            }
-            else if (blk is not null)
-            {
-                return new ObjectCorruption(obj, -sizeof(uint), ObjectCorruptionKind.SyncBlockMismatch, -1, blk.Index);
-            }
-
             if (obj.IsFree)
                 return null;
 
-            //verify members
+            // Validate members
             bool verifyMembers;
             try
             {
-                verifyMembers = ShouldVerifyMembers(seg, obj);
+                // Type can't be null, we checked above.  The compiler just get lost in the IsFree checks.
+                verifyMembers = obj.Type!.ContainsPointers && ShouldVerifyMembers(seg, obj);
             }
             catch (IOException)
             {
                 return new ObjectCorruption(obj, 0, ObjectCorruptionKind.CouldNotReadCardTable);
             }
 
-            if (!verifyMembers)
-                return null;
-
-            // Type can't be null, we checked above.  The compiler just get lost in the IsFree checks.
-            if (obj.Type!.ContainsPointers)
+            if (verifyMembers)
             {
                 GCDesc gcdesc = obj.Type!.GCDesc;
                 if (gcdesc.IsEmpty)
@@ -391,22 +408,46 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
                     if ((objRef & ((uint)_memoryReader.PointerSize - 1)) != 0)
                         return new ObjectCorruption(obj, offset, ObjectCorruptionKind.ObjectReferenceNotPointerAligned);
                     if (!_memoryReader.Read(objRef, out ulong mt) || !IsValidMethodTable(mt))
-                        return new ObjectCorruption(obj, offset, ObjectCorruptionKind.BadObjectReference);
-                    else if (mt == freeMt)
+                        return new ObjectCorruption(obj, offset, ObjectCorruptionKind.InvalidObjectReference);
+                    else if ((mt & ~1ul) == freeMt)
                         return new ObjectCorruption(obj, offset, ObjectCorruptionKind.FreeObjectReference);
                 }
 
                 ArrayPool<byte>.Shared.Return(buffer);
             }
 
+            // Object header validation tests:
+            uint objHeader = _memoryReader.Read<uint>(obj - sizeof(uint));
+
+            // Validate SyncBlock
+            SyncBlock? blk = syncBlocks.TryGetSyncBlock(obj);
+            if ((objHeader & SyncBlockHashOrSyncBlockIndex) != 0 && (objHeader & SyncBlockHashCodeIndex) == 0)
+            {
+                uint index = (objHeader & SyncBlockIndexMask);
+                int clrIndex = blk?.Index ?? -1;
+
+                if (index == 0)
+                    return new ObjectCorruption(obj, -sizeof(uint), ObjectCorruptionKind.SyncBlockZero, -1, clrIndex);
+                else if (index != clrIndex)
+                    return new ObjectCorruption(obj, -sizeof(uint), ObjectCorruptionKind.SyncBlockMismatch, (int)index, clrIndex);
+            }
+            else if (blk is not null)
+            {
+                return new ObjectCorruption(obj, -sizeof(uint), ObjectCorruptionKind.SyncBlockMismatch, -1, blk.Index);
+            }
+
+            // Validate Thinlock
+            if (HasThinlock(objHeader))
+            {
+                ClrRuntime runtime = seg.SubHeap.Heap.Runtime;
+                (uint threadId, _) = GetThinlockData(objHeader);
+                ulong address = _sos.GetThreadFromThinlockId(threadId);
+                if (address == 0 || !runtime.Threads.Any(th => th.Address == address))
+                    return new ObjectCorruption(obj, -4, ObjectCorruptionKind.InvalidThinlock);
+            }
 
             return null;
         }
-
-        private const uint HashOrSyncBlockIndex = 0x08000000;
-        private const uint HashCodeIndex = 0x04000000;
-        private const int SyncBlockIndexBits = 26;
-        private const uint SyncBlockIndexMask = ((1u << SyncBlockIndexBits) - 1u);
 
         private bool ShouldVerifyMembers(ClrSegment seg, ClrObject obj)
         {
@@ -504,6 +545,9 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
 
         public bool IsValidMethodTable(ulong mt)
         {
+            // clear the mark bit
+            mt &= ~1ul;
+
             HashSet<ulong> validMts = _validMethodTables ??= new();
             lock (validMts)
                 if (validMts.Contains(mt))

--- a/src/Microsoft.Diagnostics.Runtime/Implementation/ClrHeapHelpers.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Implementation/ClrHeapHelpers.cs
@@ -373,7 +373,7 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
 
             // Check object size
             int intSize = obj.Size > int.MaxValue ? int.MaxValue : (int)obj.Size;
-            if (obj.Size > seg.MaxObjectSize || obj + obj.Size > seg.ObjectRange.End)
+            if (obj + obj.Size > seg.ObjectRange.End || (!obj.IsFree && obj.Size > seg.MaxObjectSize))
                 return new ObjectCorruption(obj, _memoryReader.PointerSize, ObjectCorruptionKind.ObjectTooLarge);
 
             if (obj.IsFree)

--- a/src/Microsoft.Diagnostics.Runtime/Implementation/IClrHeapHelpers.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Implementation/IClrHeapHelpers.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
         IEnumerable<SyncBlock> EnumerateSyncBlocks();
         ImmutableArray<ClrSubHeap> GetSubHeaps(ClrHeap heap);
         IEnumerable<ClrSegment> EnumerateSegments(ClrSubHeap heap);
+        ClrThinlock? GetThinlock(ClrHeap clrHeap, uint header);
         ObjectCorruption? VerifyObject(SyncBlockContainer syncBlocks, ClrSegment seg, ClrObject obj);
         bool IsValidMethodTable(ulong mt);
     }

--- a/src/Microsoft.Diagnostics.Runtime/ObjectCorruption.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ObjectCorruption.cs
@@ -48,25 +48,34 @@ namespace Microsoft.Diagnostics.Runtime
 
             string type = Object.Type?.Name != null ? $" {Object.Type.Name}" : "";
 
-            return $"[{Kind}] {Object:x}{offset}{type}";
+            return $"[{Kind}] {Object.Address:x}{offset}{type}";
         }
     }
 
     public enum ObjectCorruptionKind
     {
-        None,
+        None = 0,
+
+        // Not object failures
         ObjectNotOnTheHeap,
-        CouldNotReadMethodTable,
-        BadMethodTable,
-        BadObjectReference,
-        ObjectTooLarge,
+        ObjectNotPointerAligned,
+
+        // Object failures
+        ObjectTooLarge = 10,
+        InvalidMethodTable,
+        InvalidThinlock,
+        SyncBlockMismatch,
+        SyncBlockZero,
+
+        // Object reference failures
+        ObjectReferenceNotPointerAligned = 100,
+        InvalidObjectReference,
+        FreeObjectReference,
+
+        // Memory Read Errors
+        CouldNotReadMethodTable = 200,
         CouldNotReadCardTable,
         CouldNotReadObject,
         CouldNotReadGCDesc,
-        FreeObjectReference,
-        SyncBlockMismatch,
-        SyncBlockZero,
-        ObjectNotPointerAligned,
-        ObjectReferenceNotPointerAligned,
     }
 }


### PR DESCRIPTION
- Added support for Thinlocks
- Fixed object mark MethodTable issue
- Fixed issue with Free objects being marked as too large
- Rearranged ObjectCorruptionKind enum, renamed some entries
- Check object header after validating members