### PR TITLE
Generate better exceptions with bad dump files

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/DacLibrary.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacLibrary.cs
@@ -116,8 +116,13 @@ namespace Microsoft.Diagnostics.Runtime
             GC.KeepAlive(wrapper);
 #endif
 
-            if (res != 0)
-                throw new ClrDiagnosticsException($"Failure loading DAC: CreateDacInstance failed 0x{res:x}", res);
+            unchecked
+            {
+                if ((uint)res == 0x80131c4f)
+                    throw new ClrDiagnosticsException($"Failure loading DAC: CreateDacInstance failed 0x{res:x}, which usually indicates the dump file was taken incorrectly.", res);
+                else if (res != 0)
+                    throw new ClrDiagnosticsException($"Failure loading DAC: CreateDacInstance failed 0x{res:x}", res);
+            }
 
             InternalDacPrivateInterface = new ClrDataProcess(this, iUnk);
         }

--- a/src/Microsoft.Diagnostics.Runtime/Implementation/SymbolServer.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Implementation/SymbolServer.cs
@@ -113,9 +113,16 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
             if (key == null)
                 return null;
 
-            Stream? stream = FindFileOnServer(key).Result;
-            if (stream != null)
-                return _cache.Store(stream, key);
+            Task<Stream?> findFileTask = FindFileOnServer(key);
+            try
+            {
+                Stream? stream = findFileTask.Result;
+                if (stream != null)
+                    return _cache.Store(stream, key);
+            }
+            catch (AggregateException)
+            {
+            }
 
             return null;
         }

--- a/src/Microsoft.Diagnostics.Runtime/Linux/ElfSymbolGnuHash.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Linux/ElfSymbolGnuHash.cs
@@ -39,7 +39,8 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
             BloomSize = reader.Read<int>(ref address);
             BloomShift = reader.Read<int>(ref address);
 
-            if (BucketCount <= 0 || SymbolOffset == 0)
+
+            if (BucketCount <= 0 || BucketCount >= 0x10000000 || SymbolOffset == 0)
                 throw new InvalidDataException("ELF file has a hash bucket count or symbol offset invalid");
 
             if (BloomSize < 0)


### PR DESCRIPTION
- Catch a stray AggregateException when a symbol server is not reachable.
- Prevent System.OverflowException from creeping out of `ElfFile.TryGetExportSymbol`.
- Generate a more helpful exception message when we encounter a bad dump file.

This is the exception message we generate when `CLRDataCreateInstance` fails with exception code 0x80131c4f:

Microsoft.Diagnostics.Runtime.ClrDiagnosticsException: 'Failure loading DAC: CreateDacInstance failed 0x80131c4f, which usually indicates the dump file was taken incorrectly.'

While the root cause will not always be an incorrectly generated dump file, it is the right first thing to investigate.