### PR TITLE
Update samples

### DIFF
--- a/src/Samples/ClrStack/ClrStack.cs
+++ b/src/Samples/ClrStack/ClrStack.cs
@@ -1,111 +1,70 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-// Please go to the ClrMD project page on github for full source and to report issues:
-//    https://github.com/Microsoft/clrmd
-
-using System;
 using Microsoft.Diagnostics.Runtime;
 
 class ClrStack
 {
     static void Main(string[] args)
     {
-        if (!TryParseArgs(args, out string dump, out bool dso))
+        if (!TryParseArgs(args, out string? dump, out bool dso))
         {
-            Usage();
+            Console.WriteLine("Usage: ClrStack [-dso] crash.dmp");
             return;
         }
 
         // Create the data target.  This tells us the versions of CLR loaded in the target process.
-        using DataTarget dataTarget = DataTarget.LoadDump(dump);
+        using DataTarget dataTarget = DataTarget.LoadDump(dump!);
 
         // Now check bitness of our program/target:
         bool isTarget64Bit = dataTarget.DataReader.PointerSize == 8;
         if (Environment.Is64BitProcess != isTarget64Bit)
-            throw new Exception(string.Format("Architecture mismatch:  Process is {0} but target is {1}", Environment.Is64BitProcess ? "64 bit" : "32 bit", isTarget64Bit ? "64 bit" : "32 bit"));
+            throw new InvalidOperationException($"Architecture mismatch:  Process is {(Environment.Is64BitProcess ? "64 bit" : "32 bit")} but target is {(isTarget64Bit ? "64 bit" : "32 bit")}");
 
-        // Note I just take the first version of CLR in the process.  You can loop over every loaded
-        // CLR to handle the SxS case where both desktop CLR and .Net Core are loaded in the process.
-        ClrInfo version = dataTarget.ClrVersions[0];
+        using ClrRuntime runtime = dataTarget.ClrVersions[0].CreateRuntime();
 
-        // Now that we have the DataTarget, the version of CLR, and the right dac, we create and return a
-        // ClrRuntime instance.
-        using ClrRuntime runtime = version.CreateRuntime();
-
-        // Walk each thread in the process.
         foreach (ClrThread thread in runtime.Threads)
         {
-            // The ClrRuntime.Threads will also report threads which have recently died, but their
-            // underlying datastructures have not yet been cleaned up.  This can potentially be
-            // useful in debugging (!threads displays this information with XXX displayed for their
-            // OS thread id).  You cannot walk the stack of these threads though, so we skip them
-            // here.
             if (!thread.IsAlive)
                 continue;
 
             Console.WriteLine("Thread {0:X}:", thread.OSThreadId);
             Console.WriteLine("Stack: {0:X} - {1:X}", thread.StackBase, thread.StackLimit);
 
-            // Each thread tracks a "last thrown exception".  This is the exception object which
-            // !threads prints.  If that exception object is present, we will display some basic
-            // exception data here.  Note that you can get the stack trace of the exception with
-            // ClrHeapException.StackTrace (we don't do that here).
-            ClrException? currException = thread.CurrentException;
-            if (currException is ClrException ex)
+            // Each thread tracks a "last thrown exception".
+            if (thread.CurrentException is ClrException ex)
                 Console.WriteLine("Exception: {0:X} ({1}), HRESULT={2:X}", ex.Address, ex.Type.Name, ex.HResult);
 
-            // Walk the stack of the thread and print output similar to !ClrStack.
             Console.WriteLine();
             Console.WriteLine("Managed Callstack:");
             foreach (ClrStackFrame frame in thread.EnumerateStackTrace())
-            {
-                // Note that CLRStackFrame currently only has three pieces of data: stack pointer,
-                // instruction pointer, and frame name (which comes from ToString).  Future
-                // versions of this API will allow you to get the type/function/module of the
-                // method (instead of just the name).  This is not yet implemented.
                 Console.WriteLine($"    {frame.StackPointer:x12} {frame.InstructionPointer:x12} {frame}");
-            }
 
             // Print a !DumpStackObjects equivalent.
             if (dso)
             {
-                // We'll need heap data to find objects on the stack.
                 ClrHeap heap = runtime.Heap;
 
-                // Walk each pointer aligned address on the stack.  Note that StackBase/StackLimit
-                // is exactly what they are in the TEB.  This means StackBase > StackLimit on AMD64.
+                // StackBase/StackLimit is exactly what they are in the TEB.
+                // This means StackBase > StackLimit on AMD64.
                 ulong start = thread.StackBase;
                 ulong stop = thread.StackLimit;
 
-                // We'll walk these in pointer order.
                 if (start > stop)
-                {
-                    ulong tmp = start;
-                    start = stop;
-                    stop = tmp;
-                }
+                    (start, stop) = (stop, start);
 
                 Console.WriteLine();
                 Console.WriteLine("Stack objects:");
 
-                // Walk each pointer aligned address.  Ptr is a stack address.
                 for (ulong ptr = start; ptr <= stop; ptr += (uint)IntPtr.Size)
                 {
-                    // Read the value of this pointer.  If we fail to read the memory, break.  The
-                    // stack region should be in the crash dump.
                     if (!dataTarget.DataReader.ReadPointer(ptr, out ulong obj))
                         break;
 
-                    // 003DF2A4 
-                    // We check to see if this address is a valid object by simply calling
-                    // GetObjectType.  If that returns null, it's not an object.
-                    ClrType type = heap.GetObjectType(obj);
-                    if (type == null)
+                    ClrType? type = heap.GetObjectType(obj);
+                    if (type is null)
                         continue;
 
-                    // Don't print out free objects as there tends to be a lot of them on
-                    // the stack.
                     if (!type.IsFree)
                         Console.WriteLine("{0,16:X} {1,16:X} {2}", ptr, obj, type.Name);
                 }
@@ -117,7 +76,7 @@ class ClrStack
         }
     }
 
-    public static bool TryParseArgs(string[] args, out string dump, out bool dso)
+    public static bool TryParseArgs(string[] args, out string? dump, out bool dso)
     {
         dump = null;
         dso = false;
@@ -128,7 +87,7 @@ class ClrStack
             {
                 dso = true;
             }
-            else if (dump == null)
+            else if (dump is null)
             {
                 dump = arg;
             }
@@ -139,13 +98,6 @@ class ClrStack
             }
         }
 
-        return dump != null;
-    }
-
-
-    public static void Usage()
-    {
-        string fn = System.IO.Path.GetFileName(System.Reflection.Assembly.GetExecutingAssembly().Location);
-        Console.WriteLine($"Usage: {fn} [-dso] crash.dmp");
+        return dump is not null;
     }
 }

--- a/src/Samples/ClrStack/ClrStack.csproj
+++ b/src/Samples/ClrStack/ClrStack.csproj
@@ -2,11 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Diagnostics.Runtime" Version="2.0.0-rc.20278.6" />
+    <ProjectReference Include="..\..\Microsoft.Diagnostics.Runtime\Microsoft.Diagnostics.Runtime.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Samples/DbgEngExtension/DbgEngExtension.csproj
+++ b/src/Samples/DbgEngExtension/DbgEngExtension.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PublishAot>true</PublishAot>

--- a/src/Samples/DbgEngStandalone/DbgEngStandalone.csproj
+++ b/src/Samples/DbgEngStandalone/DbgEngStandalone.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/Samples/DumpDict/DumpDict.cs
+++ b/src/Samples/DumpDict/DumpDict.cs
@@ -1,66 +1,51 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-// Please go to the ClrMD project page on github for full source and to report issues:
-//    https://github.com/Microsoft/clrmd
-
-using System;
 using Microsoft.Diagnostics.Runtime;
-using System.IO;
-using System.Linq;
 
-static class Program
+if (args.Length != 2)
 {
-
-    static void Main(string[] args)
-    {
-        if (args.Length != 3)
-        {
-            Console.WriteLine("Usage: DumpDict [dump] [objref]");
-            Environment.Exit(1);
-        }
-
-        if (ulong.TryParse(args[2], System.Globalization.NumberStyles.HexNumber, null, out ulong objAddr))
-        {
-            Console.WriteLine($"Could not parse object ref '{args[2]}'.");
-            Environment.Exit(1);
-        }
-
-        string dumpFileName = args[0];
-        string dacPath = args[1];
-
-        using DataTarget dataTarget = DataTarget.LoadDump(dumpFileName);
-        using ClrRuntime runtime = dataTarget.ClrVersions.Single().CreateRuntime();
-        ClrHeap heap = runtime.Heap;
-
-        ClrObject obj = heap.GetObject(objAddr);
-
-        if (!obj.IsValidObject)
-        {
-            Console.WriteLine("Invalid object {0:X}", obj);
-            return;
-        }
-
-        if (!obj.Type.Name.StartsWith("System.Collections.Generic.Dictionary"))
-        {
-            Console.WriteLine("Error: Expected object {0:X} to be a dictionary, instead it's of type '{1}'.");
-            return;
-        }
-
-        // Get the entries field.
-        ClrArray entries = obj.ReadObjectField("entries").AsArray();
-
-        Console.WriteLine("{0,8} {1,16} : {2}", "hash", "key", "value");
-        for (int i = 0; i < entries.Length; ++i)
-        {
-            ClrObject entry = entries.GetObjectValue(i);
-
-            // TODO: Need to handle non-object references
-            int hashCode = entry.ReadField<int>("hashCode");
-            ClrObject key = entry.ReadObjectField("key");
-            ClrObject value = entry.ReadObjectField("value");
-
-            Console.WriteLine($"{hashCode:x} {key} -> {value}");
-        }
-    }
+    Console.WriteLine("Usage: DumpDict [dump] [objref]");
+    return 1;
 }
+
+if (!ulong.TryParse(args[1], System.Globalization.NumberStyles.HexNumber, null, out ulong objAddr))
+{
+    Console.WriteLine($"Could not parse object ref '{args[1]}'.");
+    return 1;
+}
+
+using DataTarget dataTarget = DataTarget.LoadDump(args[0]);
+using ClrRuntime runtime = dataTarget.ClrVersions.Single().CreateRuntime();
+ClrHeap heap = runtime.Heap;
+
+ClrObject obj = heap.GetObject(objAddr);
+
+if (!obj.IsValid)
+{
+    Console.WriteLine("Invalid object {0:X}", obj.Address);
+    return 1;
+}
+
+if (!obj.Type!.Name!.StartsWith("System.Collections.Generic.Dictionary"))
+{
+    Console.WriteLine($"Error: Expected object {obj.Address:X} to be a dictionary, instead it's of type '{obj.Type.Name}'.");
+    return 1;
+}
+
+// Get the entries field.
+ClrArray entries = obj.ReadObjectField("_entries").AsArray();
+
+Console.WriteLine("{0,8} {1,16} : {2}", "hash", "key", "value");
+for (int i = 0; i < entries.Length; ++i)
+{
+    ClrValueType entry = entries.GetStructValue(i);
+
+    int hashCode = entry.ReadField<int>("hashCode");
+    ClrObject key = entry.ReadObjectField("key");
+    ClrObject value = entry.ReadObjectField("value");
+
+    Console.WriteLine($"{hashCode:x} {key} -> {value}");
+}
+
+return 0;

--- a/src/Samples/DumpDict/DumpDict.csproj
+++ b/src/Samples/DumpDict/DumpDict.csproj
@@ -2,11 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Diagnostics.Runtime" Version="2.0.0-rc.20278.6" />
+    <ProjectReference Include="..\..\Microsoft.Diagnostics.Runtime\Microsoft.Diagnostics.Runtime.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Samples/DumpHeap/DumpHeap.cs
+++ b/src/Samples/DumpHeap/DumpHeap.cs
@@ -2,88 +2,49 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Diagnostics.Runtime;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 
-class Program
+if (args.Length != 1)
 {
-    static void Main(string[] args)
-    {
-        if (args.Length != 1)
-        {
-            Console.WriteLine($"Usage: dumpheap.exe [crashdump]");
-            Environment.Exit(1);
-        }
-
-        Dictionary<ulong, (int Count, ulong Size, string Name)> stats = new Dictionary<ulong, (int Count, ulong Size, string Name)>();
-
-        using DataTarget dataTarget = DataTarget.LoadDump(args[0]);
-        foreach (ClrInfo clr in dataTarget.ClrVersions)
-        {
-            using ClrRuntime runtime = clr.CreateRuntime();
-            ClrHeap heap = runtime.Heap;
-
-            Console.WriteLine("{0,16} {1,16} {2,8} {3}", "Object", "MethodTable", "Size", "Type");
-            foreach (ClrObject obj in heap.EnumerateObjects())
-            {
-                Console.WriteLine($"{obj.Address:x16} {obj.Type.MethodTable:x16} {obj.Size,8:D} {obj.Type.Name}");
-
-                if (!stats.TryGetValue(obj.Type.MethodTable, out (int Count, ulong Size, string Name) item))
-                    item = (0, 0, obj.Type.Name);
-
-                stats[obj.Type.MethodTable] = (item.Count + 1, item.Size + obj.Size, item.Name);
-            }
-
-            Console.WriteLine("\nStatistics:");
-            var sorted = from i in stats
-                         orderby i.Value.Size ascending
-                         select new
-                         {
-                             i.Key,
-                             i.Value.Name,
-                             i.Value.Size,
-                             i.Value.Count
-                         };
-
-            Console.WriteLine("{0,16} {1,12} {2,12}\t{3}", "MethodTable", "Count", "Size", "Type");
-            foreach (var item in sorted)
-                Console.WriteLine($"{item.Key:x16} {item.Count,12:D} {item.Size,12:D}\t{item.Name}");
-
-            Console.WriteLine($"Total {sorted.Sum(x => x.Count):0} objects");
-
-            #region >>> Above code sample output below, similiar to !sos.dumpheap
-            //            Object MethodTable     Size Type
-            //000001d1445a1000 000001d13e08bf90       24 Free
-            //000001d1445a1018 000001d13e08bf90       24 Free
-            //000001d1445a1030 000001d13e08bf90       24 Free
-            //000001d1445a1048 00007ffb05430638      152 System.RuntimeType + RuntimeTypeCache
-            //000001d1445a10e0 00007ffb0552eed0       56 System.RuntimeType + RuntimeTypeCache + MemberInfoCache < System.Reflection.RuntimeConstructorInfo >
-            //000001d1445a1118 00007ffb0552ec60      104 System.Reflection.RuntimeConstructorInfo
-            //000001d1445a1180 00007ffb0552f078       32 System.Reflection.RuntimeConstructorInfo[]
-            //...
-            //000001d5745a3030 000001d13e08bf90       32 Free
-            //000001d5745a3050 00007ffb05316610     8184 System.Object[]
-
-            //Statistics:
-            //     MethodTable        Count         Size Type
-            //00007ffb0577d1f8            1           24  Microsoft.Extensions.Logging.Configuration.LoggerProviderConfigurationFactory
-            //00007ffb05a26c00            1           24  Microsoft.Extensions.Options.OptionsCache < Microsoft.Extensions.Logging.Console.ConsoleLoggerOptions >
-            //00007ffb05a49c78            1           24  Microsoft.Extensions.Options.OptionsMonitor < Microsoft.Extensions.Logging.Console.ConsoleLoggerOptions >
-            //00007ffb05a49dc0            1           24  Microsoft.Extensions.Primitives.ChangeToken + ChangeTokenRegistration < System.String >
-            //00007ffb05a49e70            1           24  Microsoft.Extensions.Primitives.ChangeToken + ChangeTokenRegistration < System.String >
-            //00007ffb05a4be00            1           24  Microsoft.Extensions.Logging.NullExternalScopeProvider
-            //00007ffb05a4cf90            1           24  Microsoft.Extensions.Configuration.ConfigurationBinder +<> c
-            //00007ffb05a4cd80            1           24  Microsoft.Extensions.Configuration.BinderOptions
-            //...
-            //00007ffb053ef090         2010       111364  System.Int32[]
-            //00007ffb053d2aa8         2224       126352  System.SByte[]
-            //00007ffb05413058         1297       260138  System.Char[]
-            //00007ffb05316610         2160       331512  System.Object[]
-            //00007ffb053d2360          841       558172  System.Byte[]
-            //00007ffb053d1e18         8366       718666  System.String
-            //Total 82567 objects
-            #endregion
-        }
-    }
+    Console.WriteLine("Usage: DumpHeap [crashdump]");
+    return 1;
 }
+
+Dictionary<ulong, (int Count, ulong Size, string Name)> stats = new();
+
+using DataTarget dataTarget = DataTarget.LoadDump(args[0]);
+foreach (ClrInfo clr in dataTarget.ClrVersions)
+{
+    using ClrRuntime runtime = clr.CreateRuntime();
+    ClrHeap heap = runtime.Heap;
+
+    Console.WriteLine("{0,16} {1,16} {2,8} {3}", "Object", "MethodTable", "Size", "Type");
+    foreach (ClrObject obj in heap.EnumerateObjects())
+    {
+        Console.WriteLine($"{obj.Address:x16} {obj.Type?.MethodTable ?? 0:x16} {obj.Size,8:D} {obj.Type?.Name}");
+
+        ulong mt = obj.Type?.MethodTable ?? 0;
+        if (!stats.TryGetValue(mt, out (int Count, ulong Size, string Name) item))
+            item = (0, 0, obj.Type?.Name ?? "<unknown>");
+
+        stats[mt] = (item.Count + 1, item.Size + obj.Size, item.Name);
+    }
+
+    Console.WriteLine("\nStatistics:");
+    var sorted = from i in stats
+                 orderby i.Value.Size ascending
+                 select new
+                 {
+                     i.Key,
+                     i.Value.Name,
+                     i.Value.Size,
+                     i.Value.Count
+                 };
+
+    Console.WriteLine("{0,16} {1,12} {2,12}\t{3}", "MethodTable", "Count", "Size", "Type");
+    foreach (var item in sorted)
+        Console.WriteLine($"{item.Key:x16} {item.Count,12:D} {item.Size,12:D}\t{item.Name}");
+
+    Console.WriteLine($"Total {sorted.Sum(x => x.Count):0} objects");
+}
+
+return 0;

--- a/src/Samples/DumpHeap/DumpHeap.csproj
+++ b/src/Samples/DumpHeap/DumpHeap.csproj
@@ -2,11 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Diagnostics.Runtime" Version="2.0.0-rc.20278.6" />
+    <ProjectReference Include="..\..\Microsoft.Diagnostics.Runtime\Microsoft.Diagnostics.Runtime.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Samples/GCRoot/GCRoot.csproj
+++ b/src/Samples/GCRoot/GCRoot.csproj
@@ -2,11 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Diagnostics.Runtime" Version="2.0.0-rc.20278.6" />
+    <ProjectReference Include="..\..\Microsoft.Diagnostics.Runtime\Microsoft.Diagnostics.Runtime.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Samples/GCRoot/GCRootDemo.cs
+++ b/src/Samples/GCRoot/GCRootDemo.cs
@@ -1,100 +1,51 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.IO;
-using System.Linq;
-using System.Threading;
 using Microsoft.Diagnostics.Runtime;
 
-class Program
+if (args.Length != 2)
 {
-    public static void Main(string[] args)
-    {
-        ulong target = 0;
-
-        if (args.Length != 2)
-        {
-            PrintUsage();
-            Environment.Exit(1);
-        }
-        else if (!File.Exists(args[0]))
-        {
-            PrintUsage();
-            Console.WriteLine($"File not found: '{args[0]}'.");
-            Environment.Exit(1);
-        }
-        else if (!ulong.TryParse(args[1], System.Globalization.NumberStyles.HexNumber, null, out target))
-        {
-            PrintUsage();
-            Console.WriteLine($"Could not parse object address '{args[1]}'.");
-            Environment.Exit(1);
-        }
-
-        using DataTarget dt = DataTarget.LoadDump(args[0]);
-        using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
-        ClrHeap heap = runtime.Heap;
-
-       /* At the most basic level, to implement !gcroot, simply create a GCRoot object.  Then call
-        * EnumerateGCRoots to find unique paths from the root to the target object.  This runs similarly
-        * to !gcroot.  Please note you will receive all paths each time this code is run, but the order
-        * of roots from run to run are NOT guaranteed.  Note that all operations take a cancellation token
-        * which you can use to cancel GCRoot at any time (it will throw an OperationCancelledException).
-        */
-        GCRoot gcroot = new GCRoot(heap);
-        foreach (GCRootPath rootPath in gcroot.EnumerateGCRoots(target))
-        {
-            Console.Write($"{rootPath.Root} -> ");
-            Console.WriteLine(string.Join(" -> ", rootPath.Path.Select(obj => obj.Address)));
-        }
-
-        Console.WriteLine();
-        // ==========================================
-
-        /* Since GCRoot can take a long time to run, ClrMD provides an event to get progress updates on how far
-         * along GCRoot is.
-         */
-
-        gcroot.ProgressUpdated += (GCRoot source, int current) =>
-        {
-            Console.WriteLine($"Current root {source} objects inspected={current:n0}");
-        };
-
-        // ==========================================
-
-       /* GCRoot can use parallel processing to use more of the CPU and work in parallel.  This is done
-        * automatically (and is on by default)...but only if you use .BuildCache and build the *complete* GC heap
-        * in local memory.  Since limitations in ClrMD and the APIs it's built on do not allow multithreading,
-        * we only do multithreaded processing if we never need to call into ClrMD while walking objects.
-        *
-        * One downside is that multithreaded processing means the order of roots enumerated is not stable from
-        * run to run.  You can turn off multithreaded processing so that the results of GCRoot are stable between
-        * runs (though slower to run), but GCRoot makes NO guarantees about the order of roots you receive, and
-        * they may change from build to build of ClrMD or change depending on the other flags set on the GCRoot
-        * object.
-        */
-
-        // This can be used to turn off multithreaded processing, this property is true by default:
-        // gcroot.AllowParallelSearch = false;
-
-        // ==========================================
-
-        /* Finally, we will run through the enumeration one more time, but this time using parallel processing
-         * and printing out a bunch of status messages for demonstration.
-         */
-
-        Console.WriteLine("Get ready for a lot of output, since we are raw printing status updates!");
-        Console.WriteLine();
-        foreach (GCRootPath rootPath in gcroot.EnumerateGCRoots(target, false, Environment.ProcessorCount))
-        {
-            Console.Write($"{rootPath.Root} -> ");
-            Console.WriteLine(string.Join(" -> ", rootPath.Path.Select(obj => obj.Address)));
-        }
-    }
-
-    private static void PrintUsage()
-    {
-        Console.WriteLine(@"Usage:   gcrootdemo.exe [dumpfile] [target_object]");
-        Console.WriteLine(@"Example: gcrootdemo.exe c:\path\to\crash.dmp 8dfea0");
-    }
+    Console.WriteLine("Usage:   GCRoot [dumpfile] [target_object]");
+    Console.WriteLine(@"Example: GCRoot c:\path\to\crash.dmp 8dfea0");
+    return 1;
 }
+
+if (!File.Exists(args[0]))
+{
+    Console.WriteLine($"File not found: '{args[0]}'.");
+    return 1;
+}
+
+if (!ulong.TryParse(args[1], System.Globalization.NumberStyles.HexNumber, null, out ulong target))
+{
+    Console.WriteLine($"Could not parse object address '{args[1]}'.");
+    return 1;
+}
+
+using DataTarget dt = DataTarget.LoadDump(args[0]);
+using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
+ClrHeap heap = runtime.Heap;
+
+// Create a GCRoot object with the target address we want to find roots for.
+GCRoot gcroot = new(heap, [target]);
+
+// EnumerateRootPaths finds unique paths from GC roots to the target object.
+// Note that the order of roots is NOT guaranteed between runs.
+foreach ((ClrRoot root, GCRoot.ChainLink path) in gcroot.EnumerateRootPaths())
+{
+    Console.Write($"{root} -> ");
+
+    // Walk the chain of objects from the root to the target.
+    GCRoot.ChainLink? link = path;
+    while (link is not null)
+    {
+        Console.Write($"{link.Object:x}");
+        link = link.Next;
+        if (link is not null)
+            Console.Write(" -> ");
+    }
+
+    Console.WriteLine();
+}
+
+return 0;

--- a/src/Samples/Samples.sln
+++ b/src/Samples/Samples.sln
@@ -1,19 +1,21 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30128.36
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SelfAttach", "SelfAttach\SelfAttach.csproj", "{03D8877E-2369-46A8-930E-07FF1C7F5595}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GCRoot", "GCRoot\GCRoot.csproj", "{D7405CE8-8C8D-4462-B7AD-F1215E875422}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WindbgExtension", "WindbgExtension\WindbgExtension.csproj", "{12679331-455F-470C-B2F3-A53FD6EDF2B3}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ClrStack", "ClrStack\ClrStack.csproj", "{7AC85363-DB1F-4B6D-B6B6-EB7ECE590D6A}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DumpDict", "DumpDict\DumpDict.csproj", "{61184F60-4EF9-4840-9DCB-83619376E825}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DumpDict", "DumpDict\DumpDict.csproj", "{61184F60-4EF9-4840-9DCB-83619376E825}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DumpHeap", "DumpHeap\DumpHeap.csproj", "{A82FB97A-AC9D-4E5E-9BBC-B9382039F2D1}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DumpHeap", "DumpHeap\DumpHeap.csproj", "{A82FB97A-AC9D-4E5E-9BBC-B9382039F2D1}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DbgEngExtension", "DbgEngExtension\DbgEngExtension.csproj", "{12679331-455F-470C-B2F3-A53FD6EDF2B3}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DbgEngStandalone", "DbgEngStandalone\DbgEngStandalone.csproj", "{B5E3A5C4-1D72-4D3E-9C7A-4F2E5A1B3C0D}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -29,10 +31,6 @@ Global
 		{D7405CE8-8C8D-4462-B7AD-F1215E875422}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D7405CE8-8C8D-4462-B7AD-F1215E875422}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D7405CE8-8C8D-4462-B7AD-F1215E875422}.Release|Any CPU.Build.0 = Release|Any CPU
-		{12679331-455F-470C-B2F3-A53FD6EDF2B3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{12679331-455F-470C-B2F3-A53FD6EDF2B3}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{12679331-455F-470C-B2F3-A53FD6EDF2B3}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{12679331-455F-470C-B2F3-A53FD6EDF2B3}.Release|Any CPU.Build.0 = Release|Any CPU
 		{7AC85363-DB1F-4B6D-B6B6-EB7ECE590D6A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{7AC85363-DB1F-4B6D-B6B6-EB7ECE590D6A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7AC85363-DB1F-4B6D-B6B6-EB7ECE590D6A}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -45,6 +43,14 @@ Global
 		{A82FB97A-AC9D-4E5E-9BBC-B9382039F2D1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A82FB97A-AC9D-4E5E-9BBC-B9382039F2D1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A82FB97A-AC9D-4E5E-9BBC-B9382039F2D1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{12679331-455F-470C-B2F3-A53FD6EDF2B3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{12679331-455F-470C-B2F3-A53FD6EDF2B3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{12679331-455F-470C-B2F3-A53FD6EDF2B3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{12679331-455F-470C-B2F3-A53FD6EDF2B3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B5E3A5C4-1D72-4D3E-9C7A-4F2E5A1B3C0D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B5E3A5C4-1D72-4D3E-9C7A-4F2E5A1B3C0D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B5E3A5C4-1D72-4D3E-9C7A-4F2E5A1B3C0D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B5E3A5C4-1D72-4D3E-9C7A-4F2E5A1B3C0D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Samples/SelfAttach/SelfAttach.cs
+++ b/src/Samples/SelfAttach/SelfAttach.cs
@@ -9,26 +9,15 @@
 // then delete the coredump when the user calls DataTarget.Dispose.  On Linux this operation
 // takes significantly longer (~2-10 seconds or so).
 
-using System;
 using System.Diagnostics;
-using System.Linq;
 using Microsoft.Diagnostics.Runtime;
 
-namespace DesktopTest
-{
-    class SelfAttach
-    {
-        static void Main()
-        {
-            using DataTarget dt = DataTarget.CreateSnapshotAndAttach(Process.GetCurrentProcess().Id);
-            using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
+using DataTarget dt = DataTarget.CreateSnapshotAndAttach(Process.GetCurrentProcess().Id);
+using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
 
-            foreach (ClrThread thread in runtime.Threads)
-            {
-                Console.WriteLine($"{thread.OSThreadId:x}:");
-                foreach (ClrStackFrame frame in thread.EnumerateStackTrace())
-                    Console.WriteLine($"    {frame}");
-            }
-        }
-    }
+foreach (ClrThread thread in runtime.Threads)
+{
+    Console.WriteLine($"{thread.OSThreadId:x}:");
+    foreach (ClrStackFrame frame in thread.EnumerateStackTrace())
+        Console.WriteLine($"    {frame}");
 }

--- a/src/Samples/SelfAttach/SelfAttach.csproj
+++ b/src/Samples/SelfAttach/SelfAttach.csproj
@@ -2,11 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Diagnostics.Runtime" Version="2.0.0-rc.20278.6" />
+    <ProjectReference Include="..\..\Microsoft.Diagnostics.Runtime\Microsoft.Diagnostics.Runtime.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Fixes #1272

This pull request updates the sample projects to modern .NET standards and refactors the code for improved clarity, null-safety, and maintainability. The most significant changes include migrating all sample projects to .NET 10, enabling nullable reference types and implicit usings, updating package references, and refactoring code to use newer APIs and patterns. Additionally, there are notable simplifications and improvements in the sample logic, especially around object/heap enumeration and argument handling.

**Project and SDK Modernization:**

* All sample projects (`ClrStack`, `DumpDict`, `DumpHeap`, `DbgEngExtension`, `DbgEngStandalone`) are updated to target `net10.0`, with `<ImplicitUsings>enable</ImplicitUsings>` and `<Nullable>enable</Nullable>` for improved code safety and conciseness. [[1]](diffhunk://#diff-4ba8358493ae94b26cacceb4302d87112c5c828cbf41009443e1740a239ac545L5-R11) [[2]](diffhunk://#diff-5ba7c5f15ab9fc2102c9269d5aa6ccc4fcbbaa3af078f161c6f54efa90e8a205L4-R4) [[3]](diffhunk://#diff-23b8f4fa6bcdff65c88497c0b41f2618d603dc9ec7abe89d96ec50733738f043L5-R5)
* Package references for `Microsoft.Diagnostics.Runtime` are replaced with project references to the local source, ensuring consistent builds and easier local development.

**Code Quality and Null-Safety Improvements:**

* The code in `ClrStack.cs`, `DumpDict.cs`, and `DumpHeap.cs` is refactored to use nullable reference types, explicit null checks, and modern C# idioms. This includes using `string?`, `is null`, and null-forgiving operators, as well as removing unnecessary methods and comments. [[1]](diffhunk://#diff-3a8f795b64e71347e2cc604c3a851a3111998e14aedd5a2553ffd7cefd7853e8L4-L108) [[2]](diffhunk://#diff-3a8f795b64e71347e2cc604c3a851a3111998e14aedd5a2553ffd7cefd7853e8L120-R79) [[3]](diffhunk://#diff-3a8f795b64e71347e2cc604c3a851a3111998e14aedd5a2553ffd7cefd7853e8L131-R90) [[4]](diffhunk://#diff-3a8f795b64e71347e2cc604c3a851a3111998e14aedd5a2553ffd7cefd7853e8L142-R101) [[5]](diffhunk://#diff-1983218a590898ed44e535b83a938796e6dda7165d4ad34d443ac649d663629fL4-R51) [[6]](diffhunk://#diff-048d22b2610239c35603f660dbcbd07559007fe7b75f4d2fc61fac8560020f30L5-R12) [[7]](diffhunk://#diff-048d22b2610239c35603f660dbcbd07559007fe7b75f4d2fc61fac8560020f30L30-R29)

**Sample Logic and API Updates:**

* In `DumpDict`, the logic is updated to correctly parse arguments, use the correct field name (`_entries`), and handle object validation and type checks more robustly. The sample now returns exit codes instead of calling `Environment.Exit`.
* In `DumpHeap`, the object enumeration and statistics collection now handle possible null `Type` properties, preventing potential runtime exceptions.
* In `ClrStack`, argument parsing and usage reporting are simplified, and exception handling is improved by using more specific exception types. [[1]](diffhunk://#diff-3a8f795b64e71347e2cc604c3a851a3111998e14aedd5a2553ffd7cefd7853e8L4-L108) [[2]](diffhunk://#diff-3a8f795b64e71347e2cc604c3a851a3111998e14aedd5a2553ffd7cefd7853e8L120-R79) [[3]](diffhunk://#diff-3a8f795b64e71347e2cc604c3a851a3111998e14aedd5a2553ffd7cefd7853e8L131-R90) [[4]](diffhunk://#diff-3a8f795b64e71347e2cc604c3a851a3111998e14aedd5a2553ffd7cefd7853e8L142-R101)

**DbgEngExtension Refactoring:**

* The `MAddress.cs` logic for enumerating CLR memory addresses is refactored to use the new `EnumerateClrNativeHeaps` API, removing manual traversal of app domain heaps and stub heaps, and eliminating direct dependencies on `DacInterface`. This results in cleaner, more maintainable code. [[1]](diffhunk://#diff-f114fcef1a9b8612fbf80e54c26bc932d92de82daf0b2630866ec0db2c10499fL9-L11) [[2]](diffhunk://#diff-f114fcef1a9b8612fbf80e54c26bc932d92de82daf0b2630866ec0db2c10499fL472-R494) [[3]](diffhunk://#diff-f114fcef1a9b8612fbf80e54c26bc932d92de82daf0b2630866ec0db2c10499fL499-L579)

These changes collectively modernize the samples, improve code safety, and leverage the latest APIs for better maintainability and developer experience.