### PR TITLE
Add xcopy-msbuild 17.14.0 to global.json

### DIFF
--- a/global.json
+++ b/global.json
@@ -5,7 +5,8 @@
     "allowPrerelease": true
   },
   "tools": {
-    "dotnet": "10.0.100"
+    "dotnet": "10.0.100",
+    "xcopy-msbuild": "17.14.0"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "8.0.0-beta.26117.2"


### PR DESCRIPTION
SDK 10.0.100 requires MSBuild 17.14.0+ but Arcade defaults to 17.12.0, breaking the signing validation task on CI.