### PR TITLE
Change how ClrRuntime is constructed internally

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <!-- This repo version -->
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionPrefix>3.1.0</VersionPrefix>
     <DotNetUseShippingVersions>true</DotNetUseShippingVersions>
     <AutoGenerateAssemblyVersion>true</AutoGenerateAssemblyVersion>
     <UsingToolNetFrameworkReferenceAssemblies>true</UsingToolNetFrameworkReferenceAssemblies>

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/CrossOSTest.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/CrossOSTest.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
 {
     public class CrossOSTest
     {
-        [WindowsFact] // ModuleInfo.Version only supports native modules at the moment
+        [WindowsFact]
         public void LinuxDebugTest()
         {
             string artifacts = TestTargets.GetTestArtifactFolder();

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/DataTargetTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/DataTargetTests.cs
@@ -4,6 +4,7 @@
 using System.IO;
 using System.Linq;
 using Microsoft.Diagnostics.Runtime.DacInterface;
+using Microsoft.Diagnostics.Runtime.Implementation;
 using Xunit;
 
 namespace Microsoft.Diagnostics.Runtime.Tests
@@ -20,8 +21,10 @@ namespace Microsoft.Diagnostics.Runtime.Tests
 
             using (ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime())
             {
-                library = runtime.DacLibrary.OwningLibrary;
-                sosDac = runtime.DacLibrary.SOSDacInterface;
+                ClrRuntimeHelpers runtimeHelpers = (ClrRuntimeHelpers)runtime.DacLibrary;
+
+                library = runtimeHelpers.Library.OwningLibrary;
+                sosDac = runtimeHelpers.SOSDacInterface;
 
                 // Keep library alive
                 library.AddRef();

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/ThreadReaderTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/ThreadReaderTests.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.Diagnostics.Runtime.DacInterface;
 using Microsoft.Diagnostics.Runtime.DataReaders.Implementation;
+using Microsoft.Diagnostics.Runtime.Implementation;
 using System.Collections.Generic;
 using System.Linq;
 using Xunit;
@@ -17,7 +18,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             using DataTarget dt = TestTargets.AppDomains.LoadFullDumpWithDbgEng();
             IThreadReader threadReader = (IThreadReader)dt.DataReader;
             using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
-            using SOSDac dac = runtime.DacLibrary.SOSDacInterface;
+            using SOSDac dac = ((ClrRuntimeHelpers)runtime.DacLibrary).SOSDacInterface;
 
             foreach (ClrThread thread in runtime.Threads)
             {

--- a/src/Microsoft.Diagnostics.Runtime/ClrFlavor.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrFlavor.cs
@@ -16,6 +16,12 @@ namespace Microsoft.Diagnostics.Runtime
         /// <summary>
         /// For .NET Core
         /// </summary>
-        Core = 3
+        Core = 3,
+
+        /// <summary>
+        /// NativeAOT.
+        /// This is not supported by ClrMD, but reserve the enum value here.
+        /// </summary>
+        NativeAOT,
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/ClrInfo.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrInfo.cs
@@ -415,7 +415,7 @@ namespace Microsoft.Diagnostics.Runtime
         /// </summary>
         /// <param name="dacLibrary">A fully constructed DacLibrary to use.</param>
         /// <returns>The runtime associated with this CLR.</returns>
-        public ClrRuntime CreateRuntime(DacLibrary dacLibrary)
+        internal ClrRuntime CreateRuntime(DacLibrary dacLibrary)
         {
             if (IntPtr.Size != DataTarget.DataReader.PointerSize)
                 throw new InvalidOperationException("Mismatched pointer size between this process and the dac.");

--- a/src/Microsoft.Diagnostics.Runtime/ClrInfo.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrInfo.cs
@@ -2,13 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
-using System.Linq;
-using System.Runtime.InteropServices;
+using Microsoft.Diagnostics.Runtime.AbstractDac;
 using Microsoft.Diagnostics.Runtime.Interfaces;
-using Microsoft.Diagnostics.Runtime.Utilities;
 
 namespace Microsoft.Diagnostics.Runtime
 {
@@ -17,342 +14,23 @@ namespace Microsoft.Diagnostics.Runtime
     /// </summary>
     public sealed class ClrInfo : IClrInfo
     {
-        private const string c_desktopModuleName = "clr.dll";
-        private const string c_coreModuleName = "coreclr.dll";
-        private const string c_linuxCoreModuleName = "libcoreclr.so";
-        private const string c_macOSCoreModuleName = "libcoreclr.dylib";
-
-        private const string c_desktopDacFileNameBase = "mscordacwks";
-        private const string c_coreDacFileNameBase = "mscordaccore";
-        private const string c_desktopDacFileName = c_desktopDacFileNameBase + ".dll";
-        private const string c_coreDacFileName = c_coreDacFileNameBase + ".dll";
-        private const string c_linuxCoreDacFileName = "libmscordaccore.so";
-        private const string c_macOSCoreDacFileName = "libmscordaccore.dylib";
-
-        private const string c_windowsDbiFileName = "mscordbi.dll";
-        private const string c_linuxCoreDbiFileName = "libmscordbi.so";
-        private const string c_macOSCoreDbiFileName = "libmscordbi.dylib";
-
-
-        internal ClrInfo(DataTarget dt, ClrFlavor flavor, ModuleInfo module, ulong runtimeInfo)
+        internal ClrInfo(DataTarget dt, ModuleInfo module, Version clrVersion, IClrInfoProvider provider)
         {
             DataTarget = dt ?? throw new ArgumentNullException(nameof(dt));
-            Flavor = flavor;
             ModuleInfo = module ?? throw new ArgumentNullException(nameof(module));
-            IsSingleFile = runtimeInfo != 0;
-
-            List<DebugLibraryInfo> artifacts = new(8);
-
-            OSPlatform currentPlatform = GetCurrentPlatform();
-            OSPlatform targetPlatform = dt.DataReader.TargetPlatform;
-            Architecture currentArch = RuntimeInformation.ProcessArchitecture;
-            Architecture targetArch = dt.DataReader.Architecture;
-
-            string? dacCurrentPlatform = GetDacFileName(flavor, currentPlatform);
-            string? dacTargetPlatform = GetDacFileName(flavor, targetPlatform);
-            string? dbiCurrentPlatform = GetDbiFileName(flavor, currentPlatform);
-            string? dbiTargetPlatform = GetDbiFileName(flavor, targetPlatform);
-            if (IsSingleFile)
-            {
-                if (ClrRuntimeInfo.TryReadClrRuntimeInfo(DataTarget.DataReader, runtimeInfo, out ClrRuntimeInfo info, out Version version))
-                {
-                    if (dt.DataReader.TargetPlatform == OSPlatform.Windows)
-                    {
-                        IndexTimeStamp = info.RuntimePEProperties.TimeStamp;
-                        IndexFileSize = info.RuntimePEProperties.FileSize;
-
-                        if (dacTargetPlatform is not null)
-                        {
-                            (int timeStamp, int fileSize) = info.DacPEProperties;
-                            if (timeStamp != 0 && fileSize != 0)
-                                artifacts.Add(new DebugLibraryInfo(DebugLibraryKind.Dac, dacTargetPlatform, targetArch, SymbolProperties.Self, fileSize, timeStamp));
-                        }
-
-                        if (dbiTargetPlatform is not null)
-                        {
-                            (int timeStamp, int fileSize) = info.DbiPEProperties;
-                            if (timeStamp != 0 && fileSize != 0)
-                                artifacts.Add(new DebugLibraryInfo(DebugLibraryKind.Dbi, dbiTargetPlatform, targetArch, SymbolProperties.Self, fileSize, timeStamp));
-                        }
-                    }
-                    else
-                    {
-                        BuildId = info.RuntimeBuildId;
-
-                        if (dacTargetPlatform is not null)
-                        {
-                            ImmutableArray<byte> dacBuild = info.DacBuildId;
-                            if (!dacBuild.IsDefaultOrEmpty)
-                                artifacts.Add(new DebugLibraryInfo(DebugLibraryKind.Dac, dacTargetPlatform, targetArch, targetPlatform, SymbolProperties.Self, dacBuild));
-                        }
-
-                        if (dbiTargetPlatform is not null)
-                        {
-                            ImmutableArray<byte> dbiBuild = info.DbiBuildId;
-                            if (!dbiBuild.IsDefaultOrEmpty)
-                                artifacts.Add(new DebugLibraryInfo(DebugLibraryKind.Dbi, dbiTargetPlatform, targetArch, targetPlatform, SymbolProperties.Self, dbiBuild));
-                        }
-                    }
-                }
-                Version = version;
-            }
-            else
-            {
-                IndexTimeStamp = module.IndexTimeStamp;
-                IndexFileSize = module.IndexFileSize;
-                BuildId = module.BuildId;
-                Version = module.Version;
-            }
-
-            // Long-name dac
-            if (dt.DataReader.TargetPlatform == OSPlatform.Windows && Version.Major != 0)
-                artifacts.Add(new DebugLibraryInfo(DebugLibraryKind.Dac, GetWindowsLongNameDac(flavor, currentArch, targetArch, Version), currentArch, SymbolProperties.Coreclr, IndexFileSize, IndexTimeStamp));
-
-            // Short-name dac under CLR's properties
-            if (targetPlatform == currentPlatform)
-            {
-                // We are debugging the process on the same operating system.
-                if (dacCurrentPlatform is not null)
-                {
-                    bool foundLocalDac = false;
-
-                    // Check if the user has the same CLR installed locally, and if so
-                    string? directory = Path.GetDirectoryName(module.FileName);
-                    if (!string.IsNullOrWhiteSpace(directory))
-                    {
-                        string potentialClr = Path.Combine(directory, Path.GetFileName(module.FileName));
-                        if (File.Exists(potentialClr))
-                        {
-                            try
-                            {
-                                using PEImage peimage = new(File.OpenRead(potentialClr));
-                                if (peimage.IndexFileSize == IndexFileSize && peimage.IndexTimeStamp == IndexTimeStamp)
-                                {
-                                    string dacFound = Path.Combine(directory, dacCurrentPlatform);
-                                    if (File.Exists(dacFound))
-                                    {
-                                        dacCurrentPlatform = dacFound;
-                                        foundLocalDac = true;
-                                    }
-                                }
-                            }
-                            catch
-                            {
-                            }
-                        }
-                    }
-
-                    if (IndexFileSize != 0 && IndexTimeStamp != 0)
-                    {
-                        DebugLibraryInfo dacLibraryInfo = new(DebugLibraryKind.Dac, dacCurrentPlatform, targetArch, SymbolProperties.Coreclr, IndexFileSize, IndexTimeStamp);
-                        if (foundLocalDac)
-                            artifacts.Insert(0, dacLibraryInfo);
-                        else
-                            artifacts.Add(dacLibraryInfo);
-                    }
-
-                    if (!BuildId.IsDefaultOrEmpty)
-                    {
-                        DebugLibraryInfo dacLibraryInfo = new(DebugLibraryKind.Dac, dacCurrentPlatform, targetArch, targetPlatform, SymbolProperties.Coreclr, BuildId);
-                        if (foundLocalDac)
-                            artifacts.Insert(0, dacLibraryInfo);
-                        else
-                            artifacts.Add(dacLibraryInfo);
-                    }
-                }
-
-                if (dbiCurrentPlatform is not null)
-                {
-                    if (IndexFileSize != 0 && IndexTimeStamp != 0)
-                    {
-                        artifacts.Add(new DebugLibraryInfo(DebugLibraryKind.Dbi, dbiCurrentPlatform, targetArch, SymbolProperties.Coreclr, IndexFileSize, IndexTimeStamp));
-                    }
-
-                    if (!BuildId.IsDefaultOrEmpty)
-                    {
-                        artifacts.Add(new DebugLibraryInfo(DebugLibraryKind.Dbi, dbiCurrentPlatform, targetArch, targetPlatform, SymbolProperties.Coreclr, BuildId));
-                    }
-                }
-            }
-            else
-            {
-                // We are debugging the process on a different operating system.
-                if (IndexFileSize != 0 && IndexTimeStamp != 0)
-                {
-                    // We currently only support cross-os debugging on windows targeting linux or os x runtimes.  So if we have windows properties,
-                    // then we only generate one artifact (the target one).
-                    if (dacTargetPlatform is not null)
-                        artifacts.Add(new DebugLibraryInfo(DebugLibraryKind.Dac, dacTargetPlatform, targetArch, SymbolProperties.Coreclr, IndexFileSize, IndexTimeStamp));
-
-                    if (dbiTargetPlatform is not null)
-                        artifacts.Add(new DebugLibraryInfo(DebugLibraryKind.Dbi, dbiTargetPlatform, targetArch, SymbolProperties.Coreclr, IndexFileSize, IndexTimeStamp));
-                }
-
-                if (!BuildId.IsDefaultOrEmpty)
-                {
-                    if (dacTargetPlatform is not null)
-                        artifacts.Add(new DebugLibraryInfo(DebugLibraryKind.Dac, dacTargetPlatform, targetArch, targetPlatform, SymbolProperties.Coreclr, BuildId));
-
-                    if (dbiTargetPlatform is not null)
-                        artifacts.Add(new DebugLibraryInfo(DebugLibraryKind.Dbi, dbiTargetPlatform, targetArch, targetPlatform, SymbolProperties.Coreclr, BuildId));
-
-                    if (currentPlatform == OSPlatform.Windows)
-                    {
-                        // If we are running from Windows, we can target Linux and OS X dumps. We do build cross-os, cross-architecture debug libraries to run on Windows x64 or x86
-                        if (dacCurrentPlatform is not null)
-                            artifacts.Add(new DebugLibraryInfo(DebugLibraryKind.Dac, dacCurrentPlatform, currentArch, currentPlatform, SymbolProperties.Coreclr, BuildId));
-
-                        if (dbiCurrentPlatform is not null)
-                            artifacts.Add(new DebugLibraryInfo(DebugLibraryKind.Dbi, dbiCurrentPlatform, currentArch, currentPlatform, SymbolProperties.Coreclr, BuildId));
-                    }
-                }
-            }
-
-            // Windows CLRDEBUGINFO resource
-            IResourceNode? resourceNode = module.ResourceRoot?.GetChild("RCData")?.GetChild("CLRDEBUGINFO")?.Children.FirstOrDefault();
-            if (resourceNode is not null)
-            {
-                CLR_DEBUG_RESOURCE resource = resourceNode.Read<CLR_DEBUG_RESOURCE>(0);
-                if (resource.dwVersion == 0)
-                {
-                    if (dacTargetPlatform is not null && resource.dwDacTimeStamp != 0 && resource.dwDacSizeOfImage != 0)
-                        artifacts.Add(new DebugLibraryInfo(DebugLibraryKind.Dac, dacTargetPlatform, targetArch, SymbolProperties.Self, resource.dwDacSizeOfImage, resource.dwDacTimeStamp));
-
-                    if (dbiTargetPlatform is not null && resource.dwDbiTimeStamp != 0 && resource.dwDbiSizeOfImage != 0)
-                        artifacts.Add(new DebugLibraryInfo(DebugLibraryKind.Dbi, dbiTargetPlatform, targetArch, SymbolProperties.Self, resource.dwDbiSizeOfImage, resource.dwDbiTimeStamp));
-                }
-            }
-
-            // Do NOT take a dependency on the order of enumerated libraries.  I reserve the right to change this at any time.
-            IOrderedEnumerable<DebugLibraryInfo> ordered = from artifact in EnumerateUnique(artifacts)
-                                                           orderby artifact.Kind,
-                                                                   Path.GetFileName(artifact.FileName) == artifact.FileName, // if we have a full local path, put it first
-                                                                   artifact.ArchivedUnder
-                                                           select artifact;
-
-            DebuggingLibraries = ordered.ToImmutableArray();
+            ClrInfoProvider = provider ?? throw new ArgumentNullException(nameof(provider));
+            Version = clrVersion ?? throw new ArgumentNullException(nameof(clrVersion));
         }
 
-        private static IEnumerable<DebugLibraryInfo> EnumerateUnique(List<DebugLibraryInfo> artifacts)
-        {
-            HashSet<DebugLibraryInfo> seen = new();
-
-            foreach (DebugLibraryInfo library in artifacts)
-                if (seen.Add(library))
-                    yield return library;
-        }
-
-        private static string GetWindowsLongNameDac(ClrFlavor flavor, Architecture currentArchitecture, Architecture targetArchitecture, Version version)
-        {
-            string dacNameBase = flavor == ClrFlavor.Core ? c_coreDacFileNameBase : c_desktopDacFileNameBase;
-            return $"{dacNameBase}_{ArchitectureToName(currentArchitecture)}_{ArchitectureToName(targetArchitecture)}_{version.Major}.{version.Minor}.{version.Build}.{version.Revision:D2}.dll".ToLowerInvariant();
-        }
-
-        private static string ArchitectureToName(Architecture arch)
-        {
-            return arch switch
-            {
-                Architecture.X64 => "amd64",
-                _ => arch.ToString()
-            };
-        }
-
-        internal static ClrInfo? TryCreate(DataTarget dataTarget, ModuleInfo module)
-        {
-            if (dataTarget is null)
-                throw new ArgumentNullException(nameof(dataTarget));
-
-            if (module is null)
-                throw new ArgumentNullException(nameof(module));
-
-            if (IsSupportedRuntime(module, out ClrFlavor flavor))
-                return new ClrInfo(dataTarget, flavor, module, 0);
-
-            if ((dataTarget.DataReader.TargetPlatform != OSPlatform.Windows) || Path.GetExtension(module.FileName).Equals(".exe", StringComparison.OrdinalIgnoreCase))
-            {
-                ulong singleFileRuntimeInfo = module.GetExportSymbolAddress(ClrRuntimeInfo.SymbolValue);
-                if (singleFileRuntimeInfo != 0)
-                    return new ClrInfo(dataTarget, ClrFlavor.Core, module, singleFileRuntimeInfo);
-            }
-
-            return null;
-        }
-
-        private static string? GetDbiFileName(ClrFlavor flavor, OSPlatform targetPlatform)
-        {
-            if (flavor == ClrFlavor.Core)
-            {
-                if (targetPlatform == OSPlatform.Windows)
-                    return c_windowsDbiFileName;
-                else if (targetPlatform == OSPlatform.Linux)
-                    return c_linuxCoreDbiFileName;
-                else if (targetPlatform == OSPlatform.OSX)
-                    return c_macOSCoreDbiFileName;
-            }
-
-            if (flavor == ClrFlavor.Desktop)
-            {
-                if (targetPlatform == OSPlatform.Windows)
-                    return c_windowsDbiFileName;
-            }
-
-            return null;
-        }
-
-        private static string? GetDacFileName(ClrFlavor flavor, OSPlatform targetPlatform)
-        {
-            if (flavor == ClrFlavor.Core)
-            {
-                if (targetPlatform == OSPlatform.Windows)
-                    return c_coreDacFileName;
-                else if (targetPlatform == OSPlatform.Linux)
-                    return c_linuxCoreDacFileName;
-                else if (targetPlatform == OSPlatform.OSX)
-                    return c_macOSCoreDacFileName;
-            }
-
-            if (flavor == ClrFlavor.Desktop)
-            {
-                if (targetPlatform == OSPlatform.Windows)
-                    return c_desktopDacFileName;
-            }
-
-            return null;
-        }
-
-        private static bool IsSupportedRuntime(ModuleInfo module, out ClrFlavor flavor)
-        {
-            flavor = default;
-
-            string moduleName = Path.GetFileName(module.FileName);
-            if (moduleName.Equals(c_desktopModuleName, StringComparison.OrdinalIgnoreCase))
-            {
-                flavor = ClrFlavor.Desktop;
-                return true;
-            }
-
-            if (moduleName.Equals(c_coreModuleName, StringComparison.OrdinalIgnoreCase))
-            {
-                flavor = ClrFlavor.Core;
-                return true;
-            }
-
-            if (moduleName.Equals(c_macOSCoreModuleName, StringComparison.OrdinalIgnoreCase))
-            {
-                flavor = ClrFlavor.Core;
-                return true;
-            }
-
-            if (moduleName.Equals(c_linuxCoreModuleName, StringComparison.Ordinal))
-            {
-                flavor = ClrFlavor.Core;
-                return true;
-            }
-
-            return false;
-        }
-
+        /// <summary>
+        /// The DataTarget containing this ClrInfo.
+        /// </summary>
         public DataTarget DataTarget { get; }
+
+        /// <summary>
+        /// The IClrInfoProvider which created this ClrInfo.
+        /// </summary>
+        internal IClrInfoProvider ClrInfoProvider { get; }
 
         IDataTarget IClrInfo.DataTarget => DataTarget;
 
@@ -364,18 +42,18 @@ namespace Microsoft.Diagnostics.Runtime
         /// <summary>
         /// Returns whether this CLR was built as a single file executable.
         /// </summary>
-        public bool IsSingleFile { get; }
+        public bool IsSingleFile { get; set; }
 
         /// <summary>
         /// Gets the type of CLR this module represents.
         /// </summary>
-        public ClrFlavor Flavor { get; }
+        public ClrFlavor Flavor { get; set; }
 
         /// <summary>
         /// A list of debugging libraries associated associated with this .Net runtime.
         /// This can contain both the dac (used by ClrMD) and the DBI (not used by ClrMD).
         /// </summary>
-        public ImmutableArray<DebugLibraryInfo> DebuggingLibraries { get; }
+        public ImmutableArray<DebugLibraryInfo> DebuggingLibraries { get; set; }
 
         /// <summary>
         /// Gets module information about the ClrInstance.
@@ -388,7 +66,7 @@ namespace Microsoft.Diagnostics.Runtime
         /// In a single-file scenario, the ModuleInfo will be the info of the program's main executable
         /// and not CLR's properties.
         /// </summary>
-        public int IndexTimeStamp { get; }
+        public int IndexTimeStamp { get; set; }
 
         /// <summary>
         /// The filesize under which this CLR is is archived (0 if this module is indexed under
@@ -396,13 +74,13 @@ namespace Microsoft.Diagnostics.Runtime
         /// In a single-file scenario, the ModuleInfo will be the info of the program's main executable
         /// and not CLR's properties.
         /// </summary>
-        public int IndexFileSize { get; }
+        public int IndexFileSize { get; set; }
 
         /// <summary>
         /// The BuildId under which this CLR is archived.  BuildId.IsEmptyOrDefault will be true if
         /// this runtime is archived under file/timesize instead.
         /// </summary>
-        public ImmutableArray<byte> BuildId { get; } = ImmutableArray<byte>.Empty;
+        public ImmutableArray<byte> BuildId { get; set; } = ImmutableArray<byte>.Empty;
 
         /// <summary>
         /// To string.
@@ -411,25 +89,21 @@ namespace Microsoft.Diagnostics.Runtime
         public override string ToString() => Version.ToString();
 
         /// <summary>
-        /// Creates a runtime from the DacLibrary.
-        /// </summary>
-        /// <param name="dacLibrary">A fully constructed DacLibrary to use.</param>
-        /// <returns>The runtime associated with this CLR.</returns>
-        internal ClrRuntime CreateRuntime(DacLibrary dacLibrary)
-        {
-            if (IntPtr.Size != DataTarget.DataReader.PointerSize)
-                throw new InvalidOperationException("Mismatched pointer size between this process and the dac.");
-
-            return new ClrRuntime(this, dacLibrary);
-        }
-
-        /// <summary>
         /// Creates a runtime from the given DAC file on disk.  This is equivalent to
         /// CreateRuntime(dacPath, ignoreMismatch: false).
         /// </summary>
         /// <param name="dacPath">A full path to the matching DAC dll for this process.</param>
         /// <returns>The runtime associated with this CLR.</returns>
-        public ClrRuntime CreateRuntime(string dacPath) => CreateRuntime(dacPath, ignoreMismatch: false);
+        public ClrRuntime CreateRuntime(string dacPath)
+        {
+            if (string.IsNullOrEmpty(dacPath))
+                throw new ArgumentNullException(nameof(dacPath));
+
+            if (!File.Exists(dacPath))
+                throw new FileNotFoundException(dacPath);
+
+            return CreateRuntimeWorker(dacPath, ignoreMismatch: false);
+        }
 
         /// <summary>
         /// Creates a runtime from the given DAC file on disk.
@@ -445,127 +119,25 @@ namespace Microsoft.Diagnostics.Runtime
             if (!File.Exists(dacPath))
                 throw new FileNotFoundException(dacPath);
 
-            if (!ignoreMismatch && !IsSingleFile)
-            {
-                DataTarget.PlatformFunctions.GetFileVersion(dacPath, out int major, out int minor, out int revision, out int patch);
-                if (major != Version.Major || minor != Version.Minor || revision != Version.Build || patch != Version.Revision)
-                    throw new ClrDiagnosticsException($"Mismatched dac. Dac version: {major}.{minor}.{revision}.{patch}, expected: {Version}.");
-            }
-
-            DacLibrary dacLibrary = new(DataTarget, dacPath, ModuleInfo.ImageBase);
-            return CreateRuntime(dacLibrary);
+            return CreateRuntimeWorker(dacPath, ignoreMismatch);
         }
 
         /// <summary>
         /// Creates a runtime by searching for the correct dac to load.
         /// </summary>
         /// <returns>The runtime associated with this CLR.</returns>
-        public ClrRuntime CreateRuntime()
+        public ClrRuntime CreateRuntime() => CreateRuntimeWorker(null, ignoreMismatch: false);
+
+        private ClrRuntime CreateRuntimeWorker(string? dacPath, bool ignoreMismatch)
         {
-            if (IntPtr.Size != DataTarget.DataReader.PointerSize)
-                throw new InvalidOperationException("Mismatched pointer size between this process and the dac.");
-
-            OSPlatform currentPlatform = GetCurrentPlatform();
-            Architecture currentArch = RuntimeInformation.ProcessArchitecture;
-
-            string? dacPath = null;
-            bool foundOne = false;
-            Exception? exception = null;
-
-            IFileLocator? locator = DataTarget.FileLocator;
-
-            foreach (DebugLibraryInfo dac in DebuggingLibraries.Where(r => r.Kind == DebugLibraryKind.Dac && r.Platform == currentPlatform && r.TargetArchitecture == currentArch))
-            {
-                foundOne = true;
-
-                // If we have a full path, use it.  We already validated that the CLR matches.
-                if (Path.GetFileName(dac.FileName) != dac.FileName)
-                {
-                    dacPath = dac.FileName;
-                }
-                else
-                {
-                    // The properties we are requesting under may not be the actual file properties, so don't request them.
-
-                    if (locator != null)
-                    {
-                        if (!dac.IndexBuildId.IsDefaultOrEmpty)
-                        {
-                            if (dac.Platform == OSPlatform.Windows)
-                                dacPath = locator.FindPEImage(dac.FileName, SymbolProperties.Coreclr, dac.IndexBuildId, DataTarget.DataReader.TargetPlatform, checkProperties: false);
-                            else if (dac.Platform == OSPlatform.Linux)
-                                dacPath = locator.FindElfImage(dac.FileName, SymbolProperties.Coreclr, dac.IndexBuildId, checkProperties: false);
-                            else if (dac.Platform == OSPlatform.OSX)
-                                dacPath = locator.FindMachOImage(dac.FileName, SymbolProperties.Coreclr, dac.IndexBuildId, checkProperties: false);
-                        }
-                        else if (dac.IndexTimeStamp != 0 && dac.IndexFileSize != 0)
-                        {
-                            if (dac.Platform == OSPlatform.Windows)
-                                dacPath = DataTarget.FileLocator?.FindPEImage(dac.FileName, dac.IndexTimeStamp, dac.IndexFileSize, checkProperties: false);
-                        }
-                    }
-                }
-
-                if (dacPath is not null && File.Exists(dacPath))
-                {
-                    try
-                    {
-                        return CreateRuntime(dacPath, ignoreMismatch: true);
-                    }
-                    catch (Exception ex)
-                    {
-                        exception ??= ex;
-                        dacPath = null;
-                    }
-                }
-            }
-
-            if (exception is not null)
-                throw exception;
-
-            // We should have had at least one dac enumerated if this is a supported scenario.
-            if (!foundOne)
-                ThrowCrossDebugError(currentPlatform);
-
-            throw new FileNotFoundException("Could not find matching DAC for this runtime.");
+            IClrRuntimeHelpers helpers = ClrInfoProvider.CreateRuntimeHelpers(this, dacPath, ignoreMismatch);
+            return new ClrRuntime(this, helpers);
         }
 
         IClrRuntime IClrInfo.CreateRuntime() => CreateRuntime();
 
-        IClrRuntime IClrInfo.CreateRuntime(DacLibrary dacLibrary) => CreateRuntime(dacLibrary);
-
         IClrRuntime IClrInfo.CreateRuntime(string dacPath) => CreateRuntime(dacPath);
 
         IClrRuntime IClrInfo.CreateRuntime(string dacPath, bool ignoreMismatch) => CreateRuntime(dacPath, ignoreMismatch);
-
-        private static OSPlatform GetCurrentPlatform()
-        {
-            OSPlatform currentPlatform;
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                currentPlatform = OSPlatform.Windows;
-            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-                currentPlatform = OSPlatform.Linux;
-            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-                currentPlatform = OSPlatform.OSX;
-            else
-                throw new PlatformNotSupportedException();
-            return currentPlatform;
-        }
-
-        private void ThrowCrossDebugError(OSPlatform current)
-        {
-            throw new InvalidOperationException($"Debugging a '{DataTarget.DataReader.TargetPlatform}' crash is not supported on '{current}'.");
-        }
-
-        [StructLayout(LayoutKind.Sequential, Pack = 1)]
-        private struct CLR_DEBUG_RESOURCE
-        {
-            public uint dwVersion;
-            public Guid signature;
-            public int dwDacTimeStamp;
-            public int dwDacSizeOfImage;
-            public int dwDbiTimeStamp;
-            public int dwDbiSizeOfImage;
-        }
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/ClrRuntime.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrRuntime.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Diagnostics.Runtime
         /// <summary>
         /// Used for internal purposes.
         /// </summary>
-        public DacLibrary DacLibrary { get; }
+        internal DacLibrary DacLibrary { get; }
 
         /// <summary>
         /// Gets the <see cref="ClrInfo"/> of the current runtime.

--- a/src/Microsoft.Diagnostics.Runtime/ClrRuntime.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrRuntime.cs
@@ -9,7 +9,6 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using Microsoft.Diagnostics.Runtime.AbstractDac;
-using Microsoft.Diagnostics.Runtime.Implementation;
 using Microsoft.Diagnostics.Runtime.Interfaces;
 
 namespace Microsoft.Diagnostics.Runtime
@@ -20,31 +19,18 @@ namespace Microsoft.Diagnostics.Runtime
     /// </summary>
     public sealed class ClrRuntime : IClrRuntime
     {
-        private readonly IClrRuntimeHelpers _helpers;
         private volatile ClrHeap? _heap;
         private ImmutableArray<ClrThread> _threads;
         private volatile DomainAndModules? _domainAndModules;
 
-        internal ClrRuntime(ClrInfo clrInfo, DacLibrary library)
+        internal ClrRuntime(ClrInfo clrInfo, IClrRuntimeHelpers dac)
         {
             ClrInfo = clrInfo;
             DataTarget = clrInfo.DataTarget;
-            DacLibrary = library;
-            _helpers = new ClrRuntimeHelpers(clrInfo, DacLibrary, DataTarget.CacheOptions);
+            DacLibrary = dac;
         }
 
-        internal ClrRuntime(ClrInfo clrInfo, DacLibrary library, IClrRuntimeHelpers helpers)
-        {
-            ClrInfo = clrInfo;
-            DataTarget = clrInfo.DataTarget;
-            DacLibrary = library;
-            _helpers = helpers;
-        }
-
-        /// <summary>
-        /// Used for internal purposes.
-        /// </summary>
-        internal DacLibrary DacLibrary { get; }
+        internal IClrRuntimeHelpers DacLibrary { get; }
 
         /// <summary>
         /// Gets the <see cref="ClrInfo"/> of the current runtime.
@@ -87,7 +73,7 @@ namespace Microsoft.Diagnostics.Runtime
         {
             get
             {
-                IClrThreadPoolHelpers? helper = _helpers.LegacyThreadPoolHelpers;
+                IClrThreadPoolHelpers? helper = DacLibrary.LegacyThreadPoolHelpers;
                 ClrThreadPool result = new(this, helper);
                 return result.Initialized ? result : null;
             }
@@ -107,9 +93,9 @@ namespace Microsoft.Diagnostics.Runtime
                 ImmutableArray<ClrThread>.Builder builder = ImmutableArray.CreateBuilder<ClrThread>();
 
                 int max = 20000;
-                foreach (ClrThreadInfo data in _helpers.EnumerateThreads())
+                foreach (ClrThreadInfo data in DacLibrary.EnumerateThreads())
                 {
-                    builder.Add(new ClrThread(DataTarget.DataReader, this, _helpers.ThreadHelpers, data));
+                    builder.Add(new ClrThread(DataTarget.DataReader, this, DacLibrary.ThreadHelpers, data));
 
                     if (max-- == 0)
                         break;
@@ -140,7 +126,7 @@ namespace Microsoft.Diagnostics.Runtime
             if (methodHandle == 0)
                 return null;
 
-            ulong mt = _helpers.GetMethodHandleContainingType(methodHandle);
+            ulong mt = DacLibrary.GetMethodHandleContainingType(methodHandle);
             if (mt == 0)
                 return null;
 
@@ -163,7 +149,7 @@ namespace Microsoft.Diagnostics.Runtime
         /// depending on the state of the process when we attempt to walk the handle table.
         /// </summary>
         /// <returns>An enumeration of GC handles in the process.</returns>
-        public IEnumerable<ClrHandle> EnumerateHandles() => _helpers.EnumerateHandles().Select(r => new ClrHandle(this, r));
+        public IEnumerable<ClrHandle> EnumerateHandles() => DacLibrary.EnumerateHandles().Select(r => new ClrHandle(this, r));
 
         /// <summary>
         /// Gets the GC heap of the process.
@@ -175,11 +161,11 @@ namespace Microsoft.Diagnostics.Runtime
                 ClrHeap? heap = _heap;
                 while (heap is null) // Flush can cause a race.
                 {
-                    IClrHeapHelpers heapHelpers = _helpers.GetHeapHelpers();
-                    IClrTypeHelpers typeHelpers = _helpers.GetClrTypeHelpers();
+                    IClrHeapHelpers heapHelpers = DacLibrary.GetHeapHelpers();
+                    IClrTypeHelpers typeHelpers = DacLibrary.GetClrTypeHelpers();
 
                     // These are defined as non-nullable but just in case, double check we have a non-null instance.
-                    if (heapHelpers is null || typeHelpers is null || !_helpers.GetGCState(out GCState gcInfo))
+                    if (heapHelpers is null || typeHelpers is null || !DacLibrary.GetGCState(out GCState gcInfo))
                         throw new NotSupportedException("Unable to create a ClrHeap for this runtime.");
 
                     heap = new(this, DataTarget.DataReader, heapHelpers, typeHelpers, gcInfo);
@@ -215,7 +201,7 @@ namespace Microsoft.Diagnostics.Runtime
         /// </summary>
         public ClrMethod? GetMethodByInstructionPointer(ulong ip)
         {
-            ulong md = _helpers.GetMethodHandleByInstructionPointer(ip);
+            ulong md = DacLibrary.GetMethodHandleByInstructionPointer(ip);
             return GetMethodByHandle(md);
         }
 
@@ -284,28 +270,28 @@ namespace Microsoft.Diagnostics.Runtime
                 }
             }
 
-            foreach (ClrNativeHeapInfo gcFreeRegion in _helpers.EnumerateGCFreeRegions())
+            foreach (ClrNativeHeapInfo gcFreeRegion in DacLibrary.EnumerateGCFreeRegions())
             {
                 yield return gcFreeRegion;
             }
 
-            foreach (ClrNativeHeapInfo handleHeap in _helpers.EnumerateHandleTableRegions())
+            foreach (ClrNativeHeapInfo handleHeap in DacLibrary.EnumerateHandleTableRegions())
             {
                 yield return handleHeap;
             }
 
-            foreach (ClrNativeHeapInfo bkRegions in _helpers.EnumerateGCBookkeepingRegions())
+            foreach (ClrNativeHeapInfo bkRegions in DacLibrary.EnumerateGCBookkeepingRegions())
             {
                 yield return bkRegions;
             }
         }
 
-        public IEnumerable<ClrSyncBlockCleanupData> EnumerateSyncBlockCleanupData() => _helpers.EnumerateSyncBlockCleanupData();
-        public IEnumerable<ClrRcwCleanupData> EnumerateRcwCleanupData() => _helpers.EnumerateRcwCleanupData();
+        public IEnumerable<ClrSyncBlockCleanupData> EnumerateSyncBlockCleanupData() => DacLibrary.EnumerateSyncBlockCleanupData();
+        public IEnumerable<ClrRcwCleanupData> EnumerateRcwCleanupData() => DacLibrary.EnumerateRcwCleanupData();
 
         internal RuntimeCallableWrapper? CreateRCWForObject(ulong obj)
         {
-            if (_helpers.GetRcwInfo(obj, out RcwInfo info))
+            if (DacLibrary.GetRcwInfo(obj, out RcwInfo info))
                 return new(this, info);
 
             return null;
@@ -313,7 +299,7 @@ namespace Microsoft.Diagnostics.Runtime
 
         internal ComCallableWrapper? CreateCCWForObject(ulong obj)
         {
-            if (_helpers.GetCcwInfo(obj, out CcwInfo info))
+            if (DacLibrary.GetCcwInfo(obj, out CcwInfo info))
                 return new(this, info);
 
             return null;
@@ -325,7 +311,7 @@ namespace Microsoft.Diagnostics.Runtime
         /// <returns>An enumeration of heaps.</returns>
         public IEnumerable<ClrJitManager> EnumerateJitManagers()
         {
-            return _helpers.EnumerateClrJitManagers().Select(info => new ClrJitManager(this, info, _helpers.NativeHeapHelpers));
+            return DacLibrary.EnumerateClrJitManagers().Select(info => new ClrJitManager(this, info, DacLibrary.NativeHeapHelpers));
         }
 
         /// <summary>
@@ -341,7 +327,7 @@ namespace Microsoft.Diagnostics.Runtime
             _domainAndModules = null;
             _threads = default;
             _heap = null;
-            _helpers.Flush();
+            DacLibrary.Flush();
         }
 
         /// <summary>
@@ -349,7 +335,7 @@ namespace Microsoft.Diagnostics.Runtime
         /// </summary>
         /// <param name="address">Address of a possible JIT helper function.</param>
         /// <returns>The name of the JIT helper function or <see langword="null"/> if <paramref name="address"/> isn't a JIT helper function.</returns>
-        public string? GetJitHelperFunctionName(ulong address) => _helpers.GetJitHelperFunctionName(address);
+        public string? GetJitHelperFunctionName(ulong address) => DacLibrary.GetJitHelperFunctionName(address);
 
         /// <summary>
         /// Cleans up all resources and releases them.  You may not use this ClrRuntime or any object it transitively
@@ -358,7 +344,7 @@ namespace Microsoft.Diagnostics.Runtime
         public void Dispose()
         {
             FlushCachedData();
-            _helpers.Dispose();
+            DacLibrary.Dispose();
         }
 
         private DomainAndModules GetAppDomainData()
@@ -382,9 +368,9 @@ namespace Microsoft.Diagnostics.Runtime
             ClrModule? bcl = null;
 
             ImmutableArray<ClrAppDomain>.Builder builder = ImmutableArray.CreateBuilder<ClrAppDomain>();
-            foreach (AppDomainInfo domainInfo in _helpers.EnumerateAppDomains())
+            foreach (AppDomainInfo domainInfo in DacLibrary.EnumerateAppDomains())
             {
-                ClrAppDomain domain = new(this, domainInfo, _helpers.NativeHeapHelpers);
+                ClrAppDomain domain = new(this, domainInfo, DacLibrary.NativeHeapHelpers);
 
                 switch (domainInfo.Kind)
                 {
@@ -405,12 +391,12 @@ namespace Microsoft.Diagnostics.Runtime
                 }
 
                 ImmutableArray<ClrModule>.Builder moduleBuilder = ImmutableArray.CreateBuilder<ClrModule>();
-                foreach (ulong moduleAddress in _helpers.GetModuleList(domain.Address))
+                foreach (ulong moduleAddress in DacLibrary.GetModuleList(domain.Address))
                 {
                     if (!modules.TryGetValue(moduleAddress, out ClrModule? module))
                     {
-                        ClrModuleInfo moduleInfo = _helpers.GetModuleInfo(moduleAddress);
-                        module = new(domain, moduleInfo, _helpers.ModuleHelpers, _helpers.NativeHeapHelpers, DataTarget.DataReader);
+                        ClrModuleInfo moduleInfo = DacLibrary.GetModuleInfo(moduleAddress);
+                        module = new(domain, moduleInfo, DacLibrary.ModuleHelpers, DacLibrary.NativeHeapHelpers, DataTarget.DataReader);
                         modules.Add(moduleAddress, module);
                     }
 

--- a/src/Microsoft.Diagnostics.Runtime/DacLibrary.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacLibrary.cs
@@ -2,12 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Runtime.InteropServices;
 using Microsoft.Diagnostics.Runtime.DacInterface;
 
 namespace Microsoft.Diagnostics.Runtime
 {
-    public sealed class DacLibrary : IDisposable
+    internal sealed class DacLibrary : IDisposable
     {
         private bool _disposed;
         private SOSDac? _sos;

--- a/src/Microsoft.Diagnostics.Runtime/DacLibrary.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacLibrary.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Runtime.InteropServices;
 using Microsoft.Diagnostics.Runtime.DacInterface;
 
 namespace Microsoft.Diagnostics.Runtime

--- a/src/Microsoft.Diagnostics.Runtime/DataTarget.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DataTarget.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Diagnostics.Runtime
     /// </summary>
     public sealed class DataTarget : IDisposable, IDataTarget
     {
-        private static readonly List<IClrInfoProvider> s_clrInfoProviders = new() { new DotNetClrInfoProvider() };
+        private static readonly List<IClrInfoProvider> s_clrInfoProviders = new() { new DotNetClrInfoProvider(), new SingleFileClrInfoProvider() };
 
         private readonly CustomDataTarget _target;
         private bool _disposed;

--- a/src/Microsoft.Diagnostics.Runtime/DataTarget.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DataTarget.cs
@@ -21,6 +21,8 @@ namespace Microsoft.Diagnostics.Runtime
     /// </summary>
     public sealed class DataTarget : IDisposable, IDataTarget
     {
+        private static readonly List<IClrInfoProvider> s_clrInfoProviders = new() { new DotNetClrInfoProvider() };
+
         private readonly CustomDataTarget _target;
         private bool _disposed;
         private ImmutableArray<ClrInfo> _clrs;
@@ -187,7 +189,8 @@ namespace Microsoft.Diagnostics.Runtime
                 // to debug .Net Core (assuming the user is just debugging one of them)
 
                 IEnumerable<ClrInfo> clrs = from module in EnumerateModules()
-                                            let clrInfo = ClrInfo.TryCreate(this, module)
+                                            let clrInfoEnumerable = s_clrInfoProviders.Select(provider => provider.ProvideClrInfoForModule(this, module))
+                                            let clrInfo = clrInfoEnumerable.LastOrDefault()
                                             where clrInfo != null
                                             orderby clrInfo.Flavor descending, clrInfo.Version
                                             select clrInfo;

--- a/src/Microsoft.Diagnostics.Runtime/IClrInfoProvider.cs
+++ b/src/Microsoft.Diagnostics.Runtime/IClrInfoProvider.cs
@@ -1,0 +1,28 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Diagnostics.Runtime.AbstractDac;
+
+namespace Microsoft.Diagnostics.Runtime
+{
+    internal interface IClrInfoProvider
+    {
+        /// <summary>
+        /// Inspect the given module and if it's a CLR runtime module, provide a ClrInfo for it.
+        /// </summary>
+        /// <param name="dataTarget">The DataTarget for the given module.</param>
+        /// <param name="module">The module to inspect.</param>
+        /// <returns>A ClrInfo if module is a CLR runtime, null otherwise.</returns>
+        ClrInfo? ProvideClrInfoForModule(DataTarget dataTarget, ModuleInfo module);
+
+        /// <summary>
+        /// Creates an instance of <see cref="IClrRuntimeHelpers"/> for the given <see cref="ClrInfo"/>.
+        /// Note that this will only be called on the interface which previously provided the given ClrInfo.
+        /// </summary>
+        /// <param name="clrInfo">A ClrInfo previously returned by this same instance.</param>
+        /// <param name="providedPath">The path provided to DataTarget.CreateRuntime.</param>
+        /// <param name="ignorePathMismatch">The ignore mismatch parameter provided to DataTarget.CreateRuntime.</param>
+        /// <returns>An <see cref="IClrRuntimeHelpers"/> interface to use with the specified clr runtime.</returns>
+        IClrRuntimeHelpers CreateRuntimeHelpers(ClrInfo clrInfo, string? providedPath, bool ignorePathMismatch);
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/Implementation/ClrRuntimeHelpers.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Implementation/ClrRuntimeHelpers.cs
@@ -28,10 +28,14 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
         private readonly SOSDac8? _sos8;
         private readonly SosDac12? _sos12;
         private readonly ISOSDac13? _sos13;
-        private readonly CacheOptions _cacheOptions;
         private IClrNativeHeapHelpers? _nativeHeapHelpers;
 
-        public ClrRuntimeHelpers(ClrInfo clrInfo, DacLibrary library, CacheOptions cacheOptions)
+        // for testing purposes only
+        internal DacLibrary Library => _library;
+        // for testing purposes only
+        internal SOSDac SOSDacInterface => _sos;
+
+        public ClrRuntimeHelpers(ClrInfo clrInfo, DacLibrary library)
         {
             _clrInfo = clrInfo;
             _dataReader = clrInfo.DataTarget.DataReader;
@@ -42,7 +46,6 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
             _sos8 = library.SOSDacInterface8;
             _sos12 = library.SOSDacInterface12;
             _sos13 = library.SOSDacInterface13;
-            _cacheOptions = cacheOptions;
 
             int version = 0;
             if (!_dac.Request(DacRequests.VERSION, ReadOnlySpan<byte>.Empty, new Span<byte>(&version, sizeof(int))))

--- a/src/Microsoft.Diagnostics.Runtime/Implementation/DotNetClrInfoProvider.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Implementation/DotNetClrInfoProvider.cs
@@ -1,0 +1,473 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using Microsoft.Diagnostics.Runtime.AbstractDac;
+using Microsoft.Diagnostics.Runtime.Utilities;
+
+namespace Microsoft.Diagnostics.Runtime.Implementation
+{
+    internal class DotNetClrInfoProvider : IClrInfoProvider
+    {
+        private const string c_desktopModuleName = "clr.dll";
+        private const string c_coreModuleName = "coreclr.dll";
+        private const string c_linuxCoreModuleName = "libcoreclr.so";
+        private const string c_macOSCoreModuleName = "libcoreclr.dylib";
+
+        private const string c_desktopDacFileNameBase = "mscordacwks";
+        private const string c_coreDacFileNameBase = "mscordaccore";
+        private const string c_desktopDacFileName = c_desktopDacFileNameBase + ".dll";
+        private const string c_coreDacFileName = c_coreDacFileNameBase + ".dll";
+        private const string c_linuxCoreDacFileName = "libmscordaccore.so";
+        private const string c_macOSCoreDacFileName = "libmscordaccore.dylib";
+
+        private const string c_windowsDbiFileName = "mscordbi.dll";
+        private const string c_linuxCoreDbiFileName = "libmscordbi.so";
+        private const string c_macOSCoreDbiFileName = "libmscordbi.dylib";
+
+        public IClrRuntimeHelpers CreateRuntimeHelpers(ClrInfo clrInfo, string? providedPath, bool ignoreMismatch)
+        {
+            DacLibrary library = GetDacLibraryFromPath(clrInfo, providedPath, ignoreMismatch);
+            return new ClrRuntimeHelpers(clrInfo, library);
+        }
+
+        private static DacLibrary GetDacLibraryFromPath(ClrInfo clrInfo, string? dacPath, bool ignoreMismatch)
+        {
+            OSPlatform currentPlatform = GetCurrentPlatform();
+            Architecture currentArch = RuntimeInformation.ProcessArchitecture;
+
+            if (dacPath is not null)
+                return CreateDacFromPath(clrInfo, dacPath, ignoreMismatch);
+
+            bool foundOne = false;
+            Exception? exception = null;
+
+            IFileLocator? locator = clrInfo.DataTarget.FileLocator;
+
+            foreach (DebugLibraryInfo dac in clrInfo.DebuggingLibraries.Where(r => r.Kind == DebugLibraryKind.Dac && r.Platform == currentPlatform && r.TargetArchitecture == currentArch))
+            {
+                foundOne = true;
+
+                // If we have a full path, use it.  We already validated that the CLR matches.
+                if (Path.GetFileName(dac.FileName) != dac.FileName)
+                {
+                    dacPath = dac.FileName;
+                }
+                else
+                {
+                    // The properties we are requesting under may not be the actual file properties, so don't request them.
+
+                    if (locator != null)
+                    {
+                        if (!dac.IndexBuildId.IsDefaultOrEmpty)
+                        {
+                            if (dac.Platform == OSPlatform.Windows)
+                                dacPath = locator.FindPEImage(dac.FileName, SymbolProperties.Coreclr, dac.IndexBuildId, clrInfo.DataTarget.DataReader.TargetPlatform, checkProperties: false);
+                            else if (dac.Platform == OSPlatform.Linux)
+                                dacPath = locator.FindElfImage(dac.FileName, SymbolProperties.Coreclr, dac.IndexBuildId, checkProperties: false);
+                            else if (dac.Platform == OSPlatform.OSX)
+                                dacPath = locator.FindMachOImage(dac.FileName, SymbolProperties.Coreclr, dac.IndexBuildId, checkProperties: false);
+                        }
+                        else if (dac.IndexTimeStamp != 0 && dac.IndexFileSize != 0)
+                        {
+                            if (dac.Platform == OSPlatform.Windows)
+                                dacPath = clrInfo.DataTarget.FileLocator?.FindPEImage(dac.FileName, dac.IndexTimeStamp, dac.IndexFileSize, checkProperties: false);
+                        }
+                    }
+                }
+
+                if (dacPath is not null && File.Exists(dacPath))
+                {
+                    try
+                    {
+                        // If we get the file from the symbol server, assume mismatches are expected.  Sometimes we replace dacs on the symbol
+                        // server to fix bugs.  If it's archived under the right path, use it.
+                        return CreateDacFromPath(clrInfo, dacPath, ignoreMismatch: true);
+                    }
+                    catch (Exception ex)
+                    {
+                        exception ??= ex;
+                        dacPath = null;
+                    }
+                }
+            }
+
+            if (exception is not null)
+                throw exception;
+
+            // We should have had at least one dac enumerated if this is a supported scenario.
+            if (!foundOne)
+                throw new InvalidOperationException($"Debugging a '{clrInfo.DataTarget.DataReader.TargetPlatform}' crash is not supported on '{currentPlatform}'.");
+
+            throw new FileNotFoundException("Could not find matching DAC for this runtime.");
+        }
+
+        private static DacLibrary CreateDacFromPath(ClrInfo clrInfo, string dacPath, bool ignoreMismatch)
+        {
+            if (!File.Exists(dacPath))
+                throw new FileNotFoundException(dacPath);
+
+            if (!ignoreMismatch && !clrInfo.IsSingleFile)
+            {
+                DataTarget.PlatformFunctions.GetFileVersion(dacPath, out int major, out int minor, out int revision, out int patch);
+                if (major != clrInfo.Version.Major || minor != clrInfo.Version.Minor || revision != clrInfo.Version.Build || patch != clrInfo.Version.Revision)
+                    throw new ClrDiagnosticsException($"Mismatched dac. Dac version: {major}.{minor}.{revision}.{patch}, expected: {clrInfo.Version}.");
+            }
+
+            return new(clrInfo.DataTarget, dacPath, clrInfo.ModuleInfo.ImageBase);
+        }
+
+        public ClrInfo? ProvideClrInfoForModule(DataTarget dataTarget, ModuleInfo module)
+        {
+            ulong runtimeInfo = 0;
+            bool isSingleFile = false;
+            if (!IsSupportedRuntime(module, out ClrFlavor flavor))
+            {
+                if ((dataTarget.DataReader.TargetPlatform != OSPlatform.Windows) || Path.GetExtension(module.FileName).Equals(".exe", StringComparison.OrdinalIgnoreCase))
+                {
+                    runtimeInfo = module.GetExportSymbolAddress(ClrRuntimeInfo.SymbolValue);
+                    if (runtimeInfo == 0)
+                        return null;
+
+                    flavor = ClrFlavor.Core;
+                    isSingleFile = true;
+                }
+                else
+                {
+                    return null;
+                }
+            }
+
+            Version version;
+            int indexTimeStamp = 0;
+            int indexFileSize = 0;
+            ImmutableArray<byte> buildId = ImmutableArray<byte>.Empty;
+            List<DebugLibraryInfo> artifacts = new(8);
+
+            OSPlatform currentPlatform = GetCurrentPlatform();
+            OSPlatform targetPlatform = dataTarget.DataReader.TargetPlatform;
+            Architecture currentArch = RuntimeInformation.ProcessArchitecture;
+            Architecture targetArch = dataTarget.DataReader.Architecture;
+
+            string? dacCurrentPlatform = GetDacFileName(flavor, currentPlatform);
+            string? dacTargetPlatform = GetDacFileName(flavor, targetPlatform);
+            string? dbiCurrentPlatform = GetDbiFileName(flavor, currentPlatform);
+            string? dbiTargetPlatform = GetDbiFileName(flavor, targetPlatform);
+            if (isSingleFile)
+            {
+                if (ClrRuntimeInfo.TryReadClrRuntimeInfo(dataTarget.DataReader, runtimeInfo, out ClrRuntimeInfo info, out version))
+                {
+                    if (dataTarget.DataReader.TargetPlatform == OSPlatform.Windows)
+                    {
+                        indexTimeStamp = info.RuntimePEProperties.TimeStamp;
+                        indexFileSize = info.RuntimePEProperties.FileSize;
+
+                        if (dacTargetPlatform is not null)
+                        {
+                            (int timeStamp, int fileSize) = info.DacPEProperties;
+                            if (timeStamp != 0 && fileSize != 0)
+                                artifacts.Add(new DebugLibraryInfo(DebugLibraryKind.Dac, dacTargetPlatform, targetArch, SymbolProperties.Self, fileSize, timeStamp));
+                        }
+
+                        if (dbiTargetPlatform is not null)
+                        {
+                            (int timeStamp, int fileSize) = info.DbiPEProperties;
+                            if (timeStamp != 0 && fileSize != 0)
+                                artifacts.Add(new DebugLibraryInfo(DebugLibraryKind.Dbi, dbiTargetPlatform, targetArch, SymbolProperties.Self, fileSize, timeStamp));
+                        }
+                    }
+                    else
+                    {
+                        buildId = info.RuntimeBuildId;
+
+                        if (dacTargetPlatform is not null)
+                        {
+                            ImmutableArray<byte> dacBuild = info.DacBuildId;
+                            if (!dacBuild.IsDefaultOrEmpty)
+                                artifacts.Add(new DebugLibraryInfo(DebugLibraryKind.Dac, dacTargetPlatform, targetArch, targetPlatform, SymbolProperties.Self, dacBuild));
+                        }
+
+                        if (dbiTargetPlatform is not null)
+                        {
+                            ImmutableArray<byte> dbiBuild = info.DbiBuildId;
+                            if (!dbiBuild.IsDefaultOrEmpty)
+                                artifacts.Add(new DebugLibraryInfo(DebugLibraryKind.Dbi, dbiTargetPlatform, targetArch, targetPlatform, SymbolProperties.Self, dbiBuild));
+                        }
+                    }
+                }
+            }
+            else
+            {
+                indexTimeStamp = module.IndexTimeStamp;
+                indexFileSize = module.IndexFileSize;
+                buildId = module.BuildId;
+                version = module.Version;
+            }
+
+            // Long-name dac
+            if (dataTarget.DataReader.TargetPlatform == OSPlatform.Windows && version.Major != 0)
+                artifacts.Add(new DebugLibraryInfo(DebugLibraryKind.Dac, GetWindowsLongNameDac(flavor, currentArch, targetArch, version), currentArch, SymbolProperties.Coreclr, indexFileSize, indexTimeStamp));
+
+            // Short-name dac under CLR's properties
+            if (targetPlatform == currentPlatform)
+            {
+                // We are debugging the process on the same operating system.
+                if (dacCurrentPlatform is not null)
+                {
+                    bool foundLocalDac = false;
+
+                    // Check if the user has the same CLR installed locally, and if so
+                    string? directory = Path.GetDirectoryName(module.FileName);
+                    if (!string.IsNullOrWhiteSpace(directory))
+                    {
+                        string potentialClr = Path.Combine(directory, Path.GetFileName(module.FileName));
+                        if (File.Exists(potentialClr))
+                        {
+                            try
+                            {
+                                using PEImage peimage = new(File.OpenRead(potentialClr));
+                                if (peimage.IndexFileSize == indexFileSize && peimage.IndexTimeStamp == indexTimeStamp)
+                                {
+                                    string dacFound = Path.Combine(directory, dacCurrentPlatform);
+                                    if (File.Exists(dacFound))
+                                    {
+                                        dacCurrentPlatform = dacFound;
+                                        foundLocalDac = true;
+                                    }
+                                }
+                            }
+                            catch
+                            {
+                            }
+                        }
+                    }
+
+                    if (indexFileSize != 0 && indexTimeStamp != 0)
+                    {
+                        DebugLibraryInfo dacLibraryInfo = new(DebugLibraryKind.Dac, dacCurrentPlatform, targetArch, SymbolProperties.Coreclr, indexFileSize, indexTimeStamp);
+                        if (foundLocalDac)
+                            artifacts.Insert(0, dacLibraryInfo);
+                        else
+                            artifacts.Add(dacLibraryInfo);
+                    }
+
+                    if (!buildId.IsDefaultOrEmpty)
+                    {
+                        DebugLibraryInfo dacLibraryInfo = new(DebugLibraryKind.Dac, dacCurrentPlatform, targetArch, targetPlatform, SymbolProperties.Coreclr, buildId);
+                        if (foundLocalDac)
+                            artifacts.Insert(0, dacLibraryInfo);
+                        else
+                            artifacts.Add(dacLibraryInfo);
+                    }
+                }
+
+                if (dbiCurrentPlatform is not null)
+                {
+                    if (indexFileSize != 0 && indexTimeStamp != 0)
+                    {
+                        artifacts.Add(new DebugLibraryInfo(DebugLibraryKind.Dbi, dbiCurrentPlatform, targetArch, SymbolProperties.Coreclr, indexFileSize, indexTimeStamp));
+                    }
+
+                    if (!buildId.IsDefaultOrEmpty)
+                    {
+                        artifacts.Add(new DebugLibraryInfo(DebugLibraryKind.Dbi, dbiCurrentPlatform, targetArch, targetPlatform, SymbolProperties.Coreclr, buildId));
+                    }
+                }
+            }
+            else
+            {
+                // We are debugging the process on a different operating system.
+                if (indexFileSize != 0 && indexTimeStamp != 0)
+                {
+                    // We currently only support cross-os debugging on windows targeting linux or os x runtimes.  So if we have windows properties,
+                    // then we only generate one artifact (the target one).
+                    if (dacTargetPlatform is not null)
+                        artifacts.Add(new DebugLibraryInfo(DebugLibraryKind.Dac, dacTargetPlatform, targetArch, SymbolProperties.Coreclr, indexFileSize, indexTimeStamp));
+
+                    if (dbiTargetPlatform is not null)
+                        artifacts.Add(new DebugLibraryInfo(DebugLibraryKind.Dbi, dbiTargetPlatform, targetArch, SymbolProperties.Coreclr, indexFileSize, indexTimeStamp));
+                }
+
+                if (!buildId.IsDefaultOrEmpty)
+                {
+                    if (dacTargetPlatform is not null)
+                        artifacts.Add(new DebugLibraryInfo(DebugLibraryKind.Dac, dacTargetPlatform, targetArch, targetPlatform, SymbolProperties.Coreclr, buildId));
+
+                    if (dbiTargetPlatform is not null)
+                        artifacts.Add(new DebugLibraryInfo(DebugLibraryKind.Dbi, dbiTargetPlatform, targetArch, targetPlatform, SymbolProperties.Coreclr, buildId));
+
+                    if (currentPlatform == OSPlatform.Windows)
+                    {
+                        // If we are running from Windows, we can target Linux and OS X dumps. We do build cross-os, cross-architecture debug libraries to run on Windows x64 or x86
+                        if (dacCurrentPlatform is not null)
+                            artifacts.Add(new DebugLibraryInfo(DebugLibraryKind.Dac, dacCurrentPlatform, currentArch, currentPlatform, SymbolProperties.Coreclr, buildId));
+
+                        if (dbiCurrentPlatform is not null)
+                            artifacts.Add(new DebugLibraryInfo(DebugLibraryKind.Dbi, dbiCurrentPlatform, currentArch, currentPlatform, SymbolProperties.Coreclr, buildId));
+                    }
+                }
+            }
+
+            // Windows CLRDEBUGINFO resource
+            IResourceNode? resourceNode = module.ResourceRoot?.GetChild("RCData")?.GetChild("CLRDEBUGINFO")?.Children.FirstOrDefault();
+            if (resourceNode is not null)
+            {
+                CLR_DEBUG_RESOURCE resource = resourceNode.Read<CLR_DEBUG_RESOURCE>(0);
+                if (resource.dwVersion == 0)
+                {
+                    if (dacTargetPlatform is not null && resource.dwDacTimeStamp != 0 && resource.dwDacSizeOfImage != 0)
+                        artifacts.Add(new DebugLibraryInfo(DebugLibraryKind.Dac, dacTargetPlatform, targetArch, SymbolProperties.Self, resource.dwDacSizeOfImage, resource.dwDacTimeStamp));
+
+                    if (dbiTargetPlatform is not null && resource.dwDbiTimeStamp != 0 && resource.dwDbiSizeOfImage != 0)
+                        artifacts.Add(new DebugLibraryInfo(DebugLibraryKind.Dbi, dbiTargetPlatform, targetArch, SymbolProperties.Self, resource.dwDbiSizeOfImage, resource.dwDbiTimeStamp));
+                }
+            }
+
+            // Do NOT take a dependency on the order of enumerated libraries.  I reserve the right to change this at any time.
+            IOrderedEnumerable<DebugLibraryInfo> orderedDebugLibraries = from artifact in EnumerateUnique(artifacts)
+                                                                         orderby artifact.Kind,
+                                                                                 Path.GetFileName(artifact.FileName) == artifact.FileName, // if we have a full local path, put it first
+                                                                                 artifact.ArchivedUnder
+                                                                         select artifact;
+
+            ClrInfo result = new(dataTarget, module, version, this)
+            {
+                IsSingleFile = isSingleFile,
+                Flavor = flavor,
+                DebuggingLibraries = orderedDebugLibraries.ToImmutableArray(),
+                IndexFileSize = indexFileSize,
+                IndexTimeStamp = indexTimeStamp,
+                BuildId = buildId,
+            };
+
+            return result;
+        }
+
+        private static IEnumerable<DebugLibraryInfo> EnumerateUnique(List<DebugLibraryInfo> artifacts)
+        {
+            HashSet<DebugLibraryInfo> seen = new();
+
+            foreach (DebugLibraryInfo library in artifacts)
+                if (seen.Add(library))
+                    yield return library;
+        }
+
+        private static string GetWindowsLongNameDac(ClrFlavor flavor, Architecture currentArchitecture, Architecture targetArchitecture, Version version)
+        {
+            string dacNameBase = flavor == ClrFlavor.Core ? c_coreDacFileNameBase : c_desktopDacFileNameBase;
+            return $"{dacNameBase}_{ArchitectureToName(currentArchitecture)}_{ArchitectureToName(targetArchitecture)}_{version.Major}.{version.Minor}.{version.Build}.{version.Revision:D2}.dll".ToLowerInvariant();
+        }
+
+        private static string ArchitectureToName(Architecture arch)
+        {
+            return arch switch
+            {
+                Architecture.X64 => "amd64",
+                _ => arch.ToString()
+            };
+        }
+
+        private static string? GetDbiFileName(ClrFlavor flavor, OSPlatform targetPlatform)
+        {
+            if (flavor == ClrFlavor.Core)
+            {
+                if (targetPlatform == OSPlatform.Windows)
+                    return c_windowsDbiFileName;
+                else if (targetPlatform == OSPlatform.Linux)
+                    return c_linuxCoreDbiFileName;
+                else if (targetPlatform == OSPlatform.OSX)
+                    return c_macOSCoreDbiFileName;
+            }
+
+            if (flavor == ClrFlavor.Desktop)
+            {
+                if (targetPlatform == OSPlatform.Windows)
+                    return c_windowsDbiFileName;
+            }
+
+            return null;
+        }
+
+        private static string? GetDacFileName(ClrFlavor flavor, OSPlatform targetPlatform)
+        {
+            if (flavor == ClrFlavor.Core)
+            {
+                if (targetPlatform == OSPlatform.Windows)
+                    return c_coreDacFileName;
+                else if (targetPlatform == OSPlatform.Linux)
+                    return c_linuxCoreDacFileName;
+                else if (targetPlatform == OSPlatform.OSX)
+                    return c_macOSCoreDacFileName;
+            }
+
+            if (flavor == ClrFlavor.Desktop)
+            {
+                if (targetPlatform == OSPlatform.Windows)
+                    return c_desktopDacFileName;
+            }
+
+            return null;
+        }
+
+        private static bool IsSupportedRuntime(ModuleInfo module, out ClrFlavor flavor)
+        {
+            flavor = default;
+
+            string moduleName = Path.GetFileName(module.FileName);
+            if (moduleName.Equals(c_desktopModuleName, StringComparison.OrdinalIgnoreCase))
+            {
+                flavor = ClrFlavor.Desktop;
+                return true;
+            }
+
+            if (moduleName.Equals(c_coreModuleName, StringComparison.OrdinalIgnoreCase))
+            {
+                flavor = ClrFlavor.Core;
+                return true;
+            }
+
+            if (moduleName.Equals(c_macOSCoreModuleName, StringComparison.OrdinalIgnoreCase))
+            {
+                flavor = ClrFlavor.Core;
+                return true;
+            }
+
+            if (moduleName.Equals(c_linuxCoreModuleName, StringComparison.Ordinal))
+            {
+                flavor = ClrFlavor.Core;
+                return true;
+            }
+
+            return false;
+        }
+        private static OSPlatform GetCurrentPlatform()
+        {
+            OSPlatform currentPlatform;
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                currentPlatform = OSPlatform.Windows;
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                currentPlatform = OSPlatform.Linux;
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                currentPlatform = OSPlatform.OSX;
+            else
+                throw new PlatformNotSupportedException();
+            return currentPlatform;
+        }
+
+        [StructLayout(LayoutKind.Sequential, Pack = 1)]
+        private struct CLR_DEBUG_RESOURCE
+        {
+            public uint dwVersion;
+            public Guid signature;
+            public int dwDacTimeStamp;
+            public int dwDacSizeOfImage;
+            public int dwDbiTimeStamp;
+            public int dwDbiSizeOfImage;
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/Interfaces/IClrInfo.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Interfaces/IClrInfo.cs
@@ -19,7 +19,6 @@ namespace Microsoft.Diagnostics.Runtime.Interfaces
         Version Version { get; }
 
         IClrRuntime CreateRuntime();
-        IClrRuntime CreateRuntime(DacLibrary dacLibrary);
         IClrRuntime CreateRuntime(string dacPath);
         IClrRuntime CreateRuntime(string dacPath, bool ignoreMismatch);
     }

--- a/src/Microsoft.Diagnostics.Runtime/SingleFileClrInfoProvider.cs
+++ b/src/Microsoft.Diagnostics.Runtime/SingleFileClrInfoProvider.cs
@@ -1,0 +1,27 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using Microsoft.Diagnostics.Runtime.Implementation;
+
+namespace Microsoft.Diagnostics.Runtime
+{
+    internal class SingleFileClrInfoProvider : DotNetClrInfoProvider
+    {
+        public override ClrInfo? ProvideClrInfoForModule(DataTarget dataTarget, ModuleInfo module)
+        {
+            ulong runtimeInfo = 0;
+            if ((dataTarget.DataReader.TargetPlatform != OSPlatform.Windows) || Path.GetExtension(module.FileName).Equals(".exe", StringComparison.OrdinalIgnoreCase))
+                runtimeInfo = module.GetExportSymbolAddress(ClrRuntimeInfo.SymbolValue);
+
+            if (runtimeInfo == 0)
+                return null;
+
+            ClrInfo result = CreateClrInfo(dataTarget, module, runtimeInfo, ClrFlavor.Core);
+            result.IsSingleFile = true;
+            return result;
+        }
+    }
+}


### PR DESCRIPTION
- Mostly internal-only changes to refactor how ClrRuntime is created.
- Marked DacLibrary as internal, since all components of it are internal now.