### PR TITLE
Make dependencies to System.Collection.Immutable and System.Runtime.CompilerService.Unsafe conditional

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/Microsoft.Diagnostics.Runtime.csproj
+++ b/src/Microsoft.Diagnostics.Runtime/Microsoft.Diagnostics.Runtime.csproj
@@ -30,6 +30,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Diagnostics.NETCore.Client" Version="0.2.410101" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
     <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
   </ItemGroup>


### PR DESCRIPTION
System.Collection.Immutable and System.Runtime.CompilerService.Unsafe both are included in .NET 6.0, so there is no need to reference their packages.
With it, dependent project will also not include that unneeded dependencies.