### PR TITLE
MoveToImmutable can throw IVO if capacity != count.

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/ClrException.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrException.cs
@@ -293,7 +293,7 @@ namespace Microsoft.Diagnostics.Runtime
                 dataPtr += (ulong)elementSize;
             }
 
-            return result.MoveToImmutable();
+            return result.MoveOrCopyToImmutable();
         }
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/Implementation/ClrHeapHelpers.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Implementation/ClrHeapHelpers.cs
@@ -149,7 +149,7 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
                     }
                 }
 
-                return heapsBuilder.MoveToImmutable();
+                return heapsBuilder.MoveOrCopyToImmutable();
             }
             else
             {

--- a/src/Microsoft.Diagnostics.Runtime/Implementation/ClrRuntimeHelpers.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Implementation/ClrRuntimeHelpers.cs
@@ -132,7 +132,7 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
                         builder.Add(domain);
                 }
 
-                domainData.AppDomains = builder.MoveToImmutable();
+                domainData.AppDomains = builder.MoveOrCopyToImmutable();
 
                 ClrModule? bcl = null;
                 if (_sos.GetCommonMethodTables(out CommonMethodTables mts))

--- a/src/Microsoft.Diagnostics.Runtime/Implementation/ClrTypeHelpers.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Implementation/ClrTypeHelpers.cs
@@ -117,7 +117,7 @@ namespace Microsoft.Diagnostics.Runtime
             for (int i = 0; i < ifs.Length; i++)
                 result[i] = new ComInterfaceData(_typeFactory.GetOrCreateType(ifs[i].MethodTable, 0), ifs[i].InterfacePointer);
 
-            return result.MoveToImmutable();
+            return result.MoveOrCopyToImmutable();
         }
 
         public ClrType? CreateRuntimeType(ClrObject obj)

--- a/src/Microsoft.Diagnostics.Runtime/Linux/ElfFile.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Linux/ElfFile.cs
@@ -276,7 +276,7 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
             for (uint i = 0; i < programHeaders.Count; i++)
                 programHeaders[(int)i] = new ElfProgramHeader(Reader, Header.Is64Bit, _position + Header.ProgramHeaderOffset + i * Header.ProgramHeaderEntrySize, loadBias, _virtual);
 
-            _programHeaders = programHeaders.MoveToImmutable();
+            _programHeaders = programHeaders.MoveOrCopyToImmutable();
         }
 
         public void Dispose()

--- a/src/Microsoft.Diagnostics.Runtime/Utilities/PEImage/ResourceEntry.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Utilities/PEImage/ResourceEntry.cs
@@ -163,7 +163,7 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
                         result.Add(new ResourceEntry(Image, this, name, entry.IsLeaf, resourceStartFileOffset + entry.DataOffset));
                     }
 
-                    return _children = result.MoveToImmutable();
+                    return _children = result.MoveOrCopyToImmutable();
                 }
                 catch
                 {

--- a/src/Microsoft.Diagnostics.Runtime/Windows/Minidump.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Windows/Minidump.cs
@@ -286,7 +286,7 @@ namespace Microsoft.Diagnostics.Runtime.Windows
 
             return new ThreadReadResult()
             {
-                ContextData = contextBuilder.MoveToImmutable(),
+                ContextData = contextBuilder.MoveOrCopyToImmutable(),
                 Tebs = tebBuilder.ToImmutable(),
                 Threads = threadBuilder.ToImmutable()
             };


### PR DESCRIPTION
When there is an `if` in a copy loop `MoveToImmutable` throws IVO.  Use the existing extension method throughout for safety.

Partial stack is here:

```
System.InvalidOperationException: MoveToImmutable can only be performed when Count equals Capacity.
   at System.Collections.Immutable.ImmutableArray`1.Builder.MoveToImmutable()
   at Microsoft.Diagnostics.Runtime.Implementation.ClrHeapHelpers.GetSubHeaps(ClrHeap heap)
   at Microsoft.Diagnostics.Runtime.ClrHeap.GetSubHeapData()
   at Microsoft.Diagnostics.Runtime.ClrHeap.get_Segments()
   at Microsoft.Diagnostics.Runtime.ClrHeap.Microsoft.Diagnostics.Runtime.Interfaces.IClrHeap.get_Segments()
   at Microsoft.Diagnostics.Runtime.ObjectSet..ctor(IClrHeap heap)
```
 