### PR TITLE
Add symbol tracing environment variable

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/FileLocatorTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/FileLocatorTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
 
         internal static IFileLocator GetLocator()
         {
-            return SymbolGroup.CreateFromSymbolPath($"srv*{Helpers.TestWorkingDirectory}*http://msdl.microsoft.com/download/symbols", null);
+            return SymbolGroup.CreateFromSymbolPath($"srv*{Helpers.TestWorkingDirectory}*http://msdl.microsoft.com/download/symbols", true, null);
         }
 
         [Fact(Skip = "Touches network, don't run regularly.")]

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/TestTargets.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/TestTargets.cs
@@ -109,7 +109,8 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 DataTarget dataTarget = DataTarget.LoadDump(path);
-                dataTarget.FileLocator = SymbolGroup.CreateFromSymbolPath(string.Empty, null);
+                bool symTrace = CustomDataTarget.GetTraceEnvironmentVariable();
+                dataTarget.FileLocator = SymbolGroup.CreateFromSymbolPath(string.Empty, trace: symTrace, null);
                 return dataTarget;
             }
             else

--- a/src/Microsoft.Diagnostics.Runtime/CustomDataTarget.cs
+++ b/src/Microsoft.Diagnostics.Runtime/CustomDataTarget.cs
@@ -14,6 +14,11 @@ namespace Microsoft.Diagnostics.Runtime
     public class CustomDataTarget : IDisposable
     {
         /// <summary>
+        /// The environment variable to set to true if.
+        /// </summary>
+        public const string TraceSymbolsEnvVariable = "ClrMD_TraceSymbolRequests";
+
+        /// <summary>
         /// The data reader that ClrMD will use to read data from the target.
         /// </summary>
         public IDataReader DataReader { get; set; }
@@ -78,6 +83,18 @@ namespace Microsoft.Diagnostics.Runtime
                 if (DataReader is IDisposable disposable)
                     disposable.Dispose();
             }
+        }
+
+        internal static bool GetTraceEnvironmentVariable()
+        {
+            string? value = Environment.GetEnvironmentVariable(TraceSymbolsEnvVariable);
+            if (value is null)
+                return false;
+
+            if (bool.TryParse(value, out bool result))
+                return result;
+
+            return value.Equals("1", StringComparison.OrdinalIgnoreCase);
         }
 
         public override string ToString() => DataReader?.DisplayName ?? GetType().Name;

--- a/src/Microsoft.Diagnostics.Runtime/DataTarget.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DataTarget.cs
@@ -69,7 +69,8 @@ namespace Microsoft.Diagnostics.Runtime
             if (locator == null)
             {
                 string sympath = Environment.GetEnvironmentVariable("_NT_SYMBOL_PATH") ?? "";
-                locator = SymbolGroup.CreateFromSymbolPath(sympath, _target.SymbolTokenCredential);
+                bool symTrace = CustomDataTarget.GetTraceEnvironmentVariable();
+                locator = SymbolGroup.CreateFromSymbolPath(sympath, trace:symTrace, _target.SymbolTokenCredential);
             }
 
             FileLocator = locator;
@@ -80,7 +81,8 @@ namespace Microsoft.Diagnostics.Runtime
             if (symbolPath is null)
                 throw new ArgumentNullException(nameof(symbolPath));
 
-            FileLocator = SymbolGroup.CreateFromSymbolPath(symbolPath, _target.SymbolTokenCredential);
+            bool symTrace = CustomDataTarget.GetTraceEnvironmentVariable();
+            FileLocator = SymbolGroup.CreateFromSymbolPath(symbolPath, trace:symTrace, _target.SymbolTokenCredential);
         }
 
         public void Dispose()

--- a/src/Microsoft.Diagnostics.Runtime/Implementation/SymbolGroup.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Implementation/SymbolGroup.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
             return s_cache!;
         }
 
-        public static IFileLocator CreateFromSymbolPath(string symbolPath, TokenCredential? credential)
+        public static IFileLocator CreateFromSymbolPath(string symbolPath, bool trace, TokenCredential? credential)
         {
             FileSymbolCache defaultCache = GetDefaultCache();
             List<IFileLocator> locators = new();
@@ -114,7 +114,7 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
                 {
                     if (IsUrl(server))
                     {
-                        SymbolServer symSvr = new(cache, server, credential);
+                        SymbolServer symSvr = new(cache, server, trace, credential);
                         locators.Add(symSvr);
 
                         if (first)
@@ -142,7 +142,7 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
                 return single;
 
             if (locators.Count == 0)
-                return new SymbolServer(defaultCache, SymbolServer.Msdl, null);
+                return new SymbolServer(defaultCache, SymbolServer.Msdl, trace, null);
 
             return new SymbolGroup(locators);
         }


### PR DESCRIPTION
Setting ClrMD_TraceSymbolRequests=1 will now produce Trace messages of all symbol server requests.