### PR TITLE
Fix GetFieldByName to return derived class field when names are shadowed

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/Implementation/ClrDacType.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Implementation/ClrDacType.cs
@@ -266,7 +266,7 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
         public override ClrStaticField? GetStaticFieldByName(string name) => StaticFields.FirstOrDefault(f => f.Name == name);
 
         // TODO: remove
-        public override ClrInstanceField? GetFieldByName(string name) => Fields.FirstOrDefault(f => f.Name == name);
+        public override ClrInstanceField? GetFieldByName(string name) => Fields.LastOrDefault(f => f.Name == name);
 
         public override ulong GetArrayElementAddress(ulong objRef, int index)
         {

--- a/src/Microsoft.Diagnostics.Runtime/Implementation/ClrStringType.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Implementation/ClrStringType.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
         public override ClrStaticField? GetStaticFieldByName(string name) => StaticFields.FirstOrDefault(f => f.Name == name);
 
         // TODO: remove
-        public override ClrInstanceField? GetFieldByName(string name) => Fields.FirstOrDefault(f => f.Name == name);
+        public override ClrInstanceField? GetFieldByName(string name) => Fields.LastOrDefault(f => f.Name == name);
 
         private const uint FinalizationSuppressedFlag = 0x40000000;
         public override bool IsFinalizeSuppressed(ulong obj)


### PR DESCRIPTION
When a derived class declares a field with the same name as a base class field, GetFieldByName was returning the base class field because Fields is ordered base-first and FirstOrDefault picks the first match.

Changed to LastOrDefault so the most-derived field is returned, matching C# shadowing semantics. Fixes #1370.