### PR TITLE
Fix GetTypeByName to find cached generic instantiations

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/GenericFieldTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/GenericFieldTests.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using System.Linq;
 using Xunit;
 
@@ -30,7 +32,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
 
             Assert.True(node.IsValid, "Could not find LinkedListNode<string> on the heap.");
 
-            ClrInstanceField itemField = node.Type!.GetFieldByName("item");
+            ClrInstanceField? itemField = node.Type!.GetFieldByName("item");
             Assert.NotNull(itemField);
 
             // The field type should be System.String, not T or System.__Canon
@@ -98,6 +100,52 @@ namespace Microsoft.Diagnostics.Runtime.Tests
                     Assert.DoesNotContain("__Canon", field.Type.Name);
                 }
             }
+        }
+
+        /// <summary>
+        /// Issue #1396: All fields of LinkedListNode should have non-null types.
+        /// The next/prev fields are GenericInstantiation(LinkedListNode, Var(0)) in metadata
+        /// and the list field is GenericInstantiation(LinkedList, Var(0)).
+        /// These require resolving generic instantiations by searching cached types, not
+        /// just TypeDef maps.
+        /// </summary>
+        [Fact]
+        public void LinkedListNode_AllFields_HaveNonNullType()
+        {
+            ClrHeap heap = _connection.Runtime.Heap;
+            ClrObject node = heap.EnumerateObjects()
+                .FirstOrDefault(o => o.Type?.Name?.Contains("LinkedListNode<System.String>") == true);
+
+            Assert.True(node.IsValid, "Could not find LinkedListNode<string> on the heap.");
+
+            foreach (ClrInstanceField field in node.Type!.Fields)
+            {
+                Assert.NotNull(field.Type);
+                Assert.NotEqual(ClrElementType.Unknown, field.Type!.ElementType);
+            }
+        }
+
+        /// <summary>
+        /// Issue #1396: GetTypeByName should find generic instantiations that have
+        /// been constructed during heap enumeration, not just types in TypeDef maps.
+        /// </summary>
+        [Fact]
+        public void GetTypeByName_FindsConstructedGenericInstantiations()
+        {
+            ClrHeap heap = _connection.Runtime.Heap;
+
+            // Force heap enumeration so types get constructed and cached.
+            foreach (ClrObject obj in heap.EnumerateObjects())
+            {
+                // Touch Type to ensure it's constructed
+                _ = obj.Type;
+            }
+
+            // LinkedListNode<System.String> is a generic instantiation, not a TypeDef.
+            // GetTypeByName should find it via the cache fallback.
+            ClrType? nodeType = heap.GetTypeByName("System.Collections.Generic.LinkedListNode<System.String>");
+            Assert.NotNull(nodeType);
+            Assert.Contains("LinkedListNode", nodeType!.Name);
         }
 
         public class GenericConnection : Fixtures.ObjectConnection<GenericTypeCarrier>

--- a/src/Microsoft.Diagnostics.Runtime/ClrHeap.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrHeap.cs
@@ -1145,7 +1145,18 @@ namespace Microsoft.Diagnostics.Runtime
         }
         public ClrType? GetTypeByMethodTable(ulong methodTable) => _typeFactory.GetOrCreateType(methodTable, 0);
 
-        public ClrType? GetTypeByName(string name) => Runtime.EnumerateModules().OrderBy(m => m.Name ?? "").Select(m => GetTypeByName(m, name)).Where(r => r != null).FirstOrDefault();
+        public ClrType? GetTypeByName(string name)
+        {
+            // Search TypeDef maps across all modules (finds typedefs like System.String).
+            ClrType? result = Runtime.EnumerateModules().OrderBy(m => m.Name ?? "").Select(m => GetTypeByName(m, name)).Where(r => r != null).FirstOrDefault();
+
+            // Fallback: search all already-constructed types in the cache.  This finds
+            // generic instantiations (e.g. LinkedListNode<System.String>) that are not
+            // in any module's TypeDef map but were constructed during heap enumeration.
+            result ??= _typeFactory.TryGetCachedTypeByName(name);
+
+            return result;
+        }
 
         public ClrType? GetTypeByName(ClrModule module, string name)
         {

--- a/src/Microsoft.Diagnostics.Runtime/Implementation/ClrTypeFactory.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Implementation/ClrTypeFactory.cs
@@ -152,6 +152,25 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
             }
         }
 
+        /// <summary>
+        /// Searches all cached (already-constructed) types by name.  This finds
+        /// generic instantiations that are not present in any module's TypeDef map
+        /// but were constructed during heap enumeration.
+        /// </summary>
+        public ClrType? TryGetCachedTypeByName(string name)
+        {
+            lock (_types)
+            {
+                foreach (ClrType type in _types.Values)
+                {
+                    if (type.Name == name)
+                        return type;
+                }
+            }
+
+            return null;
+        }
+
         public ClrType? GetOrCreateTypeFromSignature(ClrModule module, SigParser parser, IEnumerable<ClrGenericParameter> typeParameters, IEnumerable<ClrGenericParameter> methodParameters, IReadOnlyList<ClrType?>? concreteTypeArgs = null)
         {
             // ECMA 335 - II.23.2.12 - Type


### PR DESCRIPTION
GetTypeByName only searched TypeDef maps, missing generic instantiations (e.g. LinkedListNode<System.String>) that were already constructed during heap enumeration. Add TryGetCachedTypeByName to ClrTypeFactory that searches all cached types by name, and use it as a fallback in ClrHeap.GetTypeByName.

This improves field type resolution for generic types where:
- The type argument is itself a generic instantiation
- The concrete generic type needs to be found by constructed name
- The field signature's GenericInstantiation or Var elements need resolved concrete types that aren't in any module's TypeDef map

Add regression tests verifying all LinkedListNode fields have non-null types and that GetTypeByName finds constructed generic instantiations.

Fixes #1396 .