### PR TITLE
Implement /proc/pid fallback on Linux

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/Linux/LinuxLiveDataReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Linux/LinuxLiveDataReader.cs
@@ -151,8 +151,15 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
                 return 0;
             }
 
-            _fileStream!.Seek((long)address, SeekOrigin.Begin);
-            return _fileStream.Read(buffer.Slice(0, readableBytesCount));
+            try
+            {
+                _fileStream!.Seek((long)address, SeekOrigin.Begin);
+                return _fileStream.Read(buffer.Slice(0, readableBytesCount));
+            }
+            catch (IOException)
+            {
+                return 0;
+            }
         }
 
         private unsafe int ReadMemoryReadv(ulong address, Span<byte> buffer)

--- a/src/Microsoft.Diagnostics.Runtime/Linux/LinuxLiveDataReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Linux/LinuxLiveDataReader.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
 
         private bool _suspended;
         private bool _disposed;
+        private FileStream? _fileStream;
 
         public string DisplayName => $"pid:{ProcessId:x}";
         public OSPlatform TargetPlatform => OSPlatform.Linux;
@@ -63,6 +64,8 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
         {
             if (_disposed)
                 return;
+
+            _fileStream?.Dispose();
 
             if (_suspended)
             {
@@ -123,7 +126,33 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
         public override int Read(ulong address, Span<byte> buffer)
         {
             DebugOnly.Assert(!buffer.IsEmpty);
-            return ReadMemoryReadv(address, buffer);
+
+            if (_fileStream == null)
+            {
+                try
+                {
+                    return ReadMemoryReadv(address, buffer);
+                }
+                catch (UnauthorizedAccessException)
+                {
+                    // process_vm_readv failed with EPERM, fallback to /proc/pid/mem
+                    _fileStream = new FileStream($"/proc/{ProcessId}/mem", FileMode.Open, FileAccess.Read, FileShare.Read);
+                }
+            }
+
+            return ReadMemoryProc(address, buffer);
+        }
+
+        private unsafe int ReadMemoryProc(ulong address, Span<byte> buffer)
+        {
+            int readableBytesCount = this.GetReadableBytesCount(this._memoryMapEntries, address, buffer.Length);
+            if (readableBytesCount <= 0)
+            {
+                return 0;
+            }
+
+            _fileStream!.Seek((long)address, SeekOrigin.Begin);
+            return _fileStream.Read(buffer.Slice(0, readableBytesCount));
         }
 
         private unsafe int ReadMemoryReadv(ulong address, Span<byte> buffer)


### PR DESCRIPTION
I ran into a situation where createdump was able to read the memory of the crashing process but ClrMD failed with an `UnauthorizedAccessException`. After digging deeper, it looks like createdump fallbacks to reading `/proc/<pid>/mem` when `process_vm_readv` returns EPERM:

https://github.com/dotnet/runtime/blob/15e98e58e6023be3121dcb0ed2e701d1d5cd098e/src/coreclr/debug/createdump/crashinfounix.cpp#L514-L531

I don't actually know _why_ `process_vm_readv` fails (it's in an ARM64 CI agent running docker), but the fallback fixes it.

