### PR TITLE
Fix Arm64 handling

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/DataReaders/Windows/WindowsProcessDataReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DataReaders/Windows/WindowsProcessDataReader.cs
@@ -239,13 +239,16 @@ namespace Microsoft.Diagnostics.Runtime
                         ((ArmContext*)ptr)->ContextFlags = contextFlags;
                     break;
 
-                default:
-                    if (context.Length < 4)
+                case Architecture.X86:
+                    if (context.Length < X86Context.Size)
                         return false;
 
                     fixed (byte* ptr = context)
-                        *(uint*)ptr = contextFlags;
+                        ((X86Context*)ptr)->ContextFlags = contextFlags;
                     break;
+
+                default:
+                    return false;
             }
 
             using SafeWin32Handle thread = OpenThread(ThreadAccess.THREAD_ALL_ACCESS, true, threadID);


### PR DESCRIPTION
This pull request updates the way architecture is determined and improves the handling of thread context flags in the `WindowsProcessDataReader`. The changes enhance platform support and make the code more robust by handling multiple architectures explicitly.

**Architecture detection and thread context handling improvements:**

* Updated the `Architecture` property to use `RuntimeInformation.ProcessArchitecture` instead of relying on `IntPtr.Size`, providing more accurate architecture detection, especially on ARM and ARM64 platforms.
* Refactored the `GetThreadContext` method to explicitly handle context flag offsets for X64, ARM64, and other architectures, improving correctness and maintainability across different platforms.

Fixes #1050.