### PR TITLE
Remove boxing when calling generic ReadField method

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/ClrObject.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrObject.cs
@@ -382,8 +382,7 @@ namespace Microsoft.Diagnostics.Runtime
         {
             ClrType type = GetTypeOrThrow();
             ClrInstanceField field = type.GetFieldByName(fieldName) ?? throw new ArgumentException($"Type '{type.Name}' does not contain a field named '{fieldName}'");
-            object value = field.Read<T>(Address, interior: false);
-            return (T)value;
+            return field.Read<T>(Address, interior: false);
         }
 
 

--- a/src/Microsoft.Diagnostics.Runtime/ClrValueType.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrValueType.cs
@@ -99,8 +99,7 @@ namespace Microsoft.Diagnostics.Runtime
         {
             ClrType type = GetTypeOrThrow();
             ClrInstanceField field = type.GetFieldByName(fieldName) ?? throw new ArgumentException($"Type '{type.Name}' does not contain a field named '{fieldName}'");
-            object value = field.Read<T>(Address, _interior);
-            return (T)value;
+            return field.Read<T>(Address, _interior);
         }
 
         /// <summary>


### PR DESCRIPTION
Remove boxing when calling ClrObject.ReadField<T> and ClrValueType.ReadField<T>.

Cast to object seems to be leftover from ClrMd v1, where ClrInstanceField.Read was not generic and returned an object.

Btw. I am unable to run the tests, I get an InvalidOperationException stating: "You must first generate test binaries and crash dumps using by running: dotnet build C:\projects\clrmd\src\TestTargets\TestTargets.csproj". But the csproj-file doesn't exist, so the command does nothing.

I am pretty sure my change is correct, but it would be nice with some documentation on how to build everything locally, so I can also run the tests :)