### PR TITLE
Fix an issue where we over-walk fields

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacTypeHelpers.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacTypeHelpers.cs
@@ -195,7 +195,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
                 yield break;
 
             ulong nextField = fieldInfo.FirstFieldAddress;
-            for (int i = baseFieldCount; i < fieldInfo.NumInstanceFields + fieldInfo.NumStaticFields + fieldInfo.NumThreadStaticFields; i++)
+            for (int i = baseFieldCount; i < fieldInfo.NumInstanceFields + fieldInfo.NumStaticFields; i++)
             {
                 if (!_sos.GetFieldData(nextField, out FieldData dacFieldData))
                     break;


### PR DESCRIPTION
When walking FieldDescs, NumStaticFields already contains all thread static fields, so we should not add that value to the values to walk.