### PR TITLE
MachOModule.cs add bound check

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/MacOS/MachOModule.cs
+++ b/src/Microsoft.Diagnostics.Runtime/MacOS/MachOModule.cs
@@ -180,6 +180,9 @@ namespace Microsoft.Diagnostics.Runtime.MacOS
             if (_dysymtab.Header.Kind != LoadCommandType.DysymTab || _symtab.Header.Kind != LoadCommandType.SymTab)
                 return null;
 
+			if (_symtab.NSyms == 0)
+				return null;
+
             ulong symbolTableAddress = GetAddressFromFileOffset(_symtab.SymOff);
             NList64[] symTable = new NList64[_symtab.NSyms];
 


### PR DESCRIPTION
`ReadSymbolTable()` will use `DataReader.Read()`
If `_symtab.NSyms` is `0` but it passed previous checks, `Read()` will assert.
Didn't remove the assert but add this check.
I don't know why but in a game some modules will cause the assert.