### PR TITLE
Fix the exception type/message for when we encounter an uninitialized runtime or truncated dump

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/ClrRuntime.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrRuntime.cs
@@ -212,7 +212,7 @@ namespace Microsoft.Diagnostics.Runtime
 
                     // These are defined as non-nullable but just in case, double check we have a non-null instance.
                     if (heapHelpers is null || typeHelpers is null)
-                        throw new NotSupportedException("Unable to create a ClrHeap for this runtime.");
+                        throw new InvalidDataException("Unable to create a ClrHeap for this runtime. This may indicate that the CLR wasn't fully initialized at the time the dump was taken, or the dump is corrupt or truncated.");
 
                     heap = new(this, DataTarget.DataReader, heapHelpers, typeHelpers);
                     Interlocked.CompareExchange(ref _heap, heap, null);

--- a/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacRuntime.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacRuntime.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
 
             int version = 0;
             if (!_dac.Request(DacRequests.VERSION, ReadOnlySpan<byte>.Empty, new Span<byte>(&version, sizeof(int))))
-                throw new InvalidDataException("This instance of CLR either has not been initialized or does not contain any data.  Failed to request DacVersion.");
+                throw new InvalidDataException("This instance of CLR either has not been initialized or does not contain any data. This may indicate the dump was taken before the CLR was fully initialized, or the dump is corrupt or truncated. Failed to request DacVersion.");
 
             if (version != 9)
                 throw new NotSupportedException($"The CLR debugging layer reported a version of {version} which this build of ClrMD does not support.");
@@ -85,7 +85,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
         public IEnumerable<AppDomainInfo> EnumerateAppDomains()
         {
             if (!_sos.GetAppDomainStoreData(out AppDomainStoreData domainStore))
-                throw new InvalidDataException("This instance of CLR either has not been initialized or does not contain any data. Failed to request AppDomainStoreData.");
+                throw new InvalidDataException("This instance of CLR either has not been initialized or does not contain any data. This may indicate the dump was taken before the CLR was fully initialized, or the dump is corrupt or truncated. Failed to request AppDomainStoreData.");
 
             if (domainStore.SharedDomain != 0)
                 yield return CreateAppDomainInfo(domainStore.SharedDomain, AppDomainKind.Shared, "Shared Domain");


### PR DESCRIPTION
Change the exception thrown when GC heap data structures cannot be loaded from NotSupportedException to ClrDiagnosticsException. The new message explains that the CLR may not have been fully initialized or the dump may be corrupt/truncated, instead of the unhelpful 'Unable to create a ClrHeap for this runtime.'

Fixes dotnet/diagnostics#5717
Fixes dotnet/diagnostics#2197