### PR TITLE
Add IClrValue.ReadObjectField/ReadValueTypeField that use IClrInstanceField

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/ClrObjectTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/ClrObjectTests.cs
@@ -145,5 +145,124 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             // Assert
             Assert.Equal(typeof(Guid).FullName, sampleGuid.Type.Name);
         }
+
+        [Fact]
+        public void ReadFieldByInstance_WhenBool_ReturnsExpected()
+        {
+            ClrObjectConnection.PrimitiveTypeCarrier prototype = _connection.Prototype;
+            ClrInstanceField field = _primitiveCarrier.Type.GetFieldByName(nameof(prototype.TrueBool));
+
+            bool actual = _primitiveCarrier.ReadField<bool>(field);
+
+            Assert.True(actual);
+        }
+
+        [Fact]
+        public void ReadFieldByInstance_WhenLong_ReturnsExpected()
+        {
+            ClrObjectConnection.PrimitiveTypeCarrier prototype = _connection.Prototype;
+            ClrInstanceField field = _primitiveCarrier.Type.GetFieldByName(nameof(prototype.OneLargerMaxInt));
+
+            long actual = _primitiveCarrier.ReadField<long>(field);
+
+            Assert.Equal(prototype.OneLargerMaxInt, actual);
+        }
+
+        [Fact]
+        public void ReadObjectFieldByInstance_WhenStringField_ReturnsExpected()
+        {
+            ClrObjectConnection.PrimitiveTypeCarrier prototype = _connection.Prototype;
+            ClrInstanceField field = _primitiveCarrier.Type.GetFieldByName(nameof(prototype.HelloWorldString));
+
+            ClrObject textPointer = _primitiveCarrier.ReadObjectField(field);
+
+            Assert.Equal(prototype.HelloWorldString, (string)textPointer);
+        }
+
+        [Fact]
+        public void ReadObjectFieldByInstance_WhenReferenceField_ReturnsExpected()
+        {
+            ClrObjectConnection.PrimitiveTypeCarrier prototype = _connection.Prototype;
+            ClrInstanceField field = _primitiveCarrier.Type.GetFieldByName(nameof(prototype.SamplePointer));
+
+            ClrObject referenceFieldValue = _primitiveCarrier.ReadObjectField(field);
+
+            Assert.Equal("SamplePointerType", referenceFieldValue.Type.Name);
+        }
+
+        [Fact]
+        public void ReadStringFieldByInstance_ReturnsExpected()
+        {
+            ClrObjectConnection.PrimitiveTypeCarrier prototype = _connection.Prototype;
+            ClrInstanceField field = _primitiveCarrier.Type.GetFieldByName(nameof(prototype.HelloWorldString));
+
+            string text = _primitiveCarrier.ReadStringField(field);
+
+            Assert.Equal(prototype.HelloWorldString, text);
+        }
+
+        [Fact]
+        public void ReadValueTypeFieldByInstance_WhenDateTime_ReturnsExpected()
+        {
+            ClrObjectConnection.PrimitiveTypeCarrier prototype = _connection.Prototype;
+            ClrInstanceField field = _primitiveCarrier.Type.GetFieldByName(nameof(prototype.Birthday));
+
+            ClrValueType birthday = _primitiveCarrier.ReadValueTypeField(field);
+
+            Assert.Equal(typeof(DateTime).FullName, birthday.Type.Name);
+        }
+
+        [Fact]
+        public void ReadValueTypeFieldByInstance_WhenGuid_ReturnsExpected()
+        {
+            ClrObjectConnection.PrimitiveTypeCarrier prototype = _connection.Prototype;
+            ClrInstanceField field = _primitiveCarrier.Type.GetFieldByName(nameof(prototype.SampleGuid));
+
+            ClrValueType sampleGuid = _primitiveCarrier.ReadValueTypeField(field);
+
+            Assert.Equal(typeof(Guid).FullName, sampleGuid.Type.Name);
+        }
+
+        [Fact]
+        public void ReadObjectFieldByInstance_WhenNull_ThrowsArgumentNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => _primitiveCarrier.ReadObjectField((ClrInstanceField)null));
+        }
+
+        [Fact]
+        public void ReadFieldByInstance_WhenNull_ThrowsArgumentNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => _primitiveCarrier.ReadField<int>((ClrInstanceField)null));
+        }
+
+        [Fact]
+        public void ReadStringFieldByInstance_WhenNull_ThrowsArgumentNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => _primitiveCarrier.ReadStringField((ClrInstanceField)null));
+        }
+
+        [Fact]
+        public void ReadValueTypeFieldByInstance_WhenNull_ThrowsArgumentNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => _primitiveCarrier.ReadValueTypeField((ClrInstanceField)null));
+        }
+
+        [Fact]
+        public void ReadStringFieldByInstance_WhenTypeMismatch_ThrowsInvalidOperation()
+        {
+            ClrObjectConnection.PrimitiveTypeCarrier prototype = _connection.Prototype;
+            ClrInstanceField field = _primitiveCarrier.Type.GetFieldByName(nameof(prototype.SomeEnum));
+
+            Assert.Throws<InvalidOperationException>(() => _primitiveCarrier.ReadStringField(field));
+        }
+
+        [Fact]
+        public void ReadObjectFieldByInstance_WhenNotObjectRef_ThrowsArgumentException()
+        {
+            ClrObjectConnection.PrimitiveTypeCarrier prototype = _connection.Prototype;
+            ClrInstanceField field = _primitiveCarrier.Type.GetFieldByName(nameof(prototype.TrueBool));
+
+            Assert.Throws<ArgumentException>(() => _primitiveCarrier.ReadObjectField(field));
+        }
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/ClrObject.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrObject.cs
@@ -335,6 +335,30 @@ namespace Microsoft.Diagnostics.Runtime
             return heap.GetObject(obj);
         }
 
+        /// <summary>
+        /// Gets the given object reference field from this ClrObject.
+        /// </summary>
+        /// <param name="field">The field to retrieve.</param>
+        /// <returns>A ClrObject of the given field.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="field"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentException">The given field is not an object reference.</exception>
+        /// <exception cref="InvalidOperationException"><see cref="IsNull"/> is <see langword="true"/>.</exception>
+        public ClrObject ReadObjectField(ClrInstanceField field)
+        {
+            if (field is null)
+                throw new ArgumentNullException(nameof(field));
+
+            GetTypeOrThrow();
+            if (!field.IsObjectReference)
+                throw new ArgumentException($"Field '{field.Name}' is not an object reference.");
+
+            ulong addr = field.GetAddress(Address);
+            if (!DataReader.ReadPointer(addr, out ulong obj))
+                return default;
+
+            return Type!.Heap.GetObject(obj);
+        }
+
         public ClrValueType ReadValueTypeField(string fieldName)
         {
             ClrType type = GetTypeOrThrow();
@@ -342,6 +366,29 @@ namespace Microsoft.Diagnostics.Runtime
             ClrInstanceField field = type.GetFieldByName(fieldName) ?? throw new ArgumentException($"Type '{type.Name}' does not contain a field named '{fieldName}'");
             if (!field.IsValueType)
                 throw new ArgumentException($"Field '{type.Name}.{fieldName}' is not a ValueClass.");
+
+            if (field.Type is null)
+                throw new InvalidOperationException("Field does not have an associated class.");
+
+            ulong addr = field.GetAddress(Address);
+            return new ClrValueType(addr, field.Type, true);
+        }
+
+        /// <summary>
+        /// Gets the given value type field from this ClrObject.
+        /// </summary>
+        /// <param name="field">The field to retrieve.</param>
+        /// <returns>A ClrValueType of the given field.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="field"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentException">The given field is not a value type.</exception>
+        public ClrValueType ReadValueTypeField(ClrInstanceField field)
+        {
+            if (field is null)
+                throw new ArgumentNullException(nameof(field));
+
+            GetTypeOrThrow();
+            if (!field.IsValueType)
+                throw new ArgumentException($"Field '{field.Name}' is not a ValueClass.");
 
             if (field.Type is null)
                 throw new InvalidOperationException("Field does not have an associated class.");
@@ -384,6 +431,22 @@ namespace Microsoft.Diagnostics.Runtime
         {
             ClrType type = GetTypeOrThrow();
             ClrInstanceField field = type.GetFieldByName(fieldName) ?? throw new ArgumentException($"Type '{type.Name}' does not contain a field named '{fieldName}'");
+            return field.Read<T>(Address, interior: false);
+        }
+
+        /// <summary>
+        /// Gets the value of a primitive field.
+        /// </summary>
+        /// <typeparam name="T">The type of the field itself.</typeparam>
+        /// <param name="field">The field to read.</param>
+        /// <returns>The value of this field.</returns>
+        public T ReadField<T>(ClrInstanceField field)
+            where T : unmanaged
+        {
+            if (field is null)
+                throw new ArgumentNullException(nameof(field));
+
+            GetTypeOrThrow();
             return field.Read<T>(Address, interior: false);
         }
 
@@ -500,6 +563,33 @@ namespace Microsoft.Diagnostics.Runtime
             return type.Heap.ReadString(strPtr, maxLength);
         }
 
+        /// <summary>
+        /// Gets a string field from the object.
+        /// </summary>
+        /// <param name="field">The field to get the value for.</param>
+        /// <param name="maxLength">The maximum length of the string returned.</param>
+        /// <returns>The value of the given field.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="field"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvalidOperationException">The field is not a string.</exception>
+        public string? ReadStringField(ClrInstanceField field, int maxLength = 4096)
+        {
+            if (field is null)
+                throw new ArgumentNullException(nameof(field));
+
+            GetTypeOrThrow();
+            if (field.ElementType != ClrElementType.String)
+                throw new InvalidOperationException($"Field '{field.Name}' is not of type 'string'.");
+
+            ulong address = field.GetAddress(Address);
+            if (!DataReader.ReadPointer(address, out ulong strPtr))
+                return null;
+
+            if (strPtr == 0)
+                return null;
+
+            return Type!.Heap.ReadString(strPtr, maxLength);
+        }
+
         public string? AsString(int maxLength = 4096)
         {
             ClrType type = GetTypeOrThrow();
@@ -598,8 +688,13 @@ namespace Microsoft.Diagnostics.Runtime
         IRuntimeCallableWrapper? IClrValue.GetRuntimeCallableWrapper() => GetRuntimeCallableWrapper();
 
         IClrValue IClrValue.ReadObjectField(string fieldName) => ReadObjectField(fieldName);
+        IClrValue IClrValue.ReadObjectField(IClrInstanceField field) => ReadObjectField((ClrInstanceField)field);
 
         IClrValue IClrValue.ReadValueTypeField(string fieldName) => ReadValueTypeField(fieldName);
+        IClrValue IClrValue.ReadValueTypeField(IClrInstanceField field) => ReadValueTypeField((ClrInstanceField)field);
+
+        T IClrValue.ReadField<T>(IClrInstanceField field) => ReadField<T>((ClrInstanceField)field);
+        string? IClrValue.ReadStringField(IClrInstanceField field, int maxLength) => ReadStringField((ClrInstanceField)field, maxLength);
 
         bool IClrValue.TryReadObjectField(string fieldName, [NotNullWhen(true)] out IClrValue? result)
         {

--- a/src/Microsoft.Diagnostics.Runtime/ClrValueType.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrValueType.cs
@@ -100,6 +100,27 @@ namespace Microsoft.Diagnostics.Runtime
         }
 
         /// <summary>
+        /// Gets the given object reference field from this ClrValueType.
+        /// </summary>
+        /// <param name="field">The field to retrieve.</param>
+        /// <returns>A ClrObject of the given field.</returns>
+        public ClrObject ReadObjectField(ClrInstanceField field)
+        {
+            if (field is null)
+                throw new ArgumentNullException(nameof(field));
+
+            GetTypeOrThrow();
+            if (!field.IsObjectReference)
+                throw new ArgumentException($"Field '{field.Name}' is not an object reference.");
+
+            ulong addr = field.GetAddress(Address, _interior);
+            if (!DataReader.ReadPointer(addr, out ulong obj))
+                return default;
+
+            return Type!.Heap.GetObject(obj);
+        }
+
+        /// <summary>
         /// Gets the value of a primitive field.  This will throw an InvalidCastException if the type parameter
         /// does not match the field's type.
         /// </summary>
@@ -115,9 +136,26 @@ namespace Microsoft.Diagnostics.Runtime
         }
 
         /// <summary>
+        /// Gets the value of a primitive field.
         /// </summary>
-        /// <param name="fieldName"></param>
-        /// <returns></returns>
+        /// <typeparam name="T">The type of the field itself.</typeparam>
+        /// <param name="field">The field to read.</param>
+        /// <returns>The value of this field.</returns>
+        public T ReadField<T>(ClrInstanceField field)
+            where T : unmanaged
+        {
+            if (field is null)
+                throw new ArgumentNullException(nameof(field));
+
+            GetTypeOrThrow();
+            return field.Read<T>(Address, _interior);
+        }
+
+        /// <summary>
+        /// Gets the given value type field from this ClrValueType.
+        /// </summary>
+        /// <param name="fieldName">The name of the field.</param>
+        /// <returns>A ClrValueType of the given field.</returns>
         public ClrValueType ReadValueTypeField(string fieldName)
         {
             ClrType type = GetTypeOrThrow();
@@ -125,6 +163,27 @@ namespace Microsoft.Diagnostics.Runtime
 
             if (!field.IsValueType)
                 throw new ArgumentException($"Field '{type.Name}.{fieldName}' is not a ValueClass.");
+
+            if (field.Type is null)
+                throw new InvalidOperationException("Field does not have an associated class.");
+
+            ulong addr = field.GetAddress(Address, _interior);
+            return new ClrValueType(addr, field.Type, true);
+        }
+
+        /// <summary>
+        /// Gets the given value type field from this ClrValueType.
+        /// </summary>
+        /// <param name="field">The field to retrieve.</param>
+        /// <returns>A ClrValueType of the given field.</returns>
+        public ClrValueType ReadValueTypeField(ClrInstanceField field)
+        {
+            if (field is null)
+                throw new ArgumentNullException(nameof(field));
+
+            GetTypeOrThrow();
+            if (!field.IsValueType)
+                throw new ArgumentException($"Field '{field.Name}' is not a ValueClass.");
 
             if (field.Type is null)
                 throw new InvalidOperationException("Field does not have an associated class.");
@@ -154,6 +213,32 @@ namespace Microsoft.Diagnostics.Runtime
                 return null;
 
             ClrObject obj = new(str, GetTypeOrThrow().Heap.StringType);
+            return obj.AsString(maxLength);
+        }
+
+        /// <summary>
+        /// Gets a string field from the object.
+        /// </summary>
+        /// <param name="field">The field to get the value for.</param>
+        /// <param name="maxLength">The maximum length of the string returned.</param>
+        /// <returns>The value of the given field.</returns>
+        public string? ReadStringField(ClrInstanceField field, int maxLength = 4096)
+        {
+            if (field is null)
+                throw new ArgumentNullException(nameof(field));
+
+            GetTypeOrThrow();
+            if (field.ElementType != ClrElementType.String)
+                throw new InvalidOperationException($"Field '{field.Name}' is not of type 'string'.");
+
+            ulong address = field.GetAddress(Address, _interior);
+            if (!DataReader.ReadPointer(address, out ulong str))
+                return null;
+
+            if (str == 0)
+                return null;
+
+            ClrObject obj = new(str, Type!.Heap.StringType);
             return obj.AsString(maxLength);
         }
 
@@ -295,6 +380,10 @@ namespace Microsoft.Diagnostics.Runtime
         }
 
         IClrValue IClrValue.ReadObjectField(string fieldName) => ReadObjectField(fieldName);
+        IClrValue IClrValue.ReadObjectField(IClrInstanceField field) => ReadObjectField((ClrInstanceField)field);
+
+        T IClrValue.ReadField<T>(IClrInstanceField field) => ReadField<T>((ClrInstanceField)field);
+        string? IClrValue.ReadStringField(IClrInstanceField field, int maxLength) => ReadStringField((ClrInstanceField)field, maxLength);
 
         bool IClrValue.TryReadField<T>(string fieldName, out T result)
         {
@@ -345,6 +434,7 @@ namespace Microsoft.Diagnostics.Runtime
         }
 
         IClrValue IClrValue.ReadValueTypeField(string fieldName) => ReadValueTypeField(fieldName);
+        IClrValue IClrValue.ReadValueTypeField(IClrInstanceField field) => ReadValueTypeField((ClrInstanceField)field);
 
         public static bool operator ==(ClrValueType left, ClrValueType right)
         {

--- a/src/Microsoft.Diagnostics.Runtime/Implementation/ClrDacType.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Implementation/ClrDacType.cs
@@ -266,7 +266,7 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
         public override ClrStaticField? GetStaticFieldByName(string name) => StaticFields.FirstOrDefault(f => f.Name == name);
 
         // TODO: remove
-        public override ClrInstanceField? GetFieldByName(string name) => Fields.FirstOrDefault(f => f.Name == name);
+        public override ClrInstanceField? GetFieldByName(string name) => Fields.LastOrDefault(f => f.Name == name);
 
         public override ulong GetArrayElementAddress(ulong objRef, int index)
         {

--- a/src/Microsoft.Diagnostics.Runtime/Implementation/ClrStringType.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Implementation/ClrStringType.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
         public override ClrStaticField? GetStaticFieldByName(string name) => StaticFields.FirstOrDefault(f => f.Name == name);
 
         // TODO: remove
-        public override ClrInstanceField? GetFieldByName(string name) => Fields.FirstOrDefault(f => f.Name == name);
+        public override ClrInstanceField? GetFieldByName(string name) => Fields.LastOrDefault(f => f.Name == name);
 
         private const uint FinalizationSuppressedFlag = 0x40000000;
         public override bool IsFinalizeSuppressed(ulong obj)

--- a/src/Microsoft.Diagnostics.Runtime/Interfaces/IClrValue.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Interfaces/IClrValue.cs
@@ -39,9 +39,13 @@ namespace Microsoft.Diagnostics.Runtime.Interfaces
         IRuntimeCallableWrapper? GetRuntimeCallableWrapper();
         T ReadBoxedValue<T>() where T : unmanaged;
         T ReadField<T>(string fieldName) where T : unmanaged;
+        T ReadField<T>(IClrInstanceField field) where T : unmanaged;
         IClrValue ReadObjectField(string fieldName);
+        IClrValue ReadObjectField(IClrInstanceField field);
         string? ReadStringField(string fieldName, int maxLength = 4096);
+        string? ReadStringField(IClrInstanceField field, int maxLength = 4096);
         IClrValue ReadValueTypeField(string fieldName);
+        IClrValue ReadValueTypeField(IClrInstanceField field);
 
         bool TryReadStringField(string fieldName, int? maxLength, out string? result);
 


### PR DESCRIPTION
Implemented:  I also would propose to add overloads for IClrValue.ReadObjectField/ReadValueTypeField that use IClrInstanceField for field indication, not just fieldName.  #1371 