### PR TITLE
Better Frame Caching

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/Implementation/IClrThreadData.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Implementation/IClrThreadData.cs
@@ -91,12 +91,11 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
 
         /// <summary>
         /// Enumerates the stack trace of this method.  Note that in the event of bugs or corrupted
-        /// state, this can occasionally produce bad data and run "forever".  Setting <paramref name="maxFrames"/>
-        /// to a reasonable number will prevent infinite loops.
+        /// state, this can occasionally produce bad data and run "forever", so be sure to break out of
+        /// the loop when a threshold is reached when calling it.
         /// </summary>
         /// <param name="includeContext">Whether to calculate and include the thread's CONTEXT record or not.
         /// Registers are always in the Windows CONTEXT format, as that's what the OS uses.</param>
-        /// 
         /// <returns>An enumeration of stack frames.</returns>
         IEnumerable<StackFrameInfo> EnumerateStackTrace(bool includeContext);
     }

--- a/src/Microsoft.Diagnostics.Runtime/Implementation/IClrThreadData.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Implementation/IClrThreadData.cs
@@ -96,9 +96,9 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
         /// </summary>
         /// <param name="includeContext">Whether to calculate and include the thread's CONTEXT record or not.
         /// Registers are always in the Windows CONTEXT format, as that's what the OS uses.</param>
-        /// <param name="maxFrames">The maximum number of frames to enumerate.</param>
+        /// 
         /// <returns>An enumeration of stack frames.</returns>
-        IEnumerable<StackFrameInfo> EnumerateStackTrace(bool includeContext, int maxFrames);
+        IEnumerable<StackFrameInfo> EnumerateStackTrace(bool includeContext);
     }
 
     /// <summary>


### PR DESCRIPTION
Do a better job caching frames:
- Don't rely on a max number of frames internally, let the user break out of the loop.
- Cache frames only if the user didn't break out of the loop.
- Root enumeration still needs to cap the number of frames sensibly, but we won't interfere with the user's enumeration if we hit an internal limit.

Contributes to https://github.com/dotnet/diagnostics/issues/4209.