### PR TITLE
now if even if value of object is null, we return its type correctly

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/ClrObject.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrObject.cs
@@ -5,8 +5,10 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+
 using Microsoft.Diagnostics.Runtime.AbstractDac;
 using Microsoft.Diagnostics.Runtime.Interfaces;
+using Microsoft.Diagnostics.Runtime.Utilities;
 
 namespace Microsoft.Diagnostics.Runtime
 {
@@ -269,7 +271,7 @@ namespace Microsoft.Diagnostics.Runtime
             if (!DataReader.ReadPointer(addr, out ulong obj))
                 return false;
 
-            result = heap.GetObject(obj);
+            result = field.Type != null ? heap.GetObject(obj, field.Type) : heap.GetObject(obj);
             return true;
         }
 
@@ -329,7 +331,7 @@ namespace Microsoft.Diagnostics.Runtime
             if (!DataReader.ReadPointer(addr, out ulong obj))
                 return default;
 
-            return heap.GetObject(obj);
+            return field.Type != null ? heap.GetObject(obj, field.Type) : heap.GetObject(obj);
         }
 
         public ClrValueType ReadValueTypeField(string fieldName)


### PR DESCRIPTION
if possible I provide type of the field. so that even if value is null, we still can get type

the covered issue: https://github.com/microsoft/clrmd/issues/1342