### PR TITLE
Fix crash analyzing system dumps (gcore/coredumpctl)

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/ClrInfo.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrInfo.cs
@@ -127,8 +127,19 @@ namespace Microsoft.Diagnostics.Runtime
 
         private ClrRuntime CreateRuntimeWorker(string? dacPath, bool ignoreMismatch)
         {
-            IServiceProvider services = ClrInfoProvider.GetDacServices(this, dacPath, ignoreMismatch, DataTarget.Options.VerifyDacOnWindows);
-            return new ClrRuntime(this, services);
+            try
+            {
+                IServiceProvider services = ClrInfoProvider.GetDacServices(this, dacPath, ignoreMismatch, DataTarget.Options.VerifyDacOnWindows);
+                return new ClrRuntime(this, services);
+            }
+            catch (Exception ex) when (DataTarget.DataReader is IDumpInfoProvider { IsCreatedByDotNetRuntime: false } provider)
+            {
+                throw new ClrDiagnosticsException(
+                    $"Failed to create ClrRuntime and the dump was not collected by the .NET runtime's " +
+                    $"createdump tool. System/kernel dumps may be missing memory required for .NET diagnostics. " +
+                    $"Recollect the dump using createdump or set DOTNET_DbgEnableMiniDump=1. Original error: {ex.Message}",
+                    ex);
+            }
         }
 
         IClrRuntime IClrInfo.CreateRuntime() => CreateRuntime();

--- a/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacModuleHelpers.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacModuleHelpers.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
             {
                 Address = moduleAddress,
                 Assembly = data.Assembly,
-                AssemblyName = _sos.GetAssemblyName(data.Assembly),
+                AssemblyName = data.Assembly != 0 ? _sos.GetAssemblyName(data.Assembly) : null,
                 Id = data.ModuleID,
                 Index = data.ModuleIndex,
                 IsPEFile = data.IsPEFile != 0,

--- a/src/Microsoft.Diagnostics.Runtime/DataReaders/Core/CoreDumpReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DataReaders/Core/CoreDumpReader.cs
@@ -11,12 +11,13 @@ using Microsoft.Diagnostics.Runtime.Utilities;
 
 namespace Microsoft.Diagnostics.Runtime
 {
-    internal sealed class CoredumpReader : CommonMemoryReader, IDataReader, IDisposable, IThreadReader
+    internal sealed class CoredumpReader : CommonMemoryReader, IDataReader, IDisposable, IThreadReader, IDumpInfoProvider
     {
         private readonly ElfCoreFile _core;
         private readonly DataTargetLimits? _limits;
         private Dictionary<uint, IElfPRStatus>? _threads;
         private List<ModuleInfo>? _modules;
+        private bool? _isCreatedByDotNetRuntime;
 
         public string DisplayName { get; }
         public OSPlatform TargetPlatform => OSPlatform.Linux;
@@ -45,6 +46,17 @@ namespace Microsoft.Diagnostics.Runtime
         }
 
         public bool IsThreadSafe => false;
+
+        public bool IsMiniOrTriage => false;
+
+        public bool IsCreatedByDotNetRuntime
+        {
+            get
+            {
+                _isCreatedByDotNetRuntime ??= SpecialDiagInfo.TryReadSpecialDiagInfo(this, out _);
+                return _isCreatedByDotNetRuntime.Value;
+            }
+        }
 
         public void Dispose()
         {

--- a/src/Microsoft.Diagnostics.Runtime/DataReaders/IDumpInfoProvider.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DataReaders/IDumpInfoProvider.cs
@@ -25,5 +25,13 @@ namespace Microsoft.Diagnostics.Runtime
         /// explicitly NOT placed into the dump).
         /// </summary>
         bool IsMiniOrTriage { get; }
+
+        /// <summary>
+        /// Returns whether the dump was collected by the .NET runtime's createdump tool (or the
+        /// .NET runtime's crash handler). When false, the dump is a system dump (e.g. from gcore,
+        /// coredumpctl, lldb, or the kernel) and may be missing memory regions required for
+        /// reliable .NET diagnostics analysis.
+        /// </summary>
+        bool IsCreatedByDotNetRuntime { get; }
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/DataReaders/Minidump/MinidumpReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DataReaders/Minidump/MinidumpReader.cs
@@ -59,6 +59,8 @@ namespace Microsoft.Diagnostics.Runtime
 
         public bool IsMiniOrTriage => _minidump.IsMiniDump;
 
+        public bool IsCreatedByDotNetRuntime => true;
+
         public void Dispose()
         {
             _minidump.Dispose();

--- a/src/Microsoft.Diagnostics.Runtime/DataTarget.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DataTarget.cs
@@ -201,7 +201,7 @@ namespace Microsoft.Diagnostics.Runtime
                         
                         // The above EnumerateModules() call populated (the sorted) _modules array
                         int found = _modules!.Search(info.RuntimeBaseAddress, (m, k) => m.ImageBase.CompareTo(k));
-                        if (found > 0)
+                        if (found >= 0)
                         {
                             // Run the module through the clr info providers to see if it is an app model/runtime supported by CLRMD
                             clrs = new(

--- a/src/Microsoft.Diagnostics.Runtime/MacOS/MachOCoreReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/MacOS/MachOCoreReader.cs
@@ -11,13 +11,25 @@ using Microsoft.Diagnostics.Runtime.Utilities;
 
 namespace Microsoft.Diagnostics.Runtime.MacOS
 {
-    internal sealed class MachOCoreReader : CommonMemoryReader, IDataReader, IThreadReader, IDisposable
+    internal sealed class MachOCoreReader : CommonMemoryReader, IDataReader, IThreadReader, IDumpInfoProvider, IDisposable
     {
         private readonly MachOCoreDump _core;
+        private bool? _isCreatedByDotNetRuntime;
 
         public string DisplayName { get; }
 
         public bool IsThreadSafe => true;
+
+        public bool IsMiniOrTriage => false;
+
+        public bool IsCreatedByDotNetRuntime
+        {
+            get
+            {
+                _isCreatedByDotNetRuntime ??= SpecialDiagInfo.TryReadSpecialDiagInfo(this, out _);
+                return _isCreatedByDotNetRuntime.Value;
+            }
+        }
 
         public OSPlatform TargetPlatform => OSPlatform.OSX;
 

--- a/src/Microsoft.Diagnostics.Runtime/SpecialDiagInfo.cs
+++ b/src/Microsoft.Diagnostics.Runtime/SpecialDiagInfo.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Diagnostics.Runtime
 
             fixed (SpecialDiagInfo* ptr = &info)
             {
-                return reader.Read(address, new Span<byte>(ptr, size)) != size || !info.IsValid;
+                return reader.Read(address, new Span<byte>(ptr, size)) == size && info.IsValid;
             }
         }
 


### PR DESCRIPTION
We shouldn't hard-crash when analyzing incorrectly taken crash dumps.  Contributes to https://github.com/dotnet/diagnostics/issues/5632.

- Add IsCreatedByDotNetRuntime to IDumpInfoProvider to detect non-createdump dumps and improve error messages
- Fix off-by-one in SpecialDiagInfo module lookup (found > 0 -> found >= 0)
- Guard against null Assembly address in GetModuleInfo