### PR TITLE
Get method's hot and cold region info based on the MethodDesc's native address

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/MethodTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/MethodTests.cs
@@ -113,7 +113,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             ClrMethod[] methods = type.Methods.ToArray();
             ClrMethod genericMethod = type.GetMethod("GenericBar");
 
-            Assert.NotEqual<uint>(0, Math.Max(genericMethod.HotColdInfo.ColdSize, genericMethod.HotColdInfo.HotSize));
+            Assert.NotEqual<uint>(0, genericMethod.HotColdInfo.ColdSize + genericMethod.HotColdInfo.HotSize);
         }
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/MethodTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/MethodTests.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Linq;
 using Xunit;
 
@@ -98,6 +99,21 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             string methodName = genericMethod.Signature;
 
             Assert.Equal(')', methodName.Last());
+        }
+
+        [Fact]
+        public void AssemblySize()
+        {
+            using DataTarget dt = TestTargets.AppDomains.LoadFullDump();
+            using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
+
+            ClrModule module = runtime.GetModule("sharedlibrary.dll");
+            ClrType type = module.GetTypeByName("Foo");
+
+            ClrMethod[] methods = type.Methods.ToArray();
+            ClrMethod genericMethod = type.GetMethod("GenericBar");
+
+            Assert.NotEqual<uint>(0, Math.Max(genericMethod.HotColdInfo.ColdSize, genericMethod.HotColdInfo.HotSize));
         }
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/Implementation/DacTypeProvider.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Implementation/DacTypeProvider.cs
@@ -143,14 +143,15 @@ namespace Microsoft.Diagnostics.Runtime
             for (uint i = 0; i < data.NumMethods; i++)
             {
                 ulong slot = _sos.GetMethodTableSlot(methodTable, i);
-                if (_sos.GetCodeHeaderData(slot, out CodeHeaderData chd) && _sos.GetMethodDescData(chd.MethodDesc, 0, out MethodDescData mdd))
+                if (_sos.GetCodeHeaderData(slot, out CodeHeaderData chd) && _sos.GetMethodDescData(chd.MethodDesc, 0, out MethodDescData mdd)
+                    && mdd.HasNativeCode == 1 && _sos.GetCodeHeaderData(mdd.NativeCodeAddr, out CodeHeaderData chdBasedOnNative))
                 {
-                    HotColdRegions regions = new(mdd.NativeCodeAddr, chd.HotRegionSize, chd.ColdRegionStart, chd.ColdRegionSize);
+                    HotColdRegions regions = new(mdd.NativeCodeAddr, chdBasedOnNative.HotRegionSize, chdBasedOnNative.ColdRegionStart, chdBasedOnNative.ColdRegionSize);
                     yield return new()
                     {
-                        MethodDesc = chd.MethodDesc,
+                        MethodDesc = chdBasedOnNative.MethodDesc,
                         Token = (int)mdd.MDToken,
-                        CompilationType = (MethodCompilationType)chd.JITType,
+                        CompilationType = (MethodCompilationType)chdBasedOnNative.JITType,
                         HotCold = regions,
                     };
                 }


### PR DESCRIPTION
The current implementation uses the CodeHeader based on the slot address, which does not provide the hot and cold region info for the method.

Instead use the MethodDesc's native address.