### PR TITLE
Disable MacOS job in internal CI

### DIFF
--- a/azure-pipelines-internal.yml
+++ b/azure-pipelines-internal.yml
@@ -121,28 +121,30 @@ extends:
               displayName: Build
               condition: succeeded()
 
-          - job: MacOS
-            pool:
-              name: Azure Pipelines
-              image: macOS-latest
-              os: macOS
-
-            strategy:
-              matrix:
-                debug:
-                  _BuildConfig: Debug
-                release:
-                  _BuildConfig: Release
-
-            steps:
-            - script: eng/common/build.sh
-                --configuration $(_BuildConfig)
-                --prepareMachine
-                --restore --build --test
-                --ci
-              name: Build
-              displayName: Build
-              condition: succeeded()
+          # MacOS job disabled in internal CI due to build failures.
+          # MacOS builds remain enabled in external (GitHub) CI via azure-pipelines-external.yml.
+          # - job: MacOS
+          #   pool:
+          #     name: Azure Pipelines
+          #     image: macOS-latest
+          #     os: macOS
+          #
+          #   strategy:
+          #     matrix:
+          #       debug:
+          #         _BuildConfig: Debug
+          #       release:
+          #         _BuildConfig: Release
+          #
+          #   steps:
+          #   - script: eng/common/build.sh
+          #       --configuration $(_BuildConfig)
+          #       --prepareMachine
+          #       --restore --build --test
+          #       --ci
+          #     name: Build
+          #     displayName: Build
+          #     condition: succeeded()
 
       - template: /eng/common/templates-official/job/publish-build-assets.yml@self
         parameters:


### PR DESCRIPTION
MacOS builds are failing in the internal Azure DevOps pipeline. Disable the MacOS job there while leaving it enabled in the external (GitHub) CI via azure-pipelines-external.yml.