### PR TITLE
[LoongArch64] Add support for loongarch64 architecture

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime.Utilities/DbgEng/DbgEngIDataReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Utilities/DbgEng/DbgEngIDataReader.cs
@@ -187,6 +187,7 @@ namespace Microsoft.Diagnostics.Runtime.Utilities.DbgEng
             (ImageFileMachine)0x01c2 or                     // THUMB
             (ImageFileMachine)0x01c4 => Architecture.Arm,   // THUMB2
             (ImageFileMachine)0xAA64 => Architecture.Arm64, // ARM64
+            (ImageFileMachine)0x6264 => (Architecture)6 /* Architecture.LoongArch64 */, // LOONGARCH64
             (ImageFileMachine)0x5064 => (Architecture)9 /* Architecture.RiscV64 */, // RISCV64
             _ => (Architecture)(-1)
         };

--- a/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacThreadHelpers.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacThreadHelpers.cs
@@ -110,6 +110,12 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
                 spOffset = 24;
                 contextSize = 544;
             }
+            else if (_dataReader.Architecture == (Architecture)6 /* Architecture.LoongArch64 */)
+            {
+                ipOffset = 120;
+                spOffset = 112;
+                contextSize = 544;
+            }
             else if (_dataReader.Architecture == Architecture.X86)
             {
                 ipOffset = 184;

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/DacDataTarget.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/DacDataTarget.cs
@@ -48,6 +48,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
                 Architecture.X86 => IMAGE_FILE_MACHINE.I386,
                 Architecture.Arm => IMAGE_FILE_MACHINE.THUMB2,
                 Architecture.Arm64 => IMAGE_FILE_MACHINE.ARM64,
+                (Architecture)6 /* Architecture.LoongArch64 */ => IMAGE_FILE_MACHINE.LOONGARCH64,
                 (Architecture)9 /* Architecture.RiscV64 */ => IMAGE_FILE_MACHINE.RISCV64,
                 _ => IMAGE_FILE_MACHINE.UNKNOWN,
             };

--- a/src/Microsoft.Diagnostics.Runtime/DataReaders/Core/CoreDumpReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DataReaders/Core/CoreDumpReader.cs
@@ -35,6 +35,9 @@ namespace Microsoft.Diagnostics.Runtime
                 ElfMachine.EM_RISCV => _core.ElfFile.Header.Is64Bit ?
                                             (8, (Architecture)9 /* Architecture.RiscV64 */) :
                                             throw new NotImplementedException($"Support for RISC-V 32bit not yet implemented."),
+                ElfMachine.EM_LOONGARCH => _core.ElfFile.Header.Is64Bit ?
+                                            (8, (Architecture)6 /* Architecture.LoongArch64 */) :
+                                            throw new NotImplementedException($"Support for LoongArch 32bit not yet implemented."),
                 _ => throw new NotImplementedException($"Support for {architecture} not yet implemented."),
             };
         }

--- a/src/Microsoft.Diagnostics.Runtime/DataReaders/Registers/LoongArch64Context.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DataReaders/Registers/LoongArch64Context.cs
@@ -1,0 +1,179 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.InteropServices;
+
+namespace Microsoft.Diagnostics.Runtime
+{
+    /// <summary>
+    /// LoongArch-specific thread context.
+    /// </summary>
+    [StructLayout(LayoutKind.Explicit, Pack = 1)]
+    public struct LoongArch64Context
+    {
+        public const uint Context = 0x00800000;
+        public const uint ContextControl = Context | 0x1;
+        public const uint ContextInteger = Context | 0x2;
+        public const uint ContextFloatingPoint = Context | 0x4;
+        public const uint ContextDebugRegisters = Context | 0x8;
+
+        public static int Size => 0x220;
+
+        // Control flags
+
+        [FieldOffset(0x0)]
+        public uint ContextFlags;
+
+        #region General and control registers
+
+        [Register(RegisterType.General)]
+        [FieldOffset(0x8)]
+        public ulong R0;
+
+        [Register(RegisterType.General)]
+        [FieldOffset(0x10)]
+        public ulong Ra;
+
+        [Register(RegisterType.Control)]
+        [FieldOffset(0x18)]
+        public ulong Tp;
+
+        [Register(RegisterType.General | RegisterType.StackPointer)]
+        [FieldOffset(0x20)]
+        public ulong Sp;
+
+        [Register(RegisterType.General)]
+        [FieldOffset(0x28)]
+        public ulong A0;
+
+        [Register(RegisterType.General)]
+        [FieldOffset(0x30)]
+        public ulong A1;
+
+        [Register(RegisterType.General)]
+        [FieldOffset(0x38)]
+        public ulong A2;
+
+        [Register(RegisterType.General)]
+        [FieldOffset(0x40)]
+        public ulong A3;
+
+        [Register(RegisterType.Control)]
+        [FieldOffset(0x48)]
+        public ulong A4;
+
+        [Register(RegisterType.General)]
+        [FieldOffset(0x50)]
+        public ulong A5;
+
+        [Register(RegisterType.General)]
+        [FieldOffset(0x58)]
+        public ulong A6;
+
+        [Register(RegisterType.General)]
+        [FieldOffset(0x60)]
+        public ulong A7;
+
+        [Register(RegisterType.General)]
+        [FieldOffset(0x68)]
+        public ulong T0;
+
+        [Register(RegisterType.General)]
+        [FieldOffset(0x70)]
+        public ulong T1;
+
+        [Register(RegisterType.General)]
+        [FieldOffset(0x78)]
+        public ulong T2;
+
+        [Register(RegisterType.General)]
+        [FieldOffset(0x80)]
+        public ulong T3;
+
+        [Register(RegisterType.General)]
+        [FieldOffset(0x88)]
+        public ulong T4;
+
+        [Register(RegisterType.General)]
+        [FieldOffset(0x90)]
+        public ulong T5;
+
+        [Register(RegisterType.General)]
+        [FieldOffset(0x98)]
+        public ulong T6;
+
+        [Register(RegisterType.General)]
+        [FieldOffset(0xa0)]
+        public ulong T7;
+
+        [Register(RegisterType.General)]
+        [FieldOffset(0xa8)]
+        public ulong T8;
+
+        [Register(RegisterType.General)]
+        [FieldOffset(0xb0)]
+        public ulong X0;
+
+        [Register(RegisterType.General | RegisterType.FramePointer)]
+        [FieldOffset(0xb8)]
+        public ulong Fp;
+
+        [Register(RegisterType.General)]
+        [FieldOffset(0xc0)]
+        public ulong S0;
+
+        [Register(RegisterType.General)]
+        [FieldOffset(0xc8)]
+        public ulong S1;
+
+        [Register(RegisterType.General)]
+        [FieldOffset(0xd0)]
+        public ulong S2;
+
+        [Register(RegisterType.General)]
+        [FieldOffset(0xd8)]
+        public ulong S3;
+
+        [Register(RegisterType.General)]
+        [FieldOffset(0xe0)]
+        public ulong S4;
+
+        [Register(RegisterType.General)]
+        [FieldOffset(0xe8)]
+        public ulong S5;
+
+        [Register(RegisterType.General)]
+        [FieldOffset(0xf0)]
+        public ulong S6;
+
+        [Register(RegisterType.General)]
+        [FieldOffset(0xf8)]
+        public ulong S7;
+
+        [Register(RegisterType.General)]
+        [FieldOffset(0x100)]
+        public ulong S8;
+
+        [Register(RegisterType.Control | RegisterType.ProgramCounter)]
+        [FieldOffset(0x108)]
+        public ulong Pc;
+
+        #endregion
+
+        #region Floating Point
+
+        [Register(RegisterType.FloatingPoint)]
+        [FieldOffset(0x110)]
+        public unsafe fixed ulong F[4*32];
+
+        [Register(RegisterType.FloatingPoint)]
+        [FieldOffset(0x210)]
+        public ulong Fcc;
+
+        [Register(RegisterType.FloatingPoint)]
+        [FieldOffset(0x218)]
+        public uint Fcsr;
+
+        #endregion
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/Linux/ElfCoreFile.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Linux/ElfCoreFile.cs
@@ -46,6 +46,9 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
                     ElfMachine.EM_RISCV => ElfFile.Header.Is64Bit ?
                                                 r.ReadContents<ElfPRStatusRiscV64>(0) :
                                                 throw new NotSupportedException($"Invalid architecture RISC-V 32bit"),
+                    ElfMachine.EM_LOONGARCH => ElfFile.Header.Is64Bit ?
+                                                r.ReadContents<ElfPRStatusLoongArch64>(0) :
+                                                throw new NotSupportedException($"Invalid architecture LoongArch 32bit"),
                     _ => throw new NotSupportedException($"Invalid architecture {architecture}"),
                 };
             });

--- a/src/Microsoft.Diagnostics.Runtime/Linux/IElfPRStatus.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Linux/IElfPRStatus.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
         ///
         /// <see cref="Arm64Context"/>
         /// <see cref="RiscV64Context"/>
+        /// <see cref="LoongArch64Context"/>
         /// <see cref="AMD64Context"/>
         /// <see cref="ArmContext"/>
         /// <see cref="X86Context"/>

--- a/src/Microsoft.Diagnostics.Runtime/Linux/LinuxLiveDataReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Linux/LinuxLiveDataReader.cs
@@ -216,6 +216,7 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
                 Architecture.Arm => sizeof(RegSetArm),
                 Architecture.Arm64 => sizeof(RegSetArm64),
                 (Architecture)9 /* Architecture.RiscV64 */ => sizeof(RegSetRiscV64),
+                (Architecture)6 /* Architecture.LoongArch64 */ => sizeof(RegSetLoongArch64),
                 Architecture.X64 => sizeof(RegSetX64),
                 _ => sizeof(RegSetX86),
             };
@@ -238,6 +239,9 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
                         break;
                     case (Architecture)9 /* Architecture.RiscV64 */:
                         Unsafe.As<byte, RegSetRiscV64>(ref MemoryMarshal.GetReference(buffer.AsSpan())).CopyContext(context);
+                        break;
+                    case (Architecture)6 /* Architecture.LoongArch64 */:
+                        Unsafe.As<byte, RegSetLoongArch64>(ref MemoryMarshal.GetReference(buffer.AsSpan())).CopyContext(context);
                         break;
                     case Architecture.X64:
                         Unsafe.As<byte, RegSetX64>(ref MemoryMarshal.GetReference(buffer.AsSpan())).CopyContext(context);

--- a/src/Microsoft.Diagnostics.Runtime/Linux/Structs/ElfHeaderCommon.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Linux/Structs/ElfHeaderCommon.cs
@@ -55,6 +55,7 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
                         return reader.Read<ElfHeader64>(position);
 
                     case ElfMachine.EM_RISCV:
+                    case ElfMachine.EM_LOONGARCH:
                         if (Class == ElfClass.Class64)
                             return reader.Read<ElfHeader64>(position);
                         else

--- a/src/Microsoft.Diagnostics.Runtime/Linux/Structs/ElfMachine.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Linux/Structs/ElfMachine.cs
@@ -29,6 +29,7 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
         EM_BLACKFIN = 106,      /* ADI Blackfin Processor */
         EM_AARCH64 = 183,       /* ARM AARCH64 */
         EM_RISCV = 243,         /* RISC-V */
+        EM_LOONGARCH = 258,     /* LOONGARCH */
         EM_FRV = 0x5441,        /* Fujitsu FR-V */
         EM_AVR32 = 0x18ad       /* Atmel AVR32 */
     }

--- a/src/Microsoft.Diagnostics.Runtime/Linux/Structs/ElfPRStatusLoongArch64.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Linux/Structs/ElfPRStatusLoongArch64.cs
@@ -1,0 +1,38 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.Diagnostics.Runtime.Utilities
+{
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    internal struct ElfPRStatusLoongArch64 : IElfPRStatus
+    {
+        public ElfSignalInfo SignalInfo;
+        public short CurrentSignal;
+        private readonly ushort Padding;
+        public ulong SignalsPending;
+        public ulong SignalsHeld;
+
+        public uint Pid;
+        public uint PPid;
+        public uint PGrp;
+        public uint Sid;
+
+        public TimeVal64 UserTime;
+        public TimeVal64 SystemTime;
+        public TimeVal64 CUserTime;
+        public TimeVal64 CSystemTime;
+
+        public RegSetLoongArch64 RegisterSet;
+
+        public int FPValid;
+
+        public uint ProcessId => PGrp;
+
+        public uint ThreadId => Pid;
+
+        public bool CopyRegistersAsContext(Span<byte> context) => RegisterSet.CopyContext(context);
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/Linux/Structs/RegSetLoongArch64.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Linux/Structs/RegSetLoongArch64.cs
@@ -1,0 +1,92 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.Diagnostics.Runtime.Utilities
+{
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    internal struct RegSetLoongArch64
+    {
+        public readonly ulong R0;
+        public readonly ulong Ra;
+        public readonly ulong Tp;
+        public readonly ulong Sp;
+        public readonly ulong A0;
+        public readonly ulong A1;
+        public readonly ulong A2;
+        public readonly ulong A3;
+        public readonly ulong A4;
+        public readonly ulong A5;
+        public readonly ulong A6;
+        public readonly ulong A7;
+        public readonly ulong T0;
+        public readonly ulong T1;
+        public readonly ulong T2;
+        public readonly ulong T3;
+        public readonly ulong T4;
+        public readonly ulong T5;
+        public readonly ulong T6;
+        public readonly ulong T7;
+        public readonly ulong T8;
+        public readonly ulong X0;
+        public readonly ulong Fp;
+        public readonly ulong S0;
+        public readonly ulong S1;
+        public readonly ulong S2;
+        public readonly ulong S3;
+        public readonly ulong S4;
+        public readonly ulong S5;
+        public readonly ulong S6;
+        public readonly ulong S7;
+        public readonly ulong S8;
+        public readonly ulong Pc;
+
+        public unsafe bool CopyContext(Span<byte> context)
+        {
+            if (context.Length < LoongArch64Context.Size)
+                return false;
+
+            ref LoongArch64Context contextRef = ref Unsafe.As<byte, LoongArch64Context>(ref MemoryMarshal.GetReference(context));
+
+            contextRef.ContextFlags = LoongArch64Context.ContextControl | LoongArch64Context.ContextInteger;
+            contextRef.R0 = R0;
+            contextRef.Ra = Ra;
+            contextRef.Tp = Tp;
+            contextRef.Sp = Sp;
+            contextRef.A0 = A0;
+            contextRef.A1 = A1;
+            contextRef.A2 = A2;
+            contextRef.A3 = A3;
+            contextRef.A4 = A4;
+            contextRef.A5 = A5;
+            contextRef.A6 = A6;
+            contextRef.A7 = A7;
+            contextRef.T0 = T0;
+            contextRef.T1 = T1;
+            contextRef.T2 = T2;
+            contextRef.T3 = T3;
+            contextRef.T4 = T4;
+            contextRef.T5 = T5;
+            contextRef.T6 = T6;
+            contextRef.T7 = T7;
+            contextRef.T8 = T8;
+            contextRef.X0 = X0;
+            contextRef.Fp = Fp;
+            contextRef.S0 = S0;
+            contextRef.S1 = S1;
+            contextRef.S2 = S2;
+            contextRef.S3 = S3;
+            contextRef.S4 = S4;
+            contextRef.S5 = S5;
+            contextRef.S6 = S6;
+            contextRef.S7 = S7;
+            contextRef.S8 = S8;
+            contextRef.Pc = Pc;
+
+            return true;
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/Utilities/PEImage/ImageFileMachine.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Utilities/PEImage/ImageFileMachine.cs
@@ -31,6 +31,7 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
         TRICORE = 0x0520, // Infineon
         CEF = 0x0CEF,
         EBC = 0x0EBC, // EFI Byte Code
+        LOONGARCH64 = 0x6264, // LOONGARCH64
         AMD64 = 0x8664, // AMD64 (K8)
         M32R = 0x9041, // M32R little-endian
         ARM64 = 0xAA64, // ARM64 Little-endian

--- a/src/Samples/DbgEngExtension/MAddress.cs
+++ b/src/Samples/DbgEngExtension/MAddress.cs
@@ -427,6 +427,15 @@ namespace DbgEngExtension
                             sp = ctx->Sp;
                         }
                         break;
+
+                    case Architecture.LoongArch64:
+                        fixed (byte* ptrCtx = buffer)
+                        {
+                            LoongArch64Context* ctx = (LoongArch64Context*)ptrCtx;
+                            sp = ctx->Sp;
+                        }
+                        break;
+
                 }
             }
 


### PR DESCRIPTION
Add support for the new architecture LoongArch64.

* The `(Architecture)6` is `Architecture.LoongArch64`, which was introduced since .NET 7 and later.


@shushanhf