### PR TITLE
Fix the way of getting ClrMethod from method handle or instruction pointer

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/AbstractDac/IAbstractMethodLocator.cs
+++ b/src/Microsoft.Diagnostics.Runtime/AbstractDac/IAbstractMethodLocator.cs
@@ -16,5 +16,6 @@ namespace Microsoft.Diagnostics.Runtime.AbstractDac
     {
         ulong GetMethodHandleContainingType(ulong methodDesc);
         ulong GetMethodHandleByInstructionPointer(ulong ip);
+        bool GetMethodInfo(ulong methodDesc, out MethodInfo methodInfo);
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/ClrRuntime.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrRuntime.cs
@@ -169,6 +169,9 @@ namespace Microsoft.Diagnostics.Runtime
             if (locator is null)
                 return null;
 
+            if (!locator.GetMethodInfo(methodHandle, out MethodInfo mi))
+                return null;
+
             ulong mt = locator.GetMethodHandleContainingType(methodHandle);
             if (mt == 0)
                 return null;
@@ -177,7 +180,7 @@ namespace Microsoft.Diagnostics.Runtime
             if (type is null)
                 return null;
 
-            return type.Methods.FirstOrDefault(m => m.MethodDesc == methodHandle);
+            return type.GetOrCreateMethod(mi);
         }
 
         /// <summary>
@@ -249,7 +252,19 @@ namespace Microsoft.Diagnostics.Runtime
                 return null;
 
             ulong md = locator.GetMethodHandleByInstructionPointer(ip);
-            return GetMethodByHandle(md);
+
+            if (!locator.GetMethodInfo(md, out MethodInfo mi))
+                return null;
+
+            ulong mt = locator.GetMethodHandleContainingType(md);
+            if (mt == 0)
+                return null;
+
+            ClrType? type = Heap.GetTypeByMethodTable(mt);
+            if (type is null)
+                return null;
+
+            return type.GetOrCreateMethod(mi);
         }
 
         /// <summary>

--- a/src/Microsoft.Diagnostics.Runtime/ClrRuntime.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrRuntime.cs
@@ -252,19 +252,7 @@ namespace Microsoft.Diagnostics.Runtime
                 return null;
 
             ulong md = locator.GetMethodHandleByInstructionPointer(ip);
-
-            if (!locator.GetMethodInfo(md, out MethodInfo mi))
-                return null;
-
-            ulong mt = locator.GetMethodHandleContainingType(md);
-            if (mt == 0)
-                return null;
-
-            ClrType? type = Heap.GetTypeByMethodTable(mt);
-            if (type is null)
-                return null;
-
-            return type.GetOrCreateMethod(mi);
+            return GetMethodByHandle(md);
         }
 
         /// <summary>

--- a/src/Microsoft.Diagnostics.Runtime/ClrType.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrType.cs
@@ -227,7 +227,7 @@ namespace Microsoft.Diagnostics.Runtime
             }
         }
 
-        public ClrMethod GetOrCreateMethod(MethodInfo methodInfo)
+        internal ClrMethod GetOrCreateMethod(MethodInfo methodInfo)
         {
             ClrMethod? clrMethod;
 

--- a/src/Microsoft.Diagnostics.Runtime/ClrType.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrType.cs
@@ -229,7 +229,7 @@ namespace Microsoft.Diagnostics.Runtime
 
         public ClrMethod GetOrCreateMethod(MethodInfo methodInfo)
         {
-            ClrMethod clrMethod;
+            ClrMethod? clrMethod;
 
             lock (_constructedMethods)
             {

--- a/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacMethodLocator.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacMethodLocator.cs
@@ -3,7 +3,6 @@
 
 using Microsoft.Diagnostics.Runtime.AbstractDac;
 using Microsoft.Diagnostics.Runtime.DacInterface;
-using System.Security.Cryptography;
 
 namespace Microsoft.Diagnostics.Runtime.DacImplementation
 {

--- a/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacMethodLocator.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacMethodLocator.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
                 methodInfo = default;
                 return false;
             }
-            
+
             uint compilation = chd.JITType;
             ulong md = chd.MethodDesc;
 


### PR DESCRIPTION
The existing implementation is not able to get the method from an instantiated method handle or instruction pointer, as `type.Methods` only contains typical uninstantiated MethodDescs.
Change the way how we get ClrMethod to support getting instantiated method as well.