### PR TITLE
Fix internal pipeline signing validation failure by replacing CIBuild with explicit build flags

### DIFF
--- a/azure-pipelines-internal.yml
+++ b/azure-pipelines-internal.yml
@@ -77,14 +77,26 @@ extends:
                                       /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
 
             steps:
-            - script: eng\common\cibuild.cmd
+            - script: eng\common\build.cmd
                 -configuration $(_BuildConfig)
                 -prepareMachine
                 -verbosity normal
+                -restore -build -test
+                -ci
+              name: BuildDebug
+              displayName: Build and Test (Debug)
+              condition: and(succeeded(), eq(variables['_BuildConfig'], 'Debug'))
+
+            - script: eng\common\build.cmd
+                -configuration $(_BuildConfig)
+                -prepareMachine
+                -verbosity normal
+                -restore -build -test -sign -pack -publish
+                -ci
                 $(_ReleaseBuildArgs)
-              name: Build
-              displayName: Build
-              condition: succeeded()
+              name: BuildRelease
+              displayName: Build, Sign, and Publish (Release)
+              condition: and(succeeded(), ne(variables['_BuildConfig'], 'Debug'))
 
           - job: Linux
             pool:
@@ -100,9 +112,11 @@ extends:
                   _BuildConfig: Release
 
             steps:
-            - script: eng/common/cibuild.sh
+            - script: eng/common/build.sh
                 --configuration $(_BuildConfig)
                 --prepareMachine
+                --restore --build --test
+                --ci
               name: Build
               displayName: Build
               condition: succeeded()
@@ -121,9 +135,11 @@ extends:
                   _BuildConfig: Release
 
             steps:
-            - script: eng/common/cibuild.sh
+            - script: eng/common/build.sh
                 --configuration $(_BuildConfig)
                 --prepareMachine
+                --restore --build --test
+                --ci
               name: Build
               displayName: Build
               condition: succeeded()


### PR DESCRIPTION
## Problem
 
 All internal pipeline builds have been failing since February 2026 (build [2885270](https://dev.azure.com/dnceng/internal/_build/results?buildId=2885270) was the last success on Jan 22). The failure is in the post-build SignCheck validation stage, which rejects unsigned DLLs found in `-ci` suffixed packages uploaded by the Debug matrix leg.
 
 ## Root Cause
 
 Three Arcade SDK dependency updates landed between Jan–Feb 2026, upgrading from Arcade `8.0.0-beta.25611.2` to `10.0.0-beta.26164.1`. Arcade 10.x removed the `DotNetPublishUsingPipelines` condition gate from `PublishToAzureDevOpsArtifacts` in `Publish.proj` ([dotnet/arcade#15580](https://github.com/dotnet/arcade/pull/15580), merged Feb 27 2025). The intent was that callers should stop passing `-publish` if they don't want to publish, rather than relying on the property gate.
 
However, `eng/common/CIBuild.cmd` (an Arcade-managed shared file) unconditionally passes `-restore -build -test -sign -pack -publish -ci` and was never updated to account for this change. As a result:
 
 - **Old behavior (Arcade 8.x):** Debug builds called `CIBuild.cmd` → `-publish` invoked `Publish.proj` → `PublishToAzureDevOpsArtifacts` was a **no-op** because `DotNetPublishUsingPipelines` wasn't set → no packages uploaded → SignCheck passed.
 - **New behavior (Arcade 10.x):** Debug builds called `CIBuild.cmd` → `-publish` invoked `Publish.proj` → `PublishToAzureDevOpsArtifacts`  **unconditionally uploaded** unsigned `-ci` packages → SignCheck found unsigned DLLs → **build failed**.
 
 The Release leg was unaffected because it sets `/p:DotNetSignType=real`, so its packages are properly signed.
 
 ## Fix
 
 Replace all uses of `CIBuild.cmd`/`cibuild.sh` with direct calls to `build.cmd`/`build.sh` with explicit flags:
 
 | Platform | Config | Command | Flags |
 |----------|--------|---------|-------|
 | Windows | Debug | `build.cmd` | `-restore -build -test -ci` |
 | Windows | Release | `build.cmd` | `-restore -build -test -sign -pack -publish -ci` + signing args |
 | Linux | Both | `build.sh` | `--restore --build --test --ci` |
 | macOS | Both | `build.sh` | `--restore --build --test --ci` |
 
 This aligns with the Arcade team's guidance from [dotnet/arcade#15523](https://github.com/dotnet/arcade/issues/15523): 
*"[DotNetPublishUsingPipelines=false] basically just disables publishing, which can just be done by not passing `-publish`."*