### PR TITLE
Populate dependent handles

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/ClrHandle.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrHandle.cs
@@ -27,6 +27,11 @@ namespace Microsoft.Diagnostics.Runtime
             HandleKind = handle.Kind;
             ReferenceCount = handle.RefCount;
             RootKind = IsStrong ? (ClrRootKind)HandleKind : ClrRootKind.None;
+
+            if (handle.Kind == ClrHandleKind.Dependent && handle.DependentTarget != 0)
+            {
+                Dependent = runtime.Heap.GetObject(handle.DependentTarget);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
When enumerating handles, the dependent target of dependent handles was correctly fetched into the `ClrHandleInfo`, but not copied to the destination `ClrHandle`.