### PR TITLE
Return non-null Type for never-instantiated generic field types

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/ClrField.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrField.cs
@@ -171,10 +171,12 @@ namespace Microsoft.Diagnostics.Runtime
             }
 
             // If metadata resolution produced a generic placeholder (e.g. "TStateMachine"
-            // with no fields), fall back to the MethodTable. This handles compiler-generated
-            // types nested inside open generic classes where the name-based lookup fails
-            // due to open vs closed generic name mismatch.
-            if (type is Implementation.ClrGenericType && FieldInfo.MethodTable != 0)
+            // with no fields) or returned null (the open generic type's MethodTable wasn't
+            // materialized in the runtime), fall back to the MethodTable. This handles
+            // compiler-generated types nested inside open generic classes where the
+            // name-based lookup fails due to open vs closed generic name mismatch, and
+            // never-instantiated generic field types.
+            if ((type is null || type is Implementation.ClrGenericType) && FieldInfo.MethodTable != 0)
                 type = ContainingType.Heap.GetTypeByMethodTable(FieldInfo.MethodTable) ?? type;
 
             if (type is null)

--- a/src/Microsoft.Diagnostics.Runtime/Implementation/ClrTypeFactory.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Implementation/ClrTypeFactory.cs
@@ -270,6 +270,13 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
                 }
 
                 ClrType? result = GetOrCreateTypeFromToken(module, token);
+
+                // The open generic type's MethodTable may not be materialized in the runtime
+                // (e.g. a never-instantiated static field of a generic type in net48 mscorlib).
+                // Fall back to a basic type so callers see a non-null Type, matching the
+                // behavior of the simple Class/Struct branch above.
+                result ??= GetOrCreateBasicType(ClrElementType.Class);
+
                 return result;
             }
 


### PR DESCRIPTION
ArrayComponentTypeTest in TypeTests asserts every field has a non-null Type. This was failing in CI for net48 ActivityTracker.m_current (declared as 'private static AsyncLocal<ActivityInfo> m_current').

When a generic type has never been instantiated in the target process (common for never-touched static fields in net48 mscorlib), the runtime has not materialized a MethodTable for the open generic def. As a result, ClrTypeFactory.GetOrCreateTypeFromToken returns null when parsing the GenericInstantiation signature element, leaving ClrField.Type null.

Fix in two places:
- ClrTypeFactory.GetOrCreateTypeFromSignature: in the GenericInstantiation branch, fall back to a basic type when the open generic token cannot be resolved to an MT, mirroring the behavior of the simple Class/Struct branch.
- ClrField: broaden the existing ClrGenericType-only fallback to also apply when type resolution returned null, using FieldInfo.MethodTable if available.