### PR TITLE
Fix EnumerateSyncBlockCleanupData to pass NextSyncBlock on subsequent iterations

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacNativeHeaps.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacNativeHeaps.cs
@@ -76,12 +76,13 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
 
         public IEnumerable<ClrSyncBlockCleanupData> EnumerateSyncBlockCleanupData()
         {
+            HashSet<ulong> seen = [0];
             ulong syncBlock = 0;
             while (_sos.GetSyncBlockCleanupData(syncBlock, out SyncBlockCleanupData data))
             {
                 yield return new(data.SyncBlockPointer, data.BlockRCW, data.BlockCCW, data.BlockClassFactory);
 
-                if (data.NextSyncBlock == 0 || data.NextSyncBlock == syncBlock)
+                if (!seen.Add(data.NextSyncBlock))
                     break;
 
                 syncBlock = data.NextSyncBlock;


### PR DESCRIPTION
Previously, the method always passed 0 as the syncBlock argument to GetSyncBlockCleanupData, causing it to either return the same first item repeatedly or exit immediately. Now it passes data.NextSyncBlock for subsequent calls to properly walk the linked list.

Fixes #1330.