### PR TITLE
Ensure public interfaces have all the public APIs.

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/ClrGenerationData.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrGenerationData.cs
@@ -2,10 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Diagnostics.Runtime.DacInterface;
+using Microsoft.Diagnostics.Runtime.Interfaces;
 
 namespace Microsoft.Diagnostics.Runtime
 {
-    public sealed class ClrGenerationData
+    public sealed class ClrGenerationData : IClrGenerationData
     {
         public ulong StartSegment { get; }
         public ulong AllocationStart { get; }

--- a/src/Microsoft.Diagnostics.Runtime/ClrOutOfMemoryInfo.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrOutOfMemoryInfo.cs
@@ -2,10 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Diagnostics.Runtime.DacInterface;
+using Microsoft.Diagnostics.Runtime.Interfaces;
 
 namespace Microsoft.Diagnostics.Runtime
 {
-    public class ClrOutOfMemoryInfo
+    public class ClrOutOfMemoryInfo : IClrOutOfMemoryInfo
     {
         internal ClrOutOfMemoryInfo(in DacOOMData oomData)
         {

--- a/src/Microsoft.Diagnostics.Runtime/ClrSegment.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrSegment.cs
@@ -180,7 +180,8 @@ namespace Microsoft.Diagnostics.Runtime
             return $"{Kind} [{Start:x12}, {End:x12}]";
         }
 
-        IEnumerable<IClrValue> IClrSegment.EnumerateObjects() => EnumerateObjects().Cast<IClrValue>();
+        IEnumerable<IClrValue> IClrSegment.EnumerateObjects(bool carefully) => EnumerateObjects(carefully).Cast<IClrValue>();
+        IEnumerable<IClrValue> IClrSegment.EnumerateObjects(MemoryRange range, bool carefully) => EnumerateObjects(range, carefully).Cast<IClrValue>();
 
         internal uint[] ObjectMarkers
         {

--- a/src/Microsoft.Diagnostics.Runtime/ClrSubHeap.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrSubHeap.cs
@@ -91,6 +91,10 @@ namespace Microsoft.Diagnostics.Runtime
 
         ImmutableArray<IClrSegment> IClrSubHeap.Segments => Segments.CastArray<IClrSegment>();
 
+        IClrOutOfMemoryInfo? IClrSubHeap.OomInfo => this.OomInfo;
+
+        ImmutableArray<IClrGenerationData> IClrSubHeap.GenerationTable => this.GenerationTable.CastArray<IClrGenerationData>();
+
         internal enum GCState
         {
             Marking,

--- a/src/Microsoft.Diagnostics.Runtime/Interfaces/IClrGenerationData.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Interfaces/IClrGenerationData.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.Diagnostics.Runtime.Interfaces
+{
+    public interface IClrGenerationData
+    {
+        ulong StartSegment { get; }
+        ulong AllocationStart { get; }
+        ulong AllocationContextPointer { get; }
+        ulong AllocationContextLimit { get; }
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/Interfaces/IClrHeap.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Interfaces/IClrHeap.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Diagnostics.Runtime.Interfaces
 {
@@ -22,15 +23,21 @@ namespace Microsoft.Diagnostics.Runtime.Interfaces
         IEnumerable<IClrValue> EnumerateFinalizableObjects();
         IEnumerable<IClrRoot> EnumerateFinalizerRoots();
         IEnumerable<IClrValue> EnumerateObjects();
-        IEnumerable<IClrValue> EnumerateObjects(MemoryRange range);
+        IEnumerable<IClrValue> EnumerateObjects(bool carefully);
+        IEnumerable<IClrValue> EnumerateObjects(MemoryRange range, bool carefully = false);
         IEnumerable<IClrRoot> EnumerateRoots();
-        IClrValue FindNextObjectOnSegment(ulong address);
-        IClrValue FindPreviousObjectOnSegment(ulong address);
+        IEnumerable<SyncBlock> EnumerateSyncBlocks();
+        IClrValue FindNextObjectOnSegment(ulong address, bool carefully = false);
+        IClrValue FindPreviousObjectOnSegment(ulong address, bool carefully = false);
         IClrValue GetObject(ulong objRef);
         IClrType? GetObjectType(ulong objRef);
         IClrSegment? GetSegmentByAddress(ulong address);
         IClrType? GetTypeByMethodTable(ulong methodTable);
         IClrType? GetTypeByName(IClrModule module, string name);
         IClrType? GetTypeByName(string name);
+        bool IsObjectCorrupted(ulong obj, [NotNullWhen(true)] out IObjectCorruption? result);
+        bool IsObjectCorrupted(IClrValue obj, [NotNullWhen(true)] out IObjectCorruption? result);
+        IEnumerable<IObjectCorruption> VerifyHeap();
+        IEnumerable<IObjectCorruption> VerifyHeap(IEnumerable<IClrValue> objects);
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/Interfaces/IClrOutOfMemoryInfo.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Interfaces/IClrOutOfMemoryInfo.cs
@@ -1,0 +1,20 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.Diagnostics.Runtime.Interfaces
+{
+    public interface IClrOutOfMemoryInfo
+    {
+        OutOfMemoryReason Reason { get; }
+        GetMemoryFailureReason GetMemoryFailure { get; }
+        bool IsLargeObjectHeap { get; }
+        ulong AllocSize { get; }
+        ulong AvailablePageFileMB { get; }
+        ulong GCIndex { get; }
+        ulong Size { get; }
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/Interfaces/IClrSegment.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Interfaces/IClrSegment.cs
@@ -17,13 +17,14 @@ namespace Microsoft.Diagnostics.Runtime.Interfaces
         MemoryRange Generation2 { get; }
         bool IsPinned { get; }
         GCSegmentKind Kind { get; }
+        ClrSegmentFlags Flags { get; }
         ulong Length { get; }
         MemoryRange ObjectRange { get; }
         MemoryRange ReservedMemory { get; }
         ulong Start { get; }
         IClrSubHeap SubHeap { get; }
-
-        IEnumerable<IClrValue> EnumerateObjects();
+        IEnumerable<IClrValue> EnumerateObjects(bool carefully = false);
+        IEnumerable<IClrValue> EnumerateObjects(MemoryRange range, bool carefully = false);
         int GetGeneration(ulong obj);
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/Interfaces/IClrSubHeap.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Interfaces/IClrSubHeap.cs
@@ -8,6 +8,8 @@ namespace Microsoft.Diagnostics.Runtime.Interfaces
     public interface IClrSubHeap
     {
         ulong Address { get; }
+        ulong Allocated { get; }
+        ulong MarkArray { get; }
         MemoryRange AllocationContext { get; }
         bool HasBackgroundGC { get; }
         bool HasPinnedObjectHeap { get; }
@@ -15,5 +17,16 @@ namespace Microsoft.Diagnostics.Runtime.Interfaces
         IClrHeap Heap { get; }
         int Index { get; }
         ImmutableArray<IClrSegment> Segments { get; }
+        MemoryRange FinalizerQueueRoots { get; }
+        MemoryRange FinalizerQueueObjects { get; }
+        ulong SavedSweepEphemeralSegment { get; }
+        ulong SavedSweepEphemeralStart { get; }
+        ImmutableArray<IClrGenerationData> GenerationTable { get; }
+        ulong EphemeralHeapSegment { get; }
+        ulong LowestAddress { get; }
+        ulong HighestAddress { get; }
+        ulong CardTable { get; }
+        IClrOutOfMemoryInfo? OomInfo { get; }
+        MemoryRange InternalRootArray { get; }
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/Interfaces/IObjectCorruption.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Interfaces/IObjectCorruption.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.Diagnostics.Runtime.Interfaces
+{
+    public interface IObjectCorruption
+    {
+        IClrValue Object { get; }
+        int Offset { get; }
+        ObjectCorruptionKind Kind { get; }
+        int SyncBlockIndex { get; }
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/ObjectCorruption.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ObjectCorruption.cs
@@ -2,10 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using Microsoft.Diagnostics.Runtime.Interfaces;
 
 namespace Microsoft.Diagnostics.Runtime
 {
-    public class ObjectCorruption
+    public class ObjectCorruption : IObjectCorruption
     {
         public ClrObject Object { get; }
         public int Offset { get; }
@@ -21,6 +22,8 @@ namespace Microsoft.Diagnostics.Runtime
         /// SyncBlock related failures.
         /// </summary>
         public int ClrSyncBlockIndex { get; } = -1;
+
+        IClrValue IObjectCorruption.Object => this.Object;
 
         public ObjectCorruption(ClrObject obj, int offset, ObjectCorruptionKind kind)
         {


### PR DESCRIPTION
This should ensure that the interfaces for `IClrHeap`, `IClrSubHeap`, and `IClrSegment` match the public APIs of the corresponding classes.  Some new interfaces were required.