### PR TITLE
[LoongArch64] Fix the issue of incorrect printing information in the gcroot command

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacThreadHelpers.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacThreadHelpers.cs
@@ -112,9 +112,9 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
             }
             else if (_dataReader.Architecture == (Architecture)6 /* Architecture.LoongArch64 */)
             {
-                ipOffset = 120;
-                spOffset = 112;
-                contextSize = 544;
+                ipOffset = 264;
+                spOffset = 32;
+                contextSize = 1312;
             }
             else if (_dataReader.Architecture == Architecture.X86)
             {


### PR DESCRIPTION
Adjust the offset values of SP and IP as well as the contextSize value in the EnumerateSackTrace function.