### PR TITLE
Fix Linux single-file apps dumps loaded on Windows

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/ClrInfo.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrInfo.cs
@@ -268,7 +268,7 @@ namespace Microsoft.Diagnostics.Runtime
             if (IsSupportedRuntime(module, out ClrFlavor flavor))
                 return new ClrInfo(dataTarget, flavor, module, 0);
 
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || Path.GetExtension(module.FileName).Equals(".exe", StringComparison.OrdinalIgnoreCase))
+            if ((dataTarget.DataReader.TargetPlatform != OSPlatform.Windows) || Path.GetExtension(module.FileName).Equals(".exe", StringComparison.OrdinalIgnoreCase))
             {
                 ulong singleFileRuntimeInfo = module.GetExportSymbolAddress(ClrRuntimeInfo.SymbolValue);
                 if (singleFileRuntimeInfo != 0)


### PR DESCRIPTION
Loading Linux single-file core dumps either with windbg or dotnet-dump on Windows doesn't work because the perf fix added in PR #1000 checked for the host/running OS not the target OS.