### PR TITLE
Dispose dump file stream when leaveOpen is false

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/DataTarget.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DataTarget.cs
@@ -317,7 +317,7 @@ namespace Microsoft.Diagnostics.Runtime
             }
             catch
             {
-                if (leaveOpen)
+                if (!leaveOpen)
                     stream?.Dispose();
                 throw;
             }


### PR DESCRIPTION
I was writing a test that gave an invalid dump to DataTarget.LoadDump, and I noticed that the file stream wasn't closed. It looks like the condition has been wrong since it was originally added