### PR TITLE
Add ISOSDac14 for .Net 9 static variable support

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacServiceProvider.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacServiceProvider.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
         private readonly SOSDac8? _sos8;
         private readonly SosDac12? _sos12;
         private readonly ISOSDac13? _sos13;
+        private readonly SosDac14? _sos14;
 
         private IAbstractClrNativeHeaps? _nativeHeaps;
         private IAbstractComHelpers? _com;
@@ -45,6 +46,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
             _sos8 = _process.CreateSOSDacInterface8();
             _sos12 = _process.CreateSOSDacInterface12();
             _sos13 = _process.CreateSOSDacInterface13();
+            _sos14 = _process.CreateSOSDacInterface14();
 
             library.DacDataTarget.SetMagicCallback(_process.Flush);
             IsThreadSafe = _sos13 is not null || RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
@@ -63,6 +65,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
             _sos8?.Dispose();
             _sos12?.Dispose();
             _sos13?.Dispose();
+            _sos14?.Dispose();
             _dac.Dispose();
             _moduleHelper?.Dispose();
         }
@@ -87,7 +90,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
             if (serviceType == typeof(IAbstractTypeHelpers))
             {
                 _moduleHelper ??= new(_sos);
-                return _typeHelper ??= new DacTypeHelpers(_process, _sos, _sos6, _sos8, _dataReader, _moduleHelper);
+                return _typeHelper ??= new DacTypeHelpers(_process, _sos, _sos6, _sos8, _sos14, _dataReader, _moduleHelper);
             }
 
             if (serviceType == typeof(IAbstractClrNativeHeaps))

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/ClrDataProcess.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/ClrDataProcess.cs
@@ -127,6 +127,22 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             return null;
         }
 
+        public SosDac14? CreateSOSDacInterface14()
+        {
+            IntPtr result = QueryInterface(SosDac14.IID_ISOSDac14);
+            if (result == IntPtr.Zero)
+                return null;
+
+            try
+            {
+                return new SosDac14(_library, result);
+            }
+            catch (InvalidOperationException)
+            {
+                return null;
+            }
+        }
+
         public void Flush()
         {
             VTable.Flush(Self);

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/SosDac14.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/SosDac14.cs
@@ -1,0 +1,56 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using Microsoft.Diagnostics.Runtime.Utilities;
+
+namespace Microsoft.Diagnostics.Runtime.DacInterface
+{
+
+    /// <summary>
+    /// This is an undocumented, untested, and unsupported interface.  Do not use directly.
+    /// </summary>
+    internal sealed unsafe class SosDac14 : CallableCOMWrapper
+    {
+        private readonly DacLibrary _library;
+
+        internal static readonly Guid IID_ISOSDac14 = new("9aa22aca-6dc6-4a0c-b4e0-70d2416b9837");
+
+        public SosDac14(DacLibrary library, IntPtr ptr)
+            : base(library?.OwningLibrary, IID_ISOSDac14, ptr)
+        {
+            _library = library ?? throw new ArgumentNullException(nameof(library));
+        }
+
+        private ref readonly ISOSDac14VTable VTable => ref Unsafe.AsRef<ISOSDac14VTable>(_vtable);
+
+        public (ulong NonGCStaticsBase, ulong GCStaticsBase) GetStaticBaseAddress(ClrDataAddress module)
+        {
+            HResult hr = VTable.GetStaticBaseAddress(Self, module, out ClrDataAddress nonGCStaticsBase, out ClrDataAddress gcStaticsBase);
+            return hr ? (nonGCStaticsBase, gcStaticsBase) : (0, 0);
+        }
+
+        public (ulong NonGCThreadStaticsBase, ulong GCThreadStaticsBase) GetThreadStaticBaseAddress(ClrDataAddress module, ClrDataAddress thread)
+        {
+            HResult hr = VTable.GetThreadStaticBaseAddress(Self, module, thread, out ClrDataAddress nonGCThreadStaticsBase, out ClrDataAddress gcThreadStaticsBase);
+            return hr ? (nonGCThreadStaticsBase, gcThreadStaticsBase) : (0, 0);
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private readonly unsafe struct ISOSDac14VTable
+        {
+            public readonly delegate* unmanaged[Stdcall]<nint, ClrDataAddress, out ClrDataAddress, out ClrDataAddress, int> GetStaticBaseAddress;
+            public readonly delegate* unmanaged[Stdcall]<nint, ClrDataAddress, ClrDataAddress, out ClrDataAddress, out ClrDataAddress, int> GetThreadStaticBaseAddress;
+            public readonly delegate* unmanaged[Stdcall]<nint, ClrDataAddress, out MethodTableInitializationFlags, int> GetMethodTableInitializationFlags;
+        }
+    }
+
+    internal enum MethodTableInitializationFlags : int
+    {
+        Unknown,
+        MethodTableInitialized,
+        MethodTableInitializationFailed,
+    }
+}


### PR DESCRIPTION
Added ISOSDac14 support for .Net 9 statics.

Fixes https://github.com/dotnet/diagnostics/issues/4803.