### PR TITLE
Plumb limits through the rest of the data readers

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/DataReaders/Core/CoreDumpReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DataReaders/Core/CoreDumpReader.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Diagnostics.Runtime
     internal sealed class CoredumpReader : CommonMemoryReader, IDataReader, IDisposable, IThreadReader
     {
         private readonly ElfCoreFile _core;
+        private readonly DataTargetLimits? _limits;
         private Dictionary<uint, IElfPRStatus>? _threads;
         private List<ModuleInfo>? _modules;
 
@@ -23,6 +24,7 @@ namespace Microsoft.Diagnostics.Runtime
         public CoredumpReader(string path, Stream stream, bool leaveOpen, DataTargetLimits? limits = null)
         {
             DisplayName = path ?? throw new ArgumentNullException(nameof(path));
+            _limits = limits;
             _core = new ElfCoreFile(stream ?? throw new ArgumentNullException(nameof(stream)), leaveOpen, limits);
 
             ElfMachine architecture = _core.ElfFile.Header.Architecture;
@@ -92,7 +94,7 @@ namespace Microsoft.Diagnostics.Runtime
                 return new ElfModuleInfo(this, file, image.BaseAddress, size, path);
             }
 
-            return new PEModuleInfo(this, image.BaseAddress, path, true);
+            return new PEModuleInfo(this, image.BaseAddress, path, true, _limits);
         }
 
         public void FlushCachedData()

--- a/src/Microsoft.Diagnostics.Runtime/DataReaders/Minidump/MinidumpReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DataReaders/Minidump/MinidumpReader.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Diagnostics.Runtime
     internal sealed class MinidumpReader : IDataReader, IDisposable, IThreadReader, IDumpInfoProvider
     {
         private readonly Minidump _minidump;
+        private readonly DataTargetLimits? _limits;
         private IMemoryReader? _readerCached;
 
         public OSPlatform TargetPlatform => OSPlatform.Windows;
@@ -33,6 +34,7 @@ namespace Microsoft.Diagnostics.Runtime
 
             DisplayName = displayName;
 
+            _limits = limits;
             _minidump = new Minidump(displayName, stream, cacheOptions, leaveOpen, limits);
 
             Architecture = _minidump.Architecture switch
@@ -67,7 +69,7 @@ namespace Microsoft.Diagnostics.Runtime
             // We set buildId to "Empty" since only PEImages exist where minidumps are created, and we do not
             // want to try to lazily evaluate the buildId later
             return from module in _minidump.EnumerateModuleInfo()
-                   select new PEModuleInfo(this, module.BaseOfImage, module.ModuleName ?? "", true, module.DateTimeStamp, module.SizeOfImage);
+                   select new PEModuleInfo(this, module.BaseOfImage, module.ModuleName ?? "", true, module.DateTimeStamp, module.SizeOfImage, limits: _limits);
         }
 
         public void FlushCachedData()

--- a/src/Microsoft.Diagnostics.Runtime/DataReaders/Windows/WindowsProcessDataReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DataReaders/Windows/WindowsProcessDataReader.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Diagnostics.Runtime
     internal sealed unsafe class WindowsProcessDataReader : CommonMemoryReader, IDataReader, IDisposable
     {
         private bool _disposed;
+        private readonly DataTargetLimits? _limits;
         private readonly WindowsThreadSuspender? _suspension;
         private readonly int _originalPid;
         private readonly IntPtr _snapshotHandle;
@@ -27,8 +28,9 @@ namespace Microsoft.Diagnostics.Runtime
         public string DisplayName => $"pid:{ProcessId:x}";
         public OSPlatform TargetPlatform => OSPlatform.Windows;
 
-        public WindowsProcessDataReader(int processId, WindowsProcessDataReaderMode mode)
+        public WindowsProcessDataReader(int processId, WindowsProcessDataReaderMode mode, DataTargetLimits? limits = null)
         {
+            _limits = limits;
             if (mode == WindowsProcessDataReaderMode.Snapshot)
             {
                 _originalPid = processId;
@@ -184,7 +186,7 @@ namespace Microsoft.Diagnostics.Runtime
                 if (DataTarget.PlatformFunctions.GetFileVersion(fileName, out int major, out int minor, out int revision, out int patch))
                     version = new Version(major, minor, revision, patch);
 
-                ModuleInfo module = new PEModuleInfo(this, baseAddr, fileName, true, timestamp, filesize, version);
+                ModuleInfo module = new PEModuleInfo(this, baseAddr, fileName, true, timestamp, filesize, version, _limits);
                 result.Add(module);
             }
 

--- a/src/Microsoft.Diagnostics.Runtime/Implementation/PEModuleInfo.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Implementation/PEModuleInfo.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
     {
         private readonly IDataReader _dataReader;
         private readonly bool _isVirtual;
+        private readonly DataTargetLimits? _limits;
 
         private int _timestamp;
         private int _filesize;
@@ -34,11 +35,11 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
 
             try
             {
-                PEImage image = new(new ReadVirtualStream(_dataReader, (long)ImageBase, int.MaxValue), leaveOpen: false, isVirtual: _isVirtual);
+                PEImage image = new(new ReadVirtualStream(_dataReader, (long)ImageBase, int.MaxValue), leaveOpen: false, isVirtual: _isVirtual, _limits);
                 if (!image.IsValid)
                 {
                     image.Dispose();
-                    image = new PEImage(new ReadVirtualStream(_dataReader, (long)ImageBase, int.MaxValue), leaveOpen: false, isVirtual: !_isVirtual);
+                    image = new PEImage(new ReadVirtualStream(_dataReader, (long)ImageBase, int.MaxValue), leaveOpen: false, isVirtual: !_isVirtual, _limits);
                 }
 
                 if (image.IsValid)
@@ -157,7 +158,7 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
 
         public override IResourceNode? ResourceRoot => GetPEImage()?.Resources;
 
-        public PEModuleInfo(IDataReader dataReader, ulong imageBase, string fileName, bool isVirtualHint)
+        public PEModuleInfo(IDataReader dataReader, ulong imageBase, string fileName, bool isVirtualHint, DataTargetLimits? limits = null)
             : base(imageBase, fileName)
         {
             if (dataReader is null)
@@ -168,10 +169,11 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
 
             _dataReader = dataReader;
             _isVirtual = isVirtualHint;
+            _limits = limits;
         }
 
-        public PEModuleInfo(IDataReader dataReader, ulong imageBase, string fileName, bool isVirtual, int timestamp, int filesize, Version? version = null)
-            : this(dataReader, imageBase, fileName, isVirtual)
+        public PEModuleInfo(IDataReader dataReader, ulong imageBase, string fileName, bool isVirtual, int timestamp, int filesize, Version? version = null, DataTargetLimits? limits = null)
+            : this(dataReader, imageBase, fileName, isVirtual, limits)
         {
             _timestamp = timestamp;
             _filesize = filesize;

--- a/src/Microsoft.Diagnostics.Runtime/Utilities/PEImage/PEImage.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Utilities/PEImage/PEImage.cs
@@ -52,18 +52,18 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
         private bool _disposed;
         private readonly DataTargetLimits _limits;
 
-        public PEImage(FileStream stream, bool leaveOpen = false, ulong loadedImageBase = 0)
-            : this(stream, leaveOpen, isVirtual: false, loadedImageBase)
+        public PEImage(FileStream stream, bool leaveOpen = false, ulong loadedImageBase = 0, DataTargetLimits? limits = null)
+            : this(stream, leaveOpen, isVirtual: false, loadedImageBase, limits)
         {
         }
 
-        public PEImage(ReadVirtualStream stream, bool leaveOpen, bool isVirtual)
-            : this(stream, leaveOpen, isVirtual, 0)
+        public PEImage(ReadVirtualStream stream, bool leaveOpen, bool isVirtual, DataTargetLimits? limits = null)
+            : this(stream, leaveOpen, isVirtual, 0, limits)
         {
         }
 
-        public PEImage(ReaderStream stream, bool leaveOpen, bool isVirtual)
-            : this(stream, leaveOpen, isVirtual, 0)
+        public PEImage(ReaderStream stream, bool leaveOpen, bool isVirtual, DataTargetLimits? limits = null)
+            : this(stream, leaveOpen, isVirtual, 0, limits)
         {
         }
 


### PR DESCRIPTION
@brianrob this is a fix for the issue you raised in the previous PR.  This plumbs through limits into PEModuleInfo in the rest of the places it's needed.