### PR TITLE
Fix issue with EnumerateObjects(MemoryRange)

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/ClrHeap.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrHeap.cs
@@ -169,9 +169,12 @@ namespace Microsoft.Diagnostics.Runtime
 
                 foreach (ClrObject obj in EnumerateObjects(seg, start, carefully))
                 {
-                    if (range.Contains(obj.Address))
+                    if (obj < range.Start)
+                        continue;
+
+                    if (obj < range.End)
                         yield return obj;
-                    else if (range.End < obj)
+                    else
                         break;
                 }
             }

--- a/src/Microsoft.Diagnostics.Runtime/ClrSegment.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrSegment.cs
@@ -130,7 +130,10 @@ namespace Microsoft.Diagnostics.Runtime
 
                 foreach (ClrObject obj in SubHeap.Heap.EnumerateObjects(this, start, carefully))
                 {
-                    if (range.Contains(obj))
+                    if (obj < range.Start)
+                        continue;
+
+                    if (obj < range.End)
                         yield return obj;
                     else
                         break;


### PR DESCRIPTION
Fix an issue where we would not properly enumerate ranges of objects.