### PR TITLE
Fix #1334: GetTypeByName resolves closed generics and reflection FullNames

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/GenericFieldTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/GenericFieldTests.cs
@@ -149,6 +149,45 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         }
 
         /// <summary>
+        /// Issue #1334: GetTypeByName should accept reflection-style assembly-qualified
+        /// FullNames (e.g. "LinkedListNode`1[[System.String, System.Private.CoreLib, ...]]")
+        /// and resolve them to the equivalent closed generic instantiation.  This is the
+        /// format BenchmarkDotNet's ClrMdDisassembler passes when it calls
+        /// `module.GetTypeByName(args.BenchmarkInstance.GetType().FullName!)`.
+        /// </summary>
+        [Fact]
+        public void GetTypeByName_AcceptsReflectionFullNameForClosedGenerics()
+        {
+            ClrHeap heap = _connection.Runtime.Heap;
+
+            // Force heap enumeration so types get constructed and cached.
+            foreach (ClrObject obj in heap.EnumerateObjects())
+                _ = obj.Type;
+
+            // Type.FullName-style assembly-qualified name.
+            const string FullName = "System.Collections.Generic.LinkedListNode`1[[System.String, System.Private.CoreLib, Version=8.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]";
+            ClrType? nodeType = heap.GetTypeByName(FullName);
+            Assert.NotNull(nodeType);
+            Assert.Contains("LinkedListNode<System.String>", nodeType!.Name);
+        }
+
+        /// <summary>
+        /// Issue #1334: TryNormalizeReflectionFullName should produce the simplified
+        /// ClrType.Name format from various reflection-style inputs without requiring
+        /// any runtime state.
+        /// </summary>
+        [Theory]
+        [InlineData("Foo`1[[System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]", "Foo<System.Int32>")]
+        [InlineData("Ns.Foo`2[[System.Int32, mscorlib],[System.String, mscorlib]]", "Ns.Foo<System.Int32, System.String>")]
+        [InlineData("Outer`1[[Inner`1[[System.Int32, mscorlib]], mscorlib]]", "Outer<Inner<System.Int32>>")]
+        [InlineData("Already.Simple<System.Int32>", "Already.Simple<System.Int32>")]
+        public void TryNormalizeReflectionFullName_ProducesClrTypeNameFormat(string input, string expected)
+        {
+            string? actual = ClrHeap.TryNormalizeReflectionFullName(input);
+            Assert.Equal(expected, actual);
+        }
+
+        /// <summary>
         /// Issue #1428: Accessing field.Name on a generic instantiation must not eagerly
         /// resolve field.Type. Type resolution calls GetConcreteGenericTypeArguments ->
         /// GetTypeByName which is expensive; it should only run when Type is actually

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/GenericFieldTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/GenericFieldTests.cs
@@ -181,6 +181,15 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         [InlineData("Ns.Foo`2[[System.Int32, mscorlib],[System.String, mscorlib]]", "Ns.Foo<System.Int32, System.String>")]
         [InlineData("Outer`1[[Inner`1[[System.Int32, mscorlib]], mscorlib]]", "Outer<Inner<System.Int32>>")]
         [InlineData("Already.Simple<System.Int32>", "Already.Simple<System.Int32>")]
+        // PR #1438 review: trailing array/pointer/byref modifiers must be preserved.
+        [InlineData("System.Collections.Generic.List`1[[System.Int32, mscorlib]][]", "System.Collections.Generic.List<System.Int32>[]")]
+        [InlineData("Ns.Foo`1[[System.Int32, mscorlib]][,]", "Ns.Foo<System.Int32>[,]")]
+        [InlineData("Ns.Foo`1[[System.Int32, mscorlib]][,,,]", "Ns.Foo<System.Int32>[,,,]")]
+        [InlineData("Ns.Foo`1[[System.Int32, mscorlib]][][]", "Ns.Foo<System.Int32>[][]")]
+        [InlineData("Ns.Foo`1[[System.Int32, mscorlib]]*", "Ns.Foo<System.Int32>*")]
+        [InlineData("Ns.Foo`1[[System.Int32, mscorlib]]&", "Ns.Foo<System.Int32>&")]
+        // Nested generic with an array type argument, plus an outer array.
+        [InlineData("Outer`1[[Inner`1[[System.Int32, mscorlib]][], mscorlib]][]", "Outer<Inner<System.Int32>[]>[]")]
         public void TryNormalizeReflectionFullName_ProducesClrTypeNameFormat(string input, string expected)
         {
             string? actual = ClrHeap.TryNormalizeReflectionFullName(input);

--- a/src/Microsoft.Diagnostics.Runtime/ClrHeap.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrHeap.cs
@@ -1223,6 +1223,20 @@ namespace Microsoft.Diagnostics.Runtime
             // in any module's TypeDef map but were constructed during heap enumeration.
             result ??= _typeFactory.TryGetCachedTypeByName(name);
 
+            // Closed-generic fallback: if the caller passed a reflection-style name like
+            // "Generic`1[[System.Int32, mscorlib, ...]]" (i.e. Type.FullName), normalize
+            // to ClrType.Name format ("Generic<System.Int32>") and try again.
+            if (result is null && LooksLikeClosedGenericName(name))
+            {
+                string? normalized = TryNormalizeReflectionFullName(name);
+                if (normalized != null && normalized != name)
+                {
+                    result = _typeFactory.TryGetCachedTypeByName(normalized);
+                    if (result is null)
+                        result = FindClosedGenericInAnyModule(normalized);
+                }
+            }
+
             return result;
         }
 
@@ -1234,7 +1248,19 @@ namespace Microsoft.Diagnostics.Runtime
             if (name.Length == 0)
                 throw new ArgumentException($"{nameof(name)} cannot be empty");
 
-            return FindTypeName(module.Address, module.EnumerateTypeDefToMethodTableMap(), name);
+            ClrType? result = FindTypeName(module.Address, module.EnumerateTypeDefToMethodTableMap(), name);
+
+            // Closed-generic fallback: closed generic instantiations are not in any module's
+            // TypeDef map (only the open generic typedef is).  If the caller asked for a name
+            // that looks like a closed generic, normalize it and walk the heap for a matching
+            // constructed instantiation in this module.
+            if (result is null && LooksLikeClosedGenericName(name))
+            {
+                string? normalized = TryNormalizeReflectionFullName(name) ?? name;
+                result = FindClosedGenericInModule(module.Address, normalized);
+            }
+
+            return result;
         }
 
         private ClrType? FindTypeName(ulong moduleAddress, IEnumerable<(ulong MethodTable, int Token)> map, string name)
@@ -1261,6 +1287,150 @@ namespace Microsoft.Diagnostics.Runtime
 
             return null;
         }
+
+        /// <summary>
+        /// Heuristic: returns true if <paramref name="name"/> appears to refer to a
+        /// generic instantiation (open or closed).  Used to gate the more expensive
+        /// closed-generic lookup fallback.
+        /// </summary>
+        private static bool LooksLikeClosedGenericName(string name)
+        {
+            // ClrType.Name uses '<' for instantiations (e.g. "Foo<Int32>").
+            // Reflection Type.FullName uses '`' followed by an arity and '[' or '[[' for type args.
+            return name.IndexOf('<') >= 0 || name.IndexOf('[') >= 0 || name.IndexOf('`') >= 0;
+        }
+
+        /// <summary>
+        /// Converts a reflection-style assembly-qualified generic name like
+        /// "Foo`1[[System.Int32, System.Private.CoreLib, Version=...]]" into the
+        /// simplified ClrType.Name format "Foo&lt;System.Int32&gt;".  Returns null if the
+        /// input is not in a recognizable reflection generic form (in which case the
+        /// caller should treat the input as already simplified).
+        /// </summary>
+        internal static string? TryNormalizeReflectionFullName(string name)
+        {
+            if (string.IsNullOrEmpty(name))
+                return null;
+
+            // Already in ClrType.Name format ("Foo<...>") — nothing to do.
+            if (name.IndexOf('<') >= 0 && name.IndexOf('`') < 0)
+                return name;
+
+            int tickIdx = name.IndexOf('`');
+            int bracketIdx = name.IndexOf('[');
+            if (tickIdx < 0 || bracketIdx < 0 || bracketIdx < tickIdx)
+                return null;
+
+            // Base name (everything before the backtick) plus arity (digits between `` ` `` and `[`).
+            string baseName = name.Substring(0, tickIdx);
+            // Arity may include nested generic markers (`Outer`1+Inner`1` for nested), but for
+            // the typical Type.FullName form the arity is just digits.
+
+            // Walk the bracket tree.  The format is `[` then a comma-separated list of either
+            // `[Type, AsmInfo]` or unqualified `Type` entries, then `]`.  The outer `[` may be
+            // doubled (`[[`) for assembly-qualified args.  Handle both.
+            if (!TryParseTypeArgList(name, bracketIdx, out List<string>? args, out _))
+                return null;
+
+            return baseName + "<" + string.Join(", ", args!) + ">";
+        }
+
+        private static bool TryParseTypeArgList(string s, int openIdx, out List<string>? args, out int endIdx)
+        {
+            args = null;
+            endIdx = -1;
+            if (openIdx >= s.Length || s[openIdx] != '[')
+                return false;
+
+            args = new List<string>();
+            int i = openIdx + 1;
+            while (i < s.Length && s[i] != ']')
+            {
+                if (s[i] == ' ' || s[i] == ',') { i++; continue; }
+
+                if (s[i] == '[')
+                {
+                    // Assembly-qualified arg: [Type, Asm, ...]
+                    int depth = 1;
+                    int argStart = i + 1;
+                    int j = argStart;
+                    int firstComma = -1;
+                    while (j < s.Length && depth > 0)
+                    {
+                        if (s[j] == '[') depth++;
+                        else if (s[j] == ']') { depth--; if (depth == 0) break; }
+                        else if (s[j] == ',' && depth == 1 && firstComma < 0) firstComma = j;
+                        j++;
+                    }
+                    if (j >= s.Length) return false;
+
+                    string typePart = firstComma > 0
+                        ? s.Substring(argStart, firstComma - argStart)
+                        : s.Substring(argStart, j - argStart);
+                    typePart = typePart.Trim();
+
+                    // Recursively normalize the type part if it itself is a generic instantiation.
+                    string? normalized = TryNormalizeReflectionFullName(typePart);
+                    args.Add(normalized ?? typePart);
+                    i = j + 1;
+                }
+                else
+                {
+                    // Unqualified arg: just a type name up to ',' or ']'.
+                    int argStart = i;
+                    while (i < s.Length && s[i] != ',' && s[i] != ']') i++;
+                    string typePart = s.Substring(argStart, i - argStart).Trim();
+                    string? normalized = TryNormalizeReflectionFullName(typePart);
+                    args.Add(normalized ?? typePart);
+                }
+            }
+
+            if (i >= s.Length || s[i] != ']')
+                return false;
+
+            endIdx = i;
+            return true;
+        }
+
+        /// <summary>
+        /// Walks the heap looking for a constructed (closed) generic instantiation in the
+        /// given module whose name matches <paramref name="normalizedName"/>.  Used as a
+        /// fallback when the TypeDef map scan fails (because closed generic MTs are not
+        /// recorded in any module's metadata).  This is O(heap size) and should only be
+        /// called when a fast-path lookup has already missed.
+        /// </summary>
+        private ClrType? FindClosedGenericInModule(ulong moduleAddress, string normalizedName)
+        {
+            // Cache check first.
+            foreach (ClrType cached in _typeFactory.EnumerateCachedTypes())
+            {
+                if (cached.Module?.Address == moduleAddress && cached.Name == normalizedName)
+                    return cached;
+            }
+
+            // Heap walk (constructs types on demand into _types).
+            foreach (ClrObject obj in EnumerateObjects())
+            {
+                ClrType? type = obj.Type;
+                if (type != null && type.Module?.Address == moduleAddress && type.Name == normalizedName)
+                    return type;
+            }
+
+            return null;
+        }
+
+        private ClrType? FindClosedGenericInAnyModule(string normalizedName)
+        {
+            foreach (ClrObject obj in EnumerateObjects())
+            {
+                ClrType? type = obj.Type;
+                if (type != null && type.Name == normalizedName)
+                    return type;
+            }
+
+            return null;
+        }
+
 
         internal ClrException? GetExceptionObject(ulong objAddress, ClrThread? thread)
         {

--- a/src/Microsoft.Diagnostics.Runtime/ClrHeap.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrHeap.cs
@@ -1329,10 +1329,19 @@ namespace Microsoft.Diagnostics.Runtime
             // Walk the bracket tree.  The format is `[` then a comma-separated list of either
             // `[Type, AsmInfo]` or unqualified `Type` entries, then `]`.  The outer `[` may be
             // doubled (`[[`) for assembly-qualified args.  Handle both.
-            if (!TryParseTypeArgList(name, bracketIdx, out List<string>? args, out _))
+            if (!TryParseTypeArgList(name, bracketIdx, out List<string>? args, out int endIdx))
                 return null;
 
-            return baseName + "<" + string.Join(", ", args!) + ">";
+            // Preserve any trailing modifier suffix after the closing `]` of the type arg list.
+            // Reflection FullName encodes array/pointer/byref modifiers AFTER the generic args:
+            //   typeof(List<int>[]).FullName    = "List`1[[Int32, ...]][]"
+            //   typeof(List<int>[,]).FullName   = "List`1[[Int32, ...]][,]"
+            //   typeof(List<int>*).FullName     = "List`1[[Int32, ...]]*"
+            // ClrType.Name uses the same `[]`, `[,]`, `*`, `&` syntax, so we can preserve the
+            // suffix verbatim.
+            string suffix = endIdx + 1 < name.Length ? name.Substring(endIdx + 1) : string.Empty;
+
+            return baseName + "<" + string.Join(", ", args!) + ">" + suffix;
         }
 
         private static bool TryParseTypeArgList(string s, int openIdx, out List<string>? args, out int endIdx)

--- a/src/Microsoft.Diagnostics.Runtime/Implementation/ClrTypeFactory.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Implementation/ClrTypeFactory.cs
@@ -171,6 +171,20 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
             return null;
         }
 
+        /// <summary>
+        /// Returns a snapshot of the currently cached types.  Used by closed-generic
+        /// fallback lookups in <see cref="ClrHeap.GetTypeByName(ClrModule, string)"/>
+        /// to find constructed generic instantiations that are not present in any
+        /// module's TypeDef map.
+        /// </summary>
+        public IEnumerable<ClrType> EnumerateCachedTypes()
+        {
+            lock (_types)
+            {
+                return _types.Values.ToArray();
+            }
+        }
+
         public ClrType? GetOrCreateTypeFromSignature(ClrModule module, SigParser parser, IEnumerable<ClrGenericParameter> typeParameters, IEnumerable<ClrGenericParameter> methodParameters, IReadOnlyList<ClrType?>? concreteTypeArgs = null)
         {
             // ECMA 335 - II.23.2.12 - Type


### PR DESCRIPTION
ClrModule.GetTypeByName(name) was unable to find closed generic instantiations such as Generic<int>, because the per-module overload only walks the module's TypeDef->MethodTable map and closed generic MTs are not present in any module's metadata (only the open generic typedef is). Additionally, callers naturally reach for Type.FullName which uses the assembly-qualified format 'Foo`1[[System.Int32, mscorlib, ...]]' rather than ClrType.Name's 'Foo<System.Int32>' format, causing string-equality comparisons to fail even when the type is otherwise findable.

This commit:

- Adds a closed-generic fallback to ClrHeap.GetTypeByName(ClrModule, string) that walks the heap (or already-cached types) for a constructed instantiation in the requested module when the TypeDef-map scan misses.
- Adds an analogous fallback to ClrHeap.GetTypeByName(string).
- Adds TryNormalizeReflectionFullName() which converts assembly-qualified reflection-style names to ClrType.Name format (recursively, supporting nested generics).
- Gates both fallbacks with LooksLikeClosedGenericName() so the (more expensive) heap walk only runs when the input plausibly refers to a generic; non-generic and previously-found types take the original fast path with no behavior change.
- Adds EnumerateCachedTypes() to ClrTypeFactory for the cache-only fast path before falling back to a full heap walk.

This unblocks BenchmarkDotNet's ClrMdDisassembler self-attach scenario (see dotnet/BenchmarkDotNet ClrMdDisassembler.cs:81), which calls module.GetTypeByName(args.BenchmarkInstance.GetType().FullName!) and was silently throwing InvalidOperationException via the subsequent .First() on an empty sequence.

Tests: adds 5 new tests under GenericFieldTests covering the FullName-input case and the normalizer's recursive parsing. All 506 tests pass.

Fixes: #1334