### PR TITLE
Fix empty debugging libraries by passing non-null module w/ build id in MacOSProcessDataReader.EnumerateModules()

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/DataReaders/MacOS/MacOSProcessDataReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DataReaders/MacOS/MacOSProcessDataReader.cs
@@ -132,8 +132,9 @@ namespace Microsoft.Diagnostics.Runtime.MacOS
                 ulong imageAddress = info.imageLoadAddress;
                 string imageFilePath = ReadNullTerminatedAscii(info.imageFilePath);
 
+                MachOModule module = new MachOModule(this, imageAddress, imageFilePath);
                 Version version = GetVersionInfo(info.imageLoadAddress) ?? new Version();
-                yield return new MachOModuleInfo(null, imageAddress, imageFilePath, version, 0);
+                yield return new MachOModuleInfo(module, imageAddress, imageFilePath, version, 0);
             }
 
             unsafe T Read<T>(ulong address, uint index = 0)


### PR DESCRIPTION
Fixes #1166