### PR TITLE
Update tracing and exceptions

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacThreadHelpers.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacThreadHelpers.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
                 if (stackRef.Object == 0)
                 {
                     if (traceErrors)
-                        Trace.TraceWarning($"EnumerateStackRoots found an unexpected entry with Object == 0, addr:{(ulong)stackRef.Address:x} srcType:{stackRef.SourceType:x}");
+                        Debug.WriteLine($"EnumerateStackRoots found an unexpected entry with Object == 0, addr:{(ulong)stackRef.Address:x} srcType:{stackRef.SourceType:x}");
                     continue;
                 }
 
@@ -139,7 +139,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
                 if (!hr)
                 {
                     if (traceErrors)
-                        Trace.TraceError($"GetContext failed, flags:{contextFlags:x} size: {contextSize:x} hr={hr}");
+                        Debug.WriteLine($"GetContext failed, flags:{contextFlags:x} size: {contextSize:x} hr={hr}");
 
                     break;
                 }
@@ -177,7 +177,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
 
                 hr = stackwalk.Next();
                 if (traceErrors && !hr)
-                    Trace.TraceInformation($"STACKWALK FAILED - hr:{hr}");
+                    Debug.WriteLine($"STACKWALK FAILED - hr:{hr}");
             }
 
             ArrayPool<byte>.Shared.Return(context);

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/SosDac.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/SosDac.cs
@@ -743,7 +743,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             }
             else
             {
-                Trace.TraceInformation($"EnumerateStackRefs for OSThreadId:{osThreadId:x} failed with hr={hr}");
+                Debug.WriteLine($"EnumerateStackRefs for OSThreadId:{osThreadId:x} failed with hr={hr}");
             }
 
             return null;

--- a/src/Microsoft.Diagnostics.Runtime/DacLibrary.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacLibrary.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Diagnostics.Runtime
                 {
                     if (!AuthenticodeUtil.VerifyDacDll(dacPath, out fileLock))
                     {
-                        throw new ClrDiagnosticsException($"Failed to load dac from {dacPath}: not properly signed");
+                        throw new ClrDiagnosticsException("Failed to load dac: not properly signed.");
                     }
                 }
 
@@ -47,7 +47,7 @@ namespace Microsoft.Diagnostics.Runtime
                 }
                 catch (Exception e) when (e is DllNotFoundException or BadImageFormatException)
                 {
-                    throw new ClrDiagnosticsException($"Failed to load dac from {dacPath}: {e.Message}", e);
+                    throw new ClrDiagnosticsException("Failed to load dac library.", e);
                 }
             }
             finally

--- a/src/Microsoft.Diagnostics.Runtime/DataReaders/DbgEng/DbgEngDataReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DataReaders/DbgEng/DbgEngDataReader.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Diagnostics.Runtime
         public DbgEngDataReader(string dumpFile)
         {
             if (!File.Exists(dumpFile))
-                throw new FileNotFoundException(dumpFile);
+                throw new FileNotFoundException("The specified dump file was not found.");
 
             DisplayName = dumpFile;
 
@@ -73,9 +73,9 @@ namespace Microsoft.Diagnostics.Runtime
                 const int STATUS_MAPPED_FILE_SIZE_ZERO = unchecked((int)0xC000011E);
 
                 if (hr == HResult.E_INVALIDARG || hr == (STATUS_MAPPED_FILE_SIZE_ZERO | 0x10000000))
-                    throw new InvalidDataException($"'{dumpFile}' is not a crash dump.");
+                    throw new InvalidDataException("The specified file is not a crash dump.");
 
-                throw new ClrDiagnosticsException($"Could not load crash dump, HRESULT: {hr}", hr).AddData("DumpFile", dumpFile);
+                throw new ClrDiagnosticsException($"Could not load crash dump, HRESULT: {hr}", hr);
             }
 
             // This actually "attaches" to the crash dump.

--- a/src/Microsoft.Diagnostics.Runtime/DataReaders/MacOS/MacOSProcessDataReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DataReaders/MacOS/MacOSProcessDataReader.cs
@@ -105,7 +105,7 @@ namespace Microsoft.Diagnostics.Runtime.MacOS
                     if (disposing)
                         throw new ClrDiagnosticsException($"Could not detach from process {ProcessId}, errno: {errno}");
                     else
-                        Trace.WriteLine($"Could not detach from process {ProcessId}, errno: {errno}");
+                        Debug.WriteLine($"Could not detach from process {ProcessId}, errno: {errno}");
                 }
 
                 _suspended = false;

--- a/src/Microsoft.Diagnostics.Runtime/DataReaders/Windows/WindowsProcessDataReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DataReaders/Windows/WindowsProcessDataReader.cs
@@ -98,7 +98,7 @@ namespace Microsoft.Diagnostics.Runtime
                     DebugOnly.Assert(hr == 0);
 
                     if (hr != 0)
-                        Trace.WriteLine($"Unable to free the snapshot of the process we took: hr={hr}");
+                        Debug.WriteLine($"Unable to free the snapshot of the process we took: hr={hr}");
                 }
 
                 if (_process != IntPtr.Zero)
@@ -113,7 +113,7 @@ namespace Microsoft.Diagnostics.Runtime
                     }
                     catch (Exception e)
                     {
-                        Trace.WriteLine($"Unable to kill the target process: {e}");
+                        Debug.WriteLine($"Unable to kill the target process: {e.GetType().Name}");
                     }
                 }
 

--- a/src/Microsoft.Diagnostics.Runtime/DataReaders/Windows/WindowsThreadSuspender.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DataReaders/Windows/WindowsThreadSuspender.cs
@@ -95,7 +95,7 @@ namespace Microsoft.Diagnostics.Runtime.DataReaders.Windows
                     //     2.  We want to finish resuming threads.
                     //     3.  There's nothing the caller can really do about it.
 
-                    Trace.WriteLine($"Failed to resume thread id:{threadId:id} in pid:{_pid:x}.");
+                    Debug.WriteLine($"Failed to resume thread id:{threadId:id} in pid:{_pid:x}.");
                 }
             }
         }

--- a/src/Microsoft.Diagnostics.Runtime/DataTarget.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DataTarget.cs
@@ -297,8 +297,8 @@ namespace Microsoft.Diagnostics.Runtime
                     DumpFileFormat.Userdump64 => throw new NotSupportedException($"This dump is in the Userdump64 format, which is not supported by ClrMD directly. " +
                                 "DbgEng can read this dump format, which can be obtained via DbgEngDataReader in the Microsoft.Diagnostics.Runtime.Utilities NuGet package."),
 
-                    DumpFileFormat.CompressedArchive => throw new InvalidDataException($"Stream '{displayName}' is a compressed archived instead of a dump file."),
-                    _ => throw new InvalidDataException($"Stream '{displayName}' is in an unknown or unsupported file format."),
+                    DumpFileFormat.CompressedArchive => throw new InvalidDataException("The provided stream is a compressed archive instead of a dump file."),
+                    _ => throw new InvalidDataException("The provided stream is in an unknown or unsupported file format."),
                 };
 
                 DataTarget result = new(reader, options);

--- a/src/Microsoft.Diagnostics.Runtime/Implementation/SymbolGroup.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Implementation/SymbolGroup.cs
@@ -133,7 +133,7 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
                     }
                     else
                     {
-                        Trace.WriteLine($"Ignoring symbol part: {server}");
+                        Debug.WriteLine($"Ignoring symbol part: {server}");
                     }
                 }
             }


### PR DESCRIPTION
- Changed Trace -> Debug, to prevent output while using the library on unix.
- Removed some file paths from exceptions to prevent leaking too much information if consumers of ClrMD display those messages raw.