### PR TITLE
Let the debugger knows DATAS is on

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/AbstractDac/IAbstractHeap.cs
+++ b/src/Microsoft.Diagnostics.Runtime/AbstractDac/IAbstractHeap.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Diagnostics.Runtime.AbstractDac
         bool IsValidMethodTable(ulong mt);
         MemoryRange GetInternalRootArray(ulong subHeapAddress);
         bool GetOOMInfo(ulong subHeapAddress, out OomInfo oomInfo);
+        int? GetDynamicAdaptationMode();
     }
 
     public struct GCState

--- a/src/Microsoft.Diagnostics.Runtime/ClrHeap.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrHeap.cs
@@ -58,6 +58,15 @@ namespace Microsoft.Diagnostics.Runtime
 
             SubHeaps = Helpers.EnumerateSubHeaps().Select(r => new ClrSubHeap(this, r)).ToImmutableArray();
             Segments = SubHeaps.SelectMany(r => r.Segments).OrderBy(r => r.FirstObjectAddress).ToImmutableArray();
+            DynamicAdaptationMode = Helpers.GetDynamicAdaptationMode();
+        }
+
+        /// <summary>
+        /// The DynamicAdaptationMode
+        /// </summary>
+        public int? DynamicAdaptationMode
+        {
+            get;
         }
 
         /// <summary>

--- a/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacHeap.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacHeap.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
         private readonly SOSDac _sos;
         private readonly SOSDac8? _sos8;
         private readonly SosDac12? _sos12;
+        private readonly ISOSDac16? _sos16;
         private readonly IMemoryReader _memoryReader;
         private readonly GCState _gcState;
         private HashSet<ulong>? _validMethodTables;
@@ -28,11 +29,12 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
         private const uint SyncBlockSpinLock = 0x10000000;
         private const uint SyncBlockHashOrSyncBlockIndex = 0x08000000;
 
-        public DacHeap(SOSDac sos, SOSDac8? sos8, SosDac12? sos12, IMemoryReader reader, in GCInfo gcInfo, in CommonMethodTables commonMethodTables)
+        public DacHeap(SOSDac sos, SOSDac8? sos8, SosDac12? sos12, ISOSDac16? sos16, IMemoryReader reader, in GCInfo gcInfo, in CommonMethodTables commonMethodTables)
         {
             _sos = sos;
             _sos8 = sos8;
             _sos12 = sos12;
+            _sos16 = sos16;
             _memoryReader = reader;
             _gcState = new()
             {
@@ -447,6 +449,18 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
                 Size = oomData.Size,
             };
             return true;
+        }
+
+        public int? GetDynamicAdaptationMode()
+        {
+            if (_sos16 != null)
+            {
+                return _sos16.GetDynamicAdaptationMode();
+            }
+            else
+            {
+                return null;
+            }
         }
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacServiceProvider.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacServiceProvider.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
         private readonly SosDac12? _sos12;
         private readonly ISOSDac13? _sos13;
         private readonly SosDac14? _sos14;
+        private readonly ISOSDac16? _sos16;
 
         private IAbstractClrNativeHeaps? _nativeHeaps;
         private IAbstractComHelpers? _com;
@@ -47,6 +48,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
             _sos12 = _process.CreateSOSDacInterface12();
             _sos13 = _process.CreateSOSDacInterface13();
             _sos14 = _process.CreateSOSDacInterface14();
+            _sos16 = _process.CreateSOSDacInterface16();
 
             library.DacDataTarget.SetMagicCallback(_process.Flush);
             IsThreadSafe = _sos13 is not null || RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
@@ -66,6 +68,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
             _sos12?.Dispose();
             _sos13?.Dispose();
             _sos14?.Dispose();
+            _sos16?.Dispose();
             _dac.Dispose();
             _moduleHelper?.Dispose();
         }
@@ -82,7 +85,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
                     return heap;
 
                 if (_sos.GetGCHeapData(out GCInfo data) && _sos.GetCommonMethodTables(out CommonMethodTables mts) && mts.ObjectMethodTable != 0)
-                    return _heapHelper = new DacHeap(_sos, _sos8, _sos12, _dataReader, data, mts);
+                    return _heapHelper = new DacHeap(_sos, _sos8, _sos12, _sos16, _dataReader, data, mts);
 
                 return null;
             }

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/ClrDataProcess.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/ClrDataProcess.cs
@@ -143,6 +143,22 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             }
         }
 
+        public ISOSDac16? CreateSOSDacInterface16()
+        {
+            IntPtr result = QueryInterface(SOSDac16.IID_ISOSDac16);
+            if (result == IntPtr.Zero)
+                return null;
+
+            try
+            {
+                return new SOSDac16(_library, result);
+            }
+            catch (InvalidOperationException)
+            {
+                return null;
+            }
+        }
+
         public void Flush()
         {
             VTable.Flush(Self);

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/ISOSDac16.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/ISOSDac16.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Microsoft.Diagnostics.Runtime.Utilities;
+
+namespace Microsoft.Diagnostics.Runtime.DacInterface
+{
+    internal interface ISOSDac16 : IDisposable
+    {
+        int? GetDynamicAdaptationMode();
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/SosDac16.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/SosDac16.cs
@@ -1,0 +1,42 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using Microsoft.Diagnostics.Runtime.Utilities;
+using static Microsoft.Diagnostics.Runtime.DacInterface.SOSDac;
+
+namespace Microsoft.Diagnostics.Runtime.DacInterface
+{
+    /// <summary>
+    /// This is an undocumented, untested, and unsupported interface.  Do not use directly.
+    /// </summary>
+    internal sealed unsafe class SOSDac16 : CallableCOMWrapper, ISOSDac16
+    {
+        private readonly DacLibrary _library;
+
+        internal static readonly Guid IID_ISOSDac16 = new("4ba12ff8-daac-4e43-ac56-98cf8d5c595d");
+
+        public SOSDac16(DacLibrary library, IntPtr ptr)
+            : base(library?.OwningLibrary, IID_ISOSDac16, ptr)
+        {
+            _library = library ?? throw new ArgumentNullException(nameof(library));
+        }
+
+        private ref readonly ISOSDac16VTable VTable => ref Unsafe.AsRef<ISOSDac16VTable>(_vtable);
+
+        public int? GetDynamicAdaptationMode()
+        {
+            HResult hr = VTable.GetDynamicAdaptationMode(Self, out int result);
+            return (hr == HResult.S_OK) ? result : null;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private readonly unsafe struct ISOSDac16VTable
+        {
+            public readonly delegate* unmanaged[Stdcall]<nint, out int, int> GetDynamicAdaptationMode;
+        }
+    }
+}


### PR DESCRIPTION
This PR is meant to support https://github.com/dotnet/diagnostics/issues/5090.

This PR is the clrmd side of the work, this exposes a new field so that the debugger can display the information.
There are two more PRs on different repos to support this:

On runtime: https://github.com/dotnet/runtime/pull/107115
On diagnostics: https://github.com/dotnet/diagnostics/pull/5164