### PR TITLE
Fall back to live source process when snapshot clone is missing pages

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/DataReaders/Windows/WindowsProcessDataReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DataReaders/Windows/WindowsProcessDataReader.cs
@@ -21,6 +21,15 @@ namespace Microsoft.Diagnostics.Runtime
         private readonly IntPtr _snapshotHandle;
         private readonly IntPtr _cloneHandle;
         private readonly IntPtr _process;
+        // When attached via a snapshot (VA clone), _process is the clone process handle. The clone
+        // does not inherit anonymous (pagefile-backed) section views from the source -- including the
+        // CoreCLR ExecutableAllocator's W^X double-mapped section that backs precode/MethodDesc storage.
+        // Reads against those addresses fail with ERROR_PARTIAL_COPY, which manifests as DAC iteration
+        // failures (e.g. LoadedMethodDescIterator returning empty for closed-generic instantiations,
+        // see clrmd issue #1334). _liveProcess is an open handle to the original (live) source process
+        // used as a read fallback when the clone returns zero bytes for an address that is committed
+        // in the source. It is IntPtr.Zero outside of snapshot mode.
+        private readonly IntPtr _liveProcess;
 
         private const int PROCESS_VM_READ = 0x10;
         private const int PROCESS_QUERY_INFORMATION = 0x0400;
@@ -55,6 +64,11 @@ namespace Microsoft.Diagnostics.Runtime
                     throw new InvalidOperationException($"Could not create snapshot to process. Error {hr}.");
 
                 ProcessId = GetProcessId(_cloneHandle);
+
+                // Open a handle to the live source process so that Read() can fall back to it when the
+                // clone is missing pages (anonymous section views are not inherited by VA clones).
+                // Failure to open is non-fatal -- we simply lose the fallback for this data target.
+                _liveProcess = WindowsFunctions.NativeMethods.OpenProcess(PROCESS_VM_READ | PROCESS_QUERY_INFORMATION, false, _originalPid);
             }
             else
             {
@@ -105,6 +119,9 @@ namespace Microsoft.Diagnostics.Runtime
 
                 if (_process != IntPtr.Zero)
                     WindowsFunctions.NativeMethods.CloseHandle(_process);
+
+                if (_liveProcess != IntPtr.Zero)
+                    WindowsFunctions.NativeMethods.CloseHandle(_liveProcess);
 
                 if (_originalPid != 0)
                 {
@@ -201,6 +218,14 @@ namespace Microsoft.Diagnostics.Runtime
                 fixed (byte* ptr = buffer)
                 {
                     int res = ReadProcessMemory(_process, address.AsIntPtr(), ptr, new IntPtr(buffer.Length), out IntPtr read);
+                    if ((int)read != 0 || _liveProcess == IntPtr.Zero)
+                        return (int)read;
+
+                    // The clone returned zero bytes. This commonly indicates a region that exists in the
+                    // live source process but was not inherited by the snapshot's VA clone (anonymous
+                    // pagefile-backed section views, including the CoreCLR ExecutableAllocator's W^X
+                    // double-mapped section). Fall back to reading directly from the live source.
+                    res = ReadProcessMemory(_liveProcess, address.AsIntPtr(), ptr, new IntPtr(buffer.Length), out read);
                     return (int)read;
                 }
             }


### PR DESCRIPTION
PssCaptureSnapshot(PSS_CAPTURE_VA_CLONE) creates a process clone that inherits MEM_PRIVATE memory and file-backed section views from the source process, but does not inherit views of anonymous pagefile-backed sections (sections created with CreateFileMapping(INVALID_HANDLE_VALUE, ...)). The CoreCLR ExecutableAllocator allocates exactly such a section to back the W^X double-mapped code/precode storage, and several other runtime data structures (notably interleaved loader heap segments) are also backed by anonymous sections.

When the DAC's LoadedMethodDescIterator walks Module::AvailableParamTypes for closed-generic instantiations, it follows pointers into those sections. Against a snapshot data target the read returns ERROR_PARTIAL_COPY (read=0), the DAC propagates CORDBG_E_READVIRTUAL_FAILURE, and EnumerateMethodInstancesByAddress returns no instances. The visible symptom in clrmd is ClrMethod.ILOffsetMap being empty for closed-generic methods under CreateSnapshotAndAttach, even though the same methods' ILOffsetMap is populated correctly when reading from a full-memory dump or from a directly-attached process.

Hold an OpenProcess handle to the live source process for the lifetime of the snapshot data reader, and when ReadProcessMemory against the clone returns zero bytes, retry the read against the live source. The fallback only fires for addresses the clone genuinely lacks; pages that exist in the clone (the vast majority) are still read from the frozen snapshot. The live source handle is closed in Dispose alongside the clone handle.

Closes #1334.