### PR TITLE
Fix generic type parameter resolution for fields (#1368, #1369)

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/GenericFieldTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/GenericFieldTests.cs
@@ -1,0 +1,129 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Linq;
+using Xunit;
+
+namespace Microsoft.Diagnostics.Runtime.Tests
+{
+    /// <summary>
+    /// Regression tests for issues #1368 and #1369: generic type parameter resolution
+    /// for fields of generic types (Dictionary, LinkedList, etc.).
+    /// </summary>
+    public class GenericFieldTests : IClassFixture<GenericFieldTests.GenericConnection>
+    {
+        private readonly GenericConnection _connection;
+
+        public GenericFieldTests(GenericConnection connection)
+            => _connection = connection;
+
+        /// <summary>
+        /// Issue #1369: LinkedListNode.item field type should be the concrete type (string),
+        /// not the unresolved generic parameter (T) or the canonical type (__Canon).
+        /// </summary>
+        [Fact]
+        public void LinkedListNode_ItemField_HasConcreteType()
+        {
+            ClrHeap heap = _connection.Runtime.Heap;
+            ClrObject node = heap.EnumerateObjects()
+                .FirstOrDefault(o => o.Type?.Name?.Contains("LinkedListNode<System.String>") == true);
+
+            Assert.True(node.IsValid, "Could not find LinkedListNode<string> on the heap.");
+
+            ClrInstanceField itemField = node.Type!.GetFieldByName("item");
+            Assert.NotNull(itemField);
+
+            // The field type should be System.String, not T or System.__Canon
+            Assert.NotNull(itemField.Type);
+            Assert.Equal("System.String", itemField.Type!.Name);
+        }
+
+        /// <summary>
+        /// Issue #1369: ReadObjectField for LinkedListNode.item should return the correct string value.
+        /// </summary>
+        [Fact]
+        public void LinkedListNode_ReadObjectField_ReturnsString()
+        {
+            ClrHeap heap = _connection.Runtime.Heap;
+            ClrObject node = heap.EnumerateObjects()
+                .FirstOrDefault(o => o.Type?.Name?.Contains("LinkedListNode<System.String>") == true);
+
+            Assert.True(node.IsValid, "Could not find LinkedListNode<string> on the heap.");
+
+            ClrObject item = node.ReadObjectField("item");
+            Assert.True(item.IsValid);
+            Assert.True(item.Type!.IsString);
+
+            string value = item.AsString()!;
+            Assert.True(value == "alpha" || value == "beta", $"Unexpected linked list item value: {value}");
+        }
+
+        /// <summary>
+        /// Issue #1368: Dictionary._entries field should be readable as a valid array.
+        /// </summary>
+        [Fact]
+        public void Dictionary_EntriesField_IsReadableArray()
+        {
+            ClrHeap heap = _connection.Runtime.Heap;
+            ClrObject dict = heap.EnumerateObjects()
+                .FirstOrDefault(o => o.Type?.Name?.Contains("Dictionary<System.String, System.Int32>") == true);
+
+            Assert.True(dict.IsValid, "Could not find Dictionary<string, int> on the heap.");
+
+            ClrObject entries = dict.ReadObjectField("_entries");
+            Assert.True(entries.IsValid, "ReadObjectField returned invalid object for _entries.");
+            Assert.True(entries.Type!.IsArray, "entries should be an array type.");
+
+            ClrArray arr = entries.AsArray();
+            Assert.True(arr.Length > 0, "entries array should have elements.");
+            Assert.Equal(1, arr.Rank);
+        }
+
+        /// <summary>
+        /// Verifies that field types containing __Canon are not exposed to users.
+        /// </summary>
+        [Fact]
+        public void Fields_ShouldNotExposeCanonTypes()
+        {
+            ClrHeap heap = _connection.Runtime.Heap;
+            ClrObject node = heap.EnumerateObjects()
+                .FirstOrDefault(o => o.Type?.Name?.Contains("LinkedListNode<System.String>") == true);
+
+            Assert.True(node.IsValid);
+
+            foreach (ClrInstanceField field in node.Type!.Fields)
+            {
+                if (field.Type?.Name != null)
+                {
+                    Assert.DoesNotContain("__Canon", field.Type.Name);
+                }
+            }
+        }
+
+        public class GenericConnection : Fixtures.ObjectConnection<GenericTypeCarrier>
+        {
+            public GenericConnection() : base(TestTargets.ClrObjects, typeof(GenericTypeCarrier).Name)
+            {
+            }
+        }
+
+        public class GenericTypeCarrier
+        {
+            public System.Collections.Generic.Dictionary<string, int> StringIntDictionary = new()
+            {
+                { "hello", 1 },
+                { "world", 2 }
+            };
+
+            public System.Collections.Generic.LinkedList<string> StringLinkedList = CreateLinkedList();
+
+            private static System.Collections.Generic.LinkedList<string> CreateLinkedList()
+            {
+                var list = new System.Collections.Generic.LinkedList<string>();
+                list.AddLast("alpha");
+                list.AddLast("beta");
+                return list;
+            }
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/ClrField.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrField.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection;
 using System.Threading;
@@ -127,7 +128,8 @@ namespace Microsoft.Diagnostics.Runtime
                 if (sigParser.GetCallingConvInfo(out int sigType) && sigType == SigParser.IMAGE_CEE_CS_CALLCONV_FIELD)
                 {
                     sigParser.SkipCustomModifiers();
-                    _type = ContainingType.Heap.GetOrCreateTypeFromSignature(ContainingType.Module, sigParser, ContainingType.EnumerateGenericParameters(), Array.Empty<ClrGenericParameter>());
+                    IReadOnlyList<ClrType?>? concreteTypeArgs = ContainingType.GetConcreteGenericTypeArguments();
+                    _type = ContainingType.Heap.GetOrCreateTypeFromSignature(ContainingType.Module, sigParser, ContainingType.EnumerateGenericParameters(), Array.Empty<ClrGenericParameter>(), concreteTypeArgs);
                 }
             }
 

--- a/src/Microsoft.Diagnostics.Runtime/ClrHeap.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrHeap.cs
@@ -1139,9 +1139,9 @@ namespace Microsoft.Diagnostics.Runtime
             }
         }
 
-        internal ClrType? GetOrCreateTypeFromSignature(ClrModule module, SigParser sigParser, IEnumerable<ClrGenericParameter> typeParameters, IEnumerable<ClrGenericParameter> methodParameters)
+        internal ClrType? GetOrCreateTypeFromSignature(ClrModule module, SigParser sigParser, IEnumerable<ClrGenericParameter> typeParameters, IEnumerable<ClrGenericParameter> methodParameters, IReadOnlyList<ClrType?>? concreteTypeArgs = null)
         {
-            return _typeFactory.GetOrCreateTypeFromSignature(module, sigParser, typeParameters, methodParameters);
+            return _typeFactory.GetOrCreateTypeFromSignature(module, sigParser, typeParameters, methodParameters, concreteTypeArgs);
         }
         public ClrType? GetTypeByMethodTable(ulong methodTable) => _typeFactory.GetOrCreateType(methodTable, 0);
 

--- a/src/Microsoft.Diagnostics.Runtime/ClrValueType.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrValueType.cs
@@ -267,7 +267,7 @@ namespace Microsoft.Diagnostics.Runtime
             if (field.ElementType != ClrElementType.String)
                 return false;
 
-            ulong addr = field.GetAddress(Address);
+            ulong addr = field.GetAddress(Address, _interior);
             if (!DataReader.ReadPointer(addr, out ulong strPtr))
                 return false;
 

--- a/src/TestTargets/ClrObjects/ClrObjects.cs
+++ b/src/TestTargets/ClrObjects/ClrObjects.cs
@@ -3,16 +3,19 @@
 
 #pragma warning disable 0162
 using System;
+using System.Collections.Generic;
 
 public class Program
 {
     public static void Main(string[] args)
     {
         var primitiveObj = new PrimitiveTypeCarrier();
+        var genericObj = new GenericTypeCarrier();
 
         throw new Exception();
 
         GC.KeepAlive(primitiveObj);
+        GC.KeepAlive(genericObj);
     }
 }
 
@@ -35,5 +38,20 @@ public class PrimitiveTypeCarrier
 
 public class SamplePointerType
 { }
+
+public class GenericTypeCarrier
+{
+    public Dictionary<string, int> StringIntDictionary = new Dictionary<string, int> { { "hello", 1 }, { "world", 2 } };
+
+    public LinkedList<string> StringLinkedList = CreateLinkedList();
+
+    private static LinkedList<string> CreateLinkedList()
+    {
+        var list = new LinkedList<string>();
+        list.AddLast("alpha");
+        list.AddLast("beta");
+        return list;
+    }
+}
 
 public enum EnumType { Zero, One, Two, PickedValue }


### PR DESCRIPTION
- Filter out System.__Canon types from field type resolution in CacheFields. When a field's MethodTable resolves to __Canon (the canonical type used for shared generic instantiations), set the type to null to trigger the metadata signature fallback path.

- Add concrete generic type argument resolution in ClrField.InitData(). Parse the parent type's name to extract concrete generic type arguments (e.g., 'LinkedListNode<System.String>' -> [System.String]) and pass them to GetOrCreateTypeFromSignature for Var/MVar substitution.

- Extend GetOrCreateTypeFromSignature to accept optional concrete type arguments. When resolving Var(index) in field signatures, use the concrete type instead of creating a ClrGenericType placeholder.

- Improve GenericInstantiation resolution to attempt looking up concrete generic types by name when concrete type arguments are available.

- Fix ClrValueType.TryReadStringField missing _interior parameter in GetAddress call.

- Add regression tests for LinkedListNode<string>.item field type resolution and Dictionary<string,int>._entries array reading.