### PR TITLE
Fix bugs in DAC names that either contain non-closed generics or non-assembly qualified names

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/DACNameParserTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/DACNameParserTests.cs
@@ -354,9 +354,9 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         {
             // NOTE: jaredpar in the Roslyn compiler team verified this is in fact a generic type in F#, but it has no arity specifier. We should be able to handle
             // these by recognizing when we encounter the [ and decide we are parsing an array specifier (which we should since we never saw a generic arity specifier)
-            // if we anything other than a ] or a , after it (i.e. say a letter), then we can assume this is one of these non-traditional generic cases and manually force
+            // if we see anything other than a ] or a , after it (i.e. say a letter), then we can assume this is one of these non-traditional generic cases and manually force
             // ourself down that path. It means we will need to figure out the arity ourselves, but that shouldn't be terribly hard, we just start at 1 and count any commas
-            // we encounter before the closing , (taking care for nested generics inside the outer generic in our counting).
+            // we encounter before the closing ] (taking care for nested generics inside the outer generic in our counting).
             string input = "FSharp.Compiler.TypedTreeBasics+loop@444-39T[a]";
             string expectedResult = "FSharp.Compiler.TypedTreeBasics+loop@444-39T<a>";
 

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/DACNameParserTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/DACNameParserTests.cs
@@ -391,6 +391,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             Assert.Equal(expectedResult, DACNameParser.Parse(input));
         }
 
+        [Fact]
         public void HandleNonTraditionObfuscatedGenericWithAssemblyQualifiedArg()
         {
             string input = "a37[[akx, yWorks.yFilesWPF.Viewer]]";
@@ -399,6 +400,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             Assert.Equal(expectedResult, DACNameParser.Parse(input));
         }
 
+        [Fact]
         public void HandleNonTraditionObfuscatedGenericWithNonAssemblyQualifiedArg()
         {
             string input = "a37[akx]";

--- a/src/Microsoft.Diagnostics.Runtime/Implementation/DACNameParser.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Implementation/DACNameParser.cs
@@ -150,7 +150,7 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
                                 }
                                 else if (name[curPos] == GenericArgListAssemblyQualifiedTypeNameOrArrayStartSpecifier)
                                 {
-                                    if(!DoAnyArgsOrTypeNamesHaveUnfulfilledGenericArguments(nameSegments, genericArgs))
+                                    if (!DoAnyArgsOrTypeNamesHaveUnfulfilledGenericArguments(nameSegments, genericArgs))
                                     {
                                         // It's possible this is an FSharp or obfuscated generic name, lacking an arity specifier (e.g. something like Microsoft.FSharp.Collections.ArrayModule+Parallel+sortingFunc@2439-1[TKey,TValue]).
                                         // Or it could be an array decl, we will want to manually check for the former here (the latter will be correctly detected inside DetermineNextStateAndPos).
@@ -425,7 +425,7 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
                                     int potentialNewPos;
                                     (potentialNewState, potentialNewPos) = DetermineNextStateAndPos(name, curPos);
 
-                                    if(potentialNewState != ParsingState.ParsingArraySpecifier && potentialNewState != ParsingState.Done)
+                                    if (potentialNewState != ParsingState.ParsingArraySpecifier && potentialNewState != ParsingState.Done)
                                     {
                                         if (isCurrentArgAssemblyQualified.Count != 0 && isCurrentArgAssemblyQualified.Peek())
                                         {
@@ -569,7 +569,7 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
                                 }
 
                                 // Done with this arg so clean up its entry
-                                if(isCurrentArgAssemblyQualified.Count != 0)
+                                if (isCurrentArgAssemblyQualified.Count != 0)
                                     isCurrentArgAssemblyQualified.Pop();
 
                                 (currentState, curPos) = DetermineNextStateAndPos(name, curPos);

--- a/src/Microsoft.Diagnostics.Runtime/Implementation/DACNameParser.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Implementation/DACNameParser.cs
@@ -1021,7 +1021,7 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
 
         private static bool DoAnyArgsOrTypeNamesHaveUnfulfilledGenericArguments(List<TypeNameSegment>? nameSegments, List<TypeNameSegment>? genericArgs)
         {
-            foreach (List<TypeNameSegment> current in new[] { genericArgs, nameSegments })
+            foreach (List<TypeNameSegment>? current in new[] { genericArgs, nameSegments })
             {
                 if (current != null)
                 {

--- a/src/Microsoft.Diagnostics.Runtime/Implementation/DACNameParser.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Implementation/DACNameParser.cs
@@ -1021,7 +1021,9 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
 
         private static bool DoAnyArgsOrTypeNamesHaveUnfulfilledGenericArguments(List<TypeNameSegment>? nameSegments, List<TypeNameSegment>? genericArgs)
         {
-            foreach (List<TypeNameSegment>? current in new[] { genericArgs, nameSegments })
+            return DoAnyArgsOrTypeNamesHaveUnfulfilledGenericArgumentsWorker(nameSegments) || DoAnyArgsOrTypeNamesHaveUnfulfilledGenericArgumentsWorker(genericArgs);
+
+            static bool DoAnyArgsOrTypeNamesHaveUnfulfilledGenericArgumentsWorker(List<TypeNameSegment>? current)
             {
                 if (current != null)
                 {
@@ -1033,9 +1035,9 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
                         }
                     }
                 }
-            }
 
-            return false;
+                return false;
+            }
         }
 
         private enum ParsingState


### PR DESCRIPTION
Fix DAC name parser to deal with non-closed generic types and non-assembly qualified names (see bug #897).

Add lots of comments to parser as its complex due to having to deal with tragedies like the type name in the ParseGenericWithComplexGenericArgs2 test.

Replace uses of char literals in numerous places with their named constants I was using elsewhere.

Correct numerous comment spelling errors (thanks VS spell checker).

Add numerous tests both for the case in 897, some variants of it, and another case I encountered internally.

Add support for non-traditional generics as produced by FSharp and various obfuscators.