### PR TITLE
Add deferred loading of module information for ClrModules

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/ClrModule.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrModule.cs
@@ -279,9 +279,7 @@ namespace Microsoft.Diagnostics.Runtime
         {
             // Not correct, but as close as we can get until we add more information to the dac.
             bool virt = Layout != ModuleLayout.Flat;
-            long size = 0;
-            if (_size is ulong sz)
-                size = (long)sz;
+            long size = (long)ModuleInfo.Size;
 
             ReadVirtualStream stream = new(DataReader, (long)ImageBase, size > 0 ? size : int.MaxValue);
             return new(stream, leaveOpen: false, isVirtual: virt);

--- a/src/Microsoft.Diagnostics.Runtime/ClrModule.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrModule.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Diagnostics.Runtime
         {
             get
             {
-                if (_moduleInfo.Address == _moduleAddress)
+                if (initialized == 1)
                 {
                     return _moduleInfo;
                 }

--- a/src/Microsoft.Diagnostics.Runtime/ClrRuntime.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrRuntime.cs
@@ -447,13 +447,13 @@ namespace Microsoft.Diagnostics.Runtime
                 }
 
                 IAbstractModuleHelpers moduleHelpers = GetServiceOrThrow<IAbstractModuleHelpers>();
+                IAbstractClrNativeHeaps? nativeHeaps = GetService<IAbstractClrNativeHeaps>();
                 ImmutableArray<ClrModule>.Builder moduleBuilder = ImmutableArray.CreateBuilder<ClrModule>();
                 foreach (ulong moduleAddress in GetDacRuntime().GetModuleList(domain.Address))
                 {
                     if (!modules.TryGetValue(moduleAddress, out ClrModule? module))
                     {
-                        ClrModuleInfo moduleInfo = moduleHelpers.GetModuleInfo(moduleAddress);
-                        module = new(domain, moduleInfo, moduleHelpers, GetService<IAbstractClrNativeHeaps>(), DataTarget.DataReader);
+                        module = new(domain, moduleAddress, moduleHelpers, nativeHeaps, DataTarget.DataReader);
                         modules.Add(moduleAddress, module);
                     }
 
@@ -475,7 +475,7 @@ namespace Microsoft.Diagnostics.Runtime
                 domain.Modules = moduleBuilder.MoveOrCopyToImmutable();
             }
 
-            return new(system, shared, builder.MoveOrCopyToImmutable(), modules.Values.OrderBy(r => (r.ImageBase, r.Name)).ToArray(), bcl);
+            return new(system, shared, builder.MoveOrCopyToImmutable(), modules.Values.ToArray(), bcl);
         }
 
         private sealed class DomainAndModules

--- a/src/Microsoft.Diagnostics.Runtime/Implementation/ClrTypeFactory.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Implementation/ClrTypeFactory.cs
@@ -379,7 +379,7 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
             }
 
             if (!_modules.TryGetValue(moduleAddress, out ClrModule? module))
-                module = _errorModule ??= new(_heap.Runtime.AppDomains[0], default, null, null, _heap.Runtime.DataTarget.DataReader);
+                module = _errorModule ??= new(_heap.Runtime.AppDomains[0], 0, _heap.Runtime.GetServiceOrThrow<IAbstractModuleHelpers>(), null, _heap.Runtime.DataTarget.DataReader);
 
             return module;
         }


### PR DESCRIPTION
For processes with numerous loaded modules, the overhead of fetching module information becomes prohibitively expensive. 

Introduce that population of module information is deferred until accessed.
A few minor changes was done to avoid triggering the load of module info.

Time measurements, of getting stack traces of a process with 200K modules loaded, showed a reduction of 9/10 of execution time. 