### PR TITLE
Change how we walk stackrefs/handles

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/SosHandleEnum.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/SosHandleEnum.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
 
         private ref readonly ISOSHandleEnumVTable VTable => ref Unsafe.AsRef<ISOSHandleEnumVTable>(_vtable);
 
-        public Span<HandleData> GetHandles()
+        public HandleData[] GetHandles()
         {
             HResult hr = VTable.GetCount(Self, out int count);
             if (!hr)
@@ -46,7 +46,10 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
                 return Array.Empty<HandleData>();
             }
 
-            return refs.AsSpan(0, read);
+            if (refs.Length != read)
+                Array.Resize(ref refs, read);
+
+            return refs;
         }
 
         public int ReadHandles(Span<HandleData> handles)

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/SosStackRefEnum.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/SosStackRefEnum.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
 
         private ref readonly ISOSStackRefEnumVTable VTable => ref Unsafe.AsRef<ISOSStackRefEnumVTable>(_vtable);
 
-        public Span<StackRefData> GetStackRefs()
+        public StackRefData[] GetStackRefs()
         {
             HResult hr = VTable.GetCount(Self, out int count);
             if (!hr)
@@ -46,7 +46,10 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
                 return Array.Empty<StackRefData>();
             }
 
-            return refs.AsSpan(0, read);
+            if (read != refs.Length)
+                Array.Resize(ref refs, read);
+
+            return refs;
         }
     }
 

--- a/src/Microsoft.Diagnostics.Runtime/Implementation/ClrHeapHelpers.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Implementation/ClrHeapHelpers.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
             if (handleEnum is null)
                 yield break;
 
-            Span<HandleData> handles = handleEnum.GetHandles();
+            HandleData[] handles = handleEnum.GetHandles();
             for (int i = 0; i < handles.Length; i++)
             {
                 if (handles[i].Type == (int)ClrHandleKind.Dependent)

--- a/src/Microsoft.Diagnostics.Runtime/Implementation/ClrHeapHelpers.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Implementation/ClrHeapHelpers.cs
@@ -86,30 +86,14 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
             if (handleEnum is null)
                 yield break;
 
-            HandleData[] handles;
-            try
+            Span<HandleData> handles = handleEnum.GetHandles();
+            for (int i = 0; i < handles.Length; i++)
             {
-                // Yes this is a huge array.  Older versions of ISOSHandleEnum have a memory leak when
-                // we loop below.  If we can fill the array without having to call back into
-                // SOSHandleEnum.ReadHandles then we avoid that leak entirely.
-                handles = new HandleData[0x18000];
-            }
-            catch (OutOfMemoryException)
-            {
-                handles = new HandleData[256];
-            }
-
-            int fetched;
-            while ((fetched = handleEnum.ReadHandles(handles)) != 0)
-            {
-                for (int i = 0; i < fetched; i++)
+                if (handles[i].Type == (int)ClrHandleKind.Dependent)
                 {
-                    if (handles[i].Type == (int)ClrHandleKind.Dependent)
-                    {
-                        ulong obj = _memoryReader.ReadPointer(handles[i].Handle);
-                        if (obj != 0)
-                            yield return (obj, handles[i].Secondary);
-                    }
+                    ulong obj = _memoryReader.ReadPointer(handles[i].Handle);
+                    if (obj != 0)
+                        yield return (obj, handles[i].Secondary);
                 }
             }
         }

--- a/src/Microsoft.Diagnostics.Runtime/Implementation/ClrRuntimeHelpers.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Implementation/ClrRuntimeHelpers.cs
@@ -266,74 +266,63 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
 
         public IEnumerable<ClrHandle> EnumerateHandles()
         {
-            // Yes this is a huge array.  Older versions of ISOSHandleEnum have a memory leak when
-            // we loop below.  If we can fill the array without having to call back into
-            // SOSHandleEnum.ReadHandles then we avoid that leak entirely.
-            HandleData[] handles = new HandleData[0xc0000];
-            return EnumerateHandleTable(Runtime, handles);
-        }
-
-        private IEnumerable<ClrHandle> EnumerateHandleTable(ClrRuntime runtime, HandleData[] handles)
-        {
             ClrAppDomainData appDomainData = GetAppDomainData();
 
             using SOSHandleEnum? handleEnum = _sos.EnumerateHandles();
             if (handleEnum is null)
                 yield break;
 
-            ClrHeap heap = runtime.Heap;
-            int fetched;
-            while ((fetched = handleEnum.ReadHandles(handles)) != 0)
+            ClrHeap heap = Runtime.Heap;
+
+            Span<HandleData> handles = handleEnum.GetHandles();
+            for (int i = 0; i < handles.Length; i++)
             {
-                for (int i = 0; i < fetched; i++)
+                ulong objAddress = _dataReader.ReadPointer(handles[i].Handle);
+                ClrObject clrObj = heap.GetObject(objAddress);
+
+                if (!clrObj.IsNull)
                 {
-                    ulong objAddress = _dataReader.ReadPointer(handles[i].Handle);
-                    ClrObject clrObj = heap.GetObject(objAddress);
+                    ClrAppDomain? domain = appDomainData.GetDomainByAddress(handles[i].AppDomain);
+                    domain ??= appDomainData.SystemDomain ?? appDomainData.SharedDomain ?? appDomainData.AppDomains.First();
 
-                    if (!clrObj.IsNull)
+                    ClrHandleKind handleKind = (ClrHandleKind)handles[i].Type;
+                    switch (handleKind)
                     {
-                        ClrAppDomain? domain = appDomainData.GetDomainByAddress(handles[i].AppDomain);
-                        domain ??= appDomainData.SystemDomain ?? appDomainData.SharedDomain ?? appDomainData.AppDomains.First();
+                        default:
+                            yield return new ClrHandle(domain, handles[i].Handle, clrObj, handleKind);
+                            break;
 
-                        ClrHandleKind handleKind = (ClrHandleKind)handles[i].Type;
-                        switch (handleKind)
-                        {
-                            default:
-                                yield return new ClrHandle(domain, handles[i].Handle, clrObj, handleKind);
-                                break;
+                        case ClrHandleKind.Dependent:
+                            ClrObject dependent = heap.GetObject(handles[i].Secondary);
+                            yield return new ClrHandle(domain, handles[i].Handle, clrObj, handleKind, dependent);
+                            break;
 
-                            case ClrHandleKind.Dependent:
-                                ClrObject dependent = heap.GetObject(handles[i].Secondary);
-                                yield return new ClrHandle(domain, handles[i].Handle, clrObj, handleKind, dependent);
-                                break;
+                        case ClrHandleKind.RefCounted:
+                            uint refCount = 0;
 
-                            case ClrHandleKind.RefCounted:
-                                uint refCount = 0;
+                            if (handles[i].IsPegged != 0)
+                                refCount = handles[i].JupiterRefCount;
 
-                                if (handles[i].IsPegged != 0)
-                                    refCount = handles[i].JupiterRefCount;
+                            if (refCount < handles[i].RefCount)
+                                refCount = handles[i].RefCount;
 
-                                if (refCount < handles[i].RefCount)
-                                    refCount = handles[i].RefCount;
-
-                                if (!clrObj.IsNull)
+                            if (!clrObj.IsNull)
+                            {
+                                ComCallableWrapper? ccw = clrObj.GetComCallableWrapper();
+                                if (ccw != null && refCount < ccw.RefCount)
                                 {
-                                    ComCallableWrapper? ccw = clrObj.GetComCallableWrapper();
-                                    if (ccw != null && refCount < ccw.RefCount)
-                                    {
-                                        refCount = (uint)ccw.RefCount;
-                                    }
-                                    else
-                                    {
-                                        RuntimeCallableWrapper? rcw = clrObj.GetRuntimeCallableWrapper();
-                                        if (rcw != null && refCount < rcw.RefCount)
-                                            refCount = (uint)rcw.RefCount;
-                                    }
+                                    refCount = (uint)ccw.RefCount;
                                 }
+                                else
+                                {
+                                    RuntimeCallableWrapper? rcw = clrObj.GetRuntimeCallableWrapper();
+                                    if (rcw != null && refCount < rcw.RefCount)
+                                        refCount = (uint)rcw.RefCount;
+                                }
+                            }
 
-                                yield return new ClrHandle(domain, handles[i].Handle, clrObj, handleKind, refCount);
-                                break;
-                        }
+                            yield return new ClrHandle(domain, handles[i].Handle, clrObj, handleKind, refCount);
+                            break;
                     }
                 }
             }

--- a/src/Microsoft.Diagnostics.Runtime/Implementation/ClrRuntimeHelpers.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Implementation/ClrRuntimeHelpers.cs
@@ -274,7 +274,7 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
 
             ClrHeap heap = Runtime.Heap;
 
-            Span<HandleData> handles = handleEnum.GetHandles();
+            HandleData[] handles = handleEnum.GetHandles();
             for (int i = 0; i < handles.Length; i++)
             {
                 ulong objAddress = _dataReader.ReadPointer(handles[i].Handle);

--- a/src/Microsoft.Diagnostics.Runtime/Implementation/ClrThreadHelpers.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Implementation/ClrThreadHelpers.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
 
             ClrAppDomain? domain = thread.CurrentAppDomain;
             ClrHeap heap = thread.Runtime.Heap;
-            Span<StackRefData> refs = stackRefEnum.GetStackRefs();
+            StackRefData[] refs = stackRefEnum.GetStackRefs();
 
             const int GCInteriorFlag = 1;
             const int GCPinnedFlag = 2;


### PR DESCRIPTION
There seems to be a bug in the dac when we pass a buffer less than the total amount of stack references or handles.

The original SOS C++ GCRoot code seems to have worked around it by finding the total number of entries and passing a buffer big enough to hold it.