### PR TITLE
Fall back to MethodTable when generic type resolution produces a placeholder

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/ClrField.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrField.cs
@@ -131,6 +131,13 @@ namespace Microsoft.Diagnostics.Runtime
                     IReadOnlyList<ClrType?>? concreteTypeArgs = ContainingType.GetConcreteGenericTypeArguments();
                     _type = ContainingType.Heap.GetOrCreateTypeFromSignature(ContainingType.Module, sigParser, ContainingType.EnumerateGenericParameters(), Array.Empty<ClrGenericParameter>(), concreteTypeArgs);
                 }
+
+                // If metadata resolution produced a generic placeholder (e.g. "TStateMachine"
+                // with no fields), fall back to the MethodTable. This handles compiler-generated
+                // types nested inside open generic classes where the name-based lookup fails
+                // due to open vs closed generic name mismatch.
+                if (_type is Implementation.ClrGenericType && FieldInfo.MethodTable != 0)
+                    _type = ContainingType.Heap.GetTypeByMethodTable(FieldInfo.MethodTable) ?? _type;
             }
 
             Interlocked.Exchange(ref _attributes, (int)info.Attributes);


### PR DESCRIPTION
When `__Canon` filtering (introduced in #1373) nulls a field's type and the metadata signature fallback resolves to a ClrGenericType placeholder (e.g. `TStateMachine` with no fields), fall back to resolving via the field's MethodTable directly.

This handles compiler-generated types nested inside open generic classes (e.g. async state machines in local functions) where GetTypeByName fails because it compares closed-generic names against open-generic TypeDefs.

The MethodTable resolves to __Canon, which restores the pre-#1373 behavior: the field reports IsObjectReference=true, so consumers use ReadObjectField to get the concrete type from the heap.