### PR TITLE
Fix stream display name handling in minidumps

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/DataTargetTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/DataTargetTests.cs
@@ -39,6 +39,26 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             _ = Assert.Throws<InvalidDataException>(() => DataTarget.LoadDump(path));
         }
 
+        [WindowsFact]
+        public void LoadDump_StreamDisplayNameDoesNotNeedToBeAFilePath()
+        {
+            using (DataTarget _ = TestTargets.Types.LoadFullDump())
+            {
+            }
+
+            string dumpPath = TestTargets.Types.BuildDumpName(GCMode.Workstation, full: true);
+            using FileStream stream = File.OpenRead(dumpPath);
+            using DataTarget dt = DataTarget.LoadDump("<display name>", stream, options: new DataTargetOptions
+            {
+                CacheOptions = new CacheOptions
+                {
+                    MaxDumpCacheSize = 0x200_0000,
+                },
+            });
+
+            Assert.NotEmpty(dt.EnumerateModules());
+        }
+
         [Theory]
         [InlineData(false)]
         [InlineData(true)]

--- a/src/Microsoft.Diagnostics.Runtime/Windows/Minidump.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Windows/Minidump.cs
@@ -131,7 +131,7 @@ namespace Microsoft.Diagnostics.Runtime.Windows
                 else
                 {
                     CacheTechnology technology = cacheOptions.UseOSMemoryFeatures ? CacheTechnology.AWE : CacheTechnology.ArrayPool;
-                    memoryReader = new CachedMemoryReader(segments, displayName, fs, cacheSize, technology, PointerSize, leaveOpen);
+                    memoryReader = new CachedMemoryReader(segments, fs.Name, fs, cacheSize, technology, PointerSize, leaveOpen);
                 }
             }
             else


### PR DESCRIPTION
Fixes #1403.

This pull request adds a new test to ensure that the `DataTarget.LoadDump` method can accept an arbitrary display name (not necessarily a file path) when loading a dump from a stream, and updates the `Minidump` implementation to always use the file stream's name as the display name for the memory reader. This clarifies the separation between user-facing display names and internal file identifiers.

**Testing improvements:**
* Added a new test `LoadDump_StreamDisplayNameDoesNotNeedToBeAFilePath` in `DataTargetTests.cs` to verify that `DataTarget.LoadDump` works correctly when given a display name that is not a file path.

**Implementation changes:**
* Updated `Minidump` in `Minidump.cs` to always pass the file stream's `Name` property as the display name to `CachedMemoryReader`, ensuring consistency and avoiding reliance on arbitrary display names for internal logic.