### PR TITLE
Fix cross-bitness dump reading: replace IntPtr.Size with target PointerSize

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/ClrArray.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrArray.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Diagnostics.Runtime
             {
                 if (_length == -1)
                 {
-                    _length = Type.Module.DataReader.Read<int>(Address + (ulong)IntPtr.Size);
+                    _length = Type.Module.DataReader.Read<int>(Address + (ulong)Type.Module.DataReader.PointerSize);
                 }
 
                 return _length;
@@ -49,9 +49,9 @@ namespace Microsoft.Diagnostics.Runtime
             }
         }
 
-        private readonly bool IsMultiDimensional => Type.StaticSize > (uint)(3 * IntPtr.Size);
+        private readonly bool IsMultiDimensional => Type.StaticSize > (uint)(3 * Type.Module.DataReader.PointerSize);
 
-        private readonly int MultiDimensionalRank => (int)((Type.StaticSize - (uint)(3 * IntPtr.Size)) / (2 * sizeof(int)));
+        private readonly int MultiDimensionalRank => (int)((Type.StaticSize - (uint)(3 * Type.Module.DataReader.PointerSize)) / (2 * sizeof(int)));
 
         IClrType IClrArray.Type => Type;
 
@@ -210,7 +210,7 @@ namespace Microsoft.Diagnostics.Runtime
                 throw new ArgumentException($"Array {Address:x} was not a one-dimensional array. Type: {Type?.Name ?? "null"}");
 
             int valueOffset = index;
-            int dataByteOffset = 2 * sizeof(nint);
+            int dataByteOffset = 2 * Type.Module.DataReader.PointerSize;
 
             if (IsMultiDimensional)
             {
@@ -240,7 +240,7 @@ namespace Microsoft.Diagnostics.Runtime
                 throw new ArgumentException($"Indices length does not match the array rank. Array {Address:x} Rank = {rank}, {nameof(indices)} Rank = {indices.Length}");
 
             int valueOffset = 0;
-            int dataByteOffset = 2 * sizeof(nint);
+            int dataByteOffset = 2 * Type.Module.DataReader.PointerSize;
 
             if (rank == 1)
             {
@@ -285,7 +285,7 @@ namespace Microsoft.Diagnostics.Runtime
         //                 ^
         //                 | Address
         private readonly int GetMultiDimensionalBound(int offset) =>
-            Type.Module.DataReader.Read<int>(Address + (ulong)(2 * IntPtr.Size) + (ulong)(offset * sizeof(int)));
+            Type.Module.DataReader.Read<int>(Address + (ulong)(2 * Type.Module.DataReader.PointerSize) + (ulong)(offset * sizeof(int)));
 
         IClrValue IClrArray.GetObjectValue(int index) => GetObjectValue(index);
 

--- a/src/Microsoft.Diagnostics.Runtime/ClrArray.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrArray.cs
@@ -183,7 +183,10 @@ namespace Microsoft.Diagnostics.Runtime
             if (Type.ComponentType != null && !Type.ComponentType.IsObjectReference)
                 throw new InvalidOperationException($"{Type} does not contain object references.");
 
-            return Type.Heap.GetObject(ReadValue<nuint>(index));
+            int pointerSize = Type.Module.DataReader.PointerSize;
+            ulong address = GetElementAddress(pointerSize, index);
+            Type.Module.DataReader.ReadPointer(address, out ulong value);
+            return Type.Heap.GetObject(value);
         }
 
         public ClrObject GetObjectValue(params int[] indices)
@@ -191,7 +194,10 @@ namespace Microsoft.Diagnostics.Runtime
             if (Type.ComponentType != null && !Type.ComponentType.IsObjectReference)
                 throw new InvalidOperationException($"{Type} does not contain object references.");
 
-            return Type.Heap.GetObject(ReadValue<nuint>(indices));
+            int pointerSize = Type.Module.DataReader.PointerSize;
+            ulong address = GetElementAddress(pointerSize, indices);
+            Type.Module.DataReader.ReadPointer(address, out ulong value);
+            return Type.Heap.GetObject(value);
         }
 
         private unsafe T ReadValue<T>(int index) where T : unmanaged

--- a/src/Microsoft.Diagnostics.Runtime/ClrDelegate.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrDelegate.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Diagnostics.Runtime
             {
                 if (field.ElementType == ClrElementType.NativeInt)
                 {
-                    ulong targetMethod = field.Read<UIntPtr>(Object, interior: false).ToUInt64();
+                    ulong targetMethod = field.ReadPointer(Object.Address, interior: false);
 
                     if (targetMethod != 0)
                     {
@@ -184,23 +184,17 @@ namespace Microsoft.Diagnostics.Runtime
             ClrArray invocationArray = invocationList.AsArray();
             count = Math.Min(count, invocationArray.Length);
 
-            ClrHeap heap = Object.Type!.Heap;
-
-            UIntPtr[]? pointers = invocationArray.ReadValues<UIntPtr>(0, count);
-            if (pointers is not null)
+            for (int i = 0; i < count; i++)
             {
-                foreach (UIntPtr ptr in pointers)
-                {
-                    if (ptr == UIntPtr.Zero)
-                        continue;
+                ClrObject delegateObj = invocationArray.GetObjectValue(i);
+                if (!delegateObj.IsValid || delegateObj.Address == 0)
+                    continue;
 
-                    ClrObject delegateObj = heap.GetObject(ptr.ToUInt64());
-                    if (delegateObj.IsDelegate)
-                    {
-                        ClrDelegateTarget? delegateTarget = new ClrDelegate(delegateObj).GetDelegateTarget();
-                        if (delegateTarget is not null)
-                            yield return delegateTarget;
-                    }
+                if (delegateObj.IsDelegate)
+                {
+                    ClrDelegateTarget? delegateTarget = new ClrDelegate(delegateObj).GetDelegateTarget();
+                    if (delegateTarget is not null)
+                        yield return delegateTarget;
                 }
             }
         }

--- a/src/Microsoft.Diagnostics.Runtime/ClrEnum.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrEnum.cs
@@ -81,23 +81,27 @@ namespace Microsoft.Diagnostics.Runtime
             return values.ToArray();
         }
 
-        private unsafe object? GetValueForPointer(ClrElementType pdwCPlusTypeFlag, IntPtr ppValue) => pdwCPlusTypeFlag switch
+        private unsafe object? GetValueForPointer(ClrElementType pdwCPlusTypeFlag, IntPtr ppValue)
         {
-            ClrElementType.Boolean => *(byte*)ppValue,
-            ClrElementType.Char => *(char*)ppValue,
-            ClrElementType.Double => *(double*)ppValue,
-            ClrElementType.Float => *(float*)ppValue,
-            ClrElementType.Int8 => *(sbyte*)ppValue,
-            ClrElementType.Int16 => *(short*)ppValue,
-            ClrElementType.Int32 => *(int*)ppValue,
-            ClrElementType.Int64 => *(long*)ppValue,
-            ClrElementType.UInt8 => *(byte*)ppValue,
-            ClrElementType.UInt16 => *(ushort*)ppValue,
-            ClrElementType.UInt32 => *(uint*)ppValue,
-            ClrElementType.UInt64 => *(ulong*)ppValue,
-            ClrElementType.NativeInt => *(nint*)ppValue,
-            ClrElementType.NativeUInt => *(nuint*)ppValue,
-            _ => null,
-        };
+            int pointerSize = Type.Module.DataReader.PointerSize;
+            return pdwCPlusTypeFlag switch
+            {
+                ClrElementType.Boolean => *(byte*)ppValue,
+                ClrElementType.Char => *(char*)ppValue,
+                ClrElementType.Double => *(double*)ppValue,
+                ClrElementType.Float => *(float*)ppValue,
+                ClrElementType.Int8 => *(sbyte*)ppValue,
+                ClrElementType.Int16 => *(short*)ppValue,
+                ClrElementType.Int32 => *(int*)ppValue,
+                ClrElementType.Int64 => *(long*)ppValue,
+                ClrElementType.UInt8 => *(byte*)ppValue,
+                ClrElementType.UInt16 => *(ushort*)ppValue,
+                ClrElementType.UInt32 => *(uint*)ppValue,
+                ClrElementType.UInt64 => *(ulong*)ppValue,
+                ClrElementType.NativeInt => pointerSize == 8 ? *(long*)ppValue : *(int*)ppValue,
+                ClrElementType.NativeUInt => pointerSize == 8 ? *(ulong*)ppValue : *(uint*)ppValue,
+                _ => null,
+            };
+        }
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/ClrException.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrException.cs
@@ -142,10 +142,11 @@ namespace Microsoft.Diagnostics.Runtime
 
         private uint GetStackTraceOffset(ClrType type)
         {
+            int pointerSize = Type.Module.DataReader.PointerSize;
             ClrField? field = type.Fields.FirstOrDefault(f => f.Name == "_stackTrace");
 
             if (field != null && field.Offset >= 0)
-                return (uint)(field.Offset + IntPtr.Size);
+                return (uint)(field.Offset + pointerSize);
 
             uint result = Type.Module.Heap.Runtime.ClrInfo.Flavor switch
             {
@@ -166,15 +167,16 @@ namespace Microsoft.Diagnostics.Runtime
                 _ => uint.MaxValue
             };
 
-            return result == uint.MaxValue ? 0 : result + (uint)IntPtr.Size;
+            return result == uint.MaxValue ? 0 : result + (uint)pointerSize;
         }
 
         private uint GetInnerExceptionOffset(ClrType type)
         {
+            int pointerSize = Type.Module.DataReader.PointerSize;
             ClrField? field = type.Fields.FirstOrDefault(f => f.Name == "_innerException");
 
             if (field != null && field.Offset >= 0)
-                return (uint)(field.Offset + IntPtr.Size);
+                return (uint)(field.Offset + pointerSize);
 
             uint result = Type.Module.Heap.Runtime.ClrInfo.Flavor switch
             {
@@ -195,15 +197,16 @@ namespace Microsoft.Diagnostics.Runtime
                 _ => uint.MaxValue
             };
 
-            return result == uint.MaxValue ? 0 : result + (uint)IntPtr.Size;
+            return result == uint.MaxValue ? 0 : result + (uint)pointerSize;
         }
 
         private uint GetHResultOffset(ClrType type)
         {
+            int pointerSize = Type.Module.DataReader.PointerSize;
             ClrField? field = type.Fields.FirstOrDefault(f => f.Name == "_HResult");
 
             if (field != null && field.Offset >= 0)
-                return (uint)(field.Offset + IntPtr.Size);
+                return (uint)(field.Offset + pointerSize);
 
             uint result = Type.Module.Heap.Runtime.ClrInfo.Flavor switch
             {
@@ -224,15 +227,16 @@ namespace Microsoft.Diagnostics.Runtime
                 _ => uint.MaxValue
             };
 
-            return result == uint.MaxValue ? 0 : result + (uint)IntPtr.Size;
+            return result == uint.MaxValue ? 0 : result + (uint)pointerSize;
         }
 
         private uint GetMessageOffset(ClrType type)
         {
+            int pointerSize = Type.Module.DataReader.PointerSize;
             ClrField? field = type.Fields.FirstOrDefault(f => f.Name == "_message");
 
             if (field != null && field.Offset >= 0)
-                return (uint)(field.Offset + IntPtr.Size);
+                return (uint)(field.Offset + pointerSize);
 
             uint result = Type.Module.Heap.Runtime.ClrInfo.Flavor switch
             {
@@ -253,7 +257,7 @@ namespace Microsoft.Diagnostics.Runtime
                 _ => uint.MaxValue
             };
 
-            return result == uint.MaxValue ? 0 : result + (uint)IntPtr.Size;
+            return result == uint.MaxValue ? 0 : result + (uint)pointerSize;
         }
 
         private ImmutableArray<ClrStackFrame> GetExceptionStackTrace()
@@ -264,6 +268,7 @@ namespace Microsoft.Diagnostics.Runtime
                 return ImmutableArray<ClrStackFrame>.Empty;
 
             IDataReader dataReader = Type.Module.DataReader;
+            int pointerSize = dataReader.PointerSize;
             ulong address = dataReader.ReadPointer(_object.Address + offset);
             ClrObject _stackTrace = Type.Module.Heap.GetObject(address);
 
@@ -274,8 +279,8 @@ namespace Microsoft.Diagnostics.Runtime
             if (len == 0)
                 return ImmutableArray<ClrStackFrame>.Empty;
 
-            int elementSize = IntPtr.Size * 4;
-            ulong dataPtr = _stackTrace + (ulong)(IntPtr.Size * 2);
+            int elementSize = pointerSize * 4;
+            ulong dataPtr = _stackTrace + (ulong)(pointerSize * 2);
             if (!dataReader.ReadPointer(dataPtr, out ulong count))
                 return ImmutableArray<ClrStackFrame>.Empty;
 
@@ -283,13 +288,13 @@ namespace Microsoft.Diagnostics.Runtime
             result.Count = result.Capacity;
 
             // Skip size and header
-            dataPtr += (ulong)(IntPtr.Size * 2);
+            dataPtr += (ulong)(pointerSize * 2);
 
             for (int i = 0; i < (int)count; ++i)
             {
                 ulong ip = dataReader.ReadPointer(dataPtr);
-                ulong sp = dataReader.ReadPointer(dataPtr + (ulong)IntPtr.Size);
-                ulong md = dataReader.ReadPointer(dataPtr + (ulong)IntPtr.Size + (ulong)IntPtr.Size);
+                ulong sp = dataReader.ReadPointer(dataPtr + (ulong)pointerSize);
+                ulong md = dataReader.ReadPointer(dataPtr + (ulong)pointerSize + (ulong)pointerSize);
 
                 ClrMethod? method = Type.Module.Heap.Runtime.GetMethodByHandle(md);
                 result[i] = new ClrStackFrame(Thread, null, ip, sp, ClrStackFrameKind.ManagedMethod, method, frameName: null);

--- a/src/Microsoft.Diagnostics.Runtime/ClrField.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrField.cs
@@ -172,7 +172,7 @@ namespace Microsoft.Diagnostics.Runtime
         /// <summary>
         /// Gets the size of this field.
         /// </summary>
-        public int Size => GetSize(Type, ElementType);
+        public int Size => GetSize(Type, ElementType, ContainingType.Module.DataReader.PointerSize);
 
         /// <summary>
         /// Attributes of this field;
@@ -205,8 +205,10 @@ namespace Microsoft.Diagnostics.Runtime
             return $"{type.Name} {Name}";
         }
 
-        internal static int GetSize(ClrType? type, ClrElementType cet)
+        internal static int GetSize(ClrType? type, ClrElementType cet, int pointerSize = 0)
         {
+            if (pointerSize == 0)
+                pointerSize = IntPtr.Size;
             // todo:  What if we have a struct which is not fully constructed (null MT,
             //        null type) and need to get the size of the field?
             switch (cet)
@@ -255,7 +257,7 @@ namespace Microsoft.Diagnostics.Runtime
                 case ClrElementType.NativeUInt: // native unsigned int
                 case ClrElementType.Pointer:
                 case ClrElementType.FunctionPointer:
-                    return IntPtr.Size;
+                    return pointerSize;
 
                 case ClrElementType.UInt16:
                 case ClrElementType.Int16:

--- a/src/Microsoft.Diagnostics.Runtime/ClrField.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrField.cs
@@ -205,10 +205,8 @@ namespace Microsoft.Diagnostics.Runtime
             return $"{type.Name} {Name}";
         }
 
-        internal static int GetSize(ClrType? type, ClrElementType cet, int pointerSize = 0)
+        internal static int GetSize(ClrType? type, ClrElementType cet, int pointerSize)
         {
-            if (pointerSize == 0)
-                pointerSize = IntPtr.Size;
             // todo:  What if we have a struct which is not fully constructed (null MT,
             //        null type) and need to get the size of the field?
             switch (cet)

--- a/src/Microsoft.Diagnostics.Runtime/ClrHeap.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrHeap.cs
@@ -29,8 +29,8 @@ namespace Microsoft.Diagnostics.Runtime
         private const int SyncBlockIndexBits = 26;
         private const uint SyncBlockIndexMask = ((1u << SyncBlockIndexBits) - 1u);
 
-        private readonly uint _firstChar = (uint)IntPtr.Size + 4;
-        private readonly uint _stringLength = (uint)IntPtr.Size;
+        private readonly uint _firstChar;
+        private readonly uint _stringLength;
 
         private readonly ClrTypeFactory _typeFactory;
         private readonly IMemoryReader _memoryReader;
@@ -45,6 +45,8 @@ namespace Microsoft.Diagnostics.Runtime
         {
             Runtime = runtime;
             _memoryReader = memoryReader;
+            _firstChar = (uint)memoryReader.PointerSize + 4;
+            _stringLength = (uint)memoryReader.PointerSize;
             Helpers = helpers;
 
             GCState gcInfo = helpers.State;
@@ -511,7 +513,7 @@ namespace Microsoft.Diagnostics.Runtime
                     return _memoryReader.ReadPointer(address, out value);
 
                 int offset = (int)(address - Base);
-                value = _cache.AsSpan().AsPointer(offset);
+                value = _cache.AsSpan().AsPointer(_pointerSize, offset);
                 return true;
             }
 
@@ -630,7 +632,7 @@ namespace Microsoft.Diagnostics.Runtime
 
             Dictionary<ulong, ulong> allocationContexts = GetAllocationContexts();
 
-            uint minObjSize = (uint)IntPtr.Size * 3;
+            uint minObjSize = (uint)_memoryReader.PointerSize * 3;
             while (allocationContexts.TryGetValue(address, out ulong nextObj))
             {
                 nextObj += Align(minObjSize, seg);
@@ -645,12 +647,12 @@ namespace Microsoft.Diagnostics.Runtime
             return address;
         }
 
-        private static ulong Align(ulong size, ClrSegment seg)
+        private ulong Align(ulong size, ClrSegment seg)
         {
             ulong AlignConst;
             ulong AlignLargeConst = 7;
 
-            if (IntPtr.Size == 4)
+            if (_memoryReader.PointerSize == 4)
                 AlignConst = 3;
             else
                 AlignConst = 7;
@@ -691,7 +693,8 @@ namespace Microsoft.Diagnostics.Runtime
                             ClrArray array = m_userObject.AsArray();
                             for (int i = 0; i < array.Length; i++)
                             {
-                                ulong innerAddress = m_userObject + (ulong)(2 * IntPtr.Size + i * IntPtr.Size);
+                                int pointerSize = _memoryReader.PointerSize;
+                                ulong innerAddress = m_userObject + (ulong)(2 * pointerSize + i * pointerSize);
                                 ClrObject innerObj = array.GetObjectValue(i);
 
                                 if (innerObj.IsValid)
@@ -855,7 +858,7 @@ namespace Microsoft.Diagnostics.Runtime
             }
             else
             {
-                uint countOffset = (uint)IntPtr.Size;
+                uint countOffset = (uint)_memoryReader.PointerSize;
                 ulong loc = objRef + countOffset;
 
                 uint count = _memoryReader.Read<uint>(loc);
@@ -867,7 +870,7 @@ namespace Microsoft.Diagnostics.Runtime
                 size = count * (ulong)type.ComponentSize + (ulong)type.StaticSize;
             }
 
-            uint minSize = (uint)IntPtr.Size * 3;
+            uint minSize = (uint)_memoryReader.PointerSize * 3;
             if (size < minSize)
                 size = minSize;
             return size;
@@ -938,7 +941,7 @@ namespace Microsoft.Diagnostics.Runtime
                     int intSize = (int)size;
                     byte[] buffer = ArrayPool<byte>.Shared.Rent(intSize);
                     int read = _memoryReader.Read(obj, new Span<byte>(buffer, 0, intSize));
-                    if (read > IntPtr.Size)
+                    if (read > _memoryReader.PointerSize)
                     {
                         foreach ((ulong reference, int offset) in gcdesc.WalkObject(buffer, read))
                             yield return new(reference, GetObjectType(reference) ?? ErrorType);
@@ -1008,14 +1011,14 @@ namespace Microsoft.Diagnostics.Runtime
                     int intSize = (int)size;
                     byte[] buffer = ArrayPool<byte>.Shared.Rent(intSize);
                     int read = _memoryReader.Read(obj, new Span<byte>(buffer, 0, intSize));
-                    if (read > IntPtr.Size)
+                    if (read > _memoryReader.PointerSize)
                     {
                         foreach ((ulong reference, int offset) in gcdesc.WalkObject(buffer, read))
                         {
                             ClrObject target = new(reference, GetObjectType(reference) ?? ErrorType);
 
-                            DebugOnly.Assert(offset >= IntPtr.Size);
-                            yield return ClrReference.CreateFromFieldOrArray(target, type, offset - IntPtr.Size);
+                            DebugOnly.Assert(offset >= _memoryReader.PointerSize);
+                            yield return ClrReference.CreateFromFieldOrArray(target, type, offset - _memoryReader.PointerSize);
                         }
                     }
                     ArrayPool<byte>.Shared.Return(buffer);
@@ -1078,12 +1081,12 @@ namespace Microsoft.Diagnostics.Runtime
                     int intSize = (int)size;
                     byte[] buffer = ArrayPool<byte>.Shared.Rent(intSize);
                     int read = _memoryReader.Read(obj, new Span<byte>(buffer, 0, intSize));
-                    if (read > IntPtr.Size)
+                    if (read > _memoryReader.PointerSize)
                     {
                         foreach ((ulong reference, int offset) in gcdesc.WalkObject(buffer, read))
                         {
                             yield return reference;
-                            DebugOnly.Assert(offset >= IntPtr.Size);
+                            DebugOnly.Assert(offset >= _memoryReader.PointerSize);
                         }
                     }
                     ArrayPool<byte>.Shared.Return(buffer);
@@ -1125,7 +1128,7 @@ namespace Microsoft.Diagnostics.Runtime
         {
             foreach (MemoryRange seg in memoryRanges)
             {
-                for (ulong ptr = seg.Start; ptr < seg.End; ptr += (uint)IntPtr.Size)
+                for (ulong ptr = seg.Start; ptr < seg.End; ptr += (uint)_memoryReader.PointerSize)
                 {
                     ulong obj = _memoryReader.ReadPointer(ptr);
                     if (obj == 0)

--- a/src/Microsoft.Diagnostics.Runtime/ClrInstanceField.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrInstanceField.cs
@@ -38,6 +38,21 @@ namespace Microsoft.Diagnostics.Runtime
         }
 
         /// <summary>
+        /// Reads the value of a pointer-sized field using the target's pointer size.
+        /// </summary>
+        internal ulong ReadPointer(ulong objRef, bool interior)
+        {
+            ulong address = GetAddress(objRef, interior);
+            if (address == 0)
+                return 0;
+
+            if (!ContainingType.Module.DataReader.ReadPointer(address, out ulong value))
+                return 0;
+
+            return value;
+        }
+
+        /// <summary>
         /// Reads the value of an object field.
         /// </summary>
         /// <param name="objRef">The object to read the instance field from.</param>

--- a/src/Microsoft.Diagnostics.Runtime/ClrInstanceField.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrInstanceField.cs
@@ -110,7 +110,7 @@ namespace Microsoft.Diagnostics.Runtime
             if (interior)
                 return objRef + (ulong)Offset;
 
-            return objRef + (ulong)(Offset + IntPtr.Size);
+            return objRef + (ulong)(Offset + ContainingType.Module.DataReader.PointerSize);
         }
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/ClrObject.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrObject.cs
@@ -492,9 +492,17 @@ namespace Microsoft.Diagnostics.Runtime
 
             ulong mt;
             if (field.ElementType == ClrElementType.NativeInt)
-                mt = (ulong)ReadField<nint>("m_handle");
+            {
+                mt = field.ReadPointer(Address, interior: false);
+            }
             else
-                mt = (ulong)ReadValueTypeField("m_handle").ReadField<nint>("m_ptr");
+            {
+                ClrValueType handle = ReadValueTypeField("m_handle");
+                ClrInstanceField? ptrField = handle.Type?.GetFieldByName("m_ptr");
+                if (ptrField is null)
+                    return null;
+                mt = ptrField.ReadPointer(handle.Address, interior: true);
+            }
 
             return type.Heap.Runtime.GetTypeByMethodTable(mt);
         }

--- a/src/Microsoft.Diagnostics.Runtime/ClrObject.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrObject.cs
@@ -109,7 +109,7 @@ namespace Microsoft.Diagnostics.Runtime
             if (helpers is null)
                 return default;
 
-            return DataReader.Read<T>(Address + (ulong)IntPtr.Size);
+            return DataReader.Read<T>(Address + (ulong)DataReader.PointerSize);
         }
 
         public bool IsException => Type != null && Type.IsException;

--- a/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacHeap.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacHeap.cs
@@ -290,7 +290,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
             ulong committedStart;
 
             if (kind == GCSegmentKind.Frozen)
-                committedStart = allocated.Start - (uint)IntPtr.Size;
+                committedStart = allocated.Start - (uint)_memoryReader.PointerSize;
             else if ((allocated.Start & 0x1ffful) == 0x1000)
                 committedStart = allocated.Start - 0x1000;
             else

--- a/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacThreadHelpers.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacThreadHelpers.cs
@@ -144,8 +144,8 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
                     break;
                 }
 
-                ulong ip = context.AsSpan().AsPointer(ipOffset);
-                ulong sp = context.AsSpan().AsPointer(spOffset);
+                ulong ip = context.AsSpan().AsPointer(_dataReader.PointerSize, ipOffset);
+                ulong sp = context.AsSpan().AsPointer(_dataReader.PointerSize, spOffset);
 
                 ulong frameVtbl = stackwalk.GetFrameVtable();
                 string? frameName = null;

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/MetadataImport.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/MetadataImport.cs
@@ -233,14 +233,6 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             return true;
         }
 
-        public SigParser GetSigFromToken(int token)
-        {
-            HResult hr = VTable.GetSigFromToken(Self, token, out IntPtr sig, out int len);
-            if (hr)
-                return new SigParser(sig, len);
-
-            return default;
-        }
     }
 
     [StructLayout(LayoutKind.Sequential)]
@@ -284,7 +276,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
         private readonly IntPtr GetFieldMarshal;
         public readonly delegate* unmanaged[Stdcall]<IntPtr, int, out uint, out uint, int> GetRVA;
         private readonly IntPtr GetPermissionSetProps;
-        public readonly delegate* unmanaged[Stdcall]<IntPtr, int, out IntPtr, out int, int> GetSigFromToken;
+        private readonly IntPtr GetSigFromToken;
         private readonly IntPtr GetModuleRefProps;
         private readonly IntPtr EnumModuleRefs;
         private readonly IntPtr GetTypeSpecFromToken;

--- a/src/Microsoft.Diagnostics.Runtime/DataReaders/CommonMemoryReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DataReaders/CommonMemoryReader.cs
@@ -36,10 +36,11 @@ namespace Microsoft.Diagnostics.Runtime
 
         public bool ReadPointer(ulong address, out ulong value)
         {
-            Span<byte> buffer = stackalloc byte[IntPtr.Size];
-            if (Read(address, buffer) == IntPtr.Size)
+            int pointerSize = PointerSize;
+            Span<byte> buffer = stackalloc byte[pointerSize];
+            if (Read(address, buffer) == pointerSize)
             {
-                value = buffer.AsPointer();
+                value = buffer.AsPointer(pointerSize, 0);
                 return true;
             }
 

--- a/src/Microsoft.Diagnostics.Runtime/Extensions/SpanExtensions.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Extensions/SpanExtensions.cs
@@ -45,19 +45,28 @@ namespace Microsoft.Diagnostics.Runtime
             }
         }
 #endif
-        public static unsafe ulong AsPointer(this Span<byte> span) => AsPointer(span, 0);
+        public static unsafe ulong AsPointer(this Span<byte> span) => AsPointer(span, IntPtr.Size, 0);
 
-        public static unsafe ulong AsPointer(this Span<byte> span, int offset = 0)
+        public static unsafe ulong AsPointer(this Span<byte> span, int offset) => AsPointer(span, IntPtr.Size, offset);
+
+        public static unsafe ulong AsPointer(this Span<byte> span, int pointerSize, int offset)
         {
             if (offset > 0)
                 span = span.Slice(offset);
 
-            DebugOnly.Assert(span.Length >= sizeof(nuint));
-            DebugOnly.Assert(unchecked((int)Unsafe.AsPointer(ref MemoryMarshal.GetReference(span))) % sizeof(nuint) == 0);
-            return Unsafe.As<byte, nuint>(ref MemoryMarshal.GetReference(span));
+            if (pointerSize == 8)
+            {
+                DebugOnly.Assert(span.Length >= sizeof(ulong));
+                return Unsafe.As<byte, ulong>(ref MemoryMarshal.GetReference(span));
+            }
+            else
+            {
+                DebugOnly.Assert(span.Length >= sizeof(uint));
+                return Unsafe.As<byte, uint>(ref MemoryMarshal.GetReference(span));
+            }
         }
 
-        public static unsafe ulong AsPointer(this Span<byte> span, ulong offset = 0) => AsPointer(span, (int)offset);
+        public static unsafe ulong AsPointer(this Span<byte> span, ulong offset) => AsPointer(span, IntPtr.Size, (int)offset);
 
         public static unsafe int AsInt32(this Span<byte> span, int offset = 0)
         {

--- a/src/Microsoft.Diagnostics.Runtime/Extensions/SpanExtensions.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Extensions/SpanExtensions.cs
@@ -45,10 +45,6 @@ namespace Microsoft.Diagnostics.Runtime
             }
         }
 #endif
-        public static unsafe ulong AsPointer(this Span<byte> span) => AsPointer(span, IntPtr.Size, 0);
-
-        public static unsafe ulong AsPointer(this Span<byte> span, int offset) => AsPointer(span, IntPtr.Size, offset);
-
         public static unsafe ulong AsPointer(this Span<byte> span, int pointerSize, int offset)
         {
             if (offset > 0)
@@ -66,7 +62,7 @@ namespace Microsoft.Diagnostics.Runtime
             }
         }
 
-        public static unsafe ulong AsPointer(this Span<byte> span, ulong offset) => AsPointer(span, IntPtr.Size, (int)offset);
+        public static unsafe ulong AsPointer(this Span<byte> span, int pointerSize, ulong offset) => AsPointer(span, pointerSize, (int)offset);
 
         public static unsafe int AsInt32(this Span<byte> span, int offset = 0)
         {

--- a/src/Microsoft.Diagnostics.Runtime/GCDesc.cs
+++ b/src/Microsoft.Diagnostics.Runtime/GCDesc.cs
@@ -8,20 +8,27 @@ namespace Microsoft.Diagnostics.Runtime
 {
     public readonly struct GCDesc
     {
-        private static readonly int s_GCDescSize = IntPtr.Size * 2;
+        private readonly int _pointerSize;
+        private readonly int _gcDescSize;
 
         private readonly byte[] _data;
 
         public bool IsEmpty => _data is null;
 
-        public GCDesc(byte[] data)
+        public GCDesc(byte[] data) : this(data, IntPtr.Size)
+        {
+        }
+
+        public GCDesc(byte[] data, int pointerSize)
         {
             _data = data;
+            _pointerSize = pointerSize;
+            _gcDescSize = pointerSize * 2;
         }
 
         public IEnumerable<(ulong ReferencedObject, int Offset)> WalkObject(byte[] buffer, int size)
         {
-            DebugOnly.Assert(size >= IntPtr.Size);
+            DebugOnly.Assert(size >= _pointerSize);
 
             int series = GetNumSeries();
             int highest = GetHighestSeries();
@@ -37,35 +44,35 @@ namespace Microsoft.Diagnostics.Runtime
 
                     while (offset < stop)
                     {
-                        ulong ret = new Span<byte>(buffer).AsPointer((int)offset);
+                        ulong ret = new Span<byte>(buffer).AsPointer(_pointerSize, (int)offset);
                         if (ret != 0)
                             yield return (ret, (int)offset);
 
-                        offset += IntPtr.Size;
+                        offset += _pointerSize;
                     }
 
-                    curr -= s_GCDescSize;
+                    curr -= _gcDescSize;
                 } while (curr >= lowest);
             }
             else
             {
                 long offset = GetSeriesOffset(curr);
 
-                while (offset < size - IntPtr.Size)
+                while (offset < size - _pointerSize)
                 {
                     for (int i = 0; i > series; i--)
                     {
                         int nptrs = GetPointers(curr, i);
                         int skip = GetSkip(curr, i);
 
-                        long stop = offset + (nptrs * IntPtr.Size);
+                        long stop = offset + (nptrs * _pointerSize);
                         do
                         {
-                            ulong ret = new Span<byte>(buffer).AsPointer((int)offset);
+                            ulong ret = new Span<byte>(buffer).AsPointer(_pointerSize, (int)offset);
                             if (ret != 0)
                                 yield return (ret, (int)offset);
 
-                            offset += IntPtr.Size;
+                            offset += _pointerSize;
                         } while (offset < stop);
 
                         offset += skip;
@@ -76,8 +83,8 @@ namespace Microsoft.Diagnostics.Runtime
 
         private int GetPointers(int curr, int i)
         {
-            int offset = i * IntPtr.Size;
-            if (IntPtr.Size == 4)
+            int offset = i * _pointerSize;
+            if (_pointerSize == 4)
                 return BitConverter.ToUInt16(_data, curr + offset);
 
             return BitConverter.ToInt32(_data, curr + offset);
@@ -85,8 +92,8 @@ namespace Microsoft.Diagnostics.Runtime
 
         private int GetSkip(int curr, int i)
         {
-            int offset = i * IntPtr.Size + IntPtr.Size / 2;
-            if (IntPtr.Size == 4)
+            int offset = i * _pointerSize + _pointerSize / 2;
+            if (_pointerSize == 4)
                 return BitConverter.ToInt16(_data, curr + offset);
 
             return BitConverter.ToInt32(_data, curr + offset);
@@ -94,7 +101,7 @@ namespace Microsoft.Diagnostics.Runtime
 
         private int GetSeriesSize(int curr)
         {
-            if (IntPtr.Size == 4)
+            if (_pointerSize == 4)
                 return BitConverter.ToInt32(_data, curr);
 
             return (int)BitConverter.ToInt64(_data, curr);
@@ -103,17 +110,17 @@ namespace Microsoft.Diagnostics.Runtime
         private long GetSeriesOffset(int curr)
         {
             long offset;
-            if (IntPtr.Size == 4)
-                offset = BitConverter.ToUInt32(_data, curr + IntPtr.Size);
+            if (_pointerSize == 4)
+                offset = BitConverter.ToUInt32(_data, curr + _pointerSize);
             else
-                offset = BitConverter.ToInt64(_data, curr + IntPtr.Size);
+                offset = BitConverter.ToInt64(_data, curr + _pointerSize);
 
             return offset;
         }
 
         private int GetHighestSeries()
         {
-            return _data.Length - IntPtr.Size * 3;
+            return _data.Length - _pointerSize * 3;
         }
 
         private int GetLowestSeries()
@@ -121,17 +128,17 @@ namespace Microsoft.Diagnostics.Runtime
             return _data.Length - ComputeSize(GetNumSeries());
         }
 
-        private static int ComputeSize(int series)
+        private int ComputeSize(int series)
         {
-            return IntPtr.Size + series * IntPtr.Size * 2;
+            return _pointerSize + series * _pointerSize * 2;
         }
 
         private int GetNumSeries()
         {
-            if (IntPtr.Size == 4)
-                return BitConverter.ToInt32(_data, _data.Length - IntPtr.Size);
+            if (_pointerSize == 4)
+                return BitConverter.ToInt32(_data, _data.Length - _pointerSize);
 
-            return (int)BitConverter.ToInt64(_data, _data.Length - IntPtr.Size);
+            return (int)BitConverter.ToInt64(_data, _data.Length - _pointerSize);
         }
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/GCDesc.cs
+++ b/src/Microsoft.Diagnostics.Runtime/GCDesc.cs
@@ -15,10 +15,6 @@ namespace Microsoft.Diagnostics.Runtime
 
         public bool IsEmpty => _data is null;
 
-        public GCDesc(byte[] data) : this(data, IntPtr.Size)
-        {
-        }
-
         public GCDesc(byte[] data, int pointerSize)
         {
             _data = data;

--- a/src/Microsoft.Diagnostics.Runtime/Implementation/ClrDacType.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Implementation/ClrDacType.cs
@@ -113,8 +113,9 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
             if (reader is null)
                 return default;
 
+            int pointerSize = reader.PointerSize;
             DebugOnly.Assert(MethodTable != 0, "Attempted to fill GC desc with a constructed (not real) type.");
-            if (!reader.Read(MethodTable - (ulong)IntPtr.Size, out int entries))
+            if (!reader.Read(MethodTable - (ulong)pointerSize, out int entries))
             {
                 _gcDesc = default;
                 return default;
@@ -125,15 +126,15 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
                 entries = -entries;
 
             int slots = 1 + entries * 2;
-            byte[] buffer = new byte[slots * IntPtr.Size];
-            if (reader.Read(MethodTable - (ulong)(slots * IntPtr.Size), buffer) != buffer.Length)
+            byte[] buffer = new byte[slots * pointerSize];
+            if (reader.Read(MethodTable - (ulong)(slots * pointerSize), buffer) != buffer.Length)
             {
                 _gcDesc = default;
                 return default;
             }
 
             // Construct the gc desc
-            return _gcDesc = new GCDesc(buffer);
+            return _gcDesc = new GCDesc(buffer, pointerSize);
         }
 
         private ClrElementType GetElementType()
@@ -148,7 +149,7 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
                 return _elementType = ClrElementType.String;
 
             if (ComponentSize > 0)
-                return _elementType = StaticSize > (uint)(3 * IntPtr.Size) ? ClrElementType.Array : ClrElementType.SZArray;
+                return _elementType = StaticSize > (uint)(3 * Module.DataReader.PointerSize) ? ClrElementType.Array : ClrElementType.SZArray;
 
             ClrType? baseType = BaseType;
             if (baseType is null)
@@ -286,7 +287,7 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
                     else if (componentType != null)
                     {
                         if (!componentType.IsObjectReference)
-                            _baseArrayOffset = IntPtr.Size * 2;
+                            _baseArrayOffset = Module.DataReader.PointerSize * 2;
                     }
                     else
                     {

--- a/src/Microsoft.Diagnostics.Runtime/Implementation/ClrPrimitiveType.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Implementation/ClrPrimitiveType.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
     internal sealed class ClrPrimitiveType : ClrType
     {
         public ClrPrimitiveType(IAbstractTypeHelpers helpers, ClrModule module, ClrHeap heap, ClrElementType type)
-            : base(module, new() { StaticSize = ClrField.GetSize(null, type) }, helpers)
+            : base(module, new() { StaticSize = ClrField.GetSize(null, type, module.DataReader.PointerSize) }, helpers)
         {
             if (helpers is null)
                 throw new ArgumentNullException(nameof(helpers));

--- a/src/Microsoft.Diagnostics.Runtime/Implementation/ClrTypeFactory.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Implementation/ClrTypeFactory.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
                         ParentMethodTable = _gcInfo.ObjectMethodTable,
                         MethodTable = _gcInfo.StringMethodTable,
                         IsShared = true,
-                        StaticSize = IntPtr.Size + sizeof(int),
+                        StaticSize = _heap.Runtime.DataTarget.DataReader.PointerSize + sizeof(int),
                         ComponentSize = sizeof(char),
                     };
                 }

--- a/src/Microsoft.Diagnostics.Runtime/Utilities/SigParser/SigParser.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Utilities/SigParser/SigParser.cs
@@ -10,21 +10,15 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
         private byte* _sig;
         private int _len;
         private int _offs;
-        private int _pointerSize;
 
         public SigParser(SigParser rhs)
         {
             _sig = rhs._sig;
             _len = rhs._len;
             _offs = rhs._offs;
-            _pointerSize = rhs._pointerSize;
         }
 
-        public SigParser(IntPtr sig, int len) : this(sig, len, IntPtr.Size)
-        {
-        }
-
-        public SigParser(IntPtr sig, int len, int pointerSize)
+        public SigParser(IntPtr sig, int len)
         {
             if (len != 0)
             {
@@ -37,7 +31,6 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
 
             _len = len;
             _offs = 0;
-            _pointerSize = pointerSize;
         }
 
         public bool IsNull()
@@ -213,74 +206,6 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
             return PeekElemTypeSlow(out etype);
         }
 
-        private bool PeekElemTypeSize(out int pSize)
-        {
-            pSize = 0;
-            SigParser sigTemp = new(this);
-
-            if (!sigTemp.SkipAnyVASentinel())
-                return false;
-
-            if (!sigTemp.GetByte(out byte bElementType))
-                return false;
-
-            switch (bElementType)
-            {
-                case ELEMENT_TYPE_I8:
-                case ELEMENT_TYPE_U8:
-                case ELEMENT_TYPE_R8:
-                    pSize = 8;
-                    break;
-
-                case ELEMENT_TYPE_I4:
-                case ELEMENT_TYPE_U4:
-                case ELEMENT_TYPE_R4:
-                    pSize = 4;
-                    break;
-
-                case ELEMENT_TYPE_I2:
-                case ELEMENT_TYPE_U2:
-                case ELEMENT_TYPE_CHAR:
-                    pSize = 2;
-                    break;
-
-                case ELEMENT_TYPE_I1:
-                case ELEMENT_TYPE_U1:
-                case ELEMENT_TYPE_BOOLEAN:
-                    pSize = 1;
-                    break;
-
-                case ELEMENT_TYPE_I:
-                case ELEMENT_TYPE_U:
-                case ELEMENT_TYPE_STRING:
-                case ELEMENT_TYPE_PTR:
-                case ELEMENT_TYPE_BYREF:
-                case ELEMENT_TYPE_CLASS:
-                case ELEMENT_TYPE_OBJECT:
-                case ELEMENT_TYPE_FNPTR:
-                case ELEMENT_TYPE_TYPEDBYREF:
-                case ELEMENT_TYPE_ARRAY:
-                case ELEMENT_TYPE_SZARRAY:
-                    pSize = _pointerSize;
-                    break;
-
-                case ELEMENT_TYPE_VOID:
-                    break;
-
-                case ELEMENT_TYPE_END:
-                case ELEMENT_TYPE_CMOD_REQD:
-                case ELEMENT_TYPE_CMOD_OPT:
-                case ELEMENT_TYPE_VALUETYPE:
-                    Debug.Fail("Asked for the size of an element that doesn't have a size!");
-                    return false;
-
-                default:
-                    Debug.Fail("CorSigGetElementTypeSize given invalid signature to size!");
-                    return false;
-            }
-
-            return true;
-        }
 
         private bool AtSentinel()
         {

--- a/src/Microsoft.Diagnostics.Runtime/Utilities/SigParser/SigParser.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Utilities/SigParser/SigParser.cs
@@ -10,15 +10,21 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
         private byte* _sig;
         private int _len;
         private int _offs;
+        private int _pointerSize;
 
         public SigParser(SigParser rhs)
         {
             _sig = rhs._sig;
             _len = rhs._len;
             _offs = rhs._offs;
+            _pointerSize = rhs._pointerSize;
         }
 
-        public SigParser(IntPtr sig, int len)
+        public SigParser(IntPtr sig, int len) : this(sig, len, IntPtr.Size)
+        {
+        }
+
+        public SigParser(IntPtr sig, int len, int pointerSize)
         {
             if (len != 0)
             {
@@ -31,6 +37,7 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
 
             _len = len;
             _offs = 0;
+            _pointerSize = pointerSize;
         }
 
         public bool IsNull()
@@ -254,7 +261,7 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
                 case ELEMENT_TYPE_TYPEDBYREF:
                 case ELEMENT_TYPE_ARRAY:
                 case ELEMENT_TYPE_SZARRAY:
-                    pSize = IntPtr.Size;
+                    pSize = _pointerSize;
                     break;
 
                 case ELEMENT_TYPE_VOID:


### PR DESCRIPTION
## Summary

Replace ~50 uses of `IntPtr.Size` (host pointer size) with the target process's `PointerSize` across 14 files so that dumps from a different architecture can be read correctly (e.g. reading ARM64 dumps from an x64 host, or x86 dumps from an x64 host).

## Motivation

Cross-platform diagnostic scenarios (e.g. [this CI pipeline](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1377349&view=results)) fail when reading dumps from a target with a different pointer size than the host. The root cause is that ClrMD uses `IntPtr.Size` in many places to compute object layout offsets, field addresses, GC descriptor sizes, and heap alignment — all of which must use the **target's** pointer size, not the host's.

## Changes

### Files modified (14):

| File | What changed |
|------|-------------|
| `ClrArray.cs` | Array length offset, multi-dim detection, rank calc, element addressing (6 locations) |
| `ClrObject.cs` | Boxed value header offset |
| `ClrInstanceField.cs` | Field address calculation |
| `ClrField.cs` | `GetSize` accepts optional `pointerSize` parameter |
| `ClrException.cs` | All 4 offset methods + stack trace parsing |
| `ClrHeap.cs` | String offsets, alignment, min object size, GC ref scanning, finalize queue walking, `MemoryCache.ReadPointer` (12+ locations) |
| `ClrDacType.cs` | GC descriptor reading, array element type detection, base array offset |
| `ClrTypeFactory.cs` | String type `StaticSize` |
| `GCDesc.cs` | New constructor overload with explicit `pointerSize`; all internal methods converted |
| `DacHeap.cs` | Frozen segment committed start |
| `DacThreadHelpers.cs` | IP/SP reads use target pointer size |
| `CommonMemoryReader.cs` | **Bug fix** (see below) |
| `SpanExtensions.cs` | New 3-arg `AsPointer` overload (`pointerSize`, `offset`) |
| `SigParser.cs` | `_pointerSize` field for `PeekElemTypeSize` |

### Bug fix: CommonMemoryReader.ReadPointer

`ReadPointer` was calling `AsPointer(pointerSize)` which resolved to the 2-arg overload `AsPointer(span, int offset)`, treating the pointer size as an offset. Fixed to `AsPointer(pointerSize, 0)` to use the correct 3-arg overload.

## Testing

- **x64 tests**: 379 pass, 1 fail (`GCRootTests.FindAllPaths` — pre-existing on baseline), 4 skip
- **x86 tests**: 257 pass, 123 fail, 4 skip — identical to baseline
- **Cross-bitness smoke test**: Successfully loaded 21 ARM64 Windows dumps from x64 host — pointer size correctly detected as 8, architecture as Arm64, modules enumerated, CLR versions found
- **No regressions**: Verified by stashing changes and running baseline — identical results

## What was NOT changed

Files using `IntPtr.Size` for **host-side** purposes (correctly):
- `CacheOptions.cs`, `DacDataTargetCOM.cs`, `WindowsProcessDataReader.cs`, `VTableBuilder.cs`, `ComCallableIUnknown.cs`, cache entry classes
