### PR TITLE
Fix IClrStaticField.GetAddress(IClrAppDomain) returning 0

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/ClrStaticField.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrStaticField.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Diagnostics.Runtime
         /// <returns>The address of the field's value.</returns>
         public ulong GetAddress(ClrAppDomain appDomain) => _helpers.GetStaticFieldAddress(appDomain.AppDomainInfo, ContainingType.Module.ModuleInfo, ContainingType.TypeInfo, FieldInfo);
 
-        public ulong GetAddress(IClrAppDomain appDomain) => 0;
+        public ulong GetAddress(IClrAppDomain appDomain) => appDomain is ClrAppDomain clrAd ? GetAddress(clrAd) : 0;
 
         /// <summary>
         /// Reads the value of the field as an unmanaged struct or primitive type.


### PR DESCRIPTION
The interface implementation of GetAddress(IClrAppDomain) was hardcoded to return 0, causing all static field address lookups through the interface to fail. This fix delegates to the concrete GetAddress(ClrAppDomain) if possible.

This isn't the best of fixes, as there's the possibility that someone else will implement IClrAppDomain (mocking for example), but the guts of ClrAppDomain (like AppDomainInfo) are needed to really get the value out.  This at least will make the standard case work properly.

Fixes #1313