### PR TITLE
Add Microsoft.NET.Sdk dependency for darc-managed SDK flow

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -26,6 +26,11 @@
     <Dependency Name="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0-preview1.23124.1">
       <Uri>https://github.com/dotnet/roslyn-analyzers</Uri>
       <Sha>c6352bf2e1bd214fce090829de1042000d021497</Sha>
-    </Dependency>s
+    </Dependency>
+    <!-- Flows the .NET SDK pin in global.json. Updated automatically by darc. -->
+    <Dependency Name="Microsoft.NET.Sdk" Version="10.0.106">
+      <Uri>https://github.com/dotnet/dotnet</Uri>
+      <Sha></Sha>
+    </Dependency>
   </ToolsetDependencies>
 </Dependencies>


### PR DESCRIPTION
Adds a `Microsoft.NET.Sdk` dependency entry from `dotnet/dotnet` so darc/Maestro will automatically open PRs to roll the SDK pin in `global.json` whenever a new .NET 10 patch ships. This is the same mechanism `dotnet/diagnostics` uses; today the global.json pin has to be bumped by hand whenever a security patch lands.

The matching channel subscription (.NET 10.0.1xx SDK → microsoft/clrmd main, weekly cadence, standard auto-merge) is being added separately via this maestro-configuration PR: https://dev.azure.com/dnceng/internal/_git/maestro-configuration/pullrequest/60588

Once both this PR and the configuration PR are merged, the next servicing patch will arrive as an automated darc PR rather than a manual edit.

Drive-by: also removes a stray `s` character that was after the `Microsoft.CodeAnalysis.NetAnalyzers` dependency's closing tag.