### PR TITLE
Use metadata to find type names when appropriate

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/Implementation/ClrDacType.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Implementation/ClrDacType.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
                 if (_name == null)
                 {
                     // GetTypeName returns whether the value should be cached or not.
-                    if (!Helpers.TryGetTypeName(MethodTable, out string? name))
+                    if (!Helpers.TryGetTypeName(this, out string? name))
                         return name;
 
                     // Cache the result or "string.Empty" for null.

--- a/src/Microsoft.Diagnostics.Runtime/Implementation/ClrTypeHelpers.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Implementation/ClrTypeHelpers.cs
@@ -151,13 +151,13 @@ namespace Microsoft.Diagnostics.Runtime
             {
                 string? nameFromToken = GetNameFromToken(type.Module?.MetadataImport, type.MetadataToken);
                 if (nameFromToken is not null)
-                {
                     name = nameFromToken;
-                    return true;
-                }
+            }
+            else
+            {
+                name = DACNameParser.Parse(name);
             }
 
-            name = DACNameParser.Parse(name);
             if (CacheOptions.CacheTypeNames == StringCaching.Intern)
                 name = string.Intern(name);
 

--- a/src/Microsoft.Diagnostics.Runtime/Implementation/IClrTypeHelpers.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Implementation/IClrTypeHelpers.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
         ClrHeap Heap { get; }
         IDataReader DataReader { get; }
 
-        bool TryGetTypeName(ulong mt, out string? name);
+        bool TryGetTypeName(ClrType type, out string? name);
         ulong GetLoaderAllocatorHandle(ulong mt);
         ulong GetAssemblyLoadContextAddress(ulong mt);
 


### PR DESCRIPTION
The dac private API will return `<Unloaded Type>` for dynamic type names.  We can work around this by using metadata (when available) to produce the name.  This restores ClrMD 1.1's behavior.

Fixes https://github.com/dotnet/diagnostics/issues/4108.