### PR TITLE
Fix GCRoot _seen set poisoning across FindPathFrom calls

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/Attributes/WindowsOrNet11FactAttribute.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/Attributes/WindowsOrNet11FactAttribute.cs
@@ -1,0 +1,25 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace Microsoft.Diagnostics.Runtime.Tests
+{
+    /// <summary>
+    /// Runs on Windows unconditionally. On Linux/macOS, only runs when the
+    /// runtime version is 11.0 or higher (the DAC crash in EnumerateStackRoots
+    /// on .NET 10 was fixed in .NET 11).
+    /// </summary>
+    internal sealed class WindowsOrNet11FactAttribute : FactAttribute
+    {
+        public WindowsOrNet11FactAttribute()
+        {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && Environment.Version.Major < 11)
+            {
+                Skip = "Runtime bug: DAC crashes (SIGSEGV) in EnumerateStackRoots on .NET 10 on Linux/macOS. Fixed in .NET 11.";
+            }
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/GCRootTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/GCRootTests.cs
@@ -2,8 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.InteropServices;
 using Xunit;
 
 namespace Microsoft.Diagnostics.Runtime.Tests
@@ -140,13 +140,9 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             Assert.Equal("DoubleRef", obj.Type.Name);
         }
 
-        [Fact]
+        [WindowsOrNet11Fact]
         public void GCRoots()
         {
-            // Runtime bug: DAC crashes (SIGSEGV) in EnumerateStackRoots on .NET 10.
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && Environment.Version.Major < 11)
-                return;
-
             using DataTarget dataTarget = TestTargets.GCRoot.LoadFullDump();
             using ClrRuntime runtime = dataTarget.ClrVersions.Single().CreateRuntime();
             ClrHeap heap = runtime.Heap;
@@ -155,12 +151,9 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             ContainsPathsToTarget(heap, 0, target);
         }
 
-        [Fact]
+        [WindowsOrNet11Fact]
         public void GCRootsPredicate()
         {
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && Environment.Version.Major < 11)
-                return;
-
             using DataTarget dataTarget = TestTargets.GCRoot.LoadFullDump();
             using ClrRuntime runtime = dataTarget.ClrVersions.Single().CreateRuntime();
             ClrHeap heap = runtime.Heap;
@@ -168,12 +161,9 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             ContainsPathsToTarget(heap, 0, (obj) => obj.Type?.Name == "TargetType");
         }
 
-        [Fact]
+        [WindowsOrNet11Fact]
         public void GCRootsDirectHandles()
         {
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && Environment.Version.Major < 11)
-                return;
-
             using DataTarget dataTarget = TestTargets.GCRoot2.LoadFullDump();
             using ClrRuntime runtime = dataTarget.ClrVersions.Single().CreateRuntime();
             ClrHeap heap = runtime.Heap;
@@ -183,12 +173,9 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             ContainsPathsToTarget(heap, 0, target);
         }
 
-        [Fact]
+        [WindowsOrNet11Fact]
         public void GCRootsIndirectHandles()
         {
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && Environment.Version.Major < 11)
-                return;
-
             using DataTarget dataTarget = TestTargets.GCRoot2.LoadFullDump();
             using ClrRuntime runtime = dataTarget.ClrVersions.Single().CreateRuntime();
             ClrHeap heap = runtime.Heap;
@@ -197,19 +184,114 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             ContainsPathsToTarget(heap, 0, target);
         }
 
-        [Fact]
+        [WindowsOrNet11Fact]
         public void FindAllPaths()
         {
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && Environment.Version.Major < 11)
-                return;
-
             using DataTarget dataTarget = TestTargets.GCRoot.LoadFullDump();
             using ClrRuntime runtime = dataTarget.ClrVersions.Single().CreateRuntime();
             ClrHeap heap = runtime.Heap;
 
             GetKnownSourceAndTarget(heap, out ulong source, out ulong target);
             int totalPath = ContainsPathsToTarget(heap, source, target);
-            Assert.True(totalPath >= 3);
+            Assert.True(totalPath >= 3, $"Expected at least 3 paths, got {totalPath}");
+        }
+
+        /// <summary>
+        /// Regression test: verifies that a shared GCRoot instance finds the same set of
+        /// paths as individual fresh instances.  Before the fix, successful searches left
+        /// unwalked children in _seen, blocking later FindPathFrom calls.
+        /// </summary>
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void FindPathFromDoesNotPoisonSeenAcrossCalls(bool singleFile)
+        {
+            using DataTarget dataTarget = TestTargets.GCRoot.LoadFullDump(singleFile);
+            using ClrRuntime runtime = dataTarget.ClrVersions.Single().CreateRuntime();
+            ClrHeap heap = runtime.Heap;
+
+            ulong target = heap.GetObjectsOfType("TargetType").Single();
+
+            // Collect test-graph objects that can individually reach the target.
+            string[] relevantTypes = { "TripleRef", "DoubleRef", "SingleRef" };
+            List<ulong> candidates = heap.EnumerateObjects()
+                .Where(o => o.IsValid && o.Type is not null && relevantTypes.Contains(o.Type.Name))
+                .Select(o => o.Address)
+                .ToList();
+
+            Assert.True(candidates.Count >= 3, $"Expected at least 3 test objects, found {candidates.Count}");
+
+            // Ground truth: each object gets a fresh GCRoot (clean _seen).
+            List<ulong> objectsWithPaths = new();
+            foreach (ulong addr in candidates)
+            {
+                GCRoot fresh = new(heap, new ulong[] { target });
+                var path = fresh.FindPathFrom(heap.GetObject(addr));
+                if (path is not null)
+                    objectsWithPaths.Add(addr);
+            }
+
+            Assert.NotEmpty(objectsWithPaths);
+
+            // Shared GCRoot: every object that found a path individually
+            // must also find one when _seen state is shared across calls.
+            GCRoot shared = new(heap, new ulong[] { target });
+            foreach (ulong addr in objectsWithPaths)
+            {
+                var path = shared.FindPathFrom(heap.GetObject(addr));
+                Assert.True(path is not null,
+                    $"FindPathFrom({addr:x}) returned null with shared GCRoot but succeeded with a fresh one");
+                VerifyPath(heap, (obj) => target == obj, path);
+            }
+        }
+
+        /// <summary>
+        /// Stress test: repeats the shared-vs-fresh GCRoot comparison many times
+        /// to catch order-dependent flakiness.
+        /// </summary>
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void FindPathFromSeenStressTest(bool singleFile)
+        {
+            using DataTarget dataTarget = TestTargets.GCRoot.LoadFullDump(singleFile);
+            using ClrRuntime runtime = dataTarget.ClrVersions.Single().CreateRuntime();
+            ClrHeap heap = runtime.Heap;
+
+            ulong target = heap.GetObjectsOfType("TargetType").Single();
+
+            string[] relevantTypes = { "TripleRef", "DoubleRef", "SingleRef" };
+            List<ulong> candidates = heap.EnumerateObjects()
+                .Where(o => o.IsValid && o.Type is not null && relevantTypes.Contains(o.Type.Name))
+                .Select(o => o.Address)
+                .ToList();
+
+            // Build ground truth once.
+            List<ulong> objectsWithPaths = new();
+            foreach (ulong addr in candidates)
+            {
+                GCRoot fresh = new(heap, new ulong[] { target });
+                if (fresh.FindPathFrom(heap.GetObject(addr)) is not null)
+                    objectsWithPaths.Add(addr);
+            }
+
+            Assert.NotEmpty(objectsWithPaths);
+
+            // Run 100 iterations with different traversal orders.
+            Random rng = new(42);
+            for (int iteration = 0; iteration < 100; iteration++)
+            {
+                // Shuffle to vary which search poisons _seen first.
+                List<ulong> shuffled = objectsWithPaths.OrderBy(_ => rng.Next()).ToList();
+
+                GCRoot shared = new(heap, new ulong[] { target });
+                foreach (ulong addr in shuffled)
+                {
+                    var path = shared.FindPathFrom(heap.GetObject(addr));
+                    Assert.True(path is not null,
+                        $"Iteration {iteration}: FindPathFrom({addr:x}) returned null with shared GCRoot");
+                }
+            }
         }
 
         private static void GetKnownSourceAndTarget(ClrHeap heap, out ulong source, out ulong target)
@@ -239,8 +321,18 @@ namespace Microsoft.Diagnostics.Runtime.Tests
 
             foreach (var item in gcroot.EnumerateRootPaths())
             {
-                if (item.Path.Object == source)
-                    source = 0;
+                // Check if source appears anywhere in the chain, not just at
+                // the start.  On .NET 10+ statics are stored in an Object[]
+                // strong handle, so TheRoot may be one level deeper than the
+                // actual GC root.
+                for (GCRoot.ChainLink? link = item.Path; link is not null; link = link.Next)
+                {
+                    if (link.Object == source)
+                    {
+                        source = 0;
+                        break;
+                    }
+                }
 
                 Assert.Equal(item.Root.Object.Address, item.Path.Object);
                 GCRoot.ChainLink curr = item.Path;

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/GCRootTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/GCRootTests.cs
@@ -325,7 +325,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
                 // the start.  On .NET 10+ statics are stored in an Object[]
                 // strong handle, so TheRoot may be one level deeper than the
                 // actual GC root.
-                for (GCRoot.ChainLink? link = item.Path; link is not null; link = link.Next)
+                for (GCRoot.ChainLink link = item.Path; link is not null; link = link.Next)
                 {
                     if (link.Object == source)
                     {

--- a/src/Microsoft.Diagnostics.Runtime/GCRoot.cs
+++ b/src/Microsoft.Diagnostics.Runtime/GCRoot.cs
@@ -117,7 +117,10 @@ namespace Microsoft.Diagnostics.Runtime
             List<byte[]> stack = new();
             link = WalkObject(stack, 0, start, cancellation);
             if (link is not null)
+            {
+                DrainUnwalkedFromSeen(stack);
                 return link;
+            }
 
             while (stack.Count > 0)
             {
@@ -171,7 +174,28 @@ namespace Microsoft.Diagnostics.Runtime
                 }
             }
 
+            // Remove unwalked children from _seen.  When a search succeeds early,
+            // WalkObject may have added children to _seen that were never themselves
+            // walked.  Leaving them would prevent future searches from finding paths
+            // through those objects.
+            DrainUnwalkedFromSeen(stack);
+
             return link;
+        }
+
+        private void DrainUnwalkedFromSeen(List<byte[]> stack)
+        {
+            foreach (byte[] data in stack)
+            {
+                ReferenceList storage = data;
+                ulong child;
+                while ((child = storage.Next()) != 0)
+                    _seen.Remove(child);
+
+                storage.Dispose();
+            }
+
+            stack.Clear();
         }
 
         private ChainLink AddLink(ChainLink curr, ulong obj)
@@ -233,6 +257,13 @@ namespace Microsoft.Diagnostics.Runtime
                         TraceFound(reference, link);
 
                         _found[curr] = result;
+
+                        // Push pending references to stack so the caller can
+                        // drain them from _seen during cleanup.
+                        byte[]? pending = refList.Complete();
+                        if (pending is not null)
+                            stack.Add(pending);
+
                         return result;
                     }
                     else if (!_seen.Add(reference))

--- a/src/TestTargets/GCRoot/GCRoot.cs
+++ b/src/TestTargets/GCRoot/GCRoot.cs
@@ -4,6 +4,7 @@
 #pragma warning disable 0162
 using System;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 //                                              object
 //                                            /
@@ -38,11 +39,23 @@ class GCRootTarget
         t.Item2 = s;
         t.Item3 = new object(); // dead path
 
-
         _dependent.Add(s, target);
-        //s.Item1 = target;
+
+        // Create explicit strong roots so that EnumerateRootPaths finds multiple
+        // independent GC roots reaching the target.  On .NET 10+ statics live in
+        // a single Object[] handle and stack roots may not include locals, so
+        // without these handles only 1 root path would exist.
+        AllocRoots(target, s, t);
+
         throw new Exception();
-        GC.KeepAlive(target);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void AllocRoots(TargetType target, SingleRef s, TripleRef t)
+    {
+        GCHandle.Alloc(target);  // root → target (direct)
+        GCHandle.Alloc(s);       // root → s → target (via dependent handle)
+        GCHandle.Alloc(t);       // root → t → ... → s → target
     }
 }
 

--- a/src/TestTargets/GCRoot/GCRoot.cs
+++ b/src/TestTargets/GCRoot/GCRoot.cs
@@ -48,6 +48,7 @@ class GCRootTarget
         AllocRoots(target, s, t);
 
         throw new Exception();
+        GC.KeepAlive(target);
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]


### PR DESCRIPTION
Bug: When WalkObject adds all children of an object to _seen before walking them, and then DFS returns early on a successful match, the unwalked children remain in _seen. Future FindPathFrom calls skip those objects, missing valid paths. This caused flaky FindAllPaths failures depending on heap layout.

Fix: After a successful search, drain remaining unprocessed children from the stack's ReferenceList buffers via Next() and remove them from _seen. This preserves the cross-call optimization for fully-walked dead-end subtrees (they stay in _seen correctly) while removing only the problematic entries.

Also fixes tests for .NET 10 compatibility:
- Test target now creates explicit GCHandle.Alloc roots so EnumerateRootPaths finds multiple independent paths regardless of runtime version (on .NET 10, statics live in a single Object[] handle and stack roots may not include local variables).
- ContainsPathsToTarget searches for source anywhere in the chain, not just the first element, since TheRoot may be nested under an Object[] root.
- GCRoot tests that call EnumerateRoots use [WindowsOrNet11Fact]: they run on Windows unconditionally, and on Linux/macOS only on .NET 11+ (the DAC SIGSEGV in EnumerateStackRoots on .NET 10 is fixed in .NET 11).