### PR TITLE
Bump to macos-latest build image

### DIFF
--- a/azure-pipelines-external.yml
+++ b/azure-pipelines-external.yml
@@ -70,7 +70,7 @@ stages:
 
         - job: MacOS
           pool:
-            vmImage: macos-11
+            vmImage: macOS-latest
 
           strategy:
             matrix:


### PR DESCRIPTION
AzDO will remove macos-11 in about two weeks: https://learn.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops&tabs=yaml#recent-updates

Bump to macos-latest to match the internal build.

/cc @leculver 