### PR TITLE
Throw InvalidOperationException when AttachToProcess targets the current process

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/DataTarget.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DataTarget.cs
@@ -374,6 +374,16 @@ namespace Microsoft.Diagnostics.Runtime
         /// <returns>A <see cref="DataTarget"/> instance.</returns>
         public static DataTarget AttachToProcess(int processId, bool suspend, DataTargetOptions? options = null)
         {
+#if NET6_0_OR_GREATER
+            int currentPid = Environment.ProcessId;
+#else
+            int currentPid;
+            using (Process p = Process.GetCurrentProcess())
+                currentPid = p.Id;
+#endif
+            if (processId == currentPid)
+                throw new InvalidOperationException("Attaching to the current process is not supported. Use CreateSnapshotAndAttach instead.");
+
             options ??= new();
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))


### PR DESCRIPTION
Self-attaching with AttachToProcess leads to crashes (SIGSEGV) because the DAC reads process memory that is concurrently mutating. The stack walker encounters stale or null frame pointers, causing null dereferences in libmscordaccore.so.

Users who need to inspect the current process should use CreateSnapshotAndAttach which takes a consistent snapshot first.