### PR TITLE
Fix a couple of issues for statics in sos14

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacTypeHelpers.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacTypeHelpers.cs
@@ -233,7 +233,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
         {
             if (_sos14 is not null)
             {
-                (ulong nonGcBase, ulong gcBase) = _sos14.GetStaticBaseAddress(module.Address);
+                (ulong nonGcBase, ulong gcBase) = _sos14.GetStaticBaseAddress(type.MethodTable);
                 if (field.ElementType.IsPrimitive())
                     return nonGcBase + (uint)field.Offset;
 
@@ -275,7 +275,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
 
             if (_sos14 is not null)
             {
-                (ulong nonGcBase, ulong gcBase) = _sos14.GetThreadStaticBaseAddress(module.Address, threadAddress);
+                (ulong nonGcBase, ulong gcBase) = _sos14.GetThreadStaticBaseAddress(type.MethodTable, threadAddress);
                 if (field.ElementType.IsPrimitive())
                     return nonGcBase + (uint)field.Offset;
 

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/SosDac14.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/SosDac14.cs
@@ -26,15 +26,15 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
 
         private ref readonly ISOSDac14VTable VTable => ref Unsafe.AsRef<ISOSDac14VTable>(_vtable);
 
-        public (ulong NonGCStaticsBase, ulong GCStaticsBase) GetStaticBaseAddress(ClrDataAddress module)
+        public (ulong NonGCStaticsBase, ulong GCStaticsBase) GetStaticBaseAddress(ClrDataAddress methodTable)
         {
-            HResult hr = VTable.GetStaticBaseAddress(Self, module, out ClrDataAddress nonGCStaticsBase, out ClrDataAddress gcStaticsBase);
+            HResult hr = VTable.GetStaticBaseAddress(Self, methodTable, out ClrDataAddress nonGCStaticsBase, out ClrDataAddress gcStaticsBase);
             return hr ? (nonGCStaticsBase, gcStaticsBase) : (0, 0);
         }
 
-        public (ulong NonGCThreadStaticsBase, ulong GCThreadStaticsBase) GetThreadStaticBaseAddress(ClrDataAddress module, ClrDataAddress thread)
+        public (ulong NonGCThreadStaticsBase, ulong GCThreadStaticsBase) GetThreadStaticBaseAddress(ClrDataAddress methodTable, ClrDataAddress thread)
         {
-            HResult hr = VTable.GetThreadStaticBaseAddress(Self, module, thread, out ClrDataAddress nonGCThreadStaticsBase, out ClrDataAddress gcThreadStaticsBase);
+            HResult hr = VTable.GetThreadStaticBaseAddress(Self, methodTable, thread, out ClrDataAddress nonGCThreadStaticsBase, out ClrDataAddress gcThreadStaticsBase);
             return hr ? (nonGCThreadStaticsBase, gcThreadStaticsBase) : (0, 0);
         }
 

--- a/src/Microsoft.Diagnostics.Runtime/Extensions/ClrElementTypeExtensions.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Extensions/ClrElementTypeExtensions.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Diagnostics.Runtime
         public static bool IsPrimitive(this ClrElementType cet)
         {
             return cet is >= ClrElementType.Boolean and <= ClrElementType.Double
-                or ClrElementType.NativeInt or ClrElementType.NativeUInt;
+                or ClrElementType.NativeInt or ClrElementType.NativeUInt or ClrElementType.Pointer;
         }
 
         public static bool IsValueType(this ClrElementType cet)


### PR DESCRIPTION
- Followup to https://github.com/microsoft/clrmd/pull/1284, passed in the method table address to the statics APIs instead of the module address
- Treated `ClrElementType.Pointer` as primitive, as for thread-statics they seem to be stored in the non-GC section