### PR TITLE
Defer field type resolution to fix #1428 perf regression

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/GenericFieldTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/GenericFieldTests.cs
@@ -148,6 +148,59 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             Assert.Contains("LinkedListNode", nodeType!.Name);
         }
 
+        /// <summary>
+        /// Issue #1428: Accessing field.Name on a generic instantiation must not eagerly
+        /// resolve field.Type. Type resolution calls GetConcreteGenericTypeArguments ->
+        /// GetTypeByName which is expensive; it should only run when Type is actually
+        /// requested. This test verifies the lazy ordering still produces correct results
+        /// when Name is read before Type.
+        /// </summary>
+        [Fact]
+        public void Field_NameBeforeType_StillResolvesTypeCorrectly()
+        {
+            ClrHeap heap = _connection.Runtime.Heap;
+            ClrObject node = heap.EnumerateObjects()
+                .FirstOrDefault(o => o.Type?.Name?.Contains("LinkedListNode<System.String>") == true);
+
+            Assert.True(node.IsValid, "Could not find LinkedListNode<string> on the heap.");
+
+            ClrInstanceField? itemField = node.Type!.Fields.FirstOrDefault(f => f.Name == "item");
+            Assert.NotNull(itemField);
+
+            // Read Name first -- this must not trigger Type resolution side effects that
+            // cause Type to later return null/wrong value.
+            string? name = itemField.Name;
+            Assert.Equal("item", name);
+
+            // Now request Type. It must still resolve to the concrete instantiation.
+            Assert.NotNull(itemField.Type);
+            Assert.Equal("System.String", itemField.Type!.Name);
+        }
+
+        /// <summary>
+        /// Issue #1428: Reading Attributes before Type must not prevent later Type resolution.
+        /// </summary>
+        [Fact]
+        public void Field_AttributesBeforeType_StillResolvesTypeCorrectly()
+        {
+            ClrHeap heap = _connection.Runtime.Heap;
+            ClrObject node = heap.EnumerateObjects()
+                .FirstOrDefault(o => o.Type?.Name?.Contains("LinkedListNode<System.String>") == true);
+
+            Assert.True(node.IsValid, "Could not find LinkedListNode<string> on the heap.");
+
+            ClrInstanceField? itemField = node.Type!.Fields.FirstOrDefault(f => f.Name == "item");
+            Assert.NotNull(itemField);
+
+            // Read Attributes first.
+            System.Reflection.FieldAttributes attrs = itemField.Attributes;
+            Assert.NotEqual(System.Reflection.FieldAttributes.ReservedMask, attrs);
+
+            // Now request Type.
+            Assert.NotNull(itemField.Type);
+            Assert.Equal("System.String", itemField.Type!.Name);
+        }
+
         public class GenericConnection : Fixtures.ObjectConnection<GenericTypeCarrier>
         {
             public GenericConnection() : base(TestTargets.ClrObjects, typeof(GenericTypeCarrier).Name)

--- a/src/Microsoft.Diagnostics.Runtime/ClrField.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrField.cs
@@ -23,6 +23,7 @@ namespace Microsoft.Diagnostics.Runtime
         internal readonly IAbstractTypeHelpers _helpers;
         private ClrType? _type;
         private int _attributes = (int)FieldAttributes.ReservedMask;
+        private int _typeInitialized;
 
         internal FieldInfo FieldInfo { get; }
 
@@ -31,6 +32,8 @@ namespace Microsoft.Diagnostics.Runtime
             _helpers = helpers;
             ContainingType = containingType;
             _type = type;
+            if (_type is not null)
+                _typeInitialized = 1;
 
             if (data.ElementType == ClrElementType.Class && _type != null)
                 data.ElementType = _type.ElementType;
@@ -43,6 +46,7 @@ namespace Microsoft.Diagnostics.Runtime
         private void DebugOnlyLoadLazyValues()
         {
             InitData(false);
+            GetClrType();
         }
 
 
@@ -88,17 +92,7 @@ namespace Microsoft.Diagnostics.Runtime
         /// Gets the type of the field.  Note this property may return <see langword="null"/> on error.  There is a bug in several versions
         /// of our debugging layer which causes this.  You should always null-check the return value of this field.
         /// </summary>
-        public virtual ClrType? Type
-        {
-            get
-            {
-                if (_type != null)
-                    return _type;
-
-                InitData(false);
-                return _type;
-            }
-        }
+        public virtual ClrType? Type => GetClrType();
 
         private void InitData(bool forName)
         {
@@ -122,25 +116,79 @@ namespace Microsoft.Diagnostics.Runtime
                     _name = info.Name;
             }
 
-            if (_type is null)
-            {
-                SigParser sigParser = new(info.Signature, info.SignatureSize);
-                if (sigParser.GetCallingConvInfo(out int sigType) && sigType == SigParser.IMAGE_CEE_CS_CALLCONV_FIELD)
-                {
-                    sigParser.SkipCustomModifiers();
-                    IReadOnlyList<ClrType?>? concreteTypeArgs = ContainingType.GetConcreteGenericTypeArguments();
-                    _type = ContainingType.Heap.GetOrCreateTypeFromSignature(ContainingType.Module, sigParser, ContainingType.EnumerateGenericParameters(), Array.Empty<ClrGenericParameter>(), concreteTypeArgs);
-                }
+            Interlocked.Exchange(ref _attributes, (int)info.Attributes);
+        }
 
-                // If metadata resolution produced a generic placeholder (e.g. "TStateMachine"
-                // with no fields), fall back to the MethodTable. This handles compiler-generated
-                // types nested inside open generic classes where the name-based lookup fails
-                // due to open vs closed generic name mismatch.
-                if (_type is Implementation.ClrGenericType && FieldInfo.MethodTable != 0)
-                    _type = ContainingType.Heap.GetTypeByMethodTable(FieldInfo.MethodTable) ?? _type;
+        // Returns the field's resolved type, computing it lazily if needed.
+        //
+        // _typeInitialized has three states:
+        //   0 = not yet computed
+        //   1 = computed; _type holds the resolved value
+        //   2 = computed; the field has no resolvable type (don't retry)
+        //
+        // .NET's memory model (including ARM's relaxed ordering) does not guarantee
+        // that another thread observing _typeInitialized == 1 also observes the prior
+        // store to _type. Reference and int reads/writes are atomic, but stores can be
+        // reordered. We tolerate that by re-reading _type after _typeInitialized and,
+        // if we see the "ready" sentinel but _type still reads as null, recomputing.
+        // Recomputation is safe because the result is deterministic for a given field.
+        private ClrType? GetClrType()
+        {
+            int initialized = _typeInitialized;
+            if (initialized == 2)
+                return null;
+
+            ClrType? type = _type;
+            if (initialized == 1 && type is not null)
+                return type;
+
+            return ResolveType();
+        }
+
+        // Resolves the field's type from its metadata signature. This can be expensive for
+        // generic instantiations because GetConcreteGenericTypeArguments calls GetTypeByName,
+        // which performs a module-wide scan and triggers DAC GetMethodTableName calls. This
+        // work is deferred so that callers who only need Name/Attributes don't pay for it.
+        //
+        // May run concurrently on multiple threads. Inputs are immutable for a given field,
+        // so racing threads always compute the same result and double-computation is harmless.
+        private ClrType? ResolveType()
+        {
+            IAbstractMetadataReader? import = ContainingType.Module.MetadataReader;
+            if (import is null || !import.GetFieldDefInfo(Token, out FieldDefInfo info))
+            {
+                _typeInitialized = 2;
+                return null;
             }
 
-            Interlocked.Exchange(ref _attributes, (int)info.Attributes);
+            ClrType? type = null;
+            SigParser sigParser = new(info.Signature, info.SignatureSize);
+            if (sigParser.GetCallingConvInfo(out int sigType) && sigType == SigParser.IMAGE_CEE_CS_CALLCONV_FIELD)
+            {
+                sigParser.SkipCustomModifiers();
+                IReadOnlyList<ClrType?>? concreteTypeArgs = ContainingType.GetConcreteGenericTypeArguments();
+                type = ContainingType.Heap.GetOrCreateTypeFromSignature(ContainingType.Module, sigParser, ContainingType.EnumerateGenericParameters(), Array.Empty<ClrGenericParameter>(), concreteTypeArgs);
+            }
+
+            // If metadata resolution produced a generic placeholder (e.g. "TStateMachine"
+            // with no fields), fall back to the MethodTable. This handles compiler-generated
+            // types nested inside open generic classes where the name-based lookup fails
+            // due to open vs closed generic name mismatch.
+            if (type is Implementation.ClrGenericType && FieldInfo.MethodTable != 0)
+                type = ContainingType.Heap.GetTypeByMethodTable(FieldInfo.MethodTable) ?? type;
+
+            if (type is null)
+            {
+                _typeInitialized = 2;
+                return null;
+            }
+
+            // Publish _type before _typeInitialized so a reader that sees state == 1 is
+            // most likely to also see _type populated. Even if these stores are reordered
+            // (ARM), GetClrType() recomputes when it observes the inconsistency.
+            _type = type;
+            _typeInitialized = 1;
+            return type;
         }
 
         IClrType? IClrField.Type => Type;


### PR DESCRIPTION
ClrField.InitData was eagerly resolving the field's type signature even when the caller only requested Name or Attributes. The type-resolution path calls ContainingType.GetConcreteGenericTypeArguments, which calls ClrHeap.GetTypeByName, which performs a module-wide scan and triggers expensive mscordacwks GetMethodTableName DAC calls. This made field-heavy workloads (e.g. enumerating async state machines) ~10x slower than ClrMD 3.1.

Split the lazy load:

  - InitData(forName) populates _name and _attributes from metadata only.
  - GetClrType() / ResolveType() resolves _type from the field signature, including the ClrGenericType + MethodTable fallback from PR #1373. Runs only when the Type property is actually accessed.

Type-resolution state is tracked in a separate _typeInitialized field (0 = not computed, 1 = resolved, 2 = no resolvable type) so the _attributes sentinel no longer doubles as a type-resolution flag, and so deterministically failed resolutions don't retry on every Type access.

No locks or Interlocked are used on the type-resolution path. Reads and writes of int and reference are atomic in .NET, and the result is deterministic for a given field, so racing threads always agree. GetClrType() re-reads _type after _typeInitialized and recomputes if it sees _typeInitialized == 1 with a null _type, which tolerates write-write reordering on weakly-ordered architectures (ARM).

I also made this change adding a field because of the current alignment of ClrField.  Adding this int is free since padding is added already (even on 32bit), this just eats the hidden padding.  I'd pursue a different fix if that wasn't the case.

Add regression tests verifying that reading Name (or Attributes) before Type still produces the correct concrete generic instantiation.

Fixes #1428.