### PR TITLE
Fix dependencies for netcoreapp3.0 and older runtimes

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/Microsoft.Diagnostics.Runtime.csproj
+++ b/src/Microsoft.Diagnostics.Runtime/Microsoft.Diagnostics.Runtime.csproj
@@ -28,7 +28,14 @@
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
   </PropertyGroup>
 
-  <ItemGroup>
+  <!--Use older packages to keep working in older Core runtimes (see https://github.com/open-telemetry/opentelemetry-dotnet/issues/3448)-->
+  <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
+    <PackageReference Include="Microsoft.Diagnostics.NETCore.Client" Version="0.2.410101" />
+    <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="5.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)'!='netstandard2.0'">
     <PackageReference Include="Microsoft.Diagnostics.NETCore.Client" Version="0.2.410101" />
     <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />

--- a/src/Microsoft.Diagnostics.Runtime/Microsoft.Diagnostics.Runtime.csproj
+++ b/src/Microsoft.Diagnostics.Runtime/Microsoft.Diagnostics.Runtime.csproj
@@ -37,8 +37,6 @@
 
   <ItemGroup Condition="'$(TargetFramework)'!='netstandard2.0'">
     <PackageReference Include="Microsoft.Diagnostics.NETCore.Client" Version="0.2.410101" />
-    <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Unblocks BenchmarkDotNet to adopt v3 (https://github.com/dotnet/BenchmarkDotNet/issues/2383).