### PR TITLE
Clean up some Trace statements

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/AbstractDac/IAbstractThreadHelpers.cs
+++ b/src/Microsoft.Diagnostics.Runtime/AbstractDac/IAbstractThreadHelpers.cs
@@ -20,8 +20,9 @@ namespace Microsoft.Diagnostics.Runtime.AbstractDac
         /// Enumerates the roots of this thread.
         /// </summary>
         /// <param name="osThreadId">The thread to enumerate.</param>
+        /// <param name="traceErrors">Whether or not to Trace any errors encountered.</param>
         /// <returns>An enumeration of stack roots.</returns>
-        IEnumerable<StackRootInfo> EnumerateStackRoots(uint osThreadId);
+        IEnumerable<StackRootInfo> EnumerateStackRoots(uint osThreadId, bool traceErrors);
 
         /// <summary>
         /// Enumerates the stack trace of this method.  Note that in the event of bugs or corrupted
@@ -31,8 +32,9 @@ namespace Microsoft.Diagnostics.Runtime.AbstractDac
         /// <param name="osThreadId">The thread to enumerate.</param>
         /// <param name="includeContext">Whether to calculate and include the thread's CONTEXT record or not.
         /// Registers are always in the Windows CONTEXT format, as that's what the OS uses.</param>
+        /// <param name="traceErrors">Whether or not to Trace any errors encountered.</param>
         /// <returns>An enumeration of stack frames.</returns>
-        IEnumerable<StackFrameInfo> EnumerateStackTrace(uint osThreadId, bool includeContext);
+        IEnumerable<StackFrameInfo> EnumerateStackTrace(uint osThreadId, bool includeContext, bool traceErrors);
     }
 
     /// <summary>

--- a/src/Microsoft.Diagnostics.Runtime/ClrThread.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrThread.cs
@@ -130,7 +130,7 @@ namespace Microsoft.Diagnostics.Runtime
 
             ClrHeap heap = Runtime.Heap;
             ClrStackFrame[] frames = GetFramesForRoots();
-            IEnumerable<ClrStackRoot> roots = threadHelpers.EnumerateStackRoots(OSThreadId).Select(r => CreateClrStackRoot(heap, frames, r)).Where(r => r is not null)!;
+            IEnumerable<ClrStackRoot> roots = threadHelpers.EnumerateStackRoots(OSThreadId, traceErrors: IsAlive).Select(r => CreateClrStackRoot(heap, frames, r)).Where(r => r is not null)!;
             if (!Runtime.DataTarget.CacheOptions.CacheStackRoots)
                 return roots;
 
@@ -163,7 +163,7 @@ namespace Microsoft.Diagnostics.Runtime
             // We need to make sure we don't loop forever when enumerating the stack trace.
             // We will only cache the stack if we completed enumeratione (i.e. got less
             // than MaxFrameDefault frames)
-            ClrStackFrame[] stack = threadHelpers.EnumerateStackTrace(OSThreadId, includeContext: false).Select(r => CreateClrStackFrame(r)).Take(MaxFrameDefault).ToArray();
+            ClrStackFrame[] stack = threadHelpers.EnumerateStackTrace(OSThreadId, includeContext: false, traceErrors: IsAlive).Select(r => CreateClrStackFrame(r)).Take(MaxFrameDefault).ToArray();
             if (Runtime.DataTarget.CacheOptions.CacheStackTraces && stack.Length < MaxFrameDefault)
                 _frameCache = new(stack, includedContext: false);
 
@@ -248,7 +248,7 @@ namespace Microsoft.Diagnostics.Runtime
             if (cache is not null && (!includeContext || cache.IncludedContext))
                 return Array.AsReadOnly(cache.Elements);
 
-            IEnumerable<ClrStackFrame> frames = threadHelpers.EnumerateStackTrace(OSThreadId, includeContext).Select(r => CreateClrStackFrame(r));
+            IEnumerable<ClrStackFrame> frames = threadHelpers.EnumerateStackTrace(OSThreadId, includeContext, traceErrors: IsAlive).Select(r => CreateClrStackFrame(r));
             if (!Runtime.DataTarget.CacheOptions.CacheStackTraces)
                 return frames;
 

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/ClrDataProcess.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/ClrDataProcess.cs
@@ -143,10 +143,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
         {
             HResult hr = VTable.GetTaskByOSThreadID(Self, id, out IntPtr pUnkTask);
             if (!hr)
-            {
-                Trace.TraceInformation($"GetTaskByOSThreadID failed - id:{id:x} flags:{flags:x} hr:{hr}");
                 return null;
-            }
 
             using ClrDataTask dataTask = new(_library, pUnkTask);
             // There's a bug in certain runtimes where we will fail to release data deep in the runtime

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/ClrDataTask.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/ClrDataTask.cs
@@ -24,10 +24,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
         {
             HResult hr = VTable.CreateStackWalk(Self, flags, out IntPtr pUnk);
             if (!hr)
-            {
-                Trace.TraceInformation($"CreateStackWalk failed: flags={flags:x}, hr={hr}");
                 return null;
-            }
 
             return new ClrStackWalk(library, pUnk);
         }

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/DacDataTarget.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/DacDataTarget.cs
@@ -162,7 +162,6 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             if (_dataReader.GetThreadContext(threadID, contextFlags, span))
                 return true;
 
-            Trace.TraceInformation($"Failed to read thread context: tid:{threadID:x} flags:{contextFlags:x} size:{contextSize:x}{(context == IntPtr.Zero ? " null context!" : "")}");
             return false;
         }
 


### PR DESCRIPTION
Only publish Trace statements in stackwalking when the failure is unexpected.

Closes #1223.