### PR TITLE
Prevent exception when reading roots from the bad stack

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/Implementation/ClrThreadHelpers.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Implementation/ClrThreadHelpers.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
                 bool interior = (stackRef.Flags & GCInteriorFlag) == GCInteriorFlag;
                 bool isPinned = (stackRef.Flags & GCPinnedFlag) == GCPinnedFlag;
 
-                ClrStackFrame? frame = stack.SingleOrDefault(f => f.StackPointer == stackRef.Source || f.StackPointer == stackRef.StackPointer && f.InstructionPointer == stackRef.Source);
+                ClrStackFrame? frame = stack.FirstOrDefault(f => f.StackPointer == stackRef.Source || f.StackPointer == stackRef.StackPointer && f.InstructionPointer == stackRef.Source);
                 frame ??= new ClrStackFrame(thread, null, stackRef.Source, stackRef.StackPointer, ClrStackFrameKind.Unknown, null, null);
 
                 int regOffset = 0;


### PR DESCRIPTION
I have a memory dump in which the following operation finds 2 frames:
```
ClrStackFrame? frame = stack.SingleOrDefault(f => f.StackPointer == stackRef.Source || f.StackPointer == stackRef.StackPointer && f.InstructionPointer == stackRef.Source);
```

The dump is apparently special but contains useful information. I believe that would be nice to still be able to list the roots from the stack.