### PR TITLE
Fix cross-bitness address truncation in ClrDataAddress conversions

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/ClrThreadPool.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrThreadPool.cs
@@ -76,8 +76,8 @@ namespace Microsoft.Diagnostics.Runtime
         /// </summary>
         public int RetiredWorkerThreads { get; }
 
-        private readonly ClrDataAddress _firstLegacyWorkRequest;
-        private readonly ClrDataAddress _asyncTimerFunction;
+        private readonly ulong _firstLegacyWorkRequest;
+        private readonly ulong _asyncTimerFunction;
 
         internal ClrThreadPool(ClrRuntime runtime, IAbstractLegacyThreadPool? helpers)
         {

--- a/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacComHelpers.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacComHelpers.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;

--- a/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacComHelpers.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacComHelpers.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -23,7 +23,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
 
         public IEnumerable<ClrRcwCleanupData> EnumerateRcwCleanupData()
         {
-            return _sos.EnumerateRCWCleanup(default).Select(r => new ClrRcwCleanupData(r.Rcw.ToAddress(_target), r.Context.ToAddress(_target), r.Thread.ToAddress(_target), r.IsFreeThreaded));
+            return _sos.EnumerateRCWCleanup(ClrDataAddress.Null).Select(r => new ClrRcwCleanupData(r.Rcw.ToAddress(_target), r.Context.ToAddress(_target), r.Thread.ToAddress(_target), r.IsFreeThreaded));
         }
 
         public bool GetCcwInfo(ulong obj, out CcwInfo info)

--- a/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacComHelpers.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacComHelpers.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -13,34 +13,37 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
     internal class DacComHelpers : IAbstractComHelpers
     {
         private readonly SOSDac _sos;
+        private readonly TargetProperties _target;
 
-        public DacComHelpers(SOSDac sos)
+        public DacComHelpers(SOSDac sos, TargetProperties target)
         {
             _sos = sos;
+            _target = target;
         }
 
         public IEnumerable<ClrRcwCleanupData> EnumerateRcwCleanupData()
         {
-            return _sos.EnumerateRCWCleanup(0).Select(r => new ClrRcwCleanupData(r.Rcw, r.Context, r.Thread, r.IsFreeThreaded));
+            return _sos.EnumerateRCWCleanup(default).Select(r => new ClrRcwCleanupData(r.Rcw.ToAddress(_target), r.Context.ToAddress(_target), r.Thread.ToAddress(_target), r.IsFreeThreaded));
         }
 
         public bool GetCcwInfo(ulong obj, out CcwInfo info)
         {
             info = default;
-            if (_sos.GetObjectData(obj, out ObjectData objData) &&
-                objData.CCW != 0 &&
+            if (_sos.GetObjectData(ClrDataAddress.FromAddress(obj, _target), out ObjectData objData) &&
+                !objData.CCW.IsNull &&
                 _sos.GetCCWData(objData.CCW, out CcwData ccwData))
             {
+                ulong ccwAddr = objData.CCW.ToAddress(_target);
                 COMInterfacePointerData[]? pointers = _sos.GetCCWInterfaces(objData.CCW, ccwData.InterfaceCount);
                 info = new()
                 {
-                    Address = objData.CCW,
-                    IUnknown = ccwData.OuterIUnknown,
-                    Object = ccwData.ManagedObject,
-                    Handle = ccwData.Handle,
+                    Address = ccwAddr,
+                    IUnknown = ccwData.OuterIUnknown.ToAddress(_target),
+                    Object = ccwData.ManagedObject.ToAddress(_target),
+                    Handle = ccwData.Handle.ToAddress(_target),
                     RefCount = ccwData.RefCount,
                     JupiterRefCount = ccwData.JupiterRefCount,
-                    Interfaces = pointers?.Select(r => new ComInterfaceEntry() { InterfacePointer = r.InterfacePointer, MethodTable = r.MethodTable }).ToArray() ?? Array.Empty<ComInterfaceEntry>()
+                    Interfaces = pointers?.Select(r => new ComInterfaceEntry() { InterfacePointer = r.InterfacePointer.ToAddress(_target), MethodTable = r.MethodTable.ToAddress(_target) }).ToArray() ?? Array.Empty<ComInterfaceEntry>()
                 };
             }
 
@@ -50,21 +53,22 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
         public bool GetRcwInfo(ulong obj, out RcwInfo info)
         {
             info = default;
-            if (_sos.GetObjectData(obj, out ObjectData objData) &&
-                objData.RCW != 0 &&
+            if (_sos.GetObjectData(ClrDataAddress.FromAddress(obj, _target), out ObjectData objData) &&
+                !objData.RCW.IsNull &&
                 _sos.GetRCWData(objData.RCW, out RcwData rcwData))
             {
+                ulong rcwAddr = objData.RCW.ToAddress(_target);
                 COMInterfacePointerData[]? pointers = _sos.GetRCWInterfaces(objData.RCW, rcwData.InterfaceCount);
                 info = new()
                 {
-                    Address = objData.RCW,
-                    IUnknown = rcwData.IUnknownPointer,
-                    Object = rcwData.ManagedObject,
+                    Address = rcwAddr,
+                    IUnknown = rcwData.IUnknownPointer.ToAddress(_target),
+                    Object = rcwData.ManagedObject.ToAddress(_target),
                     RefCount = rcwData.RefCount,
-                    CreatorThread = rcwData.CreatorThread,
+                    CreatorThread = rcwData.CreatorThread.ToAddress(_target),
                     IsDisconnected = rcwData.IsDisconnected != 0,
-                    VTablePointer = rcwData.VTablePointer,
-                    Interfaces = pointers?.Select(r => new ComInterfaceEntry() { InterfacePointer = r.InterfacePointer, MethodTable = r.MethodTable }).ToArray() ?? Array.Empty<ComInterfaceEntry>()
+                    VTablePointer = rcwData.VTablePointer.ToAddress(_target),
+                    Interfaces = pointers?.Select(r => new ComInterfaceEntry() { InterfacePointer = r.InterfacePointer.ToAddress(_target), MethodTable = r.MethodTable.ToAddress(_target) }).ToArray() ?? Array.Empty<ComInterfaceEntry>()
                 };
             }
 

--- a/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacComHelpers.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacComHelpers.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
         public bool GetCcwInfo(ulong obj, out CcwInfo info)
         {
             info = default;
-            if (_sos.GetObjectData(ClrDataAddress.FromAddress(obj, _target), out ObjectData objData) &&
+            if (_sos.GetObjectData(ClrDataAddress.FromTargetAddress(obj, _target), out ObjectData objData) &&
                 !objData.CCW.IsNull &&
                 _sos.GetCCWData(objData.CCW, out CcwData ccwData))
             {
@@ -53,7 +53,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
         public bool GetRcwInfo(ulong obj, out RcwInfo info)
         {
             info = default;
-            if (_sos.GetObjectData(ClrDataAddress.FromAddress(obj, _target), out ObjectData objData) &&
+            if (_sos.GetObjectData(ClrDataAddress.FromTargetAddress(obj, _target), out ObjectData objData) &&
                 !objData.RCW.IsNull &&
                 _sos.GetRCWData(objData.RCW, out RcwData rcwData))
             {

--- a/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacComHelpers.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacComHelpers.cs
@@ -33,11 +33,10 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
                 !objData.CCW.IsNull &&
                 _sos.GetCCWData(objData.CCW, out CcwData ccwData))
             {
-                ulong ccwAddr = objData.CCW.ToAddress(_target);
                 COMInterfacePointerData[]? pointers = _sos.GetCCWInterfaces(objData.CCW, ccwData.InterfaceCount);
                 info = new()
                 {
-                    Address = ccwAddr,
+                    Address = objData.CCW.ToAddress(_target),
                     IUnknown = ccwData.OuterIUnknown.ToAddress(_target),
                     Object = ccwData.ManagedObject.ToAddress(_target),
                     Handle = ccwData.Handle.ToAddress(_target),
@@ -57,11 +56,10 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
                 !objData.RCW.IsNull &&
                 _sos.GetRCWData(objData.RCW, out RcwData rcwData))
             {
-                ulong rcwAddr = objData.RCW.ToAddress(_target);
                 COMInterfacePointerData[]? pointers = _sos.GetRCWInterfaces(objData.RCW, rcwData.InterfaceCount);
                 info = new()
                 {
-                    Address = rcwAddr,
+                    Address = objData.RCW.ToAddress(_target),
                     IUnknown = rcwData.IUnknownPointer.ToAddress(_target),
                     Object = rcwData.ManagedObject.ToAddress(_target),
                     RefCount = rcwData.RefCount,

--- a/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacHeap.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacHeap.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;

--- a/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacHeap.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacHeap.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -20,6 +20,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
         private readonly SosDac12? _sos12;
         private readonly ISOSDac16? _sos16;
         private readonly IMemoryReader _memoryReader;
+        private readonly TargetProperties _target;
         private readonly GCState _gcState;
         private HashSet<ulong>? _validMethodTables;
 
@@ -29,23 +30,25 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
         private const uint SyncBlockSpinLock = 0x10000000;
         private const uint SyncBlockHashOrSyncBlockIndex = 0x08000000;
 
-        public DacHeap(SOSDac sos, SOSDac8? sos8, SosDac12? sos12, ISOSDac16? sos16, IMemoryReader reader, in GCInfo gcInfo, in CommonMethodTables commonMethodTables)
+        public DacHeap(SOSDac sos, SOSDac8? sos8, SosDac12? sos12, ISOSDac16? sos16, IMemoryReader reader, TargetProperties target, in GCInfo gcInfo, in CommonMethodTables commonMethodTables)
         {
             _sos = sos;
             _sos8 = sos8;
             _sos12 = sos12;
             _sos16 = sos16;
             _memoryReader = reader;
+            _target = target;
+
             _gcState = new()
             {
                 Kind = gcInfo.ServerMode != 0 ? GCKind.Server : GCKind.Workstation,
                 AreGCStructuresValid = gcInfo.GCStructuresValid != 0,
                 HeapCount = gcInfo.HeapCount,
                 MaxGeneration = gcInfo.MaxGeneration,
-                ExceptionMethodTable = commonMethodTables.ExceptionMethodTable,
-                FreeMethodTable = commonMethodTables.FreeMethodTable,
-                ObjectMethodTable = commonMethodTables.ObjectMethodTable,
-                StringMethodTable = commonMethodTables.StringMethodTable,
+                ExceptionMethodTable = commonMethodTables.ExceptionMethodTable.ToAddress(target),
+                FreeMethodTable = commonMethodTables.FreeMethodTable.ToAddress(target),
+                ObjectMethodTable = commonMethodTables.ObjectMethodTable.ToAddress(target),
+                StringMethodTable = commonMethodTables.StringMethodTable.ToAddress(target),
             };
         }
 
@@ -62,16 +65,16 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
             if (!_sos.GetThreadStoreData(out ThreadStoreData threadStore))
                 yield break;
 
-            ulong address = threadStore.FirstThread;
+            ulong address = threadStore.FirstThread.ToAddress(_target);
             for (int i = 0; i < threadStore.ThreadCount && address != 0; i++)
             {
-                if (!_sos.GetThreadData(address, out ThreadData thread))
+                if (!_sos.GetThreadData(ClrDataAddress.FromAddress(address, _target), out ThreadData thread))
                     break;
 
-                if (thread.AllocationContextPointer < thread.AllocationContextLimit)
-                    yield return new(thread.AllocationContextPointer, thread.AllocationContextLimit);
+                if (thread.AllocationContextPointer.ToAddress(_target) < thread.AllocationContextLimit.ToAddress(_target))
+                    yield return new(thread.AllocationContextPointer.ToAddress(_target), thread.AllocationContextLimit.ToAddress(_target));
 
-                address = thread.NextThread;
+                address = thread.NextThread.ToAddress(_target);
             }
         }
 
@@ -85,9 +88,9 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
             {
                 if (handle.Type == (int)ClrHandleKind.Dependent)
                 {
-                    ulong obj = _memoryReader.ReadPointer(handle.Handle);
+                    ulong obj = _memoryReader.ReadPointer(handle.Handle.ToAddress(_target));
                     if (obj != 0)
-                        yield return (obj, handle.Secondary);
+                        yield return (obj, handle.Secondary.ToAddress(_target));
                 }
             }
         }
@@ -108,12 +111,12 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
                     yield return new()
                     {
                         Index = curr,
-                        Address = data.Address,
-                        Object = data.Object,
-                        AppDomain = data.AppDomain,
+                        Address = data.Address.ToAddress(_target),
+                        Object = data.Object.ToAddress(_target),
+                        AppDomain = data.AppDomain.ToAddress(_target),
                         AdditionalThreadCount = data.AdditionalThreadCount.ToSigned(),
                         COMFlags = (SyncBlockComFlags)data.COMFlags,
-                        HoldingThread = data.HoldingThread,
+                        HoldingThread = data.HoldingThread.ToAddress(_target),
                         MonitorHeldCount = data.MonitorHeld.ToSigned(),
                         Recursion = data.Recursion.ToSigned()
                     };
@@ -136,7 +139,8 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
                 {
                     if (_sos.GetServerHeapDetails(heapAddresses[i], out HeapDetails heapData))
                     {
-                        SubHeapInfo subHeapInfo = CreateSubHeapInfo(heapAddresses[i], i, heapData);
+                        ulong heapAddr = heapAddresses[i].ToAddress(_target);
+                        SubHeapInfo subHeapInfo = CreateSubHeapInfo(heapAddr, i, heapData);
                         yield return subHeapInfo;
                     }
                 }
@@ -158,47 +162,47 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
 
             if (_sos8 is not null)
             {
-                genData = (address != 0 ? _sos8.GetGenerationTable(address) : _sos8.GetGenerationTable()) ?? genData;
-                finalization = (address != 0 ? _sos8.GetFinalizationFillPointers(address) : _sos8.GetFinalizationFillPointers()) ?? finalization;
+                genData = (address != 0 ? _sos8.GetGenerationTable(ClrDataAddress.FromAddress(address, _target)) : _sos8.GetGenerationTable()) ?? genData;
+                finalization = (address != 0 ? _sos8.GetFinalizationFillPointers(ClrDataAddress.FromAddress(address, _target)) : _sos8.GetFinalizationFillPointers()) ?? finalization;
             }
 
             SubHeapInfo subHeapInfo = new()
             {
                 Address = address,
                 HeapIndex = i,
-                Allocated = heapData.Allocated,
-                MarkArray = heapData.MarkArray,
-                State = (HeapMarkState)(ulong)heapData.CurrentGCState,
-                CurrentSweepPosition = heapData.NextSweepObj,
-                SavedSweepEphemeralSegment = heapData.SavedSweepEphemeralSeg,
-                SavedSweepEphemeralStart = heapData.SavedSweepEphemeralStart,
-                BackgroundSavedLowestAddress = heapData.BackgroundSavedLowestAddress,
-                BackgroundSavedHighestAddress = heapData.BackgroundSavedHighestAddress,
-                EphemeralHeapSegment = heapData.EphemeralHeapSegment,
-                LowestAddress = heapData.LowestAddress,
-                HighestAddress = heapData.HighestAddress,
-                CardTable = heapData.CardTable,
-                EphemeralAllocContextPointer = heapData.EphemeralAllocContextPtr,
-                EphemeralAllocContextLimit = heapData.EphemeralAllocContextLimit,
+                Allocated = heapData.Allocated.ToAddress(_target),
+                MarkArray = heapData.MarkArray.ToAddress(_target),
+                State = (HeapMarkState)heapData.CurrentGCState.ToAddress(_target),
+                CurrentSweepPosition = heapData.NextSweepObj.ToAddress(_target),
+                SavedSweepEphemeralSegment = heapData.SavedSweepEphemeralSeg.ToAddress(_target),
+                SavedSweepEphemeralStart = heapData.SavedSweepEphemeralStart.ToAddress(_target),
+                BackgroundSavedLowestAddress = heapData.BackgroundSavedLowestAddress.ToAddress(_target),
+                BackgroundSavedHighestAddress = heapData.BackgroundSavedHighestAddress.ToAddress(_target),
+                EphemeralHeapSegment = heapData.EphemeralHeapSegment.ToAddress(_target),
+                LowestAddress = heapData.LowestAddress.ToAddress(_target),
+                HighestAddress = heapData.HighestAddress.ToAddress(_target),
+                CardTable = heapData.CardTable.ToAddress(_target),
+                EphemeralAllocContextPointer = heapData.EphemeralAllocContextPtr.ToAddress(_target),
+                EphemeralAllocContextLimit = heapData.EphemeralAllocContextLimit.ToAddress(_target),
 
-                FinalizationPointers = finalization.Select(r => (ulong)r).ToArray(),
-                Generations = ConvertGenerations(genData),
+                FinalizationPointers = finalization.Select(r => r.ToAddress(_target)).ToArray(),
+                Generations = ConvertGenerations(genData, _target),
             };
 
             subHeapInfo.Segments = EnumerateSegments(subHeapInfo).ToArray();
             return subHeapInfo;
         }
 
-        private static GenerationInfo[] ConvertGenerations(GenerationData[] genData)
+        private static GenerationInfo[] ConvertGenerations(GenerationData[] genData, TargetProperties target)
         {
             var result = new GenerationInfo[genData.Length];
             for (int i = 0; i < result.Length; i++)
                 result[i] = new()
                 {
-                    AllocationStart = genData[i].AllocationStart,
-                    StartSegment = genData[i].StartSegment,
-                    AllocationContextLimit = genData[i].AllocationContextLimit,
-                    AllocationContextPointer = genData[i].AllocationContextPointer,
+                    AllocationStart = genData[i].AllocationStart.ToAddress(target),
+                    StartSegment = genData[i].StartSegment.ToAddress(target),
+                    AllocationContextLimit = genData[i].AllocationContextLimit.ToAddress(target),
+                    AllocationContextPointer = genData[i].AllocationContextPointer.ToAddress(target),
                 };
 
             return result;
@@ -237,7 +241,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
 
         private bool TryCreateSegment(SubHeapInfo subHeap, ulong address, int generation, out SegmentInfo segInfo)
         {
-            if (!_sos.GetSegmentData(address, out SegmentData data))
+            if (!_sos.GetSegmentData(ClrDataAddress.FromAddress(address, _target), out SegmentData data))
             {
                 segInfo = default;
                 return false;
@@ -279,7 +283,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
             }
 
             // The range of memory occupied by allocated objects
-            MemoryRange allocated = new(data.Start, subHeap.EphemeralHeapSegment == address ? subHeap.Allocated : (ulong)data.Allocated);
+            MemoryRange allocated = new(data.Start.ToAddress(_target), subHeap.EphemeralHeapSegment == address ? subHeap.Allocated : data.Allocated.ToAddress(_target));
 
             // There's a bit of calculation involved with finding the committed start.
             // For regions, it's "allocated.Start - sizeof(aligned_plug_and_gap)".
@@ -299,7 +303,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
             MemoryRange committed, gen0, gen1, gen2;
             if (subHeap.HasRegions)
             {
-                committed = new(committedStart, data.Committed);
+                committed = new(committedStart, data.Committed.ToAddress(_target));
                 gen0 = default;
                 gen1 = default;
                 gen2 = default;
@@ -321,7 +325,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
             }
             else
             {
-                committed = new(committedStart, data.Committed);
+                committed = new(committedStart, data.Committed.ToAddress(_target));
                 if (kind == GCSegmentKind.Ephemeral)
                 {
                     gen0 = new(subHeap.Generations[0].AllocationStart, allocated.End);
@@ -337,11 +341,11 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
             }
 
             // The range of memory reserved
-            MemoryRange reserved = new(committed.End, data.Reserved);
+            MemoryRange reserved = new(committed.End, data.Reserved.ToAddress(_target));
 
             segInfo = new()
             {
-                Address = data.Address,
+                Address = data.Address.ToAddress(_target),
                 Kind = kind,
                 ObjectRange = allocated,
                 CommittedMemory = committed,
@@ -350,8 +354,8 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
                 Generation1 = gen1,
                 Generation2 = gen2,
                 Flags = flags,
-                Next = data.Next,
-                BackgroundAllocated = data.BackgroundAllocated,
+                Next = data.Next.ToAddress(_target),
+                BackgroundAllocated = data.BackgroundAllocated.ToAddress(_target),
             };
             return true;
         }
@@ -362,7 +366,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
                 return default;
 
             (uint threadId, uint recursion) = GetThinlockData(header);
-            ulong threadAddress = _sos.GetThreadFromThinlockId(threadId);
+            ulong threadAddress = _sos.GetThreadFromThinlockId(threadId).ToAddress(_target);
 
             if (threadAddress == 0)
                 return default;
@@ -393,7 +397,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
                 if (validMts.Contains(mt))
                     return true;
 
-            bool verified = _sos.GetMethodTableData(mt, out _);
+            bool verified = _sos.GetMethodTableData(ClrDataAddress.FromAddress(mt, _target), out _);
             if (verified)
             {
                 lock (validMts)
@@ -407,15 +411,16 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
         {
             DacHeapAnalyzeData analyzeData;
             if (subHeapAddress != 0)
-                _sos.GetHeapAnalyzeData(subHeapAddress, out analyzeData);
+                _sos.GetHeapAnalyzeData(ClrDataAddress.FromAddress(subHeapAddress, _target), out analyzeData);
             else
                 _sos.GetHeapAnalyzeData(out analyzeData);
 
-            if (analyzeData.InternalRootArray == 0 || analyzeData.InternalRootArrayIndex == 0)
+            if (analyzeData.InternalRootArray.IsNull || analyzeData.InternalRootArrayIndex == 0)
                 return default;
 
-            ulong end = analyzeData.InternalRootArray + (uint)_memoryReader.PointerSize * analyzeData.InternalRootArrayIndex;
-            return new(analyzeData.InternalRootArray, end);
+            ulong rootArray = analyzeData.InternalRootArray.ToAddress(_target);
+            ulong end = rootArray + (uint)_target.PointerSize * analyzeData.InternalRootArrayIndex;
+            return new(rootArray, end);
         }
 
         public bool GetOOMInfo(ulong subHeapAddress, out OomInfo oomInfo)
@@ -423,7 +428,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
             DacOOMData oomData;
             if (subHeapAddress != 0)
             {
-                if (!_sos.GetOOMData(subHeapAddress, out oomData) || oomData.Reason == OutOfMemoryReason.None && oomData.GetMemoryFailure == GetMemoryFailureReason.None)
+                if (!_sos.GetOOMData(ClrDataAddress.FromAddress(subHeapAddress, _target), out oomData) || oomData.Reason == OutOfMemoryReason.None && oomData.GetMemoryFailure == GetMemoryFailureReason.None)
                 {
                     oomInfo = default;
                     return false;

--- a/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacHeap.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacHeap.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
             ulong address = threadStore.FirstThread.ToAddress(_target);
             for (int i = 0; i < threadStore.ThreadCount && address != 0; i++)
             {
-                if (!_sos.GetThreadData(ClrDataAddress.FromAddress(address, _target), out ThreadData thread))
+                if (!_sos.GetThreadData(ClrDataAddress.FromTargetAddress(address, _target), out ThreadData thread))
                     break;
 
                 if (thread.AllocationContextPointer.ToAddress(_target) < thread.AllocationContextLimit.ToAddress(_target))
@@ -162,8 +162,8 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
 
             if (_sos8 is not null)
             {
-                genData = (address != 0 ? _sos8.GetGenerationTable(ClrDataAddress.FromAddress(address, _target)) : _sos8.GetGenerationTable()) ?? genData;
-                finalization = (address != 0 ? _sos8.GetFinalizationFillPointers(ClrDataAddress.FromAddress(address, _target)) : _sos8.GetFinalizationFillPointers()) ?? finalization;
+                genData = (address != 0 ? _sos8.GetGenerationTable(ClrDataAddress.FromTargetAddress(address, _target)) : _sos8.GetGenerationTable()) ?? genData;
+                finalization = (address != 0 ? _sos8.GetFinalizationFillPointers(ClrDataAddress.FromTargetAddress(address, _target)) : _sos8.GetFinalizationFillPointers()) ?? finalization;
             }
 
             SubHeapInfo subHeapInfo = new()
@@ -241,7 +241,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
 
         private bool TryCreateSegment(SubHeapInfo subHeap, ulong address, int generation, out SegmentInfo segInfo)
         {
-            if (!_sos.GetSegmentData(ClrDataAddress.FromAddress(address, _target), out SegmentData data))
+            if (!_sos.GetSegmentData(ClrDataAddress.FromTargetAddress(address, _target), out SegmentData data))
             {
                 segInfo = default;
                 return false;
@@ -397,7 +397,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
                 if (validMts.Contains(mt))
                     return true;
 
-            bool verified = _sos.GetMethodTableData(ClrDataAddress.FromAddress(mt, _target), out _);
+            bool verified = _sos.GetMethodTableData(ClrDataAddress.FromTargetAddress(mt, _target), out _);
             if (verified)
             {
                 lock (validMts)
@@ -411,7 +411,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
         {
             DacHeapAnalyzeData analyzeData;
             if (subHeapAddress != 0)
-                _sos.GetHeapAnalyzeData(ClrDataAddress.FromAddress(subHeapAddress, _target), out analyzeData);
+                _sos.GetHeapAnalyzeData(ClrDataAddress.FromTargetAddress(subHeapAddress, _target), out analyzeData);
             else
                 _sos.GetHeapAnalyzeData(out analyzeData);
 
@@ -428,7 +428,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
             DacOOMData oomData;
             if (subHeapAddress != 0)
             {
-                if (!_sos.GetOOMData(ClrDataAddress.FromAddress(subHeapAddress, _target), out oomData) || oomData.Reason == OutOfMemoryReason.None && oomData.GetMemoryFailure == GetMemoryFailureReason.None)
+                if (!_sos.GetOOMData(ClrDataAddress.FromTargetAddress(subHeapAddress, _target), out oomData) || oomData.Reason == OutOfMemoryReason.None && oomData.GetMemoryFailure == GetMemoryFailureReason.None)
                 {
                     oomInfo = default;
                     return false;

--- a/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacLegacyThreadPool.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacLegacyThreadPool.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;

--- a/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacLegacyThreadPool.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacLegacyThreadPool.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
 
         public bool GetLegacyWorkRequestData(ulong workRequest, out LegacyWorkRequestInfo workRequestInfo)
         {
-            bool res = _sos.GetWorkRequestData(ClrDataAddress.FromAddress(workRequest, _target), out WorkRequestData workRequestData);
+            bool res = _sos.GetWorkRequestData(ClrDataAddress.FromTargetAddress(workRequest, _target), out WorkRequestData workRequestData);
             workRequestInfo = new()
             {
                 Function = workRequestData.Function.ToAddress(_target),

--- a/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacLegacyThreadPool.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacLegacyThreadPool.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -13,10 +13,12 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
     internal class DacLegacyThreadPool : IAbstractLegacyThreadPool
     {
         private readonly SOSDac _sos;
+        private readonly TargetProperties _target;
 
-        public DacLegacyThreadPool(SOSDac sos)
+        public DacLegacyThreadPool(SOSDac sos, TargetProperties target)
         {
             _sos = sos;
+            _target = target;
         }
 
         public bool GetLegacyThreadPoolData(out LegacyThreadPoolInfo result)
@@ -24,11 +26,11 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
             HResult hr = _sos.GetThreadPoolData(out ThreadPoolData data);
             result = new()
             {
-                AsyncTimerCallbackCompletionFPtr = data.AsyncTimerCallbackCompletionFPtr,
+                AsyncTimerCallbackCompletionFPtr = data.AsyncTimerCallbackCompletionFPtr.ToAddress(_target),
                 CpuUtilization = data.CpuUtilization,
                 CurrentLimitTotalCPThreads = data.CurrentLimitTotalCPThreads,
-                FirstUnmanagedWorkRequest = data.FirstUnmanagedWorkRequest,
-                HillClimbingLog = data.HillClimbingLog,
+                FirstUnmanagedWorkRequest = data.FirstUnmanagedWorkRequest.ToAddress(_target),
+                HillClimbingLog = data.HillClimbingLog.ToAddress(_target),
                 HillClimbingLogFirstIndex = data.HillClimbingLogFirstIndex,
                 HillClimbingLogSize = data.HillClimbingLogSize,
                 MaxFreeCPThreads = data.MaxFreeCPThreads,
@@ -50,12 +52,12 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
 
         public bool GetLegacyWorkRequestData(ulong workRequest, out LegacyWorkRequestInfo workRequestInfo)
         {
-            bool res = _sos.GetWorkRequestData(workRequest, out WorkRequestData workRequestData);
+            bool res = _sos.GetWorkRequestData(ClrDataAddress.FromAddress(workRequest, _target), out WorkRequestData workRequestData);
             workRequestInfo = new()
             {
-                Function = workRequestData.Function,
-                Context = workRequestData.Context,
-                NextWorkRequest = workRequestData.NextWorkRequest,
+                Function = workRequestData.Function.ToAddress(_target),
+                Context = workRequestData.Context.ToAddress(_target),
+                NextWorkRequest = workRequestData.NextWorkRequest.ToAddress(_target),
             };
 
             return res;

--- a/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacMethodLocator.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacMethodLocator.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Diagnostics.Runtime.AbstractDac;

--- a/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacMethodLocator.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacMethodLocator.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Diagnostics.Runtime.AbstractDac;
@@ -22,7 +22,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
 
         public ulong GetMethodHandleContainingType(ulong methodDesc)
         {
-            if (!_sos.GetMethodDescData(ClrDataAddress.FromAddress(methodDesc, _target), default, out MethodDescData mdData))
+            if (!_sos.GetMethodDescData(ClrDataAddress.FromAddress(methodDesc, _target), ClrDataAddress.Null, out MethodDescData mdData))
                 return 0;
 
             return mdData.MethodTable.ToAddress(_target);
@@ -42,7 +42,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
 
         public bool GetMethodInfo(ulong methodDesc, out MethodInfo methodInfo)
         {
-            if (!_sos.GetMethodDescData(ClrDataAddress.FromAddress(methodDesc, _target), default, out MethodDescData mdd))
+            if (!_sos.GetMethodDescData(ClrDataAddress.FromAddress(methodDesc, _target), ClrDataAddress.Null, out MethodDescData mdd))
             {
                 methodInfo = default;
                 return false;

--- a/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacMethodLocator.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacMethodLocator.cs
@@ -1,35 +1,40 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Diagnostics.Runtime.AbstractDac;
 using Microsoft.Diagnostics.Runtime.DacInterface;
+using Microsoft.Diagnostics.Runtime.Utilities;
 
 namespace Microsoft.Diagnostics.Runtime.DacImplementation
 {
     internal class DacMethodLocator : IAbstractMethodLocator
     {
         private readonly SOSDac _sos;
+        private readonly IDataReader _dataReader;
+        private readonly TargetProperties _target;
 
-        public DacMethodLocator(SOSDac sos)
+        public DacMethodLocator(SOSDac sos, IDataReader dataReader, TargetProperties target)
         {
             _sos = sos;
+            _dataReader = dataReader;
+            _target = target;
         }
 
         public ulong GetMethodHandleContainingType(ulong methodDesc)
         {
-            if (!_sos.GetMethodDescData(methodDesc, 0, out MethodDescData mdData))
+            if (!_sos.GetMethodDescData(ClrDataAddress.FromAddress(methodDesc, _target), default, out MethodDescData mdData))
                 return 0;
 
-            return mdData.MethodTable;
+            return mdData.MethodTable.ToAddress(_target);
         }
 
         public ulong GetMethodHandleByInstructionPointer(ulong ip)
         {
-            ulong md = _sos.GetMethodDescPtrFromIP(ip);
+            ulong md = _sos.GetMethodDescPtrFromIP(ClrDataAddress.FromAddress(ip, _target)).ToAddress(_target);
             if (md == 0)
             {
-                if (_sos.GetCodeHeaderData(ip, out CodeHeaderData codeHeaderData))
-                    md = codeHeaderData.MethodDesc;
+                if (_sos.GetCodeHeaderData(ClrDataAddress.FromAddress(ip, _target), out CodeHeaderData codeHeaderData))
+                    md = codeHeaderData.MethodDesc.ToAddress(_target);
             }
 
             return md;
@@ -37,7 +42,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
 
         public bool GetMethodInfo(ulong methodDesc, out MethodInfo methodInfo)
         {
-            if (!_sos.GetMethodDescData(methodDesc, 0, out MethodDescData mdd))
+            if (!_sos.GetMethodDescData(ClrDataAddress.FromAddress(methodDesc, _target), default, out MethodDescData mdd))
             {
                 methodInfo = default;
                 return false;
@@ -45,11 +50,12 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
 
             if (mdd.HasNativeCode != 0 && _sos.GetCodeHeaderData(mdd.NativeCodeAddr, out CodeHeaderData chd))
             {
+                ulong nativeCodeAddr = mdd.NativeCodeAddr.ToAddress(_target);
                 methodInfo = new()
                 {
                     CompilationType = (MethodCompilationType)chd.JITType,
-                    HotCold = new(mdd.NativeCodeAddr, chd.HotRegionSize, chd.ColdRegionStart, chd.ColdRegionSize),
-                    MethodDesc = chd.MethodDesc,
+                    HotCold = new(nativeCodeAddr, chd.HotRegionSize, chd.ColdRegionStart.ToAddress(_target), chd.ColdRegionSize),
+                    MethodDesc = chd.MethodDesc.ToAddress(_target),
                     Token = (int)mdd.MDToken
                 };
             }
@@ -58,13 +64,14 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
                 // Fall back to slot-based lookup (issue #935). Reference-type generic
                 // instantiations share code via canonical method descs and may not have
                 // NativeCodeAddr set, but the method table slot points to the shared code.
-                ulong slot = _sos.GetMethodTableSlot(mdd.MethodTable, mdd.SlotNumber);
-                if (slot != 0 && _sos.GetCodeHeaderData(slot, out CodeHeaderData slotChd))
+                ClrDataAddress slot = _sos.GetMethodTableSlot(mdd.MethodTable, mdd.SlotNumber);
+                if (!slot.IsNull && _sos.GetCodeHeaderData(slot, out CodeHeaderData slotChd))
                 {
+                    ulong slotAddr = slot.ToAddress(_target);
                     methodInfo = new()
                     {
                         CompilationType = (MethodCompilationType)slotChd.JITType,
-                        HotCold = new(slot, slotChd.HotRegionSize, slotChd.ColdRegionStart, slotChd.ColdRegionSize),
+                        HotCold = new(slotAddr, slotChd.HotRegionSize, slotChd.ColdRegionStart.ToAddress(_target), slotChd.ColdRegionSize),
                         MethodDesc = methodDesc,
                         Token = (int)mdd.MDToken
                     };

--- a/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacMethodLocator.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacMethodLocator.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
 
         public ulong GetMethodHandleContainingType(ulong methodDesc)
         {
-            if (!_sos.GetMethodDescData(ClrDataAddress.FromAddress(methodDesc, _target), ClrDataAddress.Null, out MethodDescData mdData))
+            if (!_sos.GetMethodDescData(ClrDataAddress.FromTargetAddress(methodDesc, _target), ClrDataAddress.Null, out MethodDescData mdData))
                 return 0;
 
             return mdData.MethodTable.ToAddress(_target);
@@ -30,10 +30,10 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
 
         public ulong GetMethodHandleByInstructionPointer(ulong ip)
         {
-            ulong md = _sos.GetMethodDescPtrFromIP(ClrDataAddress.FromAddress(ip, _target)).ToAddress(_target);
+            ulong md = _sos.GetMethodDescPtrFromIP(ClrDataAddress.FromTargetAddress(ip, _target)).ToAddress(_target);
             if (md == 0)
             {
-                if (_sos.GetCodeHeaderData(ClrDataAddress.FromAddress(ip, _target), out CodeHeaderData codeHeaderData))
+                if (_sos.GetCodeHeaderData(ClrDataAddress.FromTargetAddress(ip, _target), out CodeHeaderData codeHeaderData))
                     md = codeHeaderData.MethodDesc.ToAddress(_target);
             }
 
@@ -42,7 +42,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
 
         public bool GetMethodInfo(ulong methodDesc, out MethodInfo methodInfo)
         {
-            if (!_sos.GetMethodDescData(ClrDataAddress.FromAddress(methodDesc, _target), ClrDataAddress.Null, out MethodDescData mdd))
+            if (!_sos.GetMethodDescData(ClrDataAddress.FromTargetAddress(methodDesc, _target), ClrDataAddress.Null, out MethodDescData mdd))
             {
                 methodInfo = default;
                 return false;

--- a/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacModuleHelpers.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacModuleHelpers.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;

--- a/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacModuleHelpers.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacModuleHelpers.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -16,30 +16,33 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
         private readonly Dictionary<ulong, DacMetadataReader?> _imports = new();
         private readonly Dictionary<ulong, ClrDataModule?> _modules = new();
         private readonly SOSDac _sos;
+        private readonly TargetProperties _target;
 
-        public DacModuleHelpers(SOSDac sos)
+        public DacModuleHelpers(SOSDac sos, TargetProperties target)
         {
             _sos = sos;
+            _target = target;
         }
 
         public ClrModuleInfo GetModuleInfo(ulong moduleAddress)
         {
-            _sos.GetModuleData(moduleAddress, out ModuleData data);
+            _sos.GetModuleData(ClrDataAddress.FromAddress(moduleAddress, _target), out ModuleData data);
 
+            ulong assemblyAddr = data.Assembly.ToAddress(_target);
             ClrModuleInfo result = new()
             {
                 Address = moduleAddress,
-                Assembly = data.Assembly,
-                AssemblyName = data.Assembly != 0 ? _sos.GetAssemblyName(data.Assembly) : null,
+                Assembly = assemblyAddr,
+                AssemblyName = assemblyAddr != 0 ? _sos.GetAssemblyName(ClrDataAddress.FromAddress(assemblyAddr, _target)) : null,
                 Id = data.ModuleID,
                 Index = data.ModuleIndex,
                 IsPEFile = data.IsPEFile != 0,
-                ImageBase = data.ILBase,
-                MetadataAddress = data.MetadataStart,
+                ImageBase = data.ILBase.ToAddress(_target),
+                MetadataAddress = data.MetadataStart.ToAddress(_target),
                 MetadataSize = data.MetadataSize,
                 IsDynamic = data.IsReflection != 0,
-                ThunkHeap = data.ThunkHeap,
-                LoaderAllocator = data.LoaderAllocator,
+                ThunkHeap = data.ThunkHeap.ToAddress(_target),
+                LoaderAllocator = data.LoaderAllocator.ToAddress(_target),
             };
 
             ClrDataModule? dataModule = GetClrDataModule(moduleAddress);
@@ -62,7 +65,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
         {
             int tokenType = kind == SOSDac.ModuleMapTraverseKind.TypeDefToMethodTable ? mdtTypeDef : mdtTypeRef;
             List<(ulong MethodTable, int Token)> result = new();
-            _sos.TraverseModuleMap(kind, module, (token, mt, _) => { result.Add((mt, token | tokenType)); });
+            _sos.TraverseModuleMap(kind, ClrDataAddress.FromAddress(module, _target), (token, mt, _) => { result.Add((mt, token | tokenType)); });
 
             return result;
         }
@@ -112,7 +115,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
                 if (_modules.TryGetValue(moduleAddress, out ClrDataModule? dataModule))
                     return dataModule;
 
-            ClrDataModule? result = _sos.GetClrDataModule(moduleAddress);
+            ClrDataModule? result = _sos.GetClrDataModule(ClrDataAddress.FromAddress(moduleAddress, _target));
 
             lock (_modules)
             {

--- a/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacModuleHelpers.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacModuleHelpers.cs
@@ -26,14 +26,14 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
 
         public ClrModuleInfo GetModuleInfo(ulong moduleAddress)
         {
-            _sos.GetModuleData(ClrDataAddress.FromAddress(moduleAddress, _target), out ModuleData data);
+            _sos.GetModuleData(ClrDataAddress.FromTargetAddress(moduleAddress, _target), out ModuleData data);
 
             ulong assemblyAddr = data.Assembly.ToAddress(_target);
             ClrModuleInfo result = new()
             {
                 Address = moduleAddress,
                 Assembly = assemblyAddr,
-                AssemblyName = assemblyAddr != 0 ? _sos.GetAssemblyName(ClrDataAddress.FromAddress(assemblyAddr, _target)) : null,
+                AssemblyName = assemblyAddr != 0 ? _sos.GetAssemblyName(ClrDataAddress.FromTargetAddress(assemblyAddr, _target)) : null,
                 Id = data.ModuleID,
                 Index = data.ModuleIndex,
                 IsPEFile = data.IsPEFile != 0,
@@ -65,7 +65,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
         {
             int tokenType = kind == SOSDac.ModuleMapTraverseKind.TypeDefToMethodTable ? mdtTypeDef : mdtTypeRef;
             List<(ulong MethodTable, int Token)> result = new();
-            _sos.TraverseModuleMap(kind, ClrDataAddress.FromAddress(module, _target), (token, mt, _) => { result.Add((mt, token | tokenType)); });
+            _sos.TraverseModuleMap(kind, ClrDataAddress.FromTargetAddress(module, _target), (token, mt, _) => { result.Add((mt, token | tokenType)); });
 
             return result;
         }
@@ -115,7 +115,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
                 if (_modules.TryGetValue(moduleAddress, out ClrDataModule? dataModule))
                     return dataModule;
 
-            ClrDataModule? result = _sos.GetClrDataModule(ClrDataAddress.FromAddress(moduleAddress, _target));
+            ClrDataModule? result = _sos.GetClrDataModule(ClrDataAddress.FromTargetAddress(moduleAddress, _target));
 
             lock (_modules)
             {

--- a/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacNativeHeaps.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacNativeHeaps.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
             HResult hr = default;
             // For back-compat with older versions of CLRMD, SOS returns E_INVALIDARG if you pass in 0 for the sync block.
             // So we will continue on E_INVALIDARG if it is this special case of passing 0 to start enumerating.
-            while ((hr = _sos.GetSyncBlockCleanupData(ClrDataAddress.FromAddress(syncBlock, _target), out SyncBlockCleanupData data)) || (hr == HResult.E_INVALIDARG && syncBlock == 0))
+            while ((hr = _sos.GetSyncBlockCleanupData(ClrDataAddress.FromTargetAddress(syncBlock, _target), out SyncBlockCleanupData data)) || (hr == HResult.E_INVALIDARG && syncBlock == 0))
             {
                 yield return new(data.SyncBlockPointer.ToAddress(_target), data.BlockRCW.ToAddress(_target), data.BlockCCW.ToAddress(_target), data.BlockClassFactory.ToAddress(_target));
 
@@ -129,7 +129,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
         {
             List<ClrNativeHeapInfo>? codeLoaderHeaps = null;
 
-            foreach (JitCodeHeapInfo mem in _sos.GetCodeHeapList(ClrDataAddress.FromAddress(jitManager, _target)))
+            foreach (JitCodeHeapInfo mem in _sos.GetCodeHeapList(ClrDataAddress.FromTargetAddress(jitManager, _target)))
             {
                 if (mem.Kind == CodeHeapKind.Loader)
                 {
@@ -157,13 +157,13 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
 
             ulong loaderAllocator;
             if (_sos13 is not null
-                && (loaderAllocator = _sos13.GetDomainLoaderAllocator(ClrDataAddress.FromAddress(domain, _target)).ToAddress(_target)) != 0
+                && (loaderAllocator = _sos13.GetDomainLoaderAllocator(ClrDataAddress.FromTargetAddress(domain, _target)).ToAddress(_target)) != 0
                 && GetNativeHeaps().Length > 0)
             {
                 foreach (ClrNativeHeapInfo heap in EnumerateLoaderAllocatorNativeHeaps(loaderAllocator))
                     yield return heap;
             }
-            else if (_sos.GetAppDomainData(ClrDataAddress.FromAddress(domain, _target), out AppDomainData data))
+            else if (_sos.GetAppDomainData(ClrDataAddress.FromTargetAddress(domain, _target), out AppDomainData data))
             {
                 foreach (ClrNativeHeapInfo heapInfo in LegacyEnumerateLoaderAllocatorHeaps(data.StubHeap.ToAddress(_target), LoaderHeapKind.LoaderHeapKindNormal, NativeHeapKind.StubHeap))
                     yield return heapInfo;
@@ -191,7 +191,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
 
             List<ClrNativeHeapInfo>? result = null;
 
-            (ClrDataAddress Address, LoaderHeapKind Kind)[] heaps = _sos13.GetLoaderAllocatorHeaps(ClrDataAddress.FromAddress(loaderAllocator, _target));
+            (ClrDataAddress Address, LoaderHeapKind Kind)[] heaps = _sos13.GetLoaderAllocatorHeaps(ClrDataAddress.FromTargetAddress(loaderAllocator, _target));
             for (int i = 0; i < heaps.Length; i++)
             {
                 HResult hr = _sos13.TraverseLoaderHeap(heaps[i].Address, heaps[i].Kind, (address, size, current) => {
@@ -241,7 +241,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
         private void TraverseOneStubKind(ulong domain, List<ClrNativeHeapInfo> result, SOSDac.VCSHeapType vcsType, NativeHeapKind heapKind)
         {
             result.Clear();
-            HResult hr = _sos.TraverseStubHeap(ClrDataAddress.FromAddress(domain, _target), vcsType, (address, size, current) => {
+            HResult hr = _sos.TraverseStubHeap(ClrDataAddress.FromTargetAddress(domain, _target), vcsType, (address, size, current) => {
                 result.Add(new(MemoryRange.CreateFromLength(address, SanitizeSize(size)), heapKind, current != 0 ? ClrNativeHeapState.Active : ClrNativeHeapState.Inactive));
             });
 
@@ -272,7 +272,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
 
                 ulong fixedHeapAddress = FixupHeapAddress(loaderHeap, loaderHeapKind, normalNeedsAdjustment, explicitDoesNotNeedAdjustment);
 
-                HResult hr = _sos.TraverseLoaderHeap(ClrDataAddress.FromAddress(fixedHeapAddress, _target), (address, size, current) => {
+                HResult hr = _sos.TraverseLoaderHeap(ClrDataAddress.FromTargetAddress(fixedHeapAddress, _target), (address, size, current) => {
                     result ??= new(8);
                     result.Add(new(MemoryRange.CreateFromLength(address, SanitizeSize(size)), nativeHeapKind, current != 0 ? ClrNativeHeapState.Active : ClrNativeHeapState.Inactive));
                 });
@@ -295,7 +295,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
                 if (retry)
                 {
                     fixedHeapAddress = FixupHeapAddress(loaderHeap, loaderHeapKind, !normalNeedsAdjustment, !explicitDoesNotNeedAdjustment);
-                    hr = _sos.TraverseLoaderHeap(ClrDataAddress.FromAddress(fixedHeapAddress, _target), (address, size, current) => {
+                    hr = _sos.TraverseLoaderHeap(ClrDataAddress.FromTargetAddress(fixedHeapAddress, _target), (address, size, current) => {
                         result ??= new(8);
                         result.Add(new(MemoryRange.CreateFromLength(address, SanitizeSize(size)), nativeHeapKind, current != 0 ? ClrNativeHeapState.Active : ClrNativeHeapState.Inactive));
                     });
@@ -368,7 +368,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
                 // ISOSDacInterface13 understands how to walk LoaderHeaps properly, but it's only implemented in
                 // .Net 8 and beyond.
 
-                hr = sos13.TraverseLoaderHeap(ClrDataAddress.FromAddress(address, target), kind, callback);
+                hr = sos13.TraverseLoaderHeap(ClrDataAddress.FromTargetAddress(address, target), kind, callback);
             }
             else if (clrInfo.Flavor == ClrFlavor.Core && clrInfo.Version.Major == 7)
             {
@@ -377,7 +377,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
                 if (kind == LoaderHeapKind.LoaderHeapKindNormal)
                     address += (uint)target.PointerSize;
 
-                hr = sos.TraverseLoaderHeap(ClrDataAddress.FromAddress(address, target), callback);
+                hr = sos.TraverseLoaderHeap(ClrDataAddress.FromTargetAddress(address, target), callback);
             }
             else
             {
@@ -390,7 +390,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
                 if (kind == LoaderHeapKind.LoaderHeapKindExplicitControl)
                     address -= (uint)target.PointerSize;
 
-                hr = sos.TraverseLoaderHeap(ClrDataAddress.FromAddress(address, target), callback);
+                hr = sos.TraverseLoaderHeap(ClrDataAddress.FromTargetAddress(address, target), callback);
             }
 
             GC.KeepAlive(callback);

--- a/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacNativeHeaps.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacNativeHeaps.cs
@@ -18,13 +18,15 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
         private readonly SOSDac _sos;
         private readonly ISOSDac13? _sos13;
         private readonly IDataReader _dataReader;
+        private readonly TargetProperties _target;
 
-        public DacNativeHeaps(ClrInfo clrInfo, SOSDac sos, ISOSDac13? sos13, IDataReader dataReader)
+        public DacNativeHeaps(ClrInfo clrInfo, SOSDac sos, ISOSDac13? sos13, IDataReader dataReader, TargetProperties target)
         {
             _clrInfo = clrInfo;
             _sos = sos;
             _sos13 = sos13;
             _dataReader = dataReader;
+            _target = target;
         }
 
         public IEnumerable<ClrNativeHeapInfo> EnumerateGCFreeRegions()
@@ -32,9 +34,10 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
             using (SosMemoryEnum? memoryEnum = _sos13?.GetGCFreeRegions())
             {
                 if (memoryEnum is not null)
+                {
                     foreach (SosMemoryRegion mem in memoryEnum)
                     {
-                        NativeHeapKind kind = (ulong)mem.ExtraData switch
+                        NativeHeapKind kind = mem.ExtraData.ToAddress(_target) switch
                         {
                             1 => NativeHeapKind.GCFreeGlobalHugeRegion,
                             2 => NativeHeapKind.GCFreeGlobalRegion,
@@ -44,13 +47,14 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
                             _ => NativeHeapKind.GCFreeRegion
                         };
 
-                        ulong raw = (ulong)mem.Start;
+                        ulong raw = mem.Start.ToAddress(_target);
                         ulong start = raw & ~0xfful;
                         ulong diff = raw - start;
-                        ulong len = mem.Length + diff;
+                        ulong len = mem.Length.ToAddress(_target) + diff;
 
                         yield return new ClrNativeHeapInfo(MemoryRange.CreateFromLength(start, len), kind, ClrNativeHeapState.Inactive, mem.Heap);
                     }
+                }
             }
         }
 
@@ -59,8 +63,10 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
             using (SosMemoryEnum? memoryEnum = _sos13?.GetHandleTableRegions())
             {
                 if (memoryEnum is not null)
+                {
                     foreach (SosMemoryRegion mem in memoryEnum)
-                        yield return new ClrNativeHeapInfo(MemoryRange.CreateFromLength(mem.Start, mem.Length), NativeHeapKind.HandleTable, ClrNativeHeapState.Active, mem.Heap);
+                        yield return new ClrNativeHeapInfo(MemoryRange.CreateFromLength(mem.Start.ToAddress(_target), mem.Length.ToAddress(_target)), NativeHeapKind.HandleTable, ClrNativeHeapState.Active, mem.Heap);
+                }
             }
         }
 
@@ -69,8 +75,10 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
             using (SosMemoryEnum? memoryEnum = _sos13?.GetGCBookkeepingMemoryRegions())
             {
                 if (memoryEnum is not null)
+                {
                     foreach (SosMemoryRegion mem in memoryEnum)
-                        yield return new ClrNativeHeapInfo(MemoryRange.CreateFromLength(mem.Start, mem.Length), NativeHeapKind.GCBookkeeping, ClrNativeHeapState.RegionOfRegions);
+                        yield return new ClrNativeHeapInfo(MemoryRange.CreateFromLength(mem.Start.ToAddress(_target), mem.Length.ToAddress(_target)), NativeHeapKind.GCBookkeeping, ClrNativeHeapState.RegionOfRegions);
+                }
             }
         }
 
@@ -81,14 +89,14 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
             HResult hr = default;
             // For back-compat with older versions of CLRMD, SOS returns E_INVALIDARG if you pass in 0 for the sync block.
             // So we will continue on E_INVALIDARG if it is this special case of passing 0 to start enumerating.
-            while ((hr = _sos.GetSyncBlockCleanupData(syncBlock, out SyncBlockCleanupData data)) || (hr == HResult.E_INVALIDARG && syncBlock == 0))
+            while ((hr = _sos.GetSyncBlockCleanupData(ClrDataAddress.FromAddress(syncBlock, _target), out SyncBlockCleanupData data)) || (hr == HResult.E_INVALIDARG && syncBlock == 0))
             {
-                yield return new(data.SyncBlockPointer, data.BlockRCW, data.BlockCCW, data.BlockClassFactory);
+                yield return new(data.SyncBlockPointer.ToAddress(_target), data.BlockRCW.ToAddress(_target), data.BlockCCW.ToAddress(_target), data.BlockClassFactory.ToAddress(_target));
 
-                if (!seen.Add(data.NextSyncBlock))
+                if (!seen.Add(data.NextSyncBlock.ToAddress(_target)))
                     break;
 
-                syncBlock = data.NextSyncBlock;
+                syncBlock = data.NextSyncBlock.ToAddress(_target);
             }
         }
 
@@ -121,22 +129,23 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
         {
             List<ClrNativeHeapInfo>? codeLoaderHeaps = null;
 
-            foreach (JitCodeHeapInfo mem in _sos.GetCodeHeapList(jitManager))
+            foreach (JitCodeHeapInfo mem in _sos.GetCodeHeapList(ClrDataAddress.FromAddress(jitManager, _target)))
             {
                 if (mem.Kind == CodeHeapKind.Loader)
                 {
                     codeLoaderHeaps?.Clear();
 
-                    foreach (ClrNativeHeapInfo heap in LegacyEnumerateLoaderAllocatorHeaps(mem.Address, LoaderHeapKind.LoaderHeapKindExplicitControl, NativeHeapKind.LoaderCodeHeap))
+                    foreach (ClrNativeHeapInfo heap in LegacyEnumerateLoaderAllocatorHeaps(mem.Address.ToAddress(_target), LoaderHeapKind.LoaderHeapKindExplicitControl, NativeHeapKind.LoaderCodeHeap))
                         yield return heap;
                 }
                 else if (mem.Kind == CodeHeapKind.Host)
                 {
-                    yield return new ClrNativeHeapInfo(new(mem.Address, mem.CurrentAddress), NativeHeapKind.HostCodeHeap, ClrNativeHeapState.Active);
+                    yield return new ClrNativeHeapInfo(new(mem.Address.ToAddress(_target), mem.CurrentAddress.ToAddress(_target)), NativeHeapKind.HostCodeHeap, ClrNativeHeapState.Active);
                 }
                 else
                 {
-                    yield return new ClrNativeHeapInfo(new(mem.Address, mem.Address), NativeHeapKind.Unknown, ClrNativeHeapState.None);
+                    ulong addr = mem.Address.ToAddress(_target);
+                    yield return new ClrNativeHeapInfo(new(addr, addr), NativeHeapKind.Unknown, ClrNativeHeapState.None);
                 }
             }
         }
@@ -148,21 +157,21 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
 
             ulong loaderAllocator;
             if (_sos13 is not null
-                && (loaderAllocator = _sos13.GetDomainLoaderAllocator(domain)) != 0
+                && (loaderAllocator = _sos13.GetDomainLoaderAllocator(ClrDataAddress.FromAddress(domain, _target)).ToAddress(_target)) != 0
                 && GetNativeHeaps().Length > 0)
             {
                 foreach (ClrNativeHeapInfo heap in EnumerateLoaderAllocatorNativeHeaps(loaderAllocator))
                     yield return heap;
             }
-            else if (_sos.GetAppDomainData(domain, out AppDomainData data))
+            else if (_sos.GetAppDomainData(ClrDataAddress.FromAddress(domain, _target), out AppDomainData data))
             {
-                foreach (ClrNativeHeapInfo heapInfo in LegacyEnumerateLoaderAllocatorHeaps(data.StubHeap, LoaderHeapKind.LoaderHeapKindNormal, NativeHeapKind.StubHeap))
+                foreach (ClrNativeHeapInfo heapInfo in LegacyEnumerateLoaderAllocatorHeaps(data.StubHeap.ToAddress(_target), LoaderHeapKind.LoaderHeapKindNormal, NativeHeapKind.StubHeap))
                     yield return heapInfo;
 
-                foreach (ClrNativeHeapInfo heapInfo in LegacyEnumerateLoaderAllocatorHeaps(data.HighFrequencyHeap, LoaderHeapKind.LoaderHeapKindNormal, NativeHeapKind.HighFrequencyHeap))
+                foreach (ClrNativeHeapInfo heapInfo in LegacyEnumerateLoaderAllocatorHeaps(data.HighFrequencyHeap.ToAddress(_target), LoaderHeapKind.LoaderHeapKindNormal, NativeHeapKind.HighFrequencyHeap))
                     yield return heapInfo;
 
-                foreach (ClrNativeHeapInfo heapInfo in LegacyEnumerateLoaderAllocatorHeaps(data.LowFrequencyHeap, LoaderHeapKind.LoaderHeapKindNormal, NativeHeapKind.LowFrequencyHeap))
+                foreach (ClrNativeHeapInfo heapInfo in LegacyEnumerateLoaderAllocatorHeaps(data.LowFrequencyHeap.ToAddress(_target), LoaderHeapKind.LoaderHeapKindNormal, NativeHeapKind.LowFrequencyHeap))
                     yield return heapInfo;
 
                 foreach (ClrNativeHeapInfo heapInfo in LegacyEnumerateStubHeaps(domain))
@@ -182,7 +191,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
 
             List<ClrNativeHeapInfo>? result = null;
 
-            (ClrDataAddress Address, LoaderHeapKind Kind)[] heaps = _sos13.GetLoaderAllocatorHeaps(loaderAllocator);
+            (ClrDataAddress Address, LoaderHeapKind Kind)[] heaps = _sos13.GetLoaderAllocatorHeaps(ClrDataAddress.FromAddress(loaderAllocator, _target));
             for (int i = 0; i < heaps.Length; i++)
             {
                 HResult hr = _sos13.TraverseLoaderHeap(heaps[i].Address, heaps[i].Kind, (address, size, current) => {
@@ -232,7 +241,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
         private void TraverseOneStubKind(ulong domain, List<ClrNativeHeapInfo> result, SOSDac.VCSHeapType vcsType, NativeHeapKind heapKind)
         {
             result.Clear();
-            HResult hr = _sos.TraverseStubHeap(domain, vcsType, (address, size, current) => {
+            HResult hr = _sos.TraverseStubHeap(ClrDataAddress.FromAddress(domain, _target), vcsType, (address, size, current) => {
                 result.Add(new(MemoryRange.CreateFromLength(address, SanitizeSize(size)), heapKind, current != 0 ? ClrNativeHeapState.Active : ClrNativeHeapState.Inactive));
             });
 
@@ -263,7 +272,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
 
                 ulong fixedHeapAddress = FixupHeapAddress(loaderHeap, loaderHeapKind, normalNeedsAdjustment, explicitDoesNotNeedAdjustment);
 
-                HResult hr = _sos.TraverseLoaderHeap(fixedHeapAddress, (address, size, current) => {
+                HResult hr = _sos.TraverseLoaderHeap(ClrDataAddress.FromAddress(fixedHeapAddress, _target), (address, size, current) => {
                     result ??= new(8);
                     result.Add(new(MemoryRange.CreateFromLength(address, SanitizeSize(size)), nativeHeapKind, current != 0 ? ClrNativeHeapState.Active : ClrNativeHeapState.Inactive));
                 });
@@ -286,7 +295,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
                 if (retry)
                 {
                     fixedHeapAddress = FixupHeapAddress(loaderHeap, loaderHeapKind, !normalNeedsAdjustment, !explicitDoesNotNeedAdjustment);
-                    hr = _sos.TraverseLoaderHeap(fixedHeapAddress, (address, size, current) => {
+                    hr = _sos.TraverseLoaderHeap(ClrDataAddress.FromAddress(fixedHeapAddress, _target), (address, size, current) => {
                         result ??= new(8);
                         result.Add(new(MemoryRange.CreateFromLength(address, SanitizeSize(size)), nativeHeapKind, current != 0 ? ClrNativeHeapState.Active : ClrNativeHeapState.Inactive));
                     });
@@ -346,9 +355,9 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
         }
 
         private HResult TraverseLoaderHeap(ulong address, LoaderHeapKind kind, SOSDac.LoaderHeapTraverse callback)
-            => TraverseLoaderHeap(_clrInfo, _sos, _sos13, address, kind, (uint)_dataReader.PointerSize, callback);
+            => TraverseLoaderHeap(_clrInfo, _sos, _sos13, address, kind, _target, callback);
 
-        private static HResult TraverseLoaderHeap(ClrInfo clrInfo, SOSDac sos, ISOSDac13? sos13, ulong address, LoaderHeapKind kind, uint pointerSize, SOSDac.LoaderHeapTraverse callback)
+        private static HResult TraverseLoaderHeap(ClrInfo clrInfo, SOSDac sos, ISOSDac13? sos13, ulong address, LoaderHeapKind kind, TargetProperties target, SOSDac.LoaderHeapTraverse callback)
         {
             if (address == 0)
                 return HResult.E_INVALIDARG;
@@ -359,16 +368,16 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
                 // ISOSDacInterface13 understands how to walk LoaderHeaps properly, but it's only implemented in
                 // .Net 8 and beyond.
 
-                hr = sos13.TraverseLoaderHeap(address, kind, callback);
+                hr = sos13.TraverseLoaderHeap(ClrDataAddress.FromAddress(address, target), kind, callback);
             }
             else if (clrInfo.Flavor == ClrFlavor.Core && clrInfo.Version.Major == 7)
             {
                 // See note below, .Net 7 inverts the logic that everything else uses.
 
                 if (kind == LoaderHeapKind.LoaderHeapKindNormal)
-                    address += pointerSize;
+                    address += (uint)target.PointerSize;
 
-                hr = sos.TraverseLoaderHeap(address, callback);
+                hr = sos.TraverseLoaderHeap(ClrDataAddress.FromAddress(address, target), callback);
             }
             else
             {
@@ -379,9 +388,9 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
                 // the enumeration code will work properly.
 
                 if (kind == LoaderHeapKind.LoaderHeapKindExplicitControl)
-                    address -= pointerSize;
+                    address -= (uint)target.PointerSize;
 
-                hr = sos.TraverseLoaderHeap(address, callback);
+                hr = sos.TraverseLoaderHeap(ClrDataAddress.FromAddress(address, target), callback);
             }
 
             GC.KeepAlive(callback);

--- a/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacRuntime.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacRuntime.cs
@@ -125,16 +125,16 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
                 Kind = kind,
                 Name = name,
                 Id = int.MinValue,
-                ConfigFile = _sos.GetConfigFile(ClrDataAddress.FromAddress(address, _target)),
-                ApplicationBase = _sos.GetAppBase(ClrDataAddress.FromAddress(address, _target)),
+                ConfigFile = _sos.GetConfigFile(ClrDataAddress.FromTargetAddress(address, _target)),
+                ApplicationBase = _sos.GetAppBase(ClrDataAddress.FromTargetAddress(address, _target)),
             };
 
-            if (_sos.GetAppDomainData(ClrDataAddress.FromAddress(address, _target), out AppDomainData data))
+            if (_sos.GetAppDomainData(ClrDataAddress.FromTargetAddress(address, _target), out AppDomainData data))
                 result.Id = data.Id;
 
             if (_sos13 is not null)
             {
-                result.LoaderAllocator = _sos13.GetDomainLoaderAllocator(ClrDataAddress.FromAddress(address, _target)).ToAddress(_target);
+                result.LoaderAllocator = _sos13.GetDomainLoaderAllocator(ClrDataAddress.FromTargetAddress(address, _target)).ToAddress(_target);
             }
 
             return result;
@@ -142,7 +142,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
 
         public IEnumerable<ulong> GetModuleList(ulong domain)
         {
-            return _sos.GetAssemblyList(ClrDataAddress.FromAddress(domain, _target))
+            return _sos.GetAssemblyList(ClrDataAddress.FromTargetAddress(domain, _target))
                 .SelectMany(assembly => _sos.GetModuleList(assembly))
                 .Select(module => module.ToAddress(_target));
         }
@@ -179,6 +179,6 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
                 };
         }
 
-        public string? GetJitHelperFunctionName(ulong address) => _sos.GetJitHelperFunctionName(ClrDataAddress.FromAddress(address, _target));
+        public string? GetJitHelperFunctionName(ulong address) => _sos.GetJitHelperFunctionName(ClrDataAddress.FromTargetAddress(address, _target));
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacRuntime.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacRuntime.cs
@@ -19,13 +19,15 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
         private readonly ClrDataProcess _dac;
         private readonly SOSDac _sos;
         private readonly ISOSDac13? _sos13;
+        private readonly TargetProperties _target;
 
-        public DacRuntime(ClrInfo clrInfo, ClrDataProcess dac, SOSDac sos, ISOSDac13? sos13)
+        public DacRuntime(ClrInfo clrInfo, ClrDataProcess dac, SOSDac sos, ISOSDac13? sos13, TargetProperties target)
         {
             _dataReader = clrInfo.DataTarget.DataReader;
             _dac = dac;
             _sos = sos;
             _sos13 = sos13;
+            _target = target;
 
             int version = 0;
             if (!_dac.Request(DacRequests.VERSION, ReadOnlySpan<byte>.Empty, new Span<byte>(&version, sizeof(int))))
@@ -43,18 +45,17 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
                 yield break;
 
             HashSet<ulong> seen = new() { 0 };
-            ulong threadAddress = threadStore.FirstThread;
-
-            uint pointerSize = (uint)_dataReader.PointerSize;
+            ClrDataAddress currentThread = threadStore.FirstThread;
+            ulong threadAddress = currentThread.ToAddress(_target);
 
             for (int i = 0; i < threadStore.ThreadCount && seen.Add(threadAddress); i++)
             {
-                if (!_sos.GetThreadData(threadAddress, out ThreadData threadData))
+                if (!_sos.GetThreadData(currentThread, out ThreadData threadData))
                     break;
 
                 ulong ex = 0;
-                if (threadData.LastThrownObjectHandle != 0)
-                    ex = _dataReader.ReadPointer(threadData.LastThrownObjectHandle);
+                if (!threadData.LastThrownObjectHandle.IsNull)
+                    ex = _dataReader.ReadPointer(threadData.LastThrownObjectHandle.ToAddress(_target));
 
                 ulong stackBase = 0;
                 ulong stackLimit = 0;
@@ -67,22 +68,22 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
                     teb = threadReader.GetThreadTeb(threadData.OSThreadId);
 
                 if (teb == 0)
-                    teb = threadData.Teb;
+                    teb = threadData.Teb.ToAddress(_target);
 
                 if (teb != 0)
                 {
-                    stackBase = _dataReader.ReadPointer(teb + pointerSize);
-                    stackLimit = _dataReader.ReadPointer(teb + pointerSize * 2);
+                    stackBase = _dataReader.ReadPointer(teb + (uint)_target.PointerSize);
+                    stackLimit = _dataReader.ReadPointer(teb + (uint)_target.PointerSize * 2);
                 }
 
                 yield return new()
                 {
                     Address = threadAddress,
-                    AppDomain = threadData.Domain,
+                    AppDomain = threadData.Domain.ToAddress(_target),
                     ExceptionInFlight = ex,
                     GCMode = threadData.PreemptiveGCDisabled == 0 ? GCMode.Preemptive : GCMode.Cooperative,
-                    IsFinalizer = threadStore.FinalizerThread == threadAddress,
-                    IsGC = threadStore.GCThread == threadAddress,
+                    IsFinalizer = threadStore.FinalizerThread.ToAddress(_target) == threadAddress,
+                    IsGC = threadStore.GCThread.ToAddress(_target) == threadAddress,
                     LockCount = threadData.LockCount,
                     ManagedThreadId = threadData.ManagedThreadId < int.MaxValue ? (int)threadData.ManagedThreadId : int.MaxValue,
                     OSThreadId = threadData.OSThreadId,
@@ -92,7 +93,8 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
                     Teb = teb,
                 };
 
-                threadAddress = threadData.NextThread;
+                currentThread = threadData.NextThread;
+                threadAddress = currentThread.ToAddress(_target);
             }
         }
 
@@ -101,16 +103,17 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
             if (!_sos.GetAppDomainStoreData(out AppDomainStoreData domainStore))
                 throw new InvalidDataException("This instance of CLR either has not been initialized or does not contain any data. This may indicate the dump was taken before the CLR was fully initialized, or the dump is corrupt or truncated. Failed to request AppDomainStoreData.");
 
-            if (domainStore.SharedDomain != 0)
-                yield return CreateAppDomainInfo(domainStore.SharedDomain, AppDomainKind.Shared, "Shared Domain");
+            if (!domainStore.SharedDomain.IsNull)
+                yield return CreateAppDomainInfo(domainStore.SharedDomain.ToAddress(_target), AppDomainKind.Shared, "Shared Domain");
 
-            if (domainStore.SystemDomain != 0)
-                yield return CreateAppDomainInfo(domainStore.SystemDomain, AppDomainKind.System, "System Domain");
+            if (!domainStore.SystemDomain.IsNull)
+                yield return CreateAppDomainInfo(domainStore.SystemDomain.ToAddress(_target), AppDomainKind.System, "System Domain");
 
-            foreach (ulong domain in _sos.GetAppDomainList())
+            foreach (ClrDataAddress domain in _sos.GetAppDomainList())
             {
+                ulong domainAddr = domain.ToAddress(_target);
                 string name = _sos.GetAppDomainName(domain) ?? "";
-                yield return CreateAppDomainInfo(domain, AppDomainKind.Normal, name);
+                yield return CreateAppDomainInfo(domainAddr, AppDomainKind.Normal, name);
             }
         }
 
@@ -122,20 +125,27 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
                 Kind = kind,
                 Name = name,
                 Id = int.MinValue,
-                ConfigFile = _sos.GetConfigFile(address),
-                ApplicationBase = _sos.GetAppBase(address),
+                ConfigFile = _sos.GetConfigFile(ClrDataAddress.FromAddress(address, _target)),
+                ApplicationBase = _sos.GetAppBase(ClrDataAddress.FromAddress(address, _target)),
             };
 
-            if (_sos.GetAppDomainData(address, out AppDomainData data))
+            if (_sos.GetAppDomainData(ClrDataAddress.FromAddress(address, _target), out AppDomainData data))
                 result.Id = data.Id;
 
             if (_sos13 is not null)
-                result.LoaderAllocator = _sos13.GetDomainLoaderAllocator(address);
+            {
+                result.LoaderAllocator = _sos13.GetDomainLoaderAllocator(ClrDataAddress.FromAddress(address, _target)).ToAddress(_target);
+            }
 
             return result;
         }
 
-        public IEnumerable<ulong> GetModuleList(ulong domain) => _sos.GetAssemblyList(domain).SelectMany(assembly => _sos.GetModuleList(assembly)).Select(module => (ulong)module);
+        public IEnumerable<ulong> GetModuleList(ulong domain)
+        {
+            return _sos.GetAssemblyList(ClrDataAddress.FromAddress(domain, _target))
+                .SelectMany(assembly => _sos.GetModuleList(assembly))
+                .Select(module => module.ToAddress(_target));
+        }
 
         public IEnumerable<ClrHandleInfo> EnumerateHandles()
         {
@@ -145,13 +155,14 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
 
             foreach (HandleData handle in handleEnum.ReadHandles())
             {
+                ulong handleAddr = handle.Handle.ToAddress(_target);
                 yield return new ClrHandleInfo()
                 {
-                    Address = handle.Handle,
-                    Object = _dataReader.ReadPointer(handle.Handle),
+                    Address = handleAddr,
+                    Object = _dataReader.ReadPointer(handleAddr),
                     Kind = (ClrHandleKind)handle.Type,
-                    AppDomain = handle.AppDomain,
-                    DependentTarget = handle.Secondary,
+                    AppDomain = handle.AppDomain.ToAddress(_target),
+                    DependentTarget = handle.Secondary.ToAddress(_target),
                     RefCount = handle.IsPegged != 0 ? handle.JupiterRefCount : handle.RefCount,
                 };
             }
@@ -162,12 +173,12 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
             foreach (JitManagerData jitMgr in _sos.GetJitManagers())
                 yield return new()
                 {
-                    Address = jitMgr.Address,
+                    Address = jitMgr.Address.ToAddress(_target),
                     Kind = jitMgr.Kind,
-                    HeapList = jitMgr.HeapList,
+                    HeapList = jitMgr.HeapList.ToAddress(_target),
                 };
         }
 
-        public string? GetJitHelperFunctionName(ulong address) => _sos.GetJitHelperFunctionName(address);
+        public string? GetJitHelperFunctionName(ulong address) => _sos.GetJitHelperFunctionName(ClrDataAddress.FromAddress(address, _target));
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacServiceProvider.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacServiceProvider.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;

--- a/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacServiceProvider.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacServiceProvider.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -76,7 +76,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
         public object? GetService(Type serviceType)
         {
             if (serviceType == typeof(IAbstractRuntime))
-                return _runtime ??= new DacRuntime(_clrInfo, _process, _sos, _sos13);
+                return _runtime ??= new DacRuntime(_clrInfo, _process, _sos, _sos13, _dac.TargetProperties);
 
             if (serviceType == typeof(IAbstractHeap))
             {
@@ -84,35 +84,35 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
                 if (heap is not null)
                     return heap;
 
-                if (_sos.GetGCHeapData(out GCInfo data) && _sos.GetCommonMethodTables(out CommonMethodTables mts) && mts.ObjectMethodTable != 0)
-                    return _heapHelper = new DacHeap(_sos, _sos8, _sos12, _sos16, _dataReader, data, mts);
+                if (_sos.GetGCHeapData(out GCInfo data) && _sos.GetCommonMethodTables(out CommonMethodTables mts) && !mts.ObjectMethodTable.IsNull)
+                    return _heapHelper = new DacHeap(_sos, _sos8, _sos12, _sos16, _dataReader, _dac.TargetProperties, data, mts);
 
                 return null;
             }
 
             if (serviceType == typeof(IAbstractTypeHelpers))
             {
-                _moduleHelper ??= new(_sos);
-                return _typeHelper ??= new DacTypeHelpers(_process, _sos, _sos6, _sos8, _sos14, _dataReader, _moduleHelper);
+                _moduleHelper ??= new(_sos, _dac.TargetProperties);
+                return _typeHelper ??= new DacTypeHelpers(_process, _sos, _sos6, _sos8, _sos14, _dataReader, _moduleHelper, _dac.TargetProperties);
             }
 
             if (serviceType == typeof(IAbstractClrNativeHeaps))
-                return _nativeHeaps ??= new DacNativeHeaps(_clrInfo, _sos, _sos13, _dataReader);
+                return _nativeHeaps ??= new DacNativeHeaps(_clrInfo, _sos, _sos13, _dataReader, _dac.TargetProperties);
 
             if (serviceType == typeof(IAbstractModuleHelpers))
-                return _moduleHelper ??= new DacModuleHelpers(_sos);
+                return _moduleHelper ??= new DacModuleHelpers(_sos, _dac.TargetProperties);
 
             if (serviceType == typeof(IAbstractComHelpers))
-                return _com ??= new DacComHelpers(_sos);
+                return _com ??= new DacComHelpers(_sos, _dac.TargetProperties);
 
             if (serviceType == typeof(IAbstractLegacyThreadPool))
-                return _threadPool ??= new DacLegacyThreadPool(_sos);
+                return _threadPool ??= new DacLegacyThreadPool(_sos, _dac.TargetProperties);
 
             if (serviceType == typeof(IAbstractMethodLocator))
-                return _methodLocator ??= new DacMethodLocator(_sos);
+                return _methodLocator ??= new DacMethodLocator(_sos, _dataReader, _dac.TargetProperties);
 
             if (serviceType == typeof(IAbstractThreadHelpers))
-                return _threadHelper ??= new DacThreadHelpers(_process, _sos, _dataReader);
+                return _threadHelper ??= new DacThreadHelpers(_process, _sos, _dataReader, _dac.TargetProperties);
 
             if (serviceType == typeof(IAbstractDacController))
                 return this;
@@ -154,7 +154,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
                 _dac.DacDataTarget.EnterMagicCallbackContext();
                 try
                 {
-                    _sos.GetWorkRequestData(DacDataTarget.MagicCallbackConstant, out _);
+                    _sos.GetWorkRequestData(ClrDataAddress.FromAddress(DacDataTarget.MagicCallbackConstant, _dac.TargetProperties), out _);
                 }
                 finally
                 {

--- a/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacServiceProvider.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacServiceProvider.cs
@@ -154,7 +154,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
                 _dac.DacDataTarget.EnterMagicCallbackContext();
                 try
                 {
-                    _sos.GetWorkRequestData(ClrDataAddress.FromAddress(DacDataTarget.MagicCallbackConstant, _dac.TargetProperties), out _);
+                    _sos.GetWorkRequestData(ClrDataAddress.FromTargetAddress(DacDataTarget.MagicCallbackConstant, _dac.TargetProperties), out _);
                 }
                 finally
                 {

--- a/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacThreadHelpers.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacThreadHelpers.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;

--- a/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacThreadHelpers.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacThreadHelpers.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -18,12 +18,14 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
         private readonly ClrDataProcess _dac;
         private readonly SOSDac _sos;
         private readonly IDataReader _dataReader;
+        private readonly TargetProperties _target;
 
-        public DacThreadHelpers(ClrDataProcess dac, SOSDac sos, IDataReader reader)
+        public DacThreadHelpers(ClrDataProcess dac, SOSDac sos, IDataReader reader, TargetProperties target)
         {
             _dac = dac;
             _sos = sos;
             _dataReader = reader;
+            _target = target;
         }
 
         // IClrThreadHelpers
@@ -39,10 +41,10 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
             const int SOS_StackSourceFrame = 1;
             foreach (StackRefData stackRef in stackRefEnum.ReadStackRefs())
             {
-                if (stackRef.Object == 0)
+                if (stackRef.Object.IsNull)
                 {
                     if (traceErrors)
-                        Debug.WriteLine($"EnumerateStackRoots found an unexpected entry with Object == 0, addr:{(ulong)stackRef.Address:x} srcType:{stackRef.SourceType:x}");
+                        Debug.WriteLine($"EnumerateStackRoots found an unexpected entry with Object == 0, addr:{stackRef.Address.ToAddress(_target):x} srcType:{stackRef.SourceType:x}");
                     continue;
                 }
 
@@ -59,21 +61,21 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
                 ulong ip = 0;
                 ulong frame = 0;
                 if (stackRef.SourceType == SOS_StackSourceIP)
-                    ip = stackRef.Source;
+                    ip = stackRef.Source.ToAddress(_target);
                 else if (stackRef.SourceType == SOS_StackSourceFrame)
-                    frame = stackRef.Source;
+                    frame = stackRef.Source.ToAddress(_target);
 
                 yield return new StackRootInfo()
                 {
                     InstructionPointer = ip,
-                    StackPointer = stackRef.StackPointer,
+                    StackPointer = stackRef.StackPointer.ToAddress(_target),
                     InternalFrame = frame,
 
                     IsInterior = interior,
                     IsPinned = isPinned,
 
-                    Address = stackRef.Address,
-                    Object = stackRef.Object,
+                    Address = stackRef.Address.ToAddress(_target),
+                    Object = stackRef.Object.ToAddress(_target),
 
                     IsEnregistered = stackRef.HasRegisterInformation != 0,
                     RegisterName = regName,
@@ -147,15 +149,15 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
                 ulong ip = context.AsSpan().AsPointer(_dataReader.PointerSize, ipOffset);
                 ulong sp = context.AsSpan().AsPointer(_dataReader.PointerSize, spOffset);
 
-                ulong frameVtbl = stackwalk.GetFrameVtable();
+                ulong frameVtbl = stackwalk.GetFrameVtable().ToAddress(_target);
                 string? frameName = null;
                 ulong frameMethod = 0;
                 if (frameVtbl != 0)
                 {
                     sp = frameVtbl;
                     frameVtbl = _dataReader.ReadPointer(sp);
-                    frameName = _sos.GetFrameName(frameVtbl);
-                    frameMethod = _sos.GetMethodDescPtrFromFrame(sp);
+                    frameName = _sos.GetFrameName(ClrDataAddress.FromAddress(frameVtbl, _target));
+                    frameMethod = _sos.GetMethodDescPtrFromFrame(ClrDataAddress.FromAddress(sp, _target)).ToAddress(_target);
                 }
 
                 byte[]? contextCopy = null;

--- a/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacThreadHelpers.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacThreadHelpers.cs
@@ -156,8 +156,8 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
                 {
                     sp = frameVtbl;
                     frameVtbl = _dataReader.ReadPointer(sp);
-                    frameName = _sos.GetFrameName(ClrDataAddress.FromAddress(frameVtbl, _target));
-                    frameMethod = _sos.GetMethodDescPtrFromFrame(ClrDataAddress.FromAddress(sp, _target)).ToAddress(_target);
+                    frameName = _sos.GetFrameName(ClrDataAddress.FromTargetAddress(frameVtbl, _target));
+                    frameMethod = _sos.GetMethodDescPtrFromFrame(ClrDataAddress.FromTargetAddress(sp, _target)).ToAddress(_target);
                 }
 
                 byte[]? contextCopy = null;

--- a/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacTypeHelpers.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacTypeHelpers.cs
@@ -25,8 +25,9 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
         private readonly SosDac14? _sos14;
         private readonly IDataReader _dataReader;
         private readonly DacModuleHelpers _moduleHelpers;
+        private readonly TargetProperties _target;
 
-        public DacTypeHelpers(ClrDataProcess clrDataProcess, SOSDac sos, SOSDac6? sos6, SOSDac8? sos8, SosDac14? sos14, IDataReader dataReader, DacModuleHelpers moduleHelpers)
+        public DacTypeHelpers(ClrDataProcess clrDataProcess, SOSDac sos, SOSDac6? sos6, SOSDac8? sos8, SosDac14? sos14, IDataReader dataReader, DacModuleHelpers moduleHelpers, TargetProperties target)
         {
             _clrDataProcess = clrDataProcess;
             _sos = sos;
@@ -35,11 +36,12 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
             _sos14 = sos14;
             _dataReader = dataReader;
             _moduleHelpers = moduleHelpers;
+            _target = target;
         }
 
         public bool GetTypeInfo(ulong methodTable, out TypeInfo info)
         {
-            if (!_sos.GetMethodTableData(methodTable, out MethodTableData data))
+            if (!_sos.GetMethodTableData(ClrDataAddress.FromAddress(methodTable, _target), out MethodTableData data))
             {
                 info = default;
                 return false;
@@ -54,15 +56,15 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
                 IsShared = data.Shared != 0,
                 MethodCount = data.NumMethods,
                 MethodTable = methodTable,
-                ParentMethodTable = data.ParentMethodTable,
-                ModuleAddress = data.Module,
+                ParentMethodTable = data.ParentMethodTable.ToAddress(_target),
+                ModuleAddress = data.Module.ToAddress(_target),
             };
             return true;
         }
 
         public string? GetTypeName(ulong module, ulong methodTable, int token)
         {
-            string? name = _sos.GetMethodTableName(methodTable);
+            string? name = _sos.GetMethodTableName(ClrDataAddress.FromAddress(methodTable, _target));
             if (string.IsNullOrWhiteSpace(name) || name == UnloadedTypeName)
                 return GetTypeByToken(module, token);
 
@@ -120,32 +122,32 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
 
         public ulong GetLoaderAllocatorHandle(ulong mt)
         {
-            if (_sos6 != null && _sos6.GetMethodTableCollectibleData(mt, out MethodTableCollectibleData data) && data.Collectible != 0)
-                return data.LoaderAllocatorObjectHandle;
+            if (_sos6 != null && _sos6.GetMethodTableCollectibleData(ClrDataAddress.FromAddress(mt, _target), out MethodTableCollectibleData data) && data.Collectible != 0)
+                return data.LoaderAllocatorObjectHandle.ToAddress(_target);
 
             return 0;
         }
 
         public ulong GetAssemblyLoadContextAddress(ulong mt)
         {
-            if (_sos8 != null && _sos8.GetAssemblyLoadContext(mt, out ClrDataAddress assemblyLoadContext))
-                return assemblyLoadContext;
+            if (_sos8 != null && _sos8.GetAssemblyLoadContext(ClrDataAddress.FromAddress(mt, _target), out ClrDataAddress assemblyLoadContext))
+                return assemblyLoadContext.ToAddress(_target);
 
             return 0;
         }
 
         public bool GetObjectArrayInformation(ulong objRef, out ObjectArrayInformation data)
         {
-            if (!_sos.GetObjectData(objRef, out ObjectData objData))
+            if (!_sos.GetObjectData(ClrDataAddress.FromAddress(objRef, _target), out ObjectData objData))
             {
                 data = default;
                 return false;
             }
 
-            ulong dataPointer = objData.ArrayDataPointer > objRef ? objData.ArrayDataPointer - objRef : 0;
+            ulong dataPointer = objData.ArrayDataPointer.ToAddress(_target) > objRef ? objData.ArrayDataPointer.ToAddress(_target) - objRef : 0;
             data = new()
             {
-                ComponentType = objData.ElementTypeHandle,
+                ComponentType = objData.ElementTypeHandle.ToAddress(_target),
                 ComponentElementType = (ClrElementType)objData.ElementType,
                 DataPointer = dataPointer > int.MaxValue ? int.MaxValue : (int)dataPointer
             };
@@ -154,29 +156,29 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
 
         public IEnumerable<MethodInfo> EnumerateMethodsForType(ulong methodTable)
         {
-            if (!_sos.GetMethodTableData(methodTable, out MethodTableData data))
+            if (!_sos.GetMethodTableData(ClrDataAddress.FromAddress(methodTable, _target), out MethodTableData data))
                 yield break;
 
             for (uint i = 0; i < data.NumMethods; i++)
             {
-                ulong slot = _sos.GetMethodTableSlot(methodTable, i);
+                ClrDataAddress slot = _sos.GetMethodTableSlot(ClrDataAddress.FromAddress(methodTable, _target), i);
                 if (_sos.GetCodeHeaderData(slot, out CodeHeaderData chd))
                 {
-                    if (_sos.GetMethodDescData(chd.MethodDesc, 0, out MethodDescData mdd))
+                    if (_sos.GetMethodDescData(chd.MethodDesc, default, out MethodDescData mdd))
                     {
-                        ulong md = chd.MethodDesc;
+                        ulong md = chd.MethodDesc.ToAddress(_target);
                         uint compilation = chd.JITType;
 
                         HotColdRegions regions;
                         if (mdd.HasNativeCode != 0 && _sos.GetCodeHeaderData(mdd.NativeCodeAddr, out CodeHeaderData chdBasedOnNative))
                         {
-                            regions = new(mdd.NativeCodeAddr, chdBasedOnNative.HotRegionSize, chdBasedOnNative.ColdRegionStart, chdBasedOnNative.ColdRegionSize);
-                            md = chdBasedOnNative.MethodDesc;
+                            regions = new(mdd.NativeCodeAddr.ToAddress(_target), chdBasedOnNative.HotRegionSize, chdBasedOnNative.ColdRegionStart.ToAddress(_target), chdBasedOnNative.ColdRegionSize);
+                            md = chdBasedOnNative.MethodDesc.ToAddress(_target);
                             compilation = chdBasedOnNative.JITType;
                         }
                         else
                         {
-                            regions = new(mdd.NativeCodeAddr, chd.HotRegionSize, chd.ColdRegionStart, chd.ColdRegionSize);
+                            regions = new(mdd.NativeCodeAddr.ToAddress(_target), chd.HotRegionSize, chd.ColdRegionStart.ToAddress(_target), chd.ColdRegionSize);
                         }
 
                         yield return new()
@@ -193,13 +195,13 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
 
         public IEnumerable<FieldInfo> EnumerateFields(TypeInfo type, int baseFieldCount)
         {
-            if (!_sos.GetFieldInfo(type.MethodTable, out MethodTableFieldInfo fieldInfo) || fieldInfo.FirstFieldAddress == 0)
+            if (!_sos.GetFieldInfo(ClrDataAddress.FromAddress(type.MethodTable, _target), out MethodTableFieldInfo fieldInfo) || fieldInfo.FirstFieldAddress.IsNull)
                 yield break;
 
-            ulong nextField = fieldInfo.FirstFieldAddress;
+            ulong nextField = fieldInfo.FirstFieldAddress.ToAddress(_target);
             for (int i = baseFieldCount; i < fieldInfo.NumInstanceFields + fieldInfo.NumStaticFields; i++)
             {
-                if (!_sos.GetFieldData(nextField, out FieldData dacFieldData))
+                if (!_sos.GetFieldData(ClrDataAddress.FromAddress(nextField, _target), out FieldData dacFieldData))
                     break;
 
                 if (dacFieldData.IsContextLocal == 0)
@@ -217,7 +219,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
                     yield return new()
                     {
                         FieldDesc = nextField,
-                        MethodTable = dacFieldData.TypeMethodTable,
+                        MethodTable = dacFieldData.TypeMethodTable.ToAddress(_target),
                         ElementType = (ClrElementType)dacFieldData.ElementType,
                         Offset = dacFieldData.Offset <= int.MaxValue ? (int)dacFieldData.Offset : int.MaxValue,
                         Token = dacFieldData.FieldToken <= int.MaxValue ? (int)dacFieldData.FieldToken : int.MaxValue,
@@ -225,7 +227,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
                     };
                 }
 
-                nextField = dacFieldData.NextField;
+                nextField = dacFieldData.NextField.ToAddress(_target);
             }
         }
 
@@ -233,11 +235,11 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
         {
             if (_sos14 is not null)
             {
-                (ulong nonGcBase, ulong gcBase) = _sos14.GetStaticBaseAddress(type.MethodTable);
+                (ClrDataAddress nonGcBase, ClrDataAddress gcBase) = _sos14.GetStaticBaseAddress(ClrDataAddress.FromAddress(type.MethodTable, _target));
                 if (field.ElementType.IsPrimitive())
-                    return nonGcBase != 0 ? nonGcBase + (uint)field.Offset : 0;
+                    return !nonGcBase.IsNull ? nonGcBase.ToAddress(_target) + (uint)field.Offset : 0;
 
-                return gcBase != 0 ? gcBase + (uint)field.Offset : 0;
+                return !gcBase.IsNull ? gcBase.ToAddress(_target) + (uint)field.Offset : 0;
             }
 
             if (appDomain.Address == 0)
@@ -245,26 +247,26 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
 
             if (type.IsShared)
             {
-                if (!_sos.GetDomainLocalModuleDataFromAppDomain(appDomain.Address, (int)module.Id, out DomainLocalModuleData dlmd))
+                if (!_sos.GetDomainLocalModuleDataFromAppDomain(ClrDataAddress.FromAddress(appDomain.Address, _target), (int)module.Id, out DomainLocalModuleData dlmd))
                     return 0;
 
                 if (field.ElementType.IsPrimitive())
-                    return dlmd.NonGCStaticDataStart + (uint)field.Offset;
+                    return dlmd.NonGCStaticDataStart.ToAddress(_target) + (uint)field.Offset;
                 else
-                    return dlmd.GCStaticDataStart + (uint)field.Offset;
+                    return dlmd.GCStaticDataStart.ToAddress(_target) + (uint)field.Offset;
             }
             else
             {
-                if (!_sos.GetDomainLocalModuleDataFromModule(module.Address, out DomainLocalModuleData dlmd))
+                if (!_sos.GetDomainLocalModuleDataFromModule(ClrDataAddress.FromAddress(module.Address, _target), out DomainLocalModuleData dlmd))
                     return 0;
 
                 if (!IsInitialized(dlmd, type.MetadataToken))
                     return 0;
 
                 if (field.ElementType.IsPrimitive())
-                    return dlmd.NonGCStaticDataStart + (uint)field.Offset;
+                    return dlmd.NonGCStaticDataStart.ToAddress(_target) + (uint)field.Offset;
                 else
-                    return dlmd.GCStaticDataStart + (uint)field.Offset;
+                    return dlmd.GCStaticDataStart.ToAddress(_target) + (uint)field.Offset;
             }
         }
 
@@ -275,25 +277,25 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
 
             if (_sos14 is not null)
             {
-                (ulong nonGcBase, ulong gcBase) = _sos14.GetThreadStaticBaseAddress(type.MethodTable, threadAddress);
+                (ClrDataAddress nonGcBase, ClrDataAddress gcBase) = _sos14.GetThreadStaticBaseAddress(ClrDataAddress.FromAddress(type.MethodTable, _target), ClrDataAddress.FromAddress(threadAddress, _target));
                 if (field.ElementType.IsPrimitive())
-                    return nonGcBase != 0 ? nonGcBase + (uint)field.Offset : 0;
+                    return !nonGcBase.IsNull ? nonGcBase.ToAddress(_target) + (uint)field.Offset : 0;
 
-                return gcBase != 0 ? gcBase + (uint)field.Offset : 0;
+                return !gcBase.IsNull ? gcBase.ToAddress(_target) + (uint)field.Offset : 0;
             }
 
-            if (!_sos.GetThreadLocalModuleData(threadAddress, (uint)module.Index, out ThreadLocalModuleData threadData))
+            if (!_sos.GetThreadLocalModuleData(ClrDataAddress.FromAddress(threadAddress, _target), (uint)module.Index, out ThreadLocalModuleData threadData))
                 return 0;
 
             if (field.ElementType.IsPrimitive())
-                return threadData.NonGCStaticDataStart + (uint)field.Offset;
+                return threadData.NonGCStaticDataStart.ToAddress(_target) + (uint)field.Offset;
 
-            return threadData.GCStaticDataStart + (uint)field.Offset;
+            return threadData.GCStaticDataStart.ToAddress(_target) + (uint)field.Offset;
         }
 
         private bool IsInitialized(in DomainLocalModuleData data, int token)
         {
-            ulong flagsAddr = data.ClassData + (uint)(token & ~0x02000000u) - 1;
+            ulong flagsAddr = data.ClassData.ToAddress(_target) + (uint)(token & ~0x02000000u) - 1;
             if (!_dataReader.Read(flagsAddr, out byte flags))
                 return false;
 
@@ -302,15 +304,15 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
 
         // Method helpers
 
-        public string? GetMethodSignature(ulong methodDesc) => _sos.GetMethodDescName(methodDesc);
+        public string? GetMethodSignature(ulong methodDesc) => _sos.GetMethodDescName(ClrDataAddress.FromAddress(methodDesc, _target));
 
-        public ulong GetILForModule(ulong address, uint rva) => _sos.GetILForModule(address, rva);
+        public ulong GetILForModule(ulong address, uint rva) => _sos.GetILForModule(ClrDataAddress.FromAddress(address, _target), rva).ToAddress(_target);
 
         public ImmutableArray<ILToNativeMap> GetILMap(ulong ip, in HotColdRegions hotCold)
         {
             ImmutableArray<ILToNativeMap>.Builder result = ImmutableArray.CreateBuilder<ILToNativeMap>();
 
-            foreach (ClrDataMethod method in _clrDataProcess.EnumerateMethodInstancesByAddress(ip))
+            foreach (ClrDataMethod method in _clrDataProcess.EnumerateMethodInstancesByAddress(ClrDataAddress.FromAddress(ip, _target)))
             {
                 ILToNativeMap[]? map = method.GetILToNativeMap();
                 if (map != null)

--- a/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacTypeHelpers.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacTypeHelpers.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
 
         public bool GetTypeInfo(ulong methodTable, out TypeInfo info)
         {
-            if (!_sos.GetMethodTableData(ClrDataAddress.FromAddress(methodTable, _target), out MethodTableData data))
+            if (!_sos.GetMethodTableData(ClrDataAddress.FromTargetAddress(methodTable, _target), out MethodTableData data))
             {
                 info = default;
                 return false;
@@ -64,7 +64,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
 
         public string? GetTypeName(ulong module, ulong methodTable, int token)
         {
-            string? name = _sos.GetMethodTableName(ClrDataAddress.FromAddress(methodTable, _target));
+            string? name = _sos.GetMethodTableName(ClrDataAddress.FromTargetAddress(methodTable, _target));
             if (string.IsNullOrWhiteSpace(name) || name == UnloadedTypeName)
                 return GetTypeByToken(module, token);
 
@@ -122,7 +122,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
 
         public ulong GetLoaderAllocatorHandle(ulong mt)
         {
-            if (_sos6 != null && _sos6.GetMethodTableCollectibleData(ClrDataAddress.FromAddress(mt, _target), out MethodTableCollectibleData data) && data.Collectible != 0)
+            if (_sos6 != null && _sos6.GetMethodTableCollectibleData(ClrDataAddress.FromTargetAddress(mt, _target), out MethodTableCollectibleData data) && data.Collectible != 0)
                 return data.LoaderAllocatorObjectHandle.ToAddress(_target);
 
             return 0;
@@ -130,7 +130,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
 
         public ulong GetAssemblyLoadContextAddress(ulong mt)
         {
-            if (_sos8 != null && _sos8.GetAssemblyLoadContext(ClrDataAddress.FromAddress(mt, _target), out ClrDataAddress assemblyLoadContext))
+            if (_sos8 != null && _sos8.GetAssemblyLoadContext(ClrDataAddress.FromTargetAddress(mt, _target), out ClrDataAddress assemblyLoadContext))
                 return assemblyLoadContext.ToAddress(_target);
 
             return 0;
@@ -138,7 +138,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
 
         public bool GetObjectArrayInformation(ulong objRef, out ObjectArrayInformation data)
         {
-            if (!_sos.GetObjectData(ClrDataAddress.FromAddress(objRef, _target), out ObjectData objData))
+            if (!_sos.GetObjectData(ClrDataAddress.FromTargetAddress(objRef, _target), out ObjectData objData))
             {
                 data = default;
                 return false;
@@ -156,12 +156,12 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
 
         public IEnumerable<MethodInfo> EnumerateMethodsForType(ulong methodTable)
         {
-            if (!_sos.GetMethodTableData(ClrDataAddress.FromAddress(methodTable, _target), out MethodTableData data))
+            if (!_sos.GetMethodTableData(ClrDataAddress.FromTargetAddress(methodTable, _target), out MethodTableData data))
                 yield break;
 
             for (uint i = 0; i < data.NumMethods; i++)
             {
-                ClrDataAddress slot = _sos.GetMethodTableSlot(ClrDataAddress.FromAddress(methodTable, _target), i);
+                ClrDataAddress slot = _sos.GetMethodTableSlot(ClrDataAddress.FromTargetAddress(methodTable, _target), i);
                 if (_sos.GetCodeHeaderData(slot, out CodeHeaderData chd))
                 {
                     if (_sos.GetMethodDescData(chd.MethodDesc, default, out MethodDescData mdd))
@@ -195,13 +195,13 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
 
         public IEnumerable<FieldInfo> EnumerateFields(TypeInfo type, int baseFieldCount)
         {
-            if (!_sos.GetFieldInfo(ClrDataAddress.FromAddress(type.MethodTable, _target), out MethodTableFieldInfo fieldInfo) || fieldInfo.FirstFieldAddress.IsNull)
+            if (!_sos.GetFieldInfo(ClrDataAddress.FromTargetAddress(type.MethodTable, _target), out MethodTableFieldInfo fieldInfo) || fieldInfo.FirstFieldAddress.IsNull)
                 yield break;
 
             ulong nextField = fieldInfo.FirstFieldAddress.ToAddress(_target);
             for (int i = baseFieldCount; i < fieldInfo.NumInstanceFields + fieldInfo.NumStaticFields; i++)
             {
-                if (!_sos.GetFieldData(ClrDataAddress.FromAddress(nextField, _target), out FieldData dacFieldData))
+                if (!_sos.GetFieldData(ClrDataAddress.FromTargetAddress(nextField, _target), out FieldData dacFieldData))
                     break;
 
                 if (dacFieldData.IsContextLocal == 0)
@@ -235,7 +235,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
         {
             if (_sos14 is not null)
             {
-                (ClrDataAddress nonGcBase, ClrDataAddress gcBase) = _sos14.GetStaticBaseAddress(ClrDataAddress.FromAddress(type.MethodTable, _target));
+                (ClrDataAddress nonGcBase, ClrDataAddress gcBase) = _sos14.GetStaticBaseAddress(ClrDataAddress.FromTargetAddress(type.MethodTable, _target));
                 if (field.ElementType.IsPrimitive())
                     return !nonGcBase.IsNull ? nonGcBase.ToAddress(_target) + (uint)field.Offset : 0;
 
@@ -247,7 +247,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
 
             if (type.IsShared)
             {
-                if (!_sos.GetDomainLocalModuleDataFromAppDomain(ClrDataAddress.FromAddress(appDomain.Address, _target), (int)module.Id, out DomainLocalModuleData dlmd))
+                if (!_sos.GetDomainLocalModuleDataFromAppDomain(ClrDataAddress.FromTargetAddress(appDomain.Address, _target), (int)module.Id, out DomainLocalModuleData dlmd))
                     return 0;
 
                 if (field.ElementType.IsPrimitive())
@@ -257,7 +257,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
             }
             else
             {
-                if (!_sos.GetDomainLocalModuleDataFromModule(ClrDataAddress.FromAddress(module.Address, _target), out DomainLocalModuleData dlmd))
+                if (!_sos.GetDomainLocalModuleDataFromModule(ClrDataAddress.FromTargetAddress(module.Address, _target), out DomainLocalModuleData dlmd))
                     return 0;
 
                 if (!IsInitialized(dlmd, type.MetadataToken))
@@ -277,14 +277,14 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
 
             if (_sos14 is not null)
             {
-                (ClrDataAddress nonGcBase, ClrDataAddress gcBase) = _sos14.GetThreadStaticBaseAddress(ClrDataAddress.FromAddress(type.MethodTable, _target), ClrDataAddress.FromAddress(threadAddress, _target));
+                (ClrDataAddress nonGcBase, ClrDataAddress gcBase) = _sos14.GetThreadStaticBaseAddress(ClrDataAddress.FromTargetAddress(type.MethodTable, _target), ClrDataAddress.FromTargetAddress(threadAddress, _target));
                 if (field.ElementType.IsPrimitive())
                     return !nonGcBase.IsNull ? nonGcBase.ToAddress(_target) + (uint)field.Offset : 0;
 
                 return !gcBase.IsNull ? gcBase.ToAddress(_target) + (uint)field.Offset : 0;
             }
 
-            if (!_sos.GetThreadLocalModuleData(ClrDataAddress.FromAddress(threadAddress, _target), (uint)module.Index, out ThreadLocalModuleData threadData))
+            if (!_sos.GetThreadLocalModuleData(ClrDataAddress.FromTargetAddress(threadAddress, _target), (uint)module.Index, out ThreadLocalModuleData threadData))
                 return 0;
 
             if (field.ElementType.IsPrimitive())
@@ -304,15 +304,15 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
 
         // Method helpers
 
-        public string? GetMethodSignature(ulong methodDesc) => _sos.GetMethodDescName(ClrDataAddress.FromAddress(methodDesc, _target));
+        public string? GetMethodSignature(ulong methodDesc) => _sos.GetMethodDescName(ClrDataAddress.FromTargetAddress(methodDesc, _target));
 
-        public ulong GetILForModule(ulong address, uint rva) => _sos.GetILForModule(ClrDataAddress.FromAddress(address, _target), rva).ToAddress(_target);
+        public ulong GetILForModule(ulong address, uint rva) => _sos.GetILForModule(ClrDataAddress.FromTargetAddress(address, _target), rva).ToAddress(_target);
 
         public ImmutableArray<ILToNativeMap> GetILMap(ulong ip, in HotColdRegions hotCold)
         {
             ImmutableArray<ILToNativeMap>.Builder result = ImmutableArray.CreateBuilder<ILToNativeMap>();
 
-            foreach (ClrDataMethod method in _clrDataProcess.EnumerateMethodInstancesByAddress(ClrDataAddress.FromAddress(ip, _target)))
+            foreach (ClrDataMethod method in _clrDataProcess.EnumerateMethodInstancesByAddress(ClrDataAddress.FromTargetAddress(ip, _target)))
             {
                 ILToNativeMap[]? map = method.GetILToNativeMap();
                 if (map != null)

--- a/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacTypeHelpers.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacTypeHelpers.cs
@@ -164,7 +164,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
                 ClrDataAddress slot = _sos.GetMethodTableSlot(ClrDataAddress.FromTargetAddress(methodTable, _target), i);
                 if (_sos.GetCodeHeaderData(slot, out CodeHeaderData chd))
                 {
-                    if (_sos.GetMethodDescData(chd.MethodDesc, default, out MethodDescData mdd))
+                    if (_sos.GetMethodDescData(chd.MethodDesc, ClrDataAddress.Null, out MethodDescData mdd))
                     {
                         ulong md = chd.MethodDesc.ToAddress(_target);
                         uint compilation = chd.JITType;

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/ClrDataAddress.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/ClrDataAddress.cs
@@ -1,6 +1,70 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+//
+// ===== ClrDataAddress: Sign Extension and Marshalling Design =====
+//
+// The CLR DAC uses CLRDATA_ADDRESS (typedef ULONG64) for target-process addresses
+// on the COM wire. On 32-bit targets, the legacy DAC sign-extends addresses with
+// bit 31 set. For example:
+//
+//   32-bit address:       0x80123456
+//   Wire (CLRDATA_ADDRESS): 0xFFFFFFFF_80123456
+//
+// This convention exists for compatibility with WinDbg and OS debugging APIs.
+// The sign extension must be stripped to recover the actual 32-bit address, and
+// re-applied when passing addresses back to the DAC.
+//
+// ---- Runtime (C++) conversion macros (dacimpl.h) ----
+//
+//   TO_CDADDR(taddr):   (CLRDATA_ADDRESS)(LONG_PTR)(taddr)     // sign-extend
+//   CLRDATA_ADDRESS_TO_TADDR(cda):  validates range, then (TADDR)cda  // truncate
+//
+// ---- ClrMD (C#) equivalents ----
+//
+//   FromAddress(addr, target):  (ulong)(long)(int)(uint)addr    // sign-extend
+//   ToAddress(target):          (ulong)(uint)_value             // strip sign-ext
+//
+// The cast chains mirror the C++ macros exactly:
+//   - FromAddress: uint→int (signed reinterpret) →long (sign-extend) →ulong
+//   - ToAddress:   uint (truncate to 32 bits) →ulong (zero-extend)
+//
+// ---- ABI boundary: why we marshal as ulong, not ClrDataAddress ----
+//
+// ClrDataAddress is a readonly struct wrapping a single ulong. On the wire, the
+// DAC's COM vtable declares CLRDATA_ADDRESS params as ULONG64 — a primitive.
+// Different platform ABIs classify single-field structs differently for register
+// passing. Since ClrMD targets netstandard2.0 (no source-generated COM), we can't
+// guarantee a C# struct will be passed identically to a bare ulong.
+//
+// Solution: every vtable slot carrying a CLRDATA_ADDRESS is typed as plain ulong
+// (annotated /*ClrDataAddress*/). Managed wrappers accept ClrDataAddress and call
+// .ToInteropAddress() (a no-op unwrap) before passing to the vtable. Pointer forms
+// (ref/out/ClrDataAddress*) are safe as-is — the ABI sees them as plain pointers.
+//
+// ---- Data flow ----
+//
+//   DacImplementation (ulong)
+//       │ FromAddress(addr, _target)
+//       ▼
+//   SosDac wrapper (ClrDataAddress)
+//       │ .ToInteropAddress()
+//       ▼
+//   Vtable call (ulong on the wire)
+//       │
+//   Native DAC processes request
+//       │
+//   Returns via out struct fields (ClrDataAddress, binary-compatible with ULONG64)
+//       │ .ToAddress(_target)
+//       ▼
+//   DacImplementation (ulong — clean target address)
+//       │
+//   Public API (ulong — ClrObject.Address, ClrType.MethodTable, etc.)
+//
+// ClrDataAddress is confined to DacInterface/ and DacImplementation/. It never
+// leaks into AbstractDac/, Implementation/, or the public API surface.
+//
+
 using System;
 using System.Diagnostics;
 using System.Runtime.InteropServices;

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/ClrDataAddress.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/ClrDataAddress.cs
@@ -125,7 +125,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
         /// pointer, un-sign-extending the high 32 bits on 32-bit targets.
         /// </summary>
         public ulong ToAddress(TargetProperties target) =>
-            target.PointerSize == 4 ? (ulong)(uint)_value : _value;
+            target.PointerSize == 4 ? unchecked((ulong)(uint)_value) : _value;
 
         /// <summary>
         /// Creates a <see cref="ClrDataAddress"/> for passing into the DAC. On 32-bit targets

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/ClrDataAddress.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/ClrDataAddress.cs
@@ -22,11 +22,11 @@
 //
 // ---- ClrMD (C#) equivalents ----
 //
-//   FromAddress(addr, target):  (ulong)(long)(int)(uint)addr    // sign-extend
+//   FromTargetAddress(addr, target):  (ulong)(long)(int)(uint)addr    // sign-extend
 //   ToAddress(target):          (ulong)(uint)_value             // strip sign-ext
 //
 // The cast chains mirror the C++ macros exactly:
-//   - FromAddress: uint→int (signed reinterpret) →long (sign-extend) →ulong
+//   - FromTargetAddress: uint→int (signed reinterpret) →long (sign-extend) →ulong
 //   - ToAddress:   uint (truncate to 32 bits) →ulong (zero-extend)
 //
 // ---- ABI boundary: why we marshal as ulong, not ClrDataAddress ----
@@ -45,7 +45,7 @@
 // ---- Data flow ----
 //
 //   DacImplementation (ulong)
-//       │ FromAddress(addr, _target)
+//       │ FromTargetAddress(addr, _target)
 //       ▼
 //   SosDac wrapper (ClrDataAddress)
 //       │ .ToInteropAddress()
@@ -101,7 +101,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
         /// <summary>
         /// Creates an instance of ClrDataAddress that wraps a raw wire value.
         /// Most callers should build <see cref="ClrDataAddress"/> values through
-        /// <see cref="FromAddress(ulong, TargetProperties)"/> instead of this constructor.
+        /// <see cref="FromTargetAddress(ulong, TargetProperties)"/> instead of this constructor.
         /// </summary>
         internal ClrDataAddress(ulong rawValue) => _value = rawValue;
 
@@ -132,7 +132,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
         /// the legacy DAC expects addresses to be sign-extended (CLRDATA_ADDRESS_TO_TADDR
         /// validates that signed(addr) is in [INT_MIN, INT_MAX]).
         /// </summary>
-        public static ClrDataAddress FromAddress(ulong address, TargetProperties target)
+        public static ClrDataAddress FromTargetAddress(ulong address, TargetProperties target)
         {
             if (target.PointerSize == 4)
                 return new ClrDataAddress(unchecked((ulong)(long)(int)(uint)address));

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/ClrDataAddress.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/ClrDataAddress.cs
@@ -1,42 +1,91 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 
 namespace Microsoft.Diagnostics.Runtime.DacInterface
 {
     /// <summary>
-    /// A representation of CLR's CLRDATA_ADDRESS, which is a signed 64bit integer.
-    /// Unfortunately this can cause issues when inspecting 32bit processes, since
-    /// if the highest bit is set the value will be sign-extended.  This struct is
-    /// meant to
+    /// A managed-side wrapper for CLR's CLRDATA_ADDRESS (a signed 64-bit integer on the wire).
+    /// <para>
+    /// On 32-bit targets the legacy DAC sign-extends addresses with bit 31 set; cDAC does not.
+    /// ClrDataAddress is opaque; conversions to/from target addresses must go through the
+    /// static helpers on this type, which take a <see cref="TargetProperties"/> describing the
+    /// DAC flavor and pointer size being used.
+    /// </para>
+    /// <para>
+    /// <b>ABI boundary policy.</b> <see cref="ClrDataAddress"/> is managed-only: it never
+    /// crosses an unmanaged calling-convention boundary by value. Every vtable slot (and every
+    /// unmanaged callback) that semantically carries a CLRDATA_ADDRESS is typed as
+    /// <see cref="ulong"/> (annotated with a <c>/*ClrDataAddress*/</c> comment), and managed
+    /// wrappers unwrap via <see cref="ToInteropAddress"/> / <see cref="FromInteropAddress"/>.
+    /// This removes any cross-platform ambiguity in how a one-field struct is classified for
+    /// register/stack passing versus a primitive <see cref="ulong"/>. Pointer forms
+    /// (<c>ref</c>/<c>out</c>/<c>ClrDataAddress*</c>) are safe as-is because the ABI sees them
+    /// as plain pointers regardless of pointee type; those forms are preserved in signatures
+    /// so DAC-produced buffers can be consumed without an extra copy.
+    /// </para>
     /// </summary>
-    [DebuggerDisplay("{AsUInt64()}")]
-    internal readonly struct ClrDataAddress
+    [DebuggerDisplay("{_value,h}")]
+    [StructLayout(LayoutKind.Sequential)]
+    internal readonly struct ClrDataAddress : IEquatable<ClrDataAddress>
     {
-        /// <summary>
-        /// Gets raw value of this address.  May be sign-extended if inspecting a 32bit process.
-        /// </summary>
-        public long Value { get; }
+        private readonly ulong _value;
 
         /// <summary>
-        /// Creates an instance of ClrDataAddress.
+        /// Creates an instance of ClrDataAddress that wraps a raw wire value.
+        /// Most callers should build <see cref="ClrDataAddress"/> values through
+        /// <see cref="FromAddress(ulong, TargetProperties)"/> instead of this constructor.
         /// </summary>
-        /// <param name="value"></param>
-        public ClrDataAddress(long value) => Value = value;
+        internal ClrDataAddress(ulong rawValue) => _value = rawValue;
+
+        /// <summary>Returns true if this address is zero/null.</summary>
+        public bool IsNull => _value == 0;
+
+        public bool Equals(ClrDataAddress other) => _value == other._value;
+        public override bool Equals(object? obj) => obj is ClrDataAddress other && Equals(other);
+        public override int GetHashCode() => _value.GetHashCode();
+
+        public static bool operator ==(ClrDataAddress left, ClrDataAddress right) => left._value == right._value;
+        public static bool operator !=(ClrDataAddress left, ClrDataAddress right) => left._value != right._value;
+
+        public override string ToString() => $"0x{_value:x}";
 
         /// <summary>
-        /// Returns the value of this address and un-sign extends the value if appropriate.
+        /// Converts this <see cref="ClrDataAddress"/> returned from the DAC to a target-process
+        /// pointer, un-sign-extending the high 32 bits on 32-bit targets.
         /// </summary>
-        /// <param name="cda">The address to convert.</param>
-        public static implicit operator ulong(ClrDataAddress cda) => cda.AsUInt64();
-
-        public static implicit operator ClrDataAddress(ulong value) => new(unchecked((nint)value));
+        public ulong ToAddress(TargetProperties target) =>
+            target.PointerSize == 4 ? (ulong)(uint)_value : _value;
 
         /// <summary>
-        /// Returns the value of this address and un-sign extends the value if appropriate.
+        /// Creates a <see cref="ClrDataAddress"/> for passing into the DAC. On 32-bit targets
+        /// the legacy DAC expects addresses to be sign-extended (CLRDATA_ADDRESS_TO_TADDR
+        /// validates that signed(addr) is in [INT_MIN, INT_MAX]).
         /// </summary>
-        /// <returns>The value of this address and un-sign extends the value if appropriate.</returns>
-        private ulong AsUInt64() => unchecked((nuint)Value);
+        public static ClrDataAddress FromAddress(ulong address, TargetProperties target)
+        {
+            if (target.PointerSize == 4)
+                return new ClrDataAddress(unchecked((ulong)(long)(int)(uint)address));
+
+            return new ClrDataAddress(address);
+        }
+
+        /// <summary>
+        /// Unwraps this <see cref="ClrDataAddress"/> to the raw <see cref="ulong"/> wire value
+        /// expected by the COM vtable (where signatures are typed as ulong for ABI safety).
+        /// Does not apply any sign-extension transformation — the wrapper value is passed
+        /// through unchanged.
+        /// </summary>
+        public ulong ToInteropAddress() => _value;
+
+        /// <summary>
+        /// Wraps a raw <see cref="ulong"/> received from a COM callback
+        /// (e.g. <see cref="DacDataTarget.ReadVirtual"/>) as a <see cref="ClrDataAddress"/>
+        /// with no transformation.
+        /// </summary>
+        public static ClrDataAddress FromInteropAddress(ulong rawValue) => new ClrDataAddress(rawValue);
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/ClrDataAddress.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/ClrDataAddress.cs
@@ -44,6 +44,9 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
         /// <summary>Returns true if this address is zero/null.</summary>
         public bool IsNull => _value == 0;
 
+        /// <summary>A null (zero) ClrDataAddress.</summary>
+        public static ClrDataAddress Null => default;
+
         public bool Equals(ClrDataAddress other) => _value == other._value;
         public override bool Equals(object? obj) => obj is ClrDataAddress other && Equals(other);
         public override int GetHashCode() => _value.GetHashCode();

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/ClrDataProcess.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/ClrDataProcess.cs
@@ -19,11 +19,8 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
         private readonly DacLibrary _library;
 
         public ClrDataProcess(DacLibrary library, IntPtr pUnknown)
-            : base(library?.OwningLibrary, IID_IXCLRDataProcess, pUnknown)
+            : base(library.OwningLibrary, IID_IXCLRDataProcess, pUnknown)
         {
-            if (library is null)
-                throw new ArgumentNullException(nameof(library));
-
             _library = library;
         }
 

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/ClrDataProcess.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/ClrDataProcess.cs
@@ -194,7 +194,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
         {
             List<ClrDataMethod> result = new(1);
 
-            HResult hr = VTable.StartEnumMethodInstancesByAddress(Self, addr, IntPtr.Zero, out ClrDataAddress handle);
+            HResult hr = VTable.StartEnumMethodInstancesByAddress(Self, addr.ToInteropAddress(), IntPtr.Zero, out ulong handle);
             if (!hr)
                 return result;
 
@@ -244,13 +244,13 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
         private readonly IntPtr GetModuleByAddress;
 
         // (ulong address, [In, MarshalAs(UnmanagedType.Interface)] object appDomain, out ulong handle);
-        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, IntPtr, out ClrDataAddress, int> StartEnumMethodInstancesByAddress;
+        public readonly delegate* unmanaged[Stdcall]<IntPtr, ulong /*ClrDataAddress*/, IntPtr, out ulong, int> StartEnumMethodInstancesByAddress;
 
         // (ref ulong handle, [Out, MarshalAs(UnmanagedType.Interface)] out object method);
-        public readonly delegate* unmanaged[Stdcall]<IntPtr, ref ClrDataAddress, out IntPtr, int> EnumMethodInstanceByAddress;
+        public readonly delegate* unmanaged[Stdcall]<IntPtr, ref ulong, out IntPtr, int> EnumMethodInstanceByAddress;
 
         // (ulong handle);
-        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, int> EndEnumMethodInstancesByAddress;
+        public readonly delegate* unmanaged[Stdcall]<IntPtr, ulong, int> EndEnumMethodInstancesByAddress;
         private readonly IntPtr GetDataByAddress;
         private readonly IntPtr GetExceptionStateByExceptionRecord;
         private readonly IntPtr TranslateExceptionRecordToNotification;

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/ClrStackWalk.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/ClrStackWalk.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/ClrStackWalk.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/ClrStackWalk.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -24,7 +24,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             ulong ptr = 0xcccccccc;
 
             HResult hr = VTable.Request(Self, 0xf0000000, 0, null, 8u, (byte*)&ptr);
-            return hr ? new ClrDataAddress(ptr) : default;
+            return hr ? new ClrDataAddress(ptr) : ClrDataAddress.Null;
         }
 
         public HResult Next()

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/ClrStackWalk.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/ClrStackWalk.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
 
         public ClrDataAddress GetFrameVtable()
         {
-            long ptr = 0xcccccccc;
+            ulong ptr = 0xcccccccc;
 
             HResult hr = VTable.Request(Self, 0xf0000000, 0, null, 8u, (byte*)&ptr);
             return hr ? new ClrDataAddress(ptr) : default;

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/ClrStackWalk.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/ClrStackWalk.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
         private static readonly Guid IID_IXCLRDataStackWalk = new("E59D8D22-ADA7-49a2-89B5-A415AFCFC95F");
 
         public ClrStackWalk(DacLibrary library, IntPtr pUnk)
-            : base(library?.OwningLibrary, IID_IXCLRDataStackWalk, pUnk)
+            : base(library.OwningLibrary, IID_IXCLRDataStackWalk, pUnk)
         {
         }
 

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/DacDataTarget.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/DacDataTarget.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/DacDataTarget.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/DacDataTarget.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -60,6 +60,9 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
 
         public int PointerSize => _dataTarget.DataReader.PointerSize;
 
+        public TargetProperties TargetProperties => _targetProperties ??= new TargetProperties(pointerSize: PointerSize);
+        private TargetProperties? _targetProperties;
+
         public void Flush()
         {
             _modules = null;
@@ -117,7 +120,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
 
         public bool ReadVirtual(ClrDataAddress cda, IntPtr buffer, int bytesRequested, out int bytesRead)
         {
-            ulong address = cda;
+            ulong address = cda.ToAddress(TargetProperties);
             Span<byte> span = new(buffer.ToPointer(), bytesRequested);
 
             if (address == MagicCallbackConstant && _callbackContext > 0)

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/DacDataTargetCOM.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/DacDataTargetCOM.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #if NET6_0_OR_GREATER

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/DacDataTargetCOM.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/DacDataTargetCOM.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #if NET6_0_OR_GREATER
@@ -91,9 +91,9 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
                 vtblRaw[2] = release;
                 vtblRaw[3] = (IntPtr)(delegate* unmanaged<IntPtr, IMAGE_FILE_MACHINE*, int>)&GetMachineType;
                 vtblRaw[4] = (IntPtr)(delegate* unmanaged<IntPtr, int*, int>)&GetPointerSize;
-                vtblRaw[5] = (IntPtr)(delegate* unmanaged<IntPtr, IntPtr, ulong*, int>)&GetImageBase;
-                vtblRaw[6] = (IntPtr)(delegate* unmanaged<IntPtr, ulong, IntPtr, int, int*, int>)&ReadVirtual;
-                vtblRaw[7] = (IntPtr)(delegate* unmanaged<IntPtr, ulong, IntPtr, uint, uint*, int>)&WriteVirtual;
+                vtblRaw[5] = (IntPtr)(delegate* unmanaged<IntPtr, IntPtr, ulong* /*ClrDataAddress*/, int>)&GetImageBase;
+                vtblRaw[6] = (IntPtr)(delegate* unmanaged<IntPtr, ulong /*ClrDataAddress*/, IntPtr, int, int*, int>)&ReadVirtual;
+                vtblRaw[7] = (IntPtr)(delegate* unmanaged<IntPtr, ulong /*ClrDataAddress*/, IntPtr, uint, uint*, int>)&WriteVirtual;
                 vtblRaw[8] = (IntPtr)(delegate* unmanaged<IntPtr, uint, uint, ulong*, int>)&GetTLSValue;
                 vtblRaw[9] = (IntPtr)(delegate* unmanaged<IntPtr, uint, uint, ulong, int>)&SetTLSValue;
                 vtblRaw[10] = (IntPtr)(delegate* unmanaged<IntPtr, uint*, int>)&GetCurrentThreadID;
@@ -140,7 +140,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             {
                 DacDataTarget dacDataTarget = ComInterfaceDispatch.GetInstance<DacDataTarget>((ComInterfaceDispatch*)self);
 
-                bool result = dacDataTarget.ReadVirtual(address, buffer, bytesRequested, out int bytesRead);
+                bool result = dacDataTarget.ReadVirtual(ClrDataAddress.FromInteropAddress(address), buffer, bytesRequested, out int bytesRead);
                 *pBytesRead = bytesRead;
                 return result ? HResult.S_OK : HResult.E_FAIL;
             }
@@ -227,7 +227,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
                 vtblRaw[0] = qi;
                 vtblRaw[1] = addRef;
                 vtblRaw[2] = release;
-                vtblRaw[3] = (IntPtr)(delegate* unmanaged<IntPtr, ulong*, int>)&GetRuntimeBase;
+                vtblRaw[3] = (IntPtr)(delegate* unmanaged<IntPtr, ulong* /*ClrDataAddress*/, int>)&GetRuntimeBase;
 
                 return (IntPtr)vtblRaw;
             }
@@ -253,7 +253,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
                 vtblRaw[0] = qi;
                 vtblRaw[1] = addRef;
                 vtblRaw[2] = release;
-                vtblRaw[3] = (IntPtr)(delegate* unmanaged<IntPtr, ulong*, int>)&GetContractDescriptor;
+                vtblRaw[3] = (IntPtr)(delegate* unmanaged<IntPtr, ulong* /*ClrDataAddress*/, int>)&GetContractDescriptor;
 
                 return (IntPtr)vtblRaw;
             }

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/ISOSDac13.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/ISOSDac13.cs
@@ -15,6 +15,6 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
         string[] GetLoaderAllocatorHeapNames();
         (ClrDataAddress Address, SOSDac13.LoaderHeapKind Kind)[] GetLoaderAllocatorHeaps(ClrDataAddress loaderAllocator);
         bool LockedFlush();
-        HResult TraverseLoaderHeap(ulong heap, SOSDac13.LoaderHeapKind kind, SOSDac.LoaderHeapTraverse callback);
+        HResult TraverseLoaderHeap(ClrDataAddress heap, SOSDac13.LoaderHeapKind kind, SOSDac.LoaderHeapTraverse callback);
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/SOSDac12.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/SOSDac12.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/SOSDac12.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/SOSDac12.cs
@@ -15,12 +15,12 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
     {
         internal static readonly Guid IID_ISOSDac12 = new("1b93bacc-8ca4-432d-943a-3e6e7ec0b0a3");
 
-        private readonly DacLibrary _library;
+        private readonly TargetProperties _target;
 
         public SosDac12(DacLibrary library, IntPtr ptr)
-            : base(library?.OwningLibrary, IID_ISOSDac12, ptr)
+            : base(library.OwningLibrary, IID_ISOSDac12, ptr)
         {
-            _library = library ?? throw new ArgumentNullException(nameof(library));
+            _target = library.TargetProperties;
         }
 
         private ref readonly ISOSDac12VTable VTable => ref Unsafe.AsRef<ISOSDac12VTable>(_vtable);
@@ -28,8 +28,8 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
         public HResult GetGlobalAllocationContext(out ulong allocPtr, out ulong allocLimit)
         {
             HResult hr = VTable.GetGlobalAllocationContext(Self, out ClrDataAddress allocPtrCda, out ClrDataAddress allocLimitCda);
-            allocPtr = allocPtrCda.ToAddress(_library.TargetProperties);
-            allocLimit = allocLimitCda.ToAddress(_library.TargetProperties);
+            allocPtr = allocPtrCda.ToAddress(_target);
+            allocLimit = allocLimitCda.ToAddress(_target);
             return hr;
         }
 

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/SOSDac12.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/SOSDac12.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -15,22 +15,28 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
     {
         internal static readonly Guid IID_ISOSDac12 = new("1b93bacc-8ca4-432d-943a-3e6e7ec0b0a3");
 
+        private readonly DacLibrary _library;
+
         public SosDac12(DacLibrary library, IntPtr ptr)
             : base(library?.OwningLibrary, IID_ISOSDac12, ptr)
         {
+            _library = library ?? throw new ArgumentNullException(nameof(library));
         }
 
         private ref readonly ISOSDac12VTable VTable => ref Unsafe.AsRef<ISOSDac12VTable>(_vtable);
 
         public HResult GetGlobalAllocationContext(out ulong allocPtr, out ulong allocLimit)
         {
-            return VTable.GetGlobalAllocationContext(Self, out allocPtr, out allocLimit);
+            HResult hr = VTable.GetGlobalAllocationContext(Self, out ClrDataAddress allocPtrCda, out ClrDataAddress allocLimitCda);
+            allocPtr = allocPtrCda.ToAddress(_library.TargetProperties);
+            allocLimit = allocLimitCda.ToAddress(_library.TargetProperties);
+            return hr;
         }
 
         [StructLayout(LayoutKind.Sequential)]
         private readonly unsafe struct ISOSDac12VTable
         {
-            public readonly delegate* unmanaged[Stdcall]<IntPtr, out ulong, out ulong, int> GetGlobalAllocationContext;
+            public readonly delegate* unmanaged[Stdcall]<IntPtr, out ClrDataAddress, out ClrDataAddress, int> GetGlobalAllocationContext;
         }
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/SOSDac13Old.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/SOSDac13Old.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/SOSDac13Old.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/SOSDac13Old.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
         internal static readonly Guid IID_ISOSDac13 = new("3176a8ed-597b-4f54-a71f-83695c6a8c5d");
 
         public SOSDac13Old(DacLibrary library, IntPtr ptr)
-            : base(library?.OwningLibrary, IID_ISOSDac13, ptr)
+            : base(library.OwningLibrary, IID_ISOSDac13, ptr)
         {
         }
 

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/SOSDac13Old.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/SOSDac13Old.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -34,10 +34,10 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
         public ClrDataAddress GetDomainLoaderAllocator(ClrDataAddress domainAddress)
         {
             if (domainAddress.IsNull)
-                return default;
+                return ClrDataAddress.Null;
 
             HResult hr = VTable.GetDomainLoaderAllocator(Self, domainAddress.ToInteropAddress(), out ClrDataAddress loaderAllocator);
-            return hr ? loaderAllocator : default;
+            return hr ? loaderAllocator : ClrDataAddress.Null;
         }
 
         public string[] GetLoaderAllocatorHeapNames()

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/SOSDac13Old.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/SOSDac13Old.cs
@@ -24,20 +24,20 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
 
         private ref readonly ISOSDac13VTable VTable => ref Unsafe.AsRef<ISOSDac13VTable>(_vtable);
 
-        public HResult TraverseLoaderHeap(ulong heap, LoaderHeapKind kind, LoaderHeapTraverse callback)
+        public HResult TraverseLoaderHeap(ClrDataAddress heap, LoaderHeapKind kind, LoaderHeapTraverse callback)
         {
-            HResult hr = VTable.TraverseLoaderHeap(Self, heap, kind, Marshal.GetFunctionPointerForDelegate(callback));
+            HResult hr = VTable.TraverseLoaderHeap(Self, heap.ToInteropAddress(), kind, Marshal.GetFunctionPointerForDelegate(callback));
             GC.KeepAlive(callback);
             return hr;
         }
 
         public ClrDataAddress GetDomainLoaderAllocator(ClrDataAddress domainAddress)
         {
-            if (domainAddress == 0)
-                return 0;
+            if (domainAddress.IsNull)
+                return default;
 
-            HResult hr = VTable.GetDomainLoaderAllocator(Self, domainAddress, out ClrDataAddress loaderAllocator);
-            return hr ? loaderAllocator : 0;
+            HResult hr = VTable.GetDomainLoaderAllocator(Self, domainAddress.ToInteropAddress(), out ClrDataAddress loaderAllocator);
+            return hr ? loaderAllocator : default;
         }
 
         public string[] GetLoaderAllocatorHeapNames()
@@ -64,9 +64,9 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
 
         public (ClrDataAddress Address, LoaderHeapKind Kind)[] GetLoaderAllocatorHeaps(ClrDataAddress loaderAllocator)
         {
-            if (loaderAllocator != 0)
+            if (!loaderAllocator.IsNull)
             {
-                HResult hr = VTable.GetLoaderAllocatorHeaps(Self, loaderAllocator, 0, null, null, out int needed);
+                HResult hr = VTable.GetLoaderAllocatorHeaps(Self, loaderAllocator.ToInteropAddress(), 0, null, null, out int needed);
 
                 if (hr && needed > 0)
                 {
@@ -76,7 +76,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
                     fixed (ClrDataAddress* ptrAddresses = addresses)
                     fixed (LoaderHeapKind* ptrKinds = kinds)
                     {
-                        if (hr = VTable.GetLoaderAllocatorHeaps(Self, loaderAllocator, addresses.Length, ptrAddresses, ptrKinds, out _))
+                        if (hr = VTable.GetLoaderAllocatorHeaps(Self, loaderAllocator.ToInteropAddress(), addresses.Length, ptrAddresses, ptrKinds, out _))
                         {
                             (ClrDataAddress, LoaderHeapKind)[] result = new (ClrDataAddress, LoaderHeapKind)[needed];
                             for (int i = 0; i < needed; i++)
@@ -99,10 +99,10 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
         [StructLayout(LayoutKind.Sequential)]
         private readonly unsafe struct ISOSDac13VTable
         {
-            public readonly delegate* unmanaged[Stdcall]<nint, ClrDataAddress, LoaderHeapKind, nint, int> TraverseLoaderHeap;
-            public readonly delegate* unmanaged[Stdcall]<nint, ClrDataAddress, out ClrDataAddress, int> GetDomainLoaderAllocator;
+            public readonly delegate* unmanaged[Stdcall]<nint, ulong /*ClrDataAddress*/, LoaderHeapKind, nint, int> TraverseLoaderHeap;
+            public readonly delegate* unmanaged[Stdcall]<nint, ulong /*ClrDataAddress*/, out ClrDataAddress, int> GetDomainLoaderAllocator;
             public readonly delegate* unmanaged[Stdcall]<nint, int, nint*, out int, int> GetLoaderAllocatorHeapNames;
-            public readonly delegate* unmanaged[Stdcall]<nint, ClrDataAddress, int, ClrDataAddress*, LoaderHeapKind*, out int, int> GetLoaderAllocatorHeaps;
+            public readonly delegate* unmanaged[Stdcall]<nint, ulong /*ClrDataAddress*/, int, ClrDataAddress*, LoaderHeapKind*, out int, int> GetLoaderAllocatorHeaps;
         }
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/SosDac.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/SosDac.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/SosDac.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/SosDac.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -111,7 +111,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             if (hr)
                 return thread;
 
-            return default;
+            return ClrDataAddress.Null;
         }
 
         public string? GetMethodDescName(ClrDataAddress md)
@@ -161,13 +161,13 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
         public ClrDataAddress GetMethodTableSlot(ClrDataAddress mt, uint slot)
         {
             if (mt.IsNull)
-                return default;
+                return ClrDataAddress.Null;
 
             HResult hr = VTable.GetMethodTableSlot(Self, mt.ToInteropAddress(), slot, out ClrDataAddress ip);
             if (hr)
                 return ip;
 
-            return default;
+            return ClrDataAddress.Null;
         }
 
         public HResult GetThreadLocalModuleData(ClrDataAddress thread, uint index, out ThreadLocalModuleData data)
@@ -181,7 +181,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             if (hr)
                 return result;
 
-            return default;
+            return ClrDataAddress.Null;
         }
 
         public COMInterfacePointerData[]? GetCCWInterfaces(ClrDataAddress ccw, int count)
@@ -261,7 +261,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             if (hr)
                 return data;
 
-            return default;
+            return ClrDataAddress.Null;
         }
 
         public ClrDataAddress GetMethodDescPtrFromIP(ClrDataAddress frame)
@@ -270,7 +270,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             if (hr)
                 return data;
 
-            return default;
+            return ClrDataAddress.Null;
         }
 
         public string GetFrameName(ClrDataAddress vtable)
@@ -545,7 +545,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             if (hr)
                 return data;
 
-            return default;
+            return ClrDataAddress.Null;
         }
 
         public HResult GetModuleData(ClrDataAddress module, out ModuleData data)
@@ -782,7 +782,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             if (hr)
                 return md;
 
-            return default;
+            return ClrDataAddress.Null;
         }
         private delegate HResult DacGetJitManagerInfo(IntPtr self, ClrDataAddress addr, out JitManagerData data);
     }

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/SosDac.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/SosDac.cs
@@ -28,10 +28,10 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
         // CLRDATA_REQUEST_REVISION version from the DAC
         public int DacVersion { get; set; }
 
-        public SOSDac(DacLibrary? library, IntPtr ptr)
-            : base(library?.OwningLibrary, IID_ISOSDac, ptr)
+        public SOSDac(DacLibrary library, IntPtr ptr)
+            : base(library.OwningLibrary, IID_ISOSDac, ptr)
         {
-            _library = library ?? throw new ArgumentNullException(nameof(library));
+            _library = library;
         }
 
         private ref readonly ISOSDacVTable VTable => ref Unsafe.AsRef<ISOSDacVTable>(_vtable);

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/SosDac.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/SosDac.cs
@@ -820,7 +820,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
 
         // MethodDescs
 
-        public readonly delegate* unmanaged[Stdcall]<IntPtr, ulong /*ClrDataAddress*/, ulong, out MethodDescData, int, RejitData[]?, out int, int> GetMethodDescData;
+        public readonly delegate* unmanaged[Stdcall]<IntPtr, ulong /*ClrDataAddress*/, ulong /*ClrDataAddress*/, out MethodDescData, int, RejitData[]?, out int, int> GetMethodDescData;
         public readonly delegate* unmanaged[Stdcall]<IntPtr, ulong /*ClrDataAddress*/, out ClrDataAddress, int> GetMethodDescPtrFromIP;
         public readonly delegate* unmanaged[Stdcall]<IntPtr, ulong /*ClrDataAddress*/, int, byte*, out int, int> GetMethodDescName;
         public readonly delegate* unmanaged[Stdcall]<IntPtr, ulong /*ClrDataAddress*/, out ClrDataAddress, int> GetMethodDescPtrFromFrame;
@@ -885,7 +885,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
 
         // SyncBlock
         public readonly delegate* unmanaged[Stdcall]<IntPtr, int, out SyncBlockData, int> GetSyncBlockData;
-        public readonly delegate* unmanaged[Stdcall]<IntPtr, ulong, out SyncBlockCleanupData, int> GetSyncBlockCleanupData;
+        public readonly delegate* unmanaged[Stdcall]<IntPtr, ulong /*ClrDataAddress*/, out SyncBlockCleanupData, int> GetSyncBlockCleanupData;
 
         // Handles
         public readonly delegate* unmanaged[Stdcall]<IntPtr, out IntPtr, int> GetHandleEnum;

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/SosDac.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/SosDac.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
 
         private readonly DacLibrary _library;
         private volatile Dictionary<int, string>? _regNames;
-        private volatile Dictionary<ulong, string>? _frameNames;
+        private volatile Dictionary<ClrDataAddress, string>? _frameNames;
 
         // CLRDATA_REQUEST_REVISION version from the DAC
         public int DacVersion { get; set; }
@@ -41,13 +41,13 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             _library = lib;
         }
 
-        public RejitData[] GetRejitData(ulong md, ulong ip = 0)
+        public RejitData[] GetRejitData(ClrDataAddress md, ClrDataAddress ip = default)
         {
-            HResult hr = VTable.GetMethodDescData(Self, md, ip, out _, 0, null, out int needed);
+            HResult hr = VTable.GetMethodDescData(Self, md.ToInteropAddress(), ip.ToInteropAddress(), out _, 0, null, out int needed);
             if (hr && needed >= 1)
             {
                 RejitData[] result = new RejitData[needed];
-                hr = VTable.GetMethodDescData(Self, md, ip, out _, result.Length, result, out _);
+                hr = VTable.GetMethodDescData(Self, md.ToInteropAddress(), ip.ToInteropAddress(), out _, result.Length, result, out _);
                 if (hr)
                     return result;
             }
@@ -55,9 +55,9 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             return Array.Empty<RejitData>();
         }
 
-        public HResult GetMethodDescData(ulong md, ulong ip, out MethodDescData data)
+        public HResult GetMethodDescData(ClrDataAddress md, ClrDataAddress ip, out MethodDescData data)
         {
-            return VTable.GetMethodDescData(Self, md, ip, out data, 0, null, out _);
+            return VTable.GetMethodDescData(Self, md.ToInteropAddress(), ip.ToInteropAddress(), out data, 0, null, out _);
         }
 
         public HResult GetThreadStoreData(out ThreadStoreData data)
@@ -114,12 +114,12 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             return default;
         }
 
-        public string? GetMethodDescName(ulong md)
+        public string? GetMethodDescName(ClrDataAddress md)
         {
-            if (md == 0)
+            if (md.IsNull)
                 return null;
 
-            HResult hr = VTable.GetMethodDescName(Self, md, 0, null, out int needed);
+            HResult hr = VTable.GetMethodDescName(Self, md.ToInteropAddress(), 0, null, out int needed);
             if (!hr)
                 return null;
 
@@ -129,7 +129,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
                 int actuallyNeeded;
                 fixed (byte* bufferPtr = buffer)
                 {
-                    hr = VTable.GetMethodDescName(Self, md, needed, bufferPtr, out actuallyNeeded);
+                    hr = VTable.GetMethodDescName(Self, md.ToInteropAddress(), needed, bufferPtr, out actuallyNeeded);
                     if (!hr)
                         return null;
                 }
@@ -144,7 +144,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
                     buffer = ArrayPool<byte>.Shared.Rent(actuallyNeeded * sizeof(char));
                     fixed (byte* bufferPtr = buffer)
                     {
-                        hr = VTable.GetMethodDescName(Self, md, actuallyNeeded, bufferPtr, out actuallyNeeded);
+                        hr = VTable.GetMethodDescName(Self, md.ToInteropAddress(), actuallyNeeded, bufferPtr, out actuallyNeeded);
                         if (!hr)
                             return null;
                     }
@@ -158,38 +158,38 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             }
         }
 
-        public ulong GetMethodTableSlot(ulong mt, uint slot)
+        public ClrDataAddress GetMethodTableSlot(ClrDataAddress mt, uint slot)
         {
-            if (mt == 0)
-                return 0;
+            if (mt.IsNull)
+                return default;
 
-            HResult hr = VTable.GetMethodTableSlot(Self, mt, slot, out ClrDataAddress ip);
+            HResult hr = VTable.GetMethodTableSlot(Self, mt.ToInteropAddress(), slot, out ClrDataAddress ip);
             if (hr)
                 return ip;
 
-            return 0;
+            return default;
         }
 
-        public HResult GetThreadLocalModuleData(ulong thread, uint index, out ThreadLocalModuleData data)
+        public HResult GetThreadLocalModuleData(ClrDataAddress thread, uint index, out ThreadLocalModuleData data)
         {
-            return VTable.GetThreadLocalModuleData(Self, thread, index, out data);
+            return VTable.GetThreadLocalModuleData(Self, thread.ToInteropAddress(), index, out data);
         }
 
-        public ulong GetILForModule(ulong moduleAddr, uint rva)
+        public ClrDataAddress GetILForModule(ClrDataAddress moduleAddr, uint rva)
         {
-            HResult hr = VTable.GetILForModule(Self, moduleAddr, rva, out ClrDataAddress result);
+            HResult hr = VTable.GetILForModule(Self, moduleAddr.ToInteropAddress(), rva, out ClrDataAddress result);
             if (hr)
                 return result;
 
-            return 0;
+            return default;
         }
 
-        public COMInterfacePointerData[]? GetCCWInterfaces(ulong ccw, int count)
+        public COMInterfacePointerData[]? GetCCWInterfaces(ClrDataAddress ccw, int count)
         {
             COMInterfacePointerData[] data = new COMInterfacePointerData[count];
             fixed (COMInterfacePointerData* ptr = data)
             {
-                HResult hr = VTable.GetCCWInterfaces(Self, ccw, count, ptr, out int pNeeded);
+                HResult hr = VTable.GetCCWInterfaces(Self, ccw.ToInteropAddress(), count, ptr, out int pNeeded);
                 if (hr)
                     return data;
             }
@@ -197,12 +197,12 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             return null;
         }
 
-        public COMInterfacePointerData[]? GetRCWInterfaces(ulong ccw, int count)
+        public COMInterfacePointerData[]? GetRCWInterfaces(ClrDataAddress ccw, int count)
         {
             COMInterfacePointerData[] data = new COMInterfacePointerData[count];
             fixed (COMInterfacePointerData* ptr = data)
             {
-                HResult hr = VTable.GetRCWInterfaces(Self, ccw, count, ptr, out int pNeeded);
+                HResult hr = VTable.GetRCWInterfaces(Self, ccw.ToInteropAddress(), count, ptr, out int pNeeded);
                 if (hr)
                     return data;
             }
@@ -210,19 +210,19 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             return null;
         }
 
-        public HResult GetDomainLocalModuleDataFromModule(ulong module, out DomainLocalModuleData data)
+        public HResult GetDomainLocalModuleDataFromModule(ClrDataAddress module, out DomainLocalModuleData data)
         {
-            return VTable.GetDomainLocalModuleDataFromModule(Self, module, out data);
+            return VTable.GetDomainLocalModuleDataFromModule(Self, module.ToInteropAddress(), out data);
         }
 
-        public HResult GetDomainLocalModuleDataFromAppDomain(ulong appDomain, int id, out DomainLocalModuleData data)
+        public HResult GetDomainLocalModuleDataFromAppDomain(ClrDataAddress appDomain, int id, out DomainLocalModuleData data)
         {
-            return VTable.GetDomainLocalModuleDataFromAppDomain(Self, appDomain, id, out data);
+            return VTable.GetDomainLocalModuleDataFromAppDomain(Self, appDomain.ToInteropAddress(), id, out data);
         }
 
-        public HResult GetWorkRequestData(ulong request, out WorkRequestData data)
+        public HResult GetWorkRequestData(ClrDataAddress request, out WorkRequestData data)
         {
-            return VTable.GetWorkRequestData(Self, request, out data);
+            return VTable.GetWorkRequestData(Self, request.ToInteropAddress(), out data);
         }
 
         public HResult GetThreadPoolData(out ThreadPoolData data)
@@ -235,47 +235,47 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             return VTable.GetSyncBlockData(Self, index, out data);
         }
 
-        public string? GetAppBase(ulong domain)
+        public string? GetAppBase(ClrDataAddress domain)
         {
             return GetString(VTable.GetApplicationBase, domain);
         }
 
-        public string? GetConfigFile(ulong domain)
+        public string? GetConfigFile(ClrDataAddress domain)
         {
             return GetString(VTable.GetAppDomainConfigFile, domain);
         }
 
-        public HResult GetCodeHeaderData(ulong ip, out CodeHeaderData codeHeaderData)
+        public HResult GetCodeHeaderData(ClrDataAddress ip, out CodeHeaderData codeHeaderData)
         {
-            if (ip == 0)
+            if (ip.IsNull)
             {
                 codeHeaderData = default;
                 return HResult.E_INVALIDARG;
             }
-            return VTable.GetCodeHeaderData(Self, ip, out codeHeaderData);
+            return VTable.GetCodeHeaderData(Self, ip.ToInteropAddress(), out codeHeaderData);
         }
 
-        public ClrDataAddress GetMethodDescPtrFromFrame(ulong frame)
+        public ClrDataAddress GetMethodDescPtrFromFrame(ClrDataAddress frame)
         {
-            HResult hr = VTable.GetMethodDescPtrFromFrame(Self, frame, out ClrDataAddress data);
+            HResult hr = VTable.GetMethodDescPtrFromFrame(Self, frame.ToInteropAddress(), out ClrDataAddress data);
             if (hr)
                 return data;
 
             return default;
         }
 
-        public ClrDataAddress GetMethodDescPtrFromIP(ulong frame)
+        public ClrDataAddress GetMethodDescPtrFromIP(ClrDataAddress frame)
         {
-            HResult hr = VTable.GetMethodDescPtrFromIP(Self, frame, out ClrDataAddress data);
+            HResult hr = VTable.GetMethodDescPtrFromIP(Self, frame.ToInteropAddress(), out ClrDataAddress data);
             if (hr)
                 return data;
 
             return default;
         }
 
-        public string GetFrameName(ulong vtable)
+        public string GetFrameName(ClrDataAddress vtable)
         {
-            Dictionary<ulong, string> frameNames = _frameNames ??= new();
+            Dictionary<ClrDataAddress, string> frameNames = _frameNames ??= new();
             lock (frameNames)
             {
                 if (_frameNames.TryGetValue(vtable, out string? cached))
@@ -296,40 +296,40 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             return "Unknown Frame";
         }
 
-        public HResult GetFieldInfo(ulong mt, out MethodTableFieldInfo data)
+        public HResult GetFieldInfo(ClrDataAddress mt, out MethodTableFieldInfo data)
         {
-            if (mt == 0)
+            if (mt.IsNull)
             {
                 data = default;
                 return HResult.E_INVALIDARG;
             }
 
-            return VTable.GetMethodTableFieldData(Self, mt, out data);
+            return VTable.GetMethodTableFieldData(Self, mt.ToInteropAddress(), out data);
         }
 
-        public HResult GetFieldData(ulong fieldDesc, out FieldData data)
+        public HResult GetFieldData(ClrDataAddress fieldDesc, out FieldData data)
         {
-            return VTable.GetFieldDescData(Self, fieldDesc, out data);
+            return VTable.GetFieldDescData(Self, fieldDesc.ToInteropAddress(), out data);
         }
 
-        public HResult GetObjectData(ulong obj, out ObjectData data)
+        public HResult GetObjectData(ClrDataAddress obj, out ObjectData data)
         {
-            return VTable.GetObjectData(Self, obj, out data);
+            return VTable.GetObjectData(Self, obj.ToInteropAddress(), out data);
         }
 
-        public HResult GetCCWData(ulong ccw, out CcwData data)
+        public HResult GetCCWData(ClrDataAddress ccw, out CcwData data)
         {
-            return VTable.GetCCWData(Self, ccw, out data);
+            return VTable.GetCCWData(Self, ccw.ToInteropAddress(), out data);
         }
 
-        public HResult GetRCWData(ulong rcw, out RcwData data)
+        public HResult GetRCWData(ClrDataAddress rcw, out RcwData data)
         {
-            return VTable.GetRCWData(Self, rcw, out data);
+            return VTable.GetRCWData(Self, rcw.ToInteropAddress(), out data);
         }
 
-        public IEnumerable<(ulong Rcw, ulong Context, ulong Thread, bool IsFreeThreaded)> EnumerateRCWCleanup(ulong cleanupList)
+        public IEnumerable<(ClrDataAddress Rcw, ClrDataAddress Context, ClrDataAddress Thread, bool IsFreeThreaded)> EnumerateRCWCleanup(ClrDataAddress cleanupList)
         {
-            List<(ulong, ulong, ulong, bool)> result = new();
+            List<(ClrDataAddress, ClrDataAddress, ClrDataAddress, bool)> result = new();
             RcwCleanupTraverse traverse = (rcw, context, thread, freeThreaded, token) =>
             {
                 result.Add((rcw, context, thread, freeThreaded != 0));
@@ -337,37 +337,37 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
                 return result.Count > 16384 ? 0 : 1u;
             };
 
-            VTable.TraverseRCWCleanupList(Self, cleanupList, Marshal.GetFunctionPointerForDelegate(traverse), 0);
+            VTable.TraverseRCWCleanupList(Self, cleanupList.ToInteropAddress(), Marshal.GetFunctionPointerForDelegate(traverse), 0);
 
             GC.KeepAlive(traverse);
             return result;
         }
 
-        public HResult GetSyncBlockCleanupData(ulong syncBlockCleanupPointer, out SyncBlockCleanupData data)
+        public HResult GetSyncBlockCleanupData(ClrDataAddress syncBlockCleanupPointer, out SyncBlockCleanupData data)
         {
-            return VTable.GetSyncBlockCleanupData(Self, syncBlockCleanupPointer, out data);
+            return VTable.GetSyncBlockCleanupData(Self, syncBlockCleanupPointer.ToInteropAddress(), out data);
         }
 
         public delegate uint RcwCleanupTraverse(ClrDataAddress rcw, ClrDataAddress context, ClrDataAddress thread, uint isFreeThreaded, IntPtr token);
 
-        public ClrDataModule? GetClrDataModule(ulong module)
+        public ClrDataModule? GetClrDataModule(ClrDataAddress module)
         {
-            if (module == 0)
+            if (module.IsNull)
                 return null;
 
-            HResult hr = VTable.GetModule(Self, module, out IntPtr iunk);
+            HResult hr = VTable.GetModule(Self, module.ToInteropAddress(), out IntPtr iunk);
             if (hr)
                 return new ClrDataModule(_library, iunk);
 
             return null;
         }
 
-        public MetadataImport? GetMetadataImport(ulong module)
+        public MetadataImport? GetMetadataImport(ClrDataAddress module)
         {
-            if (module == 0)
+            if (module.IsNull)
                 return null;
 
-            HResult hr = VTable.GetModule(Self, module, out IntPtr iunk);
+            HResult hr = VTable.GetModule(Self, module.ToInteropAddress(), out IntPtr iunk);
             if (!hr)
                 return null;
 
@@ -394,42 +394,42 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             return VTable.GetUsefulGlobals(Self, out commonMTs);
         }
 
-        public ClrDataAddress[] GetAssemblyList(ulong appDomain) => GetAssemblyList(appDomain, 0);
+        public ClrDataAddress[] GetAssemblyList(ClrDataAddress appDomain) => GetAssemblyList(appDomain, 0);
 
-        public ClrDataAddress[] GetAssemblyList(ulong appDomain, int count) => GetModuleOrAssembly(appDomain, count, VTable.GetAssemblyList);
+        public ClrDataAddress[] GetAssemblyList(ClrDataAddress appDomain, int count) => GetModuleOrAssembly(appDomain, count, VTable.GetAssemblyList);
 
-        public ClrDataAddress[] GetModuleList(ulong assembly) => GetModuleList(assembly, 0);
+        public ClrDataAddress[] GetModuleList(ClrDataAddress assembly) => GetModuleList(assembly, 0);
 
-        public ClrDataAddress[] GetModuleList(ulong assembly, int count) => GetModuleOrAssembly(assembly, count, VTable.GetAssemblyModuleList);
+        public ClrDataAddress[] GetModuleList(ClrDataAddress assembly, int count) => GetModuleOrAssembly(assembly, count, VTable.GetAssemblyModuleList);
 
-        public HResult GetAssemblyData(ulong domain, ulong assembly, out AssemblyData data)
+        public HResult GetAssemblyData(ClrDataAddress domain, ClrDataAddress assembly, out AssemblyData data)
         {
             // The dac seems to have an issue where the assembly data can be filled in for a minidump.
             // If the data is partially filled in, we'll use it.
 
-            HResult hr = VTable.GetAssemblyData(Self, domain, assembly, out data);
+            HResult hr = VTable.GetAssemblyData(Self, domain.ToInteropAddress(), assembly.ToInteropAddress(), out data);
             if (!hr && data.Address == assembly)
                 return HResult.S_FALSE;
 
             return hr;
         }
 
-        public HResult GetAppDomainData(ulong addr, out AppDomainData data)
+        public HResult GetAppDomainData(ClrDataAddress addr, out AppDomainData data)
         {
             // We can face an exception while walking domain data if we catch the process
             // at a bad state.  As a workaround we will return partial data if data.Address
             // and data.StubHeap are set.
 
-            HResult hr = VTable.GetAppDomainData(Self, addr, out data);
-            if (!hr && data.Address == addr && data.StubHeap != 0)
+            HResult hr = VTable.GetAppDomainData(Self, addr.ToInteropAddress(), out data);
+            if (!hr && data.Address == addr && !data.StubHeap.IsNull)
                 return HResult.S_FALSE;
 
             return hr;
         }
 
-        public string? GetAppDomainName(ulong appDomain)
+        public string? GetAppDomainName(ClrDataAddress appDomain)
         {
-            if (appDomain == 0)
+            if (appDomain.IsNull)
             {
                 return null;
             }
@@ -437,7 +437,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             return GetString(VTable.GetAppDomainName, appDomain);
         }
 
-        public string? GetAssemblyName(ulong assembly)
+        public string? GetAssemblyName(ClrDataAddress assembly)
         {
             return GetString(VTable.GetAssemblyName, assembly);
         }
@@ -447,35 +447,35 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             return VTable.GetAppDomainStoreData(Self, out data);
         }
 
-        public HResult GetMethodTableData(ulong addr, out MethodTableData data)
+        public HResult GetMethodTableData(ClrDataAddress addr, out MethodTableData data)
         {
             // If the 2nd bit is set it means addr is actually a TypeHandle (which GetMethodTable does not support).
-            if (addr == 0 || (addr & 2) == 2)
+            if (addr.IsNull || (addr.ToInteropAddress() & 2) == 2)
             {
                 data = default;
                 return HResult.E_INVALIDARG;
             }
-            return VTable.GetMethodTableData(Self, addr, out data);
+            return VTable.GetMethodTableData(Self, addr.ToInteropAddress(), out data);
         }
 
-        public string? GetMethodTableName(ulong mt)
+        public string? GetMethodTableName(ClrDataAddress mt)
         {
             return GetString(VTable.GetMethodTableName, mt);
         }
 
-        public string? GetJitHelperFunctionName(ulong addr)
+        public string? GetJitHelperFunctionName(ClrDataAddress addr)
         {
             return GetAsciiString(VTable.GetJitHelperFunctionName, addr);
         }
 
-        public string? GetPEFileName(ulong pefile)
+        public string? GetPEFileName(ClrDataAddress pefile)
         {
             return GetString(VTable.GetPEFileName, pefile);
         }
 
-        private string? GetString(delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, int, byte*, out int, int> func, ulong addr, bool skipNull = true)
+        private string? GetString(delegate* unmanaged[Stdcall]<IntPtr, ulong /*ClrDataAddress*/, int, byte*, out int, int> func, ClrDataAddress addr, bool skipNull = true)
         {
-            HResult hr = func(Self, addr, 0, null, out int needed);
+            HResult hr = func(Self, addr.ToInteropAddress(), 0, null, out int needed);
             if (!hr)
                 return null;
 
@@ -489,7 +489,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             try
             {
                 fixed (byte* bufferPtr = buffer)
-                    hr = func(Self, addr, needed, bufferPtr, out needed);
+                    hr = func(Self, addr.ToInteropAddress(), needed, bufferPtr, out needed);
 
                 if (!hr)
                     return null;
@@ -506,9 +506,9 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             }
         }
 
-        private string? GetAsciiString(delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, int, byte*, out int, int> func, ulong addr)
+        private string? GetAsciiString(delegate* unmanaged[Stdcall]<IntPtr, ulong /*ClrDataAddress*/, int, byte*, out int, int> func, ClrDataAddress addr)
         {
-            HResult hr = func(Self, addr, 0, null, out int needed);
+            HResult hr = func(Self, addr.ToInteropAddress(), 0, null, out int needed);
             if (!hr)
                 return null;
 
@@ -521,7 +521,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             try
             {
                 fixed (byte* bufferPtr = buffer)
-                    hr = func(Self, addr, needed, bufferPtr, out needed);
+                    hr = func(Self, addr.ToInteropAddress(), needed, bufferPtr, out needed);
 
                 if (!hr)
                     return null;
@@ -539,26 +539,26 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             }
         }
 
-        public ClrDataAddress GetMethodTableByEEClass(ulong eeclass)
+        public ClrDataAddress GetMethodTableByEEClass(ClrDataAddress eeclass)
         {
-            HResult hr = VTable.GetMethodTableForEEClass(Self, eeclass, out ClrDataAddress data);
+            HResult hr = VTable.GetMethodTableForEEClass(Self, eeclass.ToInteropAddress(), out ClrDataAddress data);
             if (hr)
                 return data;
 
             return default;
         }
 
-        public HResult GetModuleData(ulong module, out ModuleData data)
+        public HResult GetModuleData(ClrDataAddress module, out ModuleData data)
         {
-            return VTable.GetModuleData(Self, module, out data);
+            return VTable.GetModuleData(Self, module.ToInteropAddress(), out data);
         }
 
-        private ClrDataAddress[] GetModuleOrAssembly(ulong address, int count, delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, int, ClrDataAddress*, out int, int> func)
+        private ClrDataAddress[] GetModuleOrAssembly(ClrDataAddress address, int count, delegate* unmanaged[Stdcall]<IntPtr, ulong /*ClrDataAddress*/, int, ClrDataAddress*, out int, int> func)
         {
             int needed;
             if (count <= 0)
             {
-                if (func(Self, address, 0, null, out needed) < 0)
+                if (func(Self, address.ToInteropAddress(), 0, null, out needed) < 0)
                     return Array.Empty<ClrDataAddress>();
 
                 count = needed;
@@ -567,7 +567,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             // We ignore the return value here since the list may be partially filled
             ClrDataAddress[] modules = new ClrDataAddress[count];
             fixed (ClrDataAddress* ptr = modules)
-                func(Self, address, modules.Length, ptr, out needed);
+                func(Self, address.ToInteropAddress(), modules.Length, ptr, out needed);
 
             return modules;
         }
@@ -590,14 +590,14 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             }
         }
 
-        public HResult GetThreadData(ulong address, out ThreadData data)
+        public HResult GetThreadData(ClrDataAddress address, out ThreadData data)
         {
-            if (address == 0)
+            if (address.IsNull)
             {
                 data = default;
                 return HResult.E_INVALIDARG;
             }
-            return VTable.GetThreadData(Self, address, out data);
+            return VTable.GetThreadData(Self, address.ToInteropAddress(), out data);
         }
 
         public HResult GetGCHeapData(out GCInfo data)
@@ -607,15 +607,15 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
 
         public HResult GetOOMData(out DacOOMData oomData) => VTable.GetOOMStaticData(Self, out oomData);
 
-        public HResult GetOOMData(ulong address, out DacOOMData oomData) => VTable.GetOOMData(Self, address, out oomData);
+        public HResult GetOOMData(ClrDataAddress address, out DacOOMData oomData) => VTable.GetOOMData(Self, address.ToInteropAddress(), out oomData);
 
         public HResult GetHeapAnalyzeData(out DacHeapAnalyzeData analyzeData) => VTable.GetHeapAnalyzeStaticData(Self, out analyzeData);
 
-        public HResult GetHeapAnalyzeData(ulong address, out DacHeapAnalyzeData analyzeData) => VTable.GetHeapAnalyzeData(Self, address, out analyzeData);
+        public HResult GetHeapAnalyzeData(ClrDataAddress address, out DacHeapAnalyzeData analyzeData) => VTable.GetHeapAnalyzeData(Self, address.ToInteropAddress(), out analyzeData);
 
-        public HResult GetSegmentData(ulong addr, out SegmentData data)
+        public HResult GetSegmentData(ClrDataAddress addr, out SegmentData data)
         {
-            return VTable.GetHeapSegmentData(Self, addr, out data);
+            return VTable.GetHeapSegmentData(Self, addr.ToInteropAddress(), out data);
         }
 
         public ClrDataAddress[] GetHeapList(int heapCount)
@@ -628,9 +628,9 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             }
         }
 
-        public HResult GetServerHeapDetails(ulong addr, out HeapDetails data)
+        public HResult GetServerHeapDetails(ClrDataAddress addr, out HeapDetails data)
         {
-            return VTable.GetGCHeapDetails(Self, addr, out data);
+            return VTable.GetGCHeapDetails(Self, addr.ToInteropAddress(), out data);
         }
 
         public HResult GetWksHeapDetails(out HeapDetails data)
@@ -652,16 +652,16 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             }
         }
 
-        public JitCodeHeapInfo[] GetCodeHeapList(ulong jitManager)
+        public JitCodeHeapInfo[] GetCodeHeapList(ClrDataAddress jitManager)
         {
-            HResult hr = VTable.GetCodeHeapList(Self, jitManager, 0, null, out int needed);
+            HResult hr = VTable.GetCodeHeapList(Self, jitManager.ToInteropAddress(), 0, null, out int needed);
             if (!hr || needed == 0)
                 return Array.Empty<JitCodeHeapInfo>();
 
             JitCodeHeapInfo[] result = new JitCodeHeapInfo[needed];
             fixed (JitCodeHeapInfo* ptr = result)
             {
-                hr = VTable.GetCodeHeapList(Self, jitManager, result.Length, ptr, out needed);
+                hr = VTable.GetCodeHeapList(Self, jitManager.ToInteropAddress(), result.Length, ptr, out needed);
                 return hr ? result : Array.Empty<JitCodeHeapInfo>();
             }
         }
@@ -674,21 +674,21 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
 
         public delegate void ModuleMapTraverse(int index, ulong methodTable, IntPtr token);
 
-        public HResult TraverseModuleMap(ModuleMapTraverseKind mt, ulong module, ModuleMapTraverse traverse)
+        public HResult TraverseModuleMap(ModuleMapTraverseKind mt, ClrDataAddress module, ModuleMapTraverse traverse)
         {
-            if (module == 0)
+            if (module.IsNull)
                 return HResult.E_INVALIDARG;
 
-            HResult hr = VTable.TraverseModuleMap(Self, mt, module, Marshal.GetFunctionPointerForDelegate(traverse), IntPtr.Zero);
+            HResult hr = VTable.TraverseModuleMap(Self, mt, module.ToInteropAddress(), Marshal.GetFunctionPointerForDelegate(traverse), IntPtr.Zero);
             GC.KeepAlive(traverse);
             return hr;
         }
 
         public delegate void LoaderHeapTraverse(ulong address, IntPtr size, int isCurrent);
 
-        public HResult TraverseLoaderHeap(ulong heap, LoaderHeapTraverse callback)
+        public HResult TraverseLoaderHeap(ClrDataAddress heap, LoaderHeapTraverse callback)
         {
-            HResult hr = VTable.TraverseLoaderHeap(Self, heap, Marshal.GetFunctionPointerForDelegate(callback));
+            HResult hr = VTable.TraverseLoaderHeap(Self, heap.ToInteropAddress(), Marshal.GetFunctionPointerForDelegate(callback));
             GC.KeepAlive(callback);
             return hr;
         }
@@ -703,12 +703,12 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             VtableHeap
         }
 
-        public HResult TraverseStubHeap(ulong heap, VCSHeapType type, LoaderHeapTraverse callback)
+        public HResult TraverseStubHeap(ClrDataAddress heap, VCSHeapType type, LoaderHeapTraverse callback)
         {
-            if (heap == 0)
+            if (heap.IsNull)
                 return HResult.E_INVALIDARG;
 
-            HResult hr = VTable.TraverseVirtCallStubHeap(Self, heap, type, Marshal.GetFunctionPointerForDelegate(callback));
+            HResult hr = VTable.TraverseVirtCallStubHeap(Self, heap.ToInteropAddress(), type, Marshal.GetFunctionPointerForDelegate(callback));
             GC.KeepAlive(callback);
             return hr;
         }
@@ -776,13 +776,13 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             return null;
         }
 
-        public ulong GetMethodDescFromToken(ulong module, int token)
+        public ClrDataAddress GetMethodDescFromToken(ClrDataAddress module, int token)
         {
-            HResult hr = VTable.GetMethodDescFromToken(Self, module, token, out ClrDataAddress md);
+            HResult hr = VTable.GetMethodDescFromToken(Self, module.ToInteropAddress(), token, out ClrDataAddress md);
             if (hr)
                 return md;
 
-            return 0;
+            return default;
         }
         private delegate HResult DacGetJitManagerInfo(IntPtr self, ClrDataAddress addr, out JitManagerData data);
     }
@@ -796,92 +796,92 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
         // AppDomains
         public readonly delegate* unmanaged[Stdcall]<IntPtr, out AppDomainStoreData, int> GetAppDomainStoreData;
         public readonly delegate* unmanaged[Stdcall]<IntPtr, int, ClrDataAddress*, out int, int> GetAppDomainList;
-        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, out AppDomainData, int> GetAppDomainData;
-        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, int, byte*, out int, int> GetAppDomainName;
+        public readonly delegate* unmanaged[Stdcall]<IntPtr, ulong /*ClrDataAddress*/, out AppDomainData, int> GetAppDomainData;
+        public readonly delegate* unmanaged[Stdcall]<IntPtr, ulong /*ClrDataAddress*/, int, byte*, out int, int> GetAppDomainName;
         public readonly IntPtr GetDomainFromContext;
 
         // Assemblies
-        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, int, ClrDataAddress*, out int, int> GetAssemblyList;
-        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, ClrDataAddress, out AssemblyData, int> GetAssemblyData;
-        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, int, byte*, out int, int> GetAssemblyName;
+        public readonly delegate* unmanaged[Stdcall]<IntPtr, ulong /*ClrDataAddress*/, int, ClrDataAddress*, out int, int> GetAssemblyList;
+        public readonly delegate* unmanaged[Stdcall]<IntPtr, ulong /*ClrDataAddress*/, ulong /*ClrDataAddress*/, out AssemblyData, int> GetAssemblyData;
+        public readonly delegate* unmanaged[Stdcall]<IntPtr, ulong /*ClrDataAddress*/, int, byte*, out int, int> GetAssemblyName;
 
         // Modules
-        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, out IntPtr, int> GetModule;
-        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, out ModuleData, int> GetModuleData;
-        public readonly delegate* unmanaged[Stdcall]<IntPtr, SOSDac.ModuleMapTraverseKind, ClrDataAddress, IntPtr, IntPtr, int> TraverseModuleMap;
-        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, int, ClrDataAddress*, out int, int> GetAssemblyModuleList;
-        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, uint, out ClrDataAddress, int> GetILForModule;
+        public readonly delegate* unmanaged[Stdcall]<IntPtr, ulong /*ClrDataAddress*/, out IntPtr, int> GetModule;
+        public readonly delegate* unmanaged[Stdcall]<IntPtr, ulong /*ClrDataAddress*/, out ModuleData, int> GetModuleData;
+        public readonly delegate* unmanaged[Stdcall]<IntPtr, SOSDac.ModuleMapTraverseKind, ulong /*ClrDataAddress*/, IntPtr, IntPtr, int> TraverseModuleMap;
+        public readonly delegate* unmanaged[Stdcall]<IntPtr, ulong /*ClrDataAddress*/, int, ClrDataAddress*, out int, int> GetAssemblyModuleList;
+        public readonly delegate* unmanaged[Stdcall]<IntPtr, ulong /*ClrDataAddress*/, uint, out ClrDataAddress, int> GetILForModule;
 
         // Threads
 
-        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, out ThreadData, int> GetThreadData;
+        public readonly delegate* unmanaged[Stdcall]<IntPtr, ulong /*ClrDataAddress*/, out ThreadData, int> GetThreadData;
         public readonly delegate* unmanaged[Stdcall]<IntPtr, uint, out ClrDataAddress, int> GetThreadFromThinlockID;
         public readonly IntPtr GetStackLimits;
 
         // MethodDescs
 
-        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, ulong, out MethodDescData, int, RejitData[]?, out int, int> GetMethodDescData;
-        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, out ClrDataAddress, int> GetMethodDescPtrFromIP;
-        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, int, byte*, out int, int> GetMethodDescName;
-        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, out ClrDataAddress, int> GetMethodDescPtrFromFrame;
-        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, int, out ClrDataAddress, int> GetMethodDescFromToken;
+        public readonly delegate* unmanaged[Stdcall]<IntPtr, ulong /*ClrDataAddress*/, ulong, out MethodDescData, int, RejitData[]?, out int, int> GetMethodDescData;
+        public readonly delegate* unmanaged[Stdcall]<IntPtr, ulong /*ClrDataAddress*/, out ClrDataAddress, int> GetMethodDescPtrFromIP;
+        public readonly delegate* unmanaged[Stdcall]<IntPtr, ulong /*ClrDataAddress*/, int, byte*, out int, int> GetMethodDescName;
+        public readonly delegate* unmanaged[Stdcall]<IntPtr, ulong /*ClrDataAddress*/, out ClrDataAddress, int> GetMethodDescPtrFromFrame;
+        public readonly delegate* unmanaged[Stdcall]<IntPtr, ulong /*ClrDataAddress*/, int, out ClrDataAddress, int> GetMethodDescFromToken;
         private readonly IntPtr GetMethodDescTransparencyData;
 
         // JIT Data
-        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, out CodeHeaderData, int> GetCodeHeaderData;
+        public readonly delegate* unmanaged[Stdcall]<IntPtr, ulong /*ClrDataAddress*/, out CodeHeaderData, int> GetCodeHeaderData;
         public readonly delegate* unmanaged[Stdcall]<IntPtr, int, JitManagerData*, out int, int> GetJitManagerList;
-        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, int, byte*, out int, int> GetJitHelperFunctionName;
+        public readonly delegate* unmanaged[Stdcall]<IntPtr, ulong /*ClrDataAddress*/, int, byte*, out int, int> GetJitHelperFunctionName;
         private readonly IntPtr GetJumpThunkTarget;
 
         // ThreadPool
 
         public readonly delegate* unmanaged[Stdcall]<IntPtr, out ThreadPoolData, int> GetThreadpoolData;
-        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, out WorkRequestData, int> GetWorkRequestData;
+        public readonly delegate* unmanaged[Stdcall]<IntPtr, ulong /*ClrDataAddress*/, out WorkRequestData, int> GetWorkRequestData;
         private readonly IntPtr GetHillClimbingLogEntry;
 
         // Objects
-        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, out ObjectData, int> GetObjectData;
+        public readonly delegate* unmanaged[Stdcall]<IntPtr, ulong /*ClrDataAddress*/, out ObjectData, int> GetObjectData;
         public readonly IntPtr GetObjectStringData;
         public readonly IntPtr GetObjectClassName;
 
         // MethodTable
-        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, int, byte*, out int, int> GetMethodTableName;
-        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, out MethodTableData, int> GetMethodTableData;
-        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, uint, out ClrDataAddress, int> GetMethodTableSlot;
-        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, out MethodTableFieldInfo, int> GetMethodTableFieldData;
+        public readonly delegate* unmanaged[Stdcall]<IntPtr, ulong /*ClrDataAddress*/, int, byte*, out int, int> GetMethodTableName;
+        public readonly delegate* unmanaged[Stdcall]<IntPtr, ulong /*ClrDataAddress*/, out MethodTableData, int> GetMethodTableData;
+        public readonly delegate* unmanaged[Stdcall]<IntPtr, ulong /*ClrDataAddress*/, uint, out ClrDataAddress, int> GetMethodTableSlot;
+        public readonly delegate* unmanaged[Stdcall]<IntPtr, ulong /*ClrDataAddress*/, out MethodTableFieldInfo, int> GetMethodTableFieldData;
         private readonly IntPtr GetMethodTableTransparencyData;
 
         // EEClass
-        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, out ClrDataAddress, int> GetMethodTableForEEClass;
+        public readonly delegate* unmanaged[Stdcall]<IntPtr, ulong /*ClrDataAddress*/, out ClrDataAddress, int> GetMethodTableForEEClass;
 
         // FieldDesc
-        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, out FieldData, int> GetFieldDescData;
+        public readonly delegate* unmanaged[Stdcall]<IntPtr, ulong /*ClrDataAddress*/, out FieldData, int> GetFieldDescData;
 
         // Frames
-        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, int, byte*, out int, int> GetFrameName;
+        public readonly delegate* unmanaged[Stdcall]<IntPtr, ulong /*ClrDataAddress*/, int, byte*, out int, int> GetFrameName;
 
         // PEFiles
         public readonly IntPtr GetPEFileBase;
-        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, int, byte*, out int, int> GetPEFileName;
+        public readonly delegate* unmanaged[Stdcall]<IntPtr, ulong /*ClrDataAddress*/, int, byte*, out int, int> GetPEFileName;
 
         // GC
         public readonly delegate* unmanaged[Stdcall]<IntPtr, out GCInfo, int> GetGCHeapData;
         public readonly delegate* unmanaged[Stdcall]<IntPtr, int, ClrDataAddress*, out int, int> GetGCHeapList; // svr only
-        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, out HeapDetails, int> GetGCHeapDetails; // wks only
+        public readonly delegate* unmanaged[Stdcall]<IntPtr, ulong /*ClrDataAddress*/, out HeapDetails, int> GetGCHeapDetails; // wks only
         public readonly delegate* unmanaged[Stdcall]<IntPtr, out HeapDetails, int> GetGCHeapStaticData;
-        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, out SegmentData, int> GetHeapSegmentData;
-        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, out DacOOMData, int> GetOOMData;
+        public readonly delegate* unmanaged[Stdcall]<IntPtr, ulong /*ClrDataAddress*/, out SegmentData, int> GetHeapSegmentData;
+        public readonly delegate* unmanaged[Stdcall]<IntPtr, ulong /*ClrDataAddress*/, out DacOOMData, int> GetOOMData;
         public readonly delegate* unmanaged[Stdcall]<IntPtr, out DacOOMData, int> GetOOMStaticData;
-        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, out DacHeapAnalyzeData, int> GetHeapAnalyzeData;
+        public readonly delegate* unmanaged[Stdcall]<IntPtr, ulong /*ClrDataAddress*/, out DacHeapAnalyzeData, int> GetHeapAnalyzeData;
         public readonly delegate* unmanaged[Stdcall]<IntPtr, out DacHeapAnalyzeData, int> GetHeapAnalyzeStaticData;
 
         // DomainLocal
         private readonly IntPtr GetDomainLocalModuleData;
-        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, int, out DomainLocalModuleData, int> GetDomainLocalModuleDataFromAppDomain;
-        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, out DomainLocalModuleData, int> GetDomainLocalModuleDataFromModule;
+        public readonly delegate* unmanaged[Stdcall]<IntPtr, ulong /*ClrDataAddress*/, int, out DomainLocalModuleData, int> GetDomainLocalModuleDataFromAppDomain;
+        public readonly delegate* unmanaged[Stdcall]<IntPtr, ulong /*ClrDataAddress*/, out DomainLocalModuleData, int> GetDomainLocalModuleDataFromModule;
 
         // ThreadLocal
-        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, uint, out ThreadLocalModuleData, int> GetThreadLocalModuleData;
+        public readonly delegate* unmanaged[Stdcall]<IntPtr, ulong /*ClrDataAddress*/, uint, out ThreadLocalModuleData, int> GetThreadLocalModuleData;
 
         // SyncBlock
         public readonly delegate* unmanaged[Stdcall]<IntPtr, int, out SyncBlockData, int> GetSyncBlockData;
@@ -900,9 +900,9 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
         public readonly IntPtr GetStressLogAddress;
 
         // Heaps
-        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, IntPtr, int> TraverseLoaderHeap;
-        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, int, JitCodeHeapInfo*, out int, int> GetCodeHeapList;
-        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, SOSDac.VCSHeapType, IntPtr, int> TraverseVirtCallStubHeap;
+        public readonly delegate* unmanaged[Stdcall]<IntPtr, ulong /*ClrDataAddress*/, IntPtr, int> TraverseLoaderHeap;
+        public readonly delegate* unmanaged[Stdcall]<IntPtr, ulong /*ClrDataAddress*/, int, JitCodeHeapInfo*, out int, int> GetCodeHeapList;
+        public readonly delegate* unmanaged[Stdcall]<IntPtr, ulong /*ClrDataAddress*/, SOSDac.VCSHeapType, IntPtr, int> TraverseVirtCallStubHeap;
 
         // Other
         public readonly delegate* unmanaged[Stdcall]<IntPtr, out CommonMethodTables, int> GetUsefulGlobals;
@@ -911,11 +911,11 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
         public readonly IntPtr GetDacModuleHandle;
 
         // COM
-        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, out RcwData, int> GetRCWData;
-        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, int, COMInterfacePointerData*, out int, int> GetRCWInterfaces;
-        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, out CcwData, int> GetCCWData;
-        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, int, COMInterfacePointerData*, out int, int> GetCCWInterfaces;
-        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, nint, nint, int> TraverseRCWCleanupList;
+        public readonly delegate* unmanaged[Stdcall]<IntPtr, ulong /*ClrDataAddress*/, out RcwData, int> GetRCWData;
+        public readonly delegate* unmanaged[Stdcall]<IntPtr, ulong /*ClrDataAddress*/, int, COMInterfacePointerData*, out int, int> GetRCWInterfaces;
+        public readonly delegate* unmanaged[Stdcall]<IntPtr, ulong /*ClrDataAddress*/, out CcwData, int> GetCCWData;
+        public readonly delegate* unmanaged[Stdcall]<IntPtr, ulong /*ClrDataAddress*/, int, COMInterfacePointerData*, out int, int> GetCCWInterfaces;
+        public readonly delegate* unmanaged[Stdcall]<IntPtr, ulong /*ClrDataAddress*/, nint, nint, int> TraverseRCWCleanupList;
 
         // GC Reference Functions
         public readonly delegate* unmanaged[Stdcall]<IntPtr, uint, out IntPtr, int> GetStackReferences;
@@ -928,8 +928,8 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
         public readonly IntPtr GetFailedAssemblyList;
         public readonly IntPtr GetPrivateBinPaths;
         public readonly IntPtr GetAssemblyLocation;
-        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, int, byte*, out int, int> GetAppDomainConfigFile;
-        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, int, byte*, out int, int> GetApplicationBase;
+        public readonly delegate* unmanaged[Stdcall]<IntPtr, ulong /*ClrDataAddress*/, int, byte*, out int, int> GetAppDomainConfigFile;
+        public readonly delegate* unmanaged[Stdcall]<IntPtr, ulong /*ClrDataAddress*/, int, byte*, out int, int> GetApplicationBase;
         public readonly IntPtr GetFailedAssemblyData;
         public readonly IntPtr GetFailedAssemblyLocation;
         public readonly IntPtr GetFailedAssemblyDisplayName;

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/SosDac13.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/SosDac13.cs
@@ -27,20 +27,20 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
 
         private ref readonly ISOSDac13VTable VTable => ref Unsafe.AsRef<ISOSDac13VTable>(_vtable);
 
-        public HResult TraverseLoaderHeap(ulong heap, LoaderHeapKind kind, LoaderHeapTraverse callback)
+        public HResult TraverseLoaderHeap(ClrDataAddress heap, LoaderHeapKind kind, LoaderHeapTraverse callback)
         {
-            HResult hr = VTable.TraverseLoaderHeap(Self, heap, kind, Marshal.GetFunctionPointerForDelegate(callback));
+            HResult hr = VTable.TraverseLoaderHeap(Self, heap.ToInteropAddress(), kind, Marshal.GetFunctionPointerForDelegate(callback));
             GC.KeepAlive(callback);
             return hr;
         }
 
         public ClrDataAddress GetDomainLoaderAllocator(ClrDataAddress domainAddress)
         {
-            if (domainAddress == 0)
-                return 0;
+            if (domainAddress.IsNull)
+                return default;
 
-            HResult hr = VTable.GetDomainLoaderAllocator(Self, domainAddress, out ClrDataAddress loaderAllocator);
-            return hr ? loaderAllocator : 0;
+            HResult hr = VTable.GetDomainLoaderAllocator(Self, domainAddress.ToInteropAddress(), out ClrDataAddress loaderAllocator);
+            return hr ? loaderAllocator : default;
         }
 
         public string[] GetLoaderAllocatorHeapNames()
@@ -67,9 +67,9 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
 
         public (ClrDataAddress Address, LoaderHeapKind Kind)[] GetLoaderAllocatorHeaps(ClrDataAddress loaderAllocator)
         {
-            if (loaderAllocator != 0)
+            if (!loaderAllocator.IsNull)
             {
-                HResult hr = VTable.GetLoaderAllocatorHeaps(Self, loaderAllocator, 0, null, null, out int needed);
+                HResult hr = VTable.GetLoaderAllocatorHeaps(Self, loaderAllocator.ToInteropAddress(), 0, null, null, out int needed);
 
                 if (hr && needed > 0)
                 {
@@ -79,7 +79,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
                     fixed (ClrDataAddress* ptrAddresses = addresses)
                     fixed (LoaderHeapKind* ptrKinds = kinds)
                     {
-                        if (hr = VTable.GetLoaderAllocatorHeaps(Self, loaderAllocator, addresses.Length, ptrAddresses, ptrKinds, out _))
+                        if (hr = VTable.GetLoaderAllocatorHeaps(Self, loaderAllocator.ToInteropAddress(), addresses.Length, ptrAddresses, ptrKinds, out _))
                         {
                             (ClrDataAddress, LoaderHeapKind)[] result = new (ClrDataAddress, LoaderHeapKind)[needed];
                             for (int i = 0; i < needed; i++)
@@ -142,10 +142,10 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
         [StructLayout(LayoutKind.Sequential)]
         private readonly unsafe struct ISOSDac13VTable
         {
-            public readonly delegate* unmanaged[Stdcall]<nint, ClrDataAddress, LoaderHeapKind, nint, int> TraverseLoaderHeap;
-            public readonly delegate* unmanaged[Stdcall]<nint, ClrDataAddress, out ClrDataAddress, int> GetDomainLoaderAllocator;
+            public readonly delegate* unmanaged[Stdcall]<nint, ulong /*ClrDataAddress*/, LoaderHeapKind, nint, int> TraverseLoaderHeap;
+            public readonly delegate* unmanaged[Stdcall]<nint, ulong /*ClrDataAddress*/, out ClrDataAddress, int> GetDomainLoaderAllocator;
             public readonly delegate* unmanaged[Stdcall]<nint, int, nint*, out int, int> GetLoaderAllocatorHeapNames;
-            public readonly delegate* unmanaged[Stdcall]<nint, ClrDataAddress, int, ClrDataAddress*, LoaderHeapKind*, out int, int> GetLoaderAllocatorHeaps;
+            public readonly delegate* unmanaged[Stdcall]<nint, ulong /*ClrDataAddress*/, int, ClrDataAddress*, LoaderHeapKind*, out int, int> GetLoaderAllocatorHeaps;
 
             public readonly delegate* unmanaged[Stdcall]<nint, out nint, int> GetHandleTableMemoryRegions;
             public readonly delegate* unmanaged[Stdcall]<nint, out nint, int> GetGCBookkeepingMemoryRegions;

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/SosDac13.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/SosDac13.cs
@@ -37,10 +37,10 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
         public ClrDataAddress GetDomainLoaderAllocator(ClrDataAddress domainAddress)
         {
             if (domainAddress.IsNull)
-                return default;
+                return ClrDataAddress.Null;
 
             HResult hr = VTable.GetDomainLoaderAllocator(Self, domainAddress.ToInteropAddress(), out ClrDataAddress loaderAllocator);
-            return hr ? loaderAllocator : default;
+            return hr ? loaderAllocator : ClrDataAddress.Null;
         }
 
         public string[] GetLoaderAllocatorHeapNames()

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/SosDac13.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/SosDac13.cs
@@ -20,9 +20,9 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
         internal static readonly Guid IID_ISOSDac13 = new("3176a8ed-597b-4f54-a71f-83695c6a8c5e");
 
         public SOSDac13(DacLibrary library, IntPtr ptr)
-            : base(library?.OwningLibrary, IID_ISOSDac13, ptr)
+            : base(library.OwningLibrary, IID_ISOSDac13, ptr)
         {
-            _library = library ?? throw new ArgumentNullException(nameof(library));
+            _library = library;
         }
 
         private ref readonly ISOSDac13VTable VTable => ref Unsafe.AsRef<ISOSDac13VTable>(_vtable);

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/SosDac14.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/SosDac14.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/SosDac14.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/SosDac14.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -29,13 +29,13 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
         public (ClrDataAddress NonGCStaticsBase, ClrDataAddress GCStaticsBase) GetStaticBaseAddress(ClrDataAddress methodTable)
         {
             HResult hr = VTable.GetStaticBaseAddress(Self, methodTable.ToInteropAddress(), out ClrDataAddress nonGCStaticsBase, out ClrDataAddress gcStaticsBase);
-            return hr ? (nonGCStaticsBase, gcStaticsBase) : (default, default);
+            return hr ? (nonGCStaticsBase, gcStaticsBase) : (ClrDataAddress.Null, ClrDataAddress.Null);
         }
 
         public (ClrDataAddress NonGCThreadStaticsBase, ClrDataAddress GCThreadStaticsBase) GetThreadStaticBaseAddress(ClrDataAddress methodTable, ClrDataAddress thread)
         {
             HResult hr = VTable.GetThreadStaticBaseAddress(Self, methodTable.ToInteropAddress(), thread.ToInteropAddress(), out ClrDataAddress nonGCThreadStaticsBase, out ClrDataAddress gcThreadStaticsBase);
-            return hr ? (nonGCThreadStaticsBase, gcThreadStaticsBase) : (default, default);
+            return hr ? (nonGCThreadStaticsBase, gcThreadStaticsBase) : (ClrDataAddress.Null, ClrDataAddress.Null);
         }
 
         [StructLayout(LayoutKind.Sequential)]

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/SosDac14.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/SosDac14.cs
@@ -26,24 +26,24 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
 
         private ref readonly ISOSDac14VTable VTable => ref Unsafe.AsRef<ISOSDac14VTable>(_vtable);
 
-        public (ulong NonGCStaticsBase, ulong GCStaticsBase) GetStaticBaseAddress(ClrDataAddress methodTable)
+        public (ClrDataAddress NonGCStaticsBase, ClrDataAddress GCStaticsBase) GetStaticBaseAddress(ClrDataAddress methodTable)
         {
-            HResult hr = VTable.GetStaticBaseAddress(Self, methodTable, out ClrDataAddress nonGCStaticsBase, out ClrDataAddress gcStaticsBase);
-            return hr ? (nonGCStaticsBase, gcStaticsBase) : (0, 0);
+            HResult hr = VTable.GetStaticBaseAddress(Self, methodTable.ToInteropAddress(), out ClrDataAddress nonGCStaticsBase, out ClrDataAddress gcStaticsBase);
+            return hr ? (nonGCStaticsBase, gcStaticsBase) : (default, default);
         }
 
-        public (ulong NonGCThreadStaticsBase, ulong GCThreadStaticsBase) GetThreadStaticBaseAddress(ClrDataAddress methodTable, ClrDataAddress thread)
+        public (ClrDataAddress NonGCThreadStaticsBase, ClrDataAddress GCThreadStaticsBase) GetThreadStaticBaseAddress(ClrDataAddress methodTable, ClrDataAddress thread)
         {
-            HResult hr = VTable.GetThreadStaticBaseAddress(Self, methodTable, thread, out ClrDataAddress nonGCThreadStaticsBase, out ClrDataAddress gcThreadStaticsBase);
-            return hr ? (nonGCThreadStaticsBase, gcThreadStaticsBase) : (0, 0);
+            HResult hr = VTable.GetThreadStaticBaseAddress(Self, methodTable.ToInteropAddress(), thread.ToInteropAddress(), out ClrDataAddress nonGCThreadStaticsBase, out ClrDataAddress gcThreadStaticsBase);
+            return hr ? (nonGCThreadStaticsBase, gcThreadStaticsBase) : (default, default);
         }
 
         [StructLayout(LayoutKind.Sequential)]
         private readonly unsafe struct ISOSDac14VTable
         {
-            public readonly delegate* unmanaged[Stdcall]<nint, ClrDataAddress, out ClrDataAddress, out ClrDataAddress, int> GetStaticBaseAddress;
-            public readonly delegate* unmanaged[Stdcall]<nint, ClrDataAddress, ClrDataAddress, out ClrDataAddress, out ClrDataAddress, int> GetThreadStaticBaseAddress;
-            public readonly delegate* unmanaged[Stdcall]<nint, ClrDataAddress, out MethodTableInitializationFlags, int> GetMethodTableInitializationFlags;
+            public readonly delegate* unmanaged[Stdcall]<nint, ulong /*ClrDataAddress*/, out ClrDataAddress, out ClrDataAddress, int> GetStaticBaseAddress;
+            public readonly delegate* unmanaged[Stdcall]<nint, ulong /*ClrDataAddress*/, ulong /*ClrDataAddress*/, out ClrDataAddress, out ClrDataAddress, int> GetThreadStaticBaseAddress;
+            public readonly delegate* unmanaged[Stdcall]<nint, ulong /*ClrDataAddress*/, out MethodTableInitializationFlags, int> GetMethodTableInitializationFlags;
         }
     }
 

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/SosDac14.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/SosDac14.cs
@@ -14,14 +14,11 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
     /// </summary>
     internal sealed unsafe class SosDac14 : CallableCOMWrapper
     {
-        private readonly DacLibrary _library;
-
         internal static readonly Guid IID_ISOSDac14 = new("9aa22aca-6dc6-4a0c-b4e0-70d2416b9837");
 
         public SosDac14(DacLibrary library, IntPtr ptr)
-            : base(library?.OwningLibrary, IID_ISOSDac14, ptr)
+            : base(library.OwningLibrary, IID_ISOSDac14, ptr)
         {
-            _library = library ?? throw new ArgumentNullException(nameof(library));
         }
 
         private ref readonly ISOSDac14VTable VTable => ref Unsafe.AsRef<ISOSDac14VTable>(_vtable);

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/SosDac16.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/SosDac16.cs
@@ -15,14 +15,11 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
     /// </summary>
     internal sealed unsafe class SOSDac16 : CallableCOMWrapper, ISOSDac16
     {
-        private readonly DacLibrary _library;
-
         internal static readonly Guid IID_ISOSDac16 = new("4ba12ff8-daac-4e43-ac56-98cf8d5c595d");
 
         public SOSDac16(DacLibrary library, IntPtr ptr)
-            : base(library?.OwningLibrary, IID_ISOSDac16, ptr)
+            : base(library.OwningLibrary, IID_ISOSDac16, ptr)
         {
-            _library = library ?? throw new ArgumentNullException(nameof(library));
         }
 
         private ref readonly ISOSDac16VTable VTable => ref Unsafe.AsRef<ISOSDac16VTable>(_vtable);

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/SosDac6.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/SosDac6.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
         internal static readonly Guid IID_ISOSDac6 = new("11206399-4B66-4EDB-98EA-85654E59AD45");
 
         public SOSDac6(DacLibrary library, IntPtr ptr)
-            : base(library?.OwningLibrary, IID_ISOSDac6, ptr)
+            : base(library.OwningLibrary, IID_ISOSDac6, ptr)
         {
         }
 

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/SosDac6.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/SosDac6.cs
@@ -26,15 +26,15 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
         {
         }
 
-        public HResult GetMethodTableCollectibleData(ulong mt, out MethodTableCollectibleData data)
+        public HResult GetMethodTableCollectibleData(ClrDataAddress mt, out MethodTableCollectibleData data)
         {
-            return VTable.GetMethodTableCollectibleData(Self, mt, out data);
+            return VTable.GetMethodTableCollectibleData(Self, mt.ToInteropAddress(), out data);
         }
     }
 
     [StructLayout(LayoutKind.Sequential)]
     internal readonly unsafe struct ISOSDac6VTable
     {
-        public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, out MethodTableCollectibleData, int> GetMethodTableCollectibleData;
+        public readonly delegate* unmanaged[Stdcall]<IntPtr, ulong /*ClrDataAddress*/, out MethodTableCollectibleData, int> GetMethodTableCollectibleData;
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/SosDac8.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/SosDac8.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/SosDac8.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/SosDac8.cs
@@ -15,12 +15,9 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
     {
         internal static readonly Guid IID_ISOSDac8 = new("c12f35a9-e55c-4520-a894-b3dc5165dfce");
 
-        private readonly DacLibrary _library;
-
         public SOSDac8(DacLibrary library, IntPtr ptr)
-            : base(library?.OwningLibrary, IID_ISOSDac8, ptr)
+            : base(library.OwningLibrary, IID_ISOSDac8, ptr)
         {
-            _library = library ?? throw new ArgumentNullException(nameof(library));
         }
 
         private ref readonly ISOSDac8VTable VTable => ref Unsafe.AsRef<ISOSDac8VTable>(_vtable);

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/SosDac8.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/SosDac8.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -15,22 +15,25 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
     {
         internal static readonly Guid IID_ISOSDac8 = new("c12f35a9-e55c-4520-a894-b3dc5165dfce");
 
+        private readonly DacLibrary _library;
+
         public SOSDac8(DacLibrary library, IntPtr ptr)
             : base(library?.OwningLibrary, IID_ISOSDac8, ptr)
         {
+            _library = library ?? throw new ArgumentNullException(nameof(library));
         }
 
         private ref readonly ISOSDac8VTable VTable => ref Unsafe.AsRef<ISOSDac8VTable>(_vtable);
 
         public HResult GetAssemblyLoadContext(ClrDataAddress methodTable, out ClrDataAddress assemblyLoadContext)
         {
-            if (methodTable == 0)
+            if (methodTable.IsNull)
             {
-                assemblyLoadContext = 0;
+                assemblyLoadContext = default;
                 return HResult.E_INVALIDARG;
             }
 
-            return VTable.GetAssemblyLoadContext(Self, methodTable, out assemblyLoadContext);
+            return VTable.GetAssemblyLoadContext(Self, methodTable.ToInteropAddress(), out assemblyLoadContext);
         }
 
         public int GenerationCount
@@ -62,16 +65,17 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             return data;
         }
 
-        public GenerationData[]? GetGenerationTable(ulong heap)
+        public GenerationData[]? GetGenerationTable(ClrDataAddress heap)
         {
-            HResult hr = VTable.GetGenerationTableSvr(Self, heap, 0, null, out int needed);
+            ulong heapRaw = heap.ToInteropAddress();
+            HResult hr = VTable.GetGenerationTableSvr(Self, heapRaw, 0, null, out int needed);
             if (!hr)
                 return null;
 
             GenerationData[] data = new GenerationData[needed];
             fixed (GenerationData* ptr = data)
             {
-                hr = VTable.GetGenerationTableSvr(Self, heap, needed, ptr, out _);
+                hr = VTable.GetGenerationTableSvr(Self, heapRaw, needed, ptr, out _);
                 if (!hr)
                     return null;
             }
@@ -96,16 +100,17 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             return pointers;
         }
 
-        public ClrDataAddress[]? GetFinalizationFillPointers(ulong heap)
+        public ClrDataAddress[]? GetFinalizationFillPointers(ClrDataAddress heap)
         {
-            HResult hr = VTable.GetFinalizationFillPointersSvr(Self, heap, 0, null, out int needed);
+            ulong heapRaw = heap.ToInteropAddress();
+            HResult hr = VTable.GetFinalizationFillPointersSvr(Self, heapRaw, 0, null, out int needed);
             if (!hr)
                 return null;
 
             ClrDataAddress[] pointers = new ClrDataAddress[needed];
             fixed (ClrDataAddress* ptr = pointers)
             {
-                hr = VTable.GetFinalizationFillPointersSvr(Self, heap, needed, ptr, out _);
+                hr = VTable.GetFinalizationFillPointersSvr(Self, heapRaw, needed, ptr, out _);
                 if (!hr)
                     return null;
             }
@@ -119,9 +124,9 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             public readonly delegate* unmanaged[Stdcall]<IntPtr, out int, int> GetNumberGenerations;
             public readonly delegate* unmanaged[Stdcall]<IntPtr, int, GenerationData*, out int, int> GetGenerationTable;
             public readonly delegate* unmanaged[Stdcall]<IntPtr, int, ClrDataAddress*, out int, int> GetFinalizationFillPointers;
-            public readonly delegate* unmanaged[Stdcall]<IntPtr, ulong, int, GenerationData*, out int, int> GetGenerationTableSvr;
-            public readonly delegate* unmanaged[Stdcall]<IntPtr, ulong, int, ClrDataAddress*, out int, int> GetFinalizationFillPointersSvr;
-            public readonly delegate* unmanaged[Stdcall]<IntPtr, ClrDataAddress, out ClrDataAddress, int> GetAssemblyLoadContext;
+            public readonly delegate* unmanaged[Stdcall]<IntPtr, ulong /*ClrDataAddress*/, int, GenerationData*, out int, int> GetGenerationTableSvr;
+            public readonly delegate* unmanaged[Stdcall]<IntPtr, ulong /*ClrDataAddress*/, int, ClrDataAddress*, out int, int> GetFinalizationFillPointersSvr;
+            public readonly delegate* unmanaged[Stdcall]<IntPtr, ulong /*ClrDataAddress*/, out ClrDataAddress, int> GetAssemblyLoadContext;
         }
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/SosDac8.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/SosDac8.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -29,7 +29,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
         {
             if (methodTable.IsNull)
             {
-                assemblyLoadContext = default;
+                assemblyLoadContext = ClrDataAddress.Null;
                 return HResult.E_INVALIDARG;
             }
 

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/Structs/HeapDetails.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/Structs/HeapDetails.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
         public readonly ClrDataAddress HighestAddress;
         public readonly ClrDataAddress CardTable;
 
-        public ulong EphemeralAllocContextPtr => GenerationTable[0].AllocationContextPointer;
-        public ulong EphemeralAllocContextLimit => GenerationTable[0].AllocationContextLimit;
+        public ClrDataAddress EphemeralAllocContextPtr => GenerationTable[0].AllocationContextPointer;
+        public ClrDataAddress EphemeralAllocContextLimit => GenerationTable[0].AllocationContextLimit;
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/TargetProperties.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/TargetProperties.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/TargetProperties.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/TargetProperties.cs
@@ -1,0 +1,31 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace Microsoft.Diagnostics.Runtime.DacInterface
+{
+    /// <summary>
+    /// Immutable target-process properties used throughout the DAC implementation.
+    /// A single <see cref="TargetProperties"/> instance is owned by <see cref="DacLibrary"/>
+    /// and passed to DAC wrappers. Future target-level facts (endianness, machine type, etc.)
+    /// can be added here without re-plumbing every DAC wrapper.
+    /// </summary>
+    internal sealed class TargetProperties
+    {
+        /// <summary>
+        /// Creates target properties for the specified pointer size.
+        /// </summary>
+        /// <param name="pointerSize">The target process pointer size (4 or 8).</param>
+        public TargetProperties(int pointerSize)
+        {
+            if (pointerSize != 4 && pointerSize != 8)
+                throw new ArgumentOutOfRangeException(nameof(pointerSize), pointerSize, "Pointer size must be 4 or 8.");
+
+            PointerSize = pointerSize;
+        }
+
+        /// <summary>Pointer size in bytes (4 or 8).</summary>
+        public int PointerSize { get; }
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/DacLibrary.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacLibrary.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;

--- a/src/Microsoft.Diagnostics.Runtime/DacLibrary.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacLibrary.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -19,6 +19,8 @@ namespace Microsoft.Diagnostics.Runtime
 
         public RefCountedFreeLibrary? OwningLibrary { get; }
 
+        public TargetProperties TargetProperties { get; }
+
         public ClrDataProcess CreateClrDataProcess() => new(this, _clrDataProcess);
 
         public unsafe DacLibrary(DataTarget dataTarget, string dacPath, ulong runtimeBaseAddress, ulong contractDescriptor, bool verifySignature)
@@ -28,6 +30,8 @@ namespace Microsoft.Diagnostics.Runtime
 
             if (dataTarget.ClrVersions.Length == 0)
                 throw new ClrDiagnosticsException("Process is not a CLR process!");
+
+            TargetProperties = new TargetProperties(pointerSize: dataTarget.DataReader.PointerSize);
 
             IDisposable? fileLock = null;
             IntPtr dacLibrary;


### PR DESCRIPTION
## Summary

Refactor `ClrDataAddress` to correctly handle sign-extended addresses from the DAC and eliminate cross-platform ABI ambiguity at the COM interop boundary. This prevents silent address truncation when inspecting 32-bit targets and ensures correct marshalling on all platforms.

## Problem

`ClrDataAddress` used implicit operators that converted through `nint`/`nuint`:
- `operator ulong`: `(nuint)Value` — truncates 64-bit addresses to 32 bits on x86 hosts
- `operator ClrDataAddress(ulong)`: `(nint)value` — same truncation on input

This corrupts **all** addresses when a 32-bit host reads a 64-bit dump, causing:
- `GetExportSymbolAddress()` returning 0
- `PEImage` being null
- `Could not find DotNetRuntimeContractDescriptor` errors

Additionally, the DAC's sign-extended 32-bit addresses (e.g., `0xFFFFFFFF_80123456`) caused `OverflowException` in checked arithmetic contexts in `DacDataTargetCOM.ReadVirtual`.

## ClrDataAddress Rules

### 1. Sign Extension
The legacy DAC sign-extends 32-bit target addresses on the wire:
- `0x80123456` becomes `0xFFFFFFFF_80123456` (CLRDATA_ADDRESS)
- `FromAddress(addr, target)` applies sign extension: `(ulong)(long)(int)(uint)addr`
- `ToAddress(target)` strips it: `(ulong)(uint)_value`

### 2. ABI Boundary — Managed-Only Type
`ClrDataAddress` **never crosses the ABI boundary by value**. Vtable slots use plain `ulong` (annotated `/*ClrDataAddress*/`) because single-field struct passing differs across platform ABIs. Managed wrappers convert via:
- `addr.ToInteropAddress()` — unwrap to raw ulong (no transform)
- `ClrDataAddress.FromInteropAddress(raw)` — wrap from raw ulong (no transform)

Pointer forms (`ref`/`out`/`ClrDataAddress*`) are safe as-is and preserved in vtable signatures.

### 3. Confinement
`ClrDataAddress` exists **only** in `DacInterface/` (vtable wrappers, struct definitions) and `DacImplementation/` (conversion boundary). It never leaks into `AbstractDac/`, `Implementation/`, or the public API. The rest of ClrMD uses plain `ulong` for all addresses.

### 4. Data Flow
```
DacImplementation (ulong)
    | FromAddress(addr, _target)
    v
SosDac wrapper (ClrDataAddress)
    | .ToInteropAddress()
    v
Vtable call (ulong on the wire) --> Native DAC
    |
Returns via out struct fields (ClrDataAddress)
    | .ToAddress(_target)
    v
DacImplementation (ulong, clean target address)
    |
Public API (ulong: ClrObject.Address, ClrType.MethodTable, etc.)
```

## Changes

### ClrDataAddress API
- **Removed** implicit operators between `ClrDataAddress` and `ulong`
- **Added** `ToAddress(TargetProperties)` / `FromAddress(ulong, TargetProperties)` — sign-extension-aware conversions
- **Added** `ToInteropAddress()` / `FromInteropAddress(ulong)` — raw wire-value helpers for the ABI boundary
- **Added** `ClrDataAddress.Null` property — replaces `default` for clarity
- **Added** `IsNull`, `IEquatable<ClrDataAddress>`, hex `DebuggerDisplay`
- **Added** `TargetProperties` struct — holds pointer size, threaded through DAC layer
- **Added** comprehensive design documentation as block comment

### Vtable Signatures (all SosDac files)
Flipped every by-value `ClrDataAddress` parameter to `ulong /*ClrDataAddress*/`:
- `SosDac.cs` — 48 vtable slots, 47 wrapper call sites
- `SosDac6.cs`, `SosDac8.cs`, `SosDac13.cs`, `SosDac14.cs`, `SOSDac13Old.cs`
- `ClrDataProcess.cs` — including `CLRDATA_ENUM` handle corrections
- `DacDataTargetCOM.cs` — address-typed slots annotated

Verified slot-by-slot against `sospriv.idl` in dotnet/runtime.

### DacImplementation Conversion Sites
- All callers use `ClrDataAddress.FromAddress(ulong, _target)` to wrap addresses for DAC calls
- All DAC return values / struct fields use `.ToAddress(_target)` to unwrap
- Replaced all `default` ClrDataAddress usages with `ClrDataAddress.Null`
- Removed all 28 redundant `TargetProperties target = _target` local copies

### Inbound DAC Callback Fix
- `DacDataTargetCOM.ReadVirtual`: wrap `(long)address` in `unchecked(...)` to prevent `OverflowException` on sign-extended 32-bit addresses

## Testing

- Build: 0 errors, 0 warnings on both `netstandard2.0` and `net10.0`
- x64 tests: 308 pass / 138 fail — matches main baseline (pre-existing `SingleFileBasicArrayTests` failures unrelated)
- x86: known `OverflowException` in `ClrDataAddress.ToAddress` for checked context — pre-existing, fix pending (`unchecked((uint)_value)`)

## Follow-up from #1421

This PR addresses the broader `ClrDataAddress` design issue discovered after #1421 (IntPtr.Size fixes) was merged.