### PR TITLE
Remove some previous tracing

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/SosStackRefEnum.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/SosStackRefEnum.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Microsoft.Diagnostics.Runtime.Utilities;
@@ -53,7 +52,6 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             fixed (StackRefData* ptr = span)
             {
                 HResult hr = VTable.Next(Self, span.Length, ptr, out int read);
-                Trace.TraceInformation($"ISOSStackRefEnum::Next({span.Length:n0}, read:{read:n0} hr={hr}");
                 span = span.Slice(0, hr ? read : 0);
                 return span;
             }

--- a/src/Microsoft.Diagnostics.Runtime/Implementation/ClrThreadHelpers.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Implementation/ClrThreadHelpers.cs
@@ -39,10 +39,8 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
             ClrHeap heap = thread.Runtime.Heap;
             const int GCInteriorFlag = 1;
             const int GCPinnedFlag = 2;
-            Trace.TraceInformation($"EnumerateStackRoots - BEGIN");
             foreach (StackRefData stackRef in stackRefEnum.ReadStackRefs())
             {
-                Trace.TraceInformation($"EnumerateStackRoots - ref:{stackRef.Address:x}");
                 if (stackRef.Object == 0)
                 {
                     Trace.TraceInformation($"EnumerateStackRoots found an entry with Object == 0, addr:{(ulong)stackRef.Address:x} srcType:{stackRef.SourceType:x}");
@@ -94,7 +92,6 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
                     yield return new ClrStackRoot(stackRef.Address, obj, isInterior: false, isPinned: isPinned, heap: heap, frame: frame, regName: regName, regOffset: regOffset);
                 }
             }
-            Trace.TraceInformation($"EnumerateStackRoots - END");
         }
 
         public IEnumerable<ClrStackFrame> EnumerateStackTrace(ClrThread thread, bool includeContext)
@@ -157,7 +154,7 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
                     frameVtbl = DataReader.ReadPointer(sp);
                 }
 
-                Trace.TraceInformation($"STACKWALK - ip:{ip:x}, sp:{sp:x} vtable:{frameVtbl:x}");
+                Trace.TraceInformation($"STACKWALK - hr:{hr}");
 
                 byte[]? contextCopy = null;
                 if (includeContext)


### PR DESCRIPTION
Remove some previous tracing used to track down a stackwalking issue.

This reverts commit e83385be84307b5f88f1d3582dfd9e25c0797664.