### PR TITLE
Add diagnostic context to ArrayComponentTypeTest assertions

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/TypeTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/TypeTests.cs
@@ -103,13 +103,19 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             foreach (ClrObject obj in heap.EnumerateObjects())
             {
                 ClrType type = obj.Type;
-                Assert.True(!type.IsArray || type.ComponentType != null);
+                Assert.True(
+                    !type.IsArray || type.ComponentType != null,
+                    $"Array type '{type.Name}' (MT=0x{type.MethodTable:x}, module='{type.Module?.Name}') has null ComponentType. Object=0x{obj.Address:x}.");
 
                 ClrGenericParameter[] generics = type.EnumerateGenericParameters().ToArray();
 
                 foreach (ClrInstanceField field in type.Fields)
                 {
-                    Assert.NotNull(field.Type);
+                    Assert.True(
+                        field.Type is not null,
+                        $"Field '{type.Name}.{field.Name}' has null Type. " +
+                        $"Token=0x{field.Token:x}, ElementType={field.ElementType}, Offset={field.Offset}, " +
+                        $"ContainingType.MethodTable=0x{type.MethodTable:x}, Module='{type.Module?.Name}', Object=0x{obj.Address:x}.");
                     Assert.Same(heap, field.Type.Heap);
                 }
             }
@@ -118,7 +124,9 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             {
                 foreach (ClrType type in module.EnumerateTypes())
                 {
-                    Assert.True(!type.IsArray || type.ComponentType != null);
+                    Assert.True(
+                        !type.IsArray || type.ComponentType != null,
+                        $"Enumerated array type '{type.Name}' (MT=0x{type.MethodTable:x}, module='{module.Name}') has null ComponentType.");
                     Assert.Same(heap, type.Heap);
                 }
             }


### PR DESCRIPTION
The test asserts that every field's Type is non-null across the entire managed heap of the AppDomains net48 dump. When this fails in CI, the bare Assert.NotNull message gives no clue which field/type was unresolvable, making the failure hard to diagnose without local repro.

Replace the bare assertions with Assert.True calls that include the containing type name, field name, token, element type, offset, method table, module, and (where applicable) object address. The same is done for the IsArray/ComponentType assertions.

No behavior change; just better failure messages.