### PR TITLE
Add cDac runtime enumeration support

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/ClrInfo.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrInfo.cs
@@ -105,7 +105,7 @@ namespace Microsoft.Diagnostics.Runtime
         /// </summary>
         /// <param name="dacPath">A full path to the matching DAC dll for this process.</param>
         /// <returns>The runtime associated with this CLR.</returns>
-        public ClrRuntime CreateRuntime(string dacPath)=> CreateRuntime(dacPath, ignoreMismatch: false, verifySignature: false);
+        public ClrRuntime CreateRuntime(string dacPath) => CreateRuntime(dacPath, ignoreMismatch: false, verifySignature: false);
 
         /// <summary>
         /// Creates a runtime from the given DAC file on disk.

--- a/src/Microsoft.Diagnostics.Runtime/ClrInfo.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrInfo.cs
@@ -61,6 +61,11 @@ namespace Microsoft.Diagnostics.Runtime
         public ModuleInfo ModuleInfo { get; }
 
         /// <summary>
+        /// The CDAC contract export address
+        /// </summary>
+        public ulong ContractDescriptor { get; set; }
+
+        /// <summary>
         /// The timestamp under which this CLR is is archived (0 if this module is indexed under
         /// a BuildId instead).  Note that this may be a different value from ModuleInfo.IndexTimeStamp.
         /// In a single-file scenario, the ModuleInfo will be the info of the program's main executable
@@ -89,21 +94,18 @@ namespace Microsoft.Diagnostics.Runtime
         public override string ToString() => Version.ToString();
 
         /// <summary>
+        /// Creates a runtime by searching for the correct dac to load.
+        /// </summary>
+        /// <returns>The runtime associated with this CLR.</returns>
+        public ClrRuntime CreateRuntime() => CreateRuntimeWorker(null, ignoreMismatch: false, verifySignature: false);
+
+        /// <summary>
         /// Creates a runtime from the given DAC file on disk.  This is equivalent to
         /// CreateRuntime(dacPath, ignoreMismatch: false).
         /// </summary>
         /// <param name="dacPath">A full path to the matching DAC dll for this process.</param>
         /// <returns>The runtime associated with this CLR.</returns>
-        public ClrRuntime CreateRuntime(string dacPath)
-        {
-            if (string.IsNullOrEmpty(dacPath))
-                throw new ArgumentNullException(nameof(dacPath));
-
-            if (!File.Exists(dacPath))
-                throw new FileNotFoundException(dacPath);
-
-            return CreateRuntimeWorker(dacPath, ignoreMismatch: false);
-        }
+        public ClrRuntime CreateRuntime(string dacPath)=> CreateRuntime(dacPath, ignoreMismatch: false, verifySignature: false);
 
         /// <summary>
         /// Creates a runtime from the given DAC file on disk.
@@ -111,7 +113,16 @@ namespace Microsoft.Diagnostics.Runtime
         /// <param name="dacPath">A full path to the matching DAC dll for this process.</param>
         /// <param name="ignoreMismatch">Whether or not to ignore mismatches between. </param>
         /// <returns>The runtime associated with this CLR.</returns>
-        public ClrRuntime CreateRuntime(string dacPath, bool ignoreMismatch)
+        public ClrRuntime CreateRuntime(string dacPath, bool ignoreMismatch) => CreateRuntime(dacPath, ignoreMismatch, verifySignature: false);
+
+        /// <summary>
+        /// Creates a runtime from the given DAC file on disk.
+        /// </summary>
+        /// <param name="dacPath">A full path to the matching DAC dll for this process.</param>
+        /// <param name="ignoreMismatch">Whether or not to ignore mismatches between.</param>
+        /// <param name="verifySignature">If true, verify the DAC signature</param>
+        /// <returns>The runtime associated with this CLR.</returns>
+        public ClrRuntime CreateRuntime(string dacPath, bool ignoreMismatch, bool verifySignature)
         {
             if (string.IsNullOrEmpty(dacPath))
                 throw new ArgumentNullException(nameof(dacPath));
@@ -119,18 +130,12 @@ namespace Microsoft.Diagnostics.Runtime
             if (!File.Exists(dacPath))
                 throw new FileNotFoundException(dacPath);
 
-            return CreateRuntimeWorker(dacPath, ignoreMismatch);
+            return CreateRuntimeWorker(dacPath, ignoreMismatch, verifySignature);
         }
 
-        /// <summary>
-        /// Creates a runtime by searching for the correct dac to load.
-        /// </summary>
-        /// <returns>The runtime associated with this CLR.</returns>
-        public ClrRuntime CreateRuntime() => CreateRuntimeWorker(null, ignoreMismatch: false);
-
-        private ClrRuntime CreateRuntimeWorker(string? dacPath, bool ignoreMismatch)
+        private ClrRuntime CreateRuntimeWorker(string? dacPath, bool ignoreMismatch, bool verifySignature)
         {
-            IServiceProvider services = ClrInfoProvider.GetDacServices(this, dacPath, ignoreMismatch);
+            IServiceProvider services = ClrInfoProvider.GetDacServices(this, dacPath, ignoreMismatch, verifySignature);
             return new ClrRuntime(this, services);
         }
 

--- a/src/Microsoft.Diagnostics.Runtime/ClrInfo.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrInfo.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Diagnostics.Runtime
         /// <summary>
         /// The CDAC contract export address
         /// </summary>
-        public ulong ContractDescriptor { get; set; }
+        public ulong ContractDescriptorAddress { get; set; }
 
         /// <summary>
         /// The timestamp under which this CLR is is archived (0 if this module is indexed under

--- a/src/Microsoft.Diagnostics.Runtime/CustomDataTarget.cs
+++ b/src/Microsoft.Diagnostics.Runtime/CustomDataTarget.cs
@@ -48,11 +48,6 @@ namespace Microsoft.Diagnostics.Runtime
         public bool ForceCompleteRuntimeEnumeration { get; set; }
 
         /// <summary>
-        /// If true, enforces the proper DAC certificate signing
-        /// </summary>
-        public bool DacSignatureVerificationEnabled { get; set; }
-
-        /// <summary>
         /// The TokenCredential to use for any Azure based symbol servers (set to null if not using one).
         /// </summary>
         public TokenCredential? SymbolTokenCredential { get; set; }

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/DacDataTarget.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/DacDataTarget.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
         internal static readonly Guid IID_IDacDataTarget = new("3E11CCEE-D08B-43e5-AF01-32717A64DA03");
         internal static readonly Guid IID_IMetadataLocator = new("aa8fa804-bc05-4642-b2c5-c353ed22fc63");
         internal static readonly Guid IID_ICLRRuntimeLocator = new("b760bf44-9377-4597-8be7-58083bdc5146");
+        internal static readonly Guid IID_ICLRContractLocator = new("17d5b8c6-34a9-407f-af4f-a930201d4e02");
 
         public const ulong MagicCallbackConstant = 0x43;
 
@@ -27,11 +28,14 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
 
         public ulong RuntimeBaseAddress { get; }
 
-        public DacDataTarget(DataTarget dataTarget, ulong runtimeBaseAddress = 0)
+        public ulong ContractDescriptor { get; }
+
+        public DacDataTarget(DataTarget dataTarget, ulong runtimeBaseAddress = 0, ulong contractDescriptor = 0)
         {
             _dataTarget = dataTarget;
             _dataReader = _dataTarget.DataReader;
             RuntimeBaseAddress = runtimeBaseAddress;
+            ContractDescriptor = contractDescriptor;
         }
 
         public void EnterMagicCallbackContext() => Interlocked.Increment(ref _callbackContext);
@@ -204,21 +208,5 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
 
             return HResult.S_OK;
         }
-
-        private delegate int GetMetadataDelegate(IntPtr self, [In][MarshalAs(UnmanagedType.LPWStr)] string fileName, int imageTimestamp, int imageSize,
-                                                     IntPtr mvid, uint mdRva, uint flags, uint bufferSize, IntPtr buffer, int* dataSize);
-        private delegate int GetMachineTypeDelegate(IntPtr self, out IMAGE_FILE_MACHINE machineType);
-        private delegate int GetPointerSizeDelegate(IntPtr self, out int pointerSize);
-        private delegate int GetImageBaseDelegate(IntPtr self, [In][MarshalAs(UnmanagedType.LPWStr)] string imagePath, out ulong baseAddress);
-        private delegate int ReadVirtualDelegate(IntPtr self, ClrDataAddress address, IntPtr buffer, int bytesRequested, out int bytesRead);
-        private delegate int WriteVirtualDelegate(IntPtr self, ClrDataAddress address, IntPtr buffer, uint bytesRequested, out uint bytesWritten);
-        private delegate int GetTLSValueDelegate(IntPtr self, uint threadID, uint index, out ulong value);
-        private delegate int SetTLSValueDelegate(IntPtr self, uint threadID, uint index, ClrDataAddress value);
-        private delegate int GetCurrentThreadIDDelegate(IntPtr self, out uint threadID);
-        private delegate int GetThreadContextDelegate(IntPtr self, uint threadID, uint contextFlags, int contextSize, IntPtr context);
-        private delegate int SetThreadContextDelegate(IntPtr self, uint threadID, uint contextSize, IntPtr context);
-        private delegate int RequestDelegate(IntPtr self, uint reqCode, uint inBufferSize, IntPtr inBuffer, IntPtr outBufferSize, out IntPtr outBuffer);
-
-        private delegate int GetRuntimeBaseDelegate([In] IntPtr self, [Out] out ulong address);
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/DebugLibraryKind.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DebugLibraryKind.cs
@@ -7,5 +7,6 @@ namespace Microsoft.Diagnostics.Runtime
     {
         Dac,
         Dbi,
+        CDac
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/IClrInfoProvider.cs
+++ b/src/Microsoft.Diagnostics.Runtime/IClrInfoProvider.cs
@@ -23,8 +23,9 @@ namespace Microsoft.Diagnostics.Runtime
         /// <param name="clrInfo">A ClrInfo previously returned by this same instance.</param>
         /// <param name="providedPath">The path provided to DataTarget.CreateRuntime.</param>
         /// <param name="ignorePathMismatch">The ignore mismatch parameter provided to DataTarget.CreateRuntime.</param>
+        /// <param name="verifySignature">If true, verify the DAC signature</param>
         /// <returns>An <see cref="IServiceProvider"/> interface to use with the specified clr runtime that provides
         /// <see cref="IAbstractRuntime"/> related services.</returns>
-        IServiceProvider GetDacServices(ClrInfo clrInfo, string? providedPath, bool ignorePathMismatch);
+        IServiceProvider GetDacServices(ClrInfo clrInfo, string? providedPath, bool ignorePathMismatch, bool verifySignature);
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/Implementation/DotNetClrInfoProvider.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Implementation/DotNetClrInfoProvider.cs
@@ -128,7 +128,7 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
                     throw new ClrDiagnosticsException($"Mismatched dac. Dac version: {major}.{minor}.{revision}.{patch}, expected: {clrInfo.Version}.");
             }
 
-            return new(clrInfo.DataTarget, dacPath, clrInfo.ModuleInfo.ImageBase, clrInfo.ContractDescriptor, verifySignature);
+            return new(clrInfo.DataTarget, dacPath, clrInfo.ModuleInfo.ImageBase, clrInfo.ContractDescriptorAddress, verifySignature);
         }
 
         public virtual ClrInfo? ProvideClrInfoForModule(DataTarget dataTarget, ModuleInfo module)
@@ -360,7 +360,7 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
             {
                 Flavor = flavor,
                 DebuggingLibraries = orderedDebugLibraries.ToImmutableArray(),
-                ContractDescriptor = contractDescriptor,
+                ContractDescriptorAddress = contractDescriptor,
                 IndexFileSize = indexFileSize,
                 IndexTimeStamp = indexTimeStamp,
                 BuildId = buildId,

--- a/src/Microsoft.Diagnostics.Runtime/Interfaces/IClrInfo.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Interfaces/IClrInfo.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Diagnostics.Runtime.Interfaces
         int IndexTimeStamp { get; }
         bool IsSingleFile { get; }
         ModuleInfo ModuleInfo { get; }
-        ulong ContractDescriptor { get; }
+        ulong ContractDescriptorAddress { get; }
         Version Version { get; }
 
         IClrRuntime CreateRuntime();

--- a/src/Microsoft.Diagnostics.Runtime/Interfaces/IClrInfo.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Interfaces/IClrInfo.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Diagnostics.Runtime.Interfaces
         int IndexTimeStamp { get; }
         bool IsSingleFile { get; }
         ModuleInfo ModuleInfo { get; }
+        ulong ContractDescriptor { get; }
         Version Version { get; }
 
         IClrRuntime CreateRuntime();

--- a/src/Microsoft.Diagnostics.Runtime/SymbolProperties.cs
+++ b/src/Microsoft.Diagnostics.Runtime/SymbolProperties.cs
@@ -16,6 +16,11 @@ namespace Microsoft.Diagnostics.Runtime
         /// <summary>
         /// The binary is archived under coreclr's properties.
         /// </summary>
-        Coreclr
+        Coreclr,
+
+        /// <summary>
+        /// The binary is NOT archived
+        /// </summary>
+        None
     }
 }


### PR DESCRIPTION
Adds a new DebugLibaryKind.CDac enum used when the data contract export is found on a runtime module.

Currently the file path to the cdac is the same directory as the clrmd module.

Currently leaves it to the client (SOS in this case) to decide when it wants to instantiate the cdac. The standalone hosting support doesn't currently pick the cdac.

Breaking changes:

Add "bool verifySignature" to IClrInfoProvider.GetDacServices and remove the CustomDataTarget.DacSignatureVerificationEnabled property.

Adds data target support for ICLRContractLocator for when clrmd loads the cdac.