### PR TITLE
FinalizerRoots and Generations

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/ClrSegment.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrSegment.cs
@@ -154,21 +154,26 @@ namespace Microsoft.Diagnostics.Runtime
         /// </summary>
         /// <param name="obj">An object in this segment.</param>
         /// <returns>
-        /// The generation of the given object if that object lies in this segment.  The return
-        /// value is undefined if the object does not lie in this segment.
+        /// The generation of the given object if that object lies in this segment.
         /// </returns>
-        public int GetGeneration(ulong obj)
+        public Generation GetGeneration(ulong obj)
         {
-            if (Generation2.Contains(obj))
-                return 2;
+            if (Kind <= GCSegmentKind.Frozen)
+                return (Generation)Kind;
 
-            if (Generation1.Contains(obj))
-                return 1;
+            if (Kind == GCSegmentKind.Ephemeral)
+            {
+                if (Generation0.Contains(obj))
+                    return Generation.Generation0;
 
-            if (Generation0.Contains(obj))
-                return 0;
+                if (Generation1.Contains(obj))
+                    return Generation.Generation1;
 
-            return -1;
+                if (Generation2.Contains(obj))
+                    return Generation.Generation2;
+            }
+
+            return Generation.Unknown;
         }
 
         /// <summary>

--- a/src/Microsoft.Diagnostics.Runtime/ClrSubHeap.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrSubHeap.cs
@@ -38,11 +38,22 @@ namespace Microsoft.Diagnostics.Runtime
             GenerationTable = genData.Select(data => new ClrGenerationData(data)).ToImmutableArray();
             FinalizationPointers = finalizationPointers.ToImmutableArray();
 
+            if (FinalizationPointers.Length == 6)
+            {
+                // Pre-Regions
+                FinalizerQueueObjects = new(FinalizationPointers[0], FinalizationPointers[3]);
+                FinalizerQueueRoots = new(FinalizationPointers[3], FinalizationPointers[5]);
+            }
+            else
+            {
+                // GC-Regions
+                FinalizerQueueObjects = new(FinalizationPointers[0], FinalizationPointers[3]);
+                FinalizerQueueRoots = new(FinalizationPointers[4], FinalizationPointers[6]);
+            }
+
             HasRegions = GenerationTable.Length >= 2 && GenerationTable[0].StartSegment != GenerationTable[1].StartSegment;
             HasPinnedObjectHeap = GenerationTable.Length > 4;
 
-            FinalizerQueueRoots = new MemoryRange(heap.FQRootsStart, heap.FQRootsStop);
-            FinalizerQueueObjects = new MemoryRange(heap.FQAllObjectsStart, heap.FQAllObjectsStop);
             AllocationContext = new MemoryRange(heap.EphemeralAllocContextPtr, heap.EphemeralAllocContextLimit);
 
             Segments = helpers.EnumerateSegments(this).ToImmutableArray();

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/Structs/HeapDetails.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/Structs/HeapDetails.cs
@@ -30,10 +30,5 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
 
         public ulong EphemeralAllocContextPtr => GenerationTable[0].AllocationContextPointer;
         public ulong EphemeralAllocContextLimit => GenerationTable[0].AllocationContextLimit;
-
-        public ulong FQAllObjectsStart => FinalizationFillPointers[0];
-        public ulong FQAllObjectsStop => FinalizationFillPointers[3];
-        public ulong FQRootsStart => FinalizationFillPointers[3];
-        public ulong FQRootsStop => FinalizationFillPointers[5];
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/GCSegmentKind.cs
+++ b/src/Microsoft.Diagnostics.Runtime/GCSegmentKind.cs
@@ -9,11 +9,6 @@ namespace Microsoft.Diagnostics.Runtime
     public enum GCSegmentKind
     {
         /// <summary>
-        /// An Ephemeral segment is one which has Gen0, Gen1, and Gen2 sections.
-        /// </summary>
-        Ephemeral,
-
-        /// <summary>
         /// This "segment" is actually a GC Gen0 region.  This is only enumerated
         /// when the GC regions feature is present in the target CLR.
         /// </summary>
@@ -32,12 +27,6 @@ namespace Microsoft.Diagnostics.Runtime
         Generation2,
 
         /// <summary>
-        /// This segment is frozen, meaning it is both pinned and no objects will
-        /// ever be collected.
-        /// </summary>
-        Frozen,
-
-        /// <summary>
         /// A large object segment.  Objects here are above a certain size (usually
         /// 85,000 bytes) and all objects here are pinned.
         /// </summary>
@@ -47,5 +36,16 @@ namespace Microsoft.Diagnostics.Runtime
         /// Pinned object segment.  All objects here are pinned.
         /// </summary>
         Pinned,
+
+        /// <summary>
+        /// This segment is frozen, meaning it is both pinned and no objects will
+        /// ever be collected.
+        /// </summary>
+        Frozen,
+
+        /// <summary>
+        /// An Ephemeral segment is one which has Gen0, Gen1, and Gen2 sections.
+        /// </summary>
+        Ephemeral,
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/Generation.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Generation.cs
@@ -1,0 +1,52 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Diagnostics.Runtime
+{
+    /// <summary>
+    /// The "generation" of an object.  Note that this is a simulated view
+    /// of what a "generation" is.  For example, Large objects are still
+    /// considered gen2 for GC collection purposes.
+    /// </summary>
+    public enum Generation
+    {
+        /// <summary>
+        /// Gen0 objects.  These may reside on an Ephemeral segment, or
+        /// on a Gen0 region.
+        /// </summary>
+        Generation0,
+
+        /// <summary>
+        /// Gen1 objects.  These may reside on an Ephemeral segment, or
+        /// on a Gen1 region.
+        /// </summary>
+        Generation1,
+
+        /// <summary>
+        /// Gen2 objects.  These may reside on an Ephemeral segment, or
+        /// on a Gen2 region.
+        /// </summary>
+        Generation2,
+
+        /// <summary>
+        /// Objects on the Large Object Heap, considered gen2 for collection.
+        /// </summary>
+        Large,
+
+        /// <summary>
+        /// Objects on the Pinned Object Heap, considered gen2 for collection.
+        /// </summary>
+        Pinned,
+
+        /// <summary>
+        /// Frozen objects will never be collected.
+        /// </summary>
+        Frozen,
+
+        /// <summary>
+        /// Unknown object generation.  Could be a bug within ClrMD or a sign
+        /// of heap corruption.
+        /// </summary>
+        Unknown
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/Interfaces/IClrSegment.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Interfaces/IClrSegment.cs
@@ -22,8 +22,7 @@ namespace Microsoft.Diagnostics.Runtime.Interfaces
         MemoryRange ReservedMemory { get; }
         ulong Start { get; }
         IClrSubHeap SubHeap { get; }
-
         IEnumerable<IClrValue> EnumerateObjects();
-        int GetGeneration(ulong obj);
+        Generation GetGeneration(ulong obj);
     }
 }


### PR DESCRIPTION
- Fix an issue with recent runtimes not properly reporting Finalizer roots.
- Change ClrSegment.GetGeneration to return an enum of what kind of generation the object belongs to.
- Re-order `GCSegmentKind` to match `Generation` ordering.