### PR TITLE
Add ClrModule.EnumerateTypesWithStaticFields

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/StaticFieldTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/StaticFieldTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Xunit;
@@ -152,6 +153,58 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             }
 
             Assert.True(foundValue, "No thread had the thread static field initialized");
+        }
+        /// <summary>
+        /// Verifies that <see cref="ClrModule.EnumerateTypesWithStaticFields"/> yields every type
+        /// that has at least one static field according to <c>ClrType.StaticFields</c>, and yields
+        /// only such types. Cross-checked against the slow path of materializing every typedef
+        /// individually so that the metadata pre-filter never drops a real result.
+        /// </summary>
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void EnumerateTypesWithStaticFields_MatchesFullScan(bool singleFile)
+        {
+            using DataTarget dt = TestTargets.Types.LoadFullDump(singleFile);
+            using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
+
+            ClrModule module = runtime.GetModule("types.dll");
+
+            HashSet<ulong> fast = module.EnumerateTypesWithStaticFields()
+                                        .Select(t => t.MethodTable)
+                                        .ToHashSet();
+
+            HashSet<ulong> slow = new();
+            foreach ((ulong methodTable, _) in module.EnumerateTypeDefToMethodTableMap())
+            {
+                if (methodTable == 0)
+                    continue;
+
+                ClrType type = runtime.Heap.GetTypeByMethodTable(methodTable);
+                if (type is null)
+                    continue;
+
+                if (type.StaticFields.Length > 0)
+                    slow.Add(methodTable);
+            }
+
+            Assert.NotEmpty(fast);
+            Assert.Equal(slow, fast);
+
+            // The Types class has many static fields and must be in the result.
+            ClrType typesClass = module.GetTypeByName("Types");
+            Assert.NotNull(typesClass);
+            Assert.Contains(typesClass.MethodTable, fast);
+
+            // ExplicitImpl has no static fields and must NOT be in the result.
+            ClrType explicitImpl = module.GetTypeByName("ExplicitImpl");
+            Assert.NotNull(explicitImpl);
+            Assert.Empty(explicitImpl.StaticFields);
+            Assert.DoesNotContain(explicitImpl.MethodTable, fast);
+
+            // Every yielded type genuinely has at least one static field.
+            foreach (ClrType type in module.EnumerateTypesWithStaticFields())
+                Assert.NotEmpty(type.StaticFields);
         }
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/StaticFieldTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/StaticFieldTests.cs
@@ -184,7 +184,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
                 if (type is null)
                     continue;
 
-                if (type.StaticFields.Length > 0)
+                if (type.StaticFields.Length > 0 || type.ThreadStaticFields.Length > 0)
                     slow.Add(methodTable);
             }
 
@@ -200,11 +200,20 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             ClrType explicitImpl = module.GetTypeByName("ExplicitImpl");
             Assert.NotNull(explicitImpl);
             Assert.Empty(explicitImpl.StaticFields);
+            Assert.Empty(explicitImpl.ThreadStaticFields);
             Assert.DoesNotContain(explicitImpl.MethodTable, fast);
 
-            // Every yielded type genuinely has at least one static field.
+            // ThreadStaticsOnly has only thread-static fields. It must STILL be returned by the
+            // enumerator because thread statics are GC roots too.
+            ClrType threadStaticsOnly = module.GetTypeByName("ThreadStaticsOnly");
+            Assert.NotNull(threadStaticsOnly);
+            Assert.Empty(threadStaticsOnly.StaticFields);
+            Assert.NotEmpty(threadStaticsOnly.ThreadStaticFields);
+            Assert.Contains(threadStaticsOnly.MethodTable, fast);
+
+            // Every yielded type genuinely has at least one static OR thread-static field.
             foreach (ClrType type in module.EnumerateTypesWithStaticFields())
-                Assert.NotEmpty(type.StaticFields);
+                Assert.True(type.StaticFields.Length + type.ThreadStaticFields.Length > 0);
         }
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/StaticFieldTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/StaticFieldTests.cs
@@ -163,6 +163,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
+#nullable enable
         public void EnumerateTypesWithStaticFields_MatchesFullScan(bool singleFile)
         {
             using DataTarget dt = TestTargets.Types.LoadFullDump(singleFile);
@@ -180,7 +181,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
                 if (methodTable == 0)
                     continue;
 
-                ClrType type = runtime.Heap.GetTypeByMethodTable(methodTable);
+                ClrType? type = runtime.Heap.GetTypeByMethodTable(methodTable);
                 if (type is null)
                     continue;
 
@@ -192,22 +193,22 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             Assert.Equal(slow, fast);
 
             // The Types class has many static fields and must be in the result.
-            ClrType typesClass = module.GetTypeByName("Types");
+            ClrType? typesClass = module.GetTypeByName("Types");
             Assert.NotNull(typesClass);
-            Assert.Contains(typesClass.MethodTable, fast);
+            Assert.Contains(typesClass!.MethodTable, fast);
 
             // ExplicitImpl has no static fields and must NOT be in the result.
-            ClrType explicitImpl = module.GetTypeByName("ExplicitImpl");
+            ClrType? explicitImpl = module.GetTypeByName("ExplicitImpl");
             Assert.NotNull(explicitImpl);
-            Assert.Empty(explicitImpl.StaticFields);
+            Assert.Empty(explicitImpl!.StaticFields);
             Assert.Empty(explicitImpl.ThreadStaticFields);
             Assert.DoesNotContain(explicitImpl.MethodTable, fast);
 
             // ThreadStaticsOnly has only thread-static fields. It must STILL be returned by the
             // enumerator because thread statics are GC roots too.
-            ClrType threadStaticsOnly = module.GetTypeByName("ThreadStaticsOnly");
+            ClrType? threadStaticsOnly = module.GetTypeByName("ThreadStaticsOnly");
             Assert.NotNull(threadStaticsOnly);
-            Assert.Empty(threadStaticsOnly.StaticFields);
+            Assert.Empty(threadStaticsOnly!.StaticFields);
             Assert.NotEmpty(threadStaticsOnly.ThreadStaticFields);
             Assert.Contains(threadStaticsOnly.MethodTable, fast);
 
@@ -215,5 +216,6 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             foreach (ClrType type in module.EnumerateTypesWithStaticFields())
                 Assert.True(type.StaticFields.Length + type.ThreadStaticFields.Length > 0);
         }
+#nullable restore
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/ClrModule.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrModule.cs
@@ -208,6 +208,55 @@ namespace Microsoft.Diagnostics.Runtime
         public IEnumerable<(ulong MethodTable, int Token)> EnumerateTypeRefToMethodTableMap() => _typeRefMap ??= (_helpers?.EnumerateTypeRefMap(Address) ?? Enumerable.Empty<(ulong, int)>()).ToArray();
 
         /// <summary>
+        /// Enumerates every constructed <see cref="ClrType"/> in this module that has at least one
+        /// static field. Types whose metadata declares no static FieldDef are skipped without
+        /// materializing the <see cref="ClrType"/>, which avoids the cost of <c>CacheFields</c>
+        /// (a recursive walk that loads every instance, static, and thread-static field, including
+        /// per-field type resolution that is especially expensive for shared generic instantiations).
+        /// On large processes (hundreds of thousands of loaded types) the majority have no statics,
+        /// so this filter is the dominant savings; callers that walk static roots should prefer
+        /// this over manually iterating <see cref="EnumerateTypeDefToMethodTableMap"/>.
+        /// </summary>
+        public IEnumerable<ClrType> EnumerateTypesWithStaticFields()
+        {
+            IAbstractMetadataReader? metadata = MetadataReader;
+
+            foreach ((ulong methodTable, int typeToken) in EnumerateTypeDefToMethodTableMap())
+            {
+                if (methodTable == 0)
+                    continue;
+
+                if (metadata != null && !HasStaticFieldDef(metadata, typeToken))
+                    continue;
+
+                ClrType? type = Heap.GetTypeByMethodTable(methodTable);
+                if (type is null || type.StaticFields.Length == 0)
+                    continue;
+
+                yield return type;
+            }
+        }
+
+        private static bool HasStaticFieldDef(IAbstractMetadataReader metadata, int typeToken)
+        {
+            try
+            {
+                foreach (FieldDefInfo info in metadata.EnumerateFields(typeToken))
+                {
+                    if ((info.Attributes & System.Reflection.FieldAttributes.Static) != 0)
+                        return true;
+                }
+            }
+            catch
+            {
+                // Unreadable metadata: fall back to the slow path so the caller still sees the type.
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
         /// Attempts to obtain a ClrType based on the name of the type.  Note this is a "best effort" due to
         /// the way that the DAC handles types.  This function will fail for Generics, and types which have
         /// never been constructed in the target process.  Please be sure to null-check the return value of

--- a/src/Microsoft.Diagnostics.Runtime/ClrModule.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrModule.cs
@@ -208,16 +208,18 @@ namespace Microsoft.Diagnostics.Runtime
         public IEnumerable<(ulong MethodTable, int Token)> EnumerateTypeRefToMethodTableMap() => _typeRefMap ??= (_helpers?.EnumerateTypeRefMap(Address) ?? Enumerable.Empty<(ulong, int)>()).ToArray();
 
         /// <summary>
-        /// Enumerates every constructed <see cref="ClrType"/> in this module that has at least one
-        /// static field — both regular statics (<see cref="ClrType.StaticFields"/>) and
-        /// thread statics (<see cref="ClrType.ThreadStaticFields"/>). Types whose metadata declares
-        /// no static FieldDef are skipped without materializing the <see cref="ClrType"/>, which
-        /// avoids the cost of <c>CacheFields</c> (a recursive walk that loads every instance,
-        /// static, and thread-static field, including per-field type resolution that is especially
-        /// expensive for shared generic instantiations). On large processes (hundreds of thousands
-        /// of loaded types) the majority have no statics at all, so this filter is the dominant
-        /// savings; callers that walk static roots should prefer this over manually iterating
-        /// <see cref="EnumerateTypeDefToMethodTableMap"/>.
+        /// Enumerates constructed <see cref="ClrType"/> instances in this module that are reachable
+        /// from <see cref="EnumerateTypeDefToMethodTableMap"/> and have at least one static field —
+        /// both regular statics (<see cref="ClrType.StaticFields"/>) and thread statics
+        /// (<see cref="ClrType.ThreadStaticFields"/>). Types whose metadata declares no static
+        /// FieldDef are skipped without materializing the <see cref="ClrType"/>, which avoids the
+        /// cost of <c>CacheFields</c> (a recursive walk that loads every instance, static, and
+        /// thread-static field, including per-field type resolution that is especially expensive
+        /// for shared generic instantiations). On large processes (hundreds of thousands of loaded
+        /// types) the majority have no statics at all, so this filter is the dominant savings.
+        /// Because this method is driven by <see cref="EnumerateTypeDefToMethodTableMap"/>, it is
+        /// not guaranteed to include closed generic instantiations that are not present in that
+        /// map.
         /// </summary>
         public IEnumerable<ClrType> EnumerateTypesWithStaticFields()
         {

--- a/src/Microsoft.Diagnostics.Runtime/ClrModule.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrModule.cs
@@ -209,13 +209,15 @@ namespace Microsoft.Diagnostics.Runtime
 
         /// <summary>
         /// Enumerates every constructed <see cref="ClrType"/> in this module that has at least one
-        /// static field. Types whose metadata declares no static FieldDef are skipped without
-        /// materializing the <see cref="ClrType"/>, which avoids the cost of <c>CacheFields</c>
-        /// (a recursive walk that loads every instance, static, and thread-static field, including
-        /// per-field type resolution that is especially expensive for shared generic instantiations).
-        /// On large processes (hundreds of thousands of loaded types) the majority have no statics,
-        /// so this filter is the dominant savings; callers that walk static roots should prefer
-        /// this over manually iterating <see cref="EnumerateTypeDefToMethodTableMap"/>.
+        /// static field — both regular statics (<see cref="ClrType.StaticFields"/>) and
+        /// thread statics (<see cref="ClrType.ThreadStaticFields"/>). Types whose metadata declares
+        /// no static FieldDef are skipped without materializing the <see cref="ClrType"/>, which
+        /// avoids the cost of <c>CacheFields</c> (a recursive walk that loads every instance,
+        /// static, and thread-static field, including per-field type resolution that is especially
+        /// expensive for shared generic instantiations). On large processes (hundreds of thousands
+        /// of loaded types) the majority have no statics at all, so this filter is the dominant
+        /// savings; callers that walk static roots should prefer this over manually iterating
+        /// <see cref="EnumerateTypeDefToMethodTableMap"/>.
         /// </summary>
         public IEnumerable<ClrType> EnumerateTypesWithStaticFields()
         {
@@ -230,7 +232,10 @@ namespace Microsoft.Diagnostics.Runtime
                     continue;
 
                 ClrType? type = Heap.GetTypeByMethodTable(methodTable);
-                if (type is null || type.StaticFields.Length == 0)
+                if (type is null)
+                    continue;
+
+                if (type.StaticFields.Length == 0 && type.ThreadStaticFields.Length == 0)
                     continue;
 
                 yield return type;

--- a/src/Microsoft.Diagnostics.Runtime/ClrModule.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrModule.cs
@@ -208,18 +208,23 @@ namespace Microsoft.Diagnostics.Runtime
         public IEnumerable<(ulong MethodTable, int Token)> EnumerateTypeRefToMethodTableMap() => _typeRefMap ??= (_helpers?.EnumerateTypeRefMap(Address) ?? Enumerable.Empty<(ulong, int)>()).ToArray();
 
         /// <summary>
-        /// Enumerates constructed <see cref="ClrType"/> instances in this module that are reachable
-        /// from <see cref="EnumerateTypeDefToMethodTableMap"/> and have at least one static field —
-        /// both regular statics (<see cref="ClrType.StaticFields"/>) and thread statics
-        /// (<see cref="ClrType.ThreadStaticFields"/>). Types whose metadata declares no static
-        /// FieldDef are skipped without materializing the <see cref="ClrType"/>, which avoids the
-        /// cost of <c>CacheFields</c> (a recursive walk that loads every instance, static, and
-        /// thread-static field, including per-field type resolution that is especially expensive
-        /// for shared generic instantiations). On large processes (hundreds of thousands of loaded
-        /// types) the majority have no statics at all, so this filter is the dominant savings.
-        /// Because this method is driven by <see cref="EnumerateTypeDefToMethodTableMap"/>, it is
-        /// not guaranteed to include closed generic instantiations that are not present in that
-        /// map.
+        /// Enumerates the <see cref="ClrType"/>s reachable through this module's
+        /// TypeDef→MethodTable map that have at least one static field — both regular statics
+        /// (<see cref="ClrType.StaticFields"/>) and thread statics
+        /// (<see cref="ClrType.ThreadStaticFields"/>). Types whose metadata declares
+        /// no static FieldDef are skipped without materializing the <see cref="ClrType"/>, which
+        /// avoids the cost of <c>CacheFields</c> (a recursive walk that loads every instance,
+        /// static, and thread-static field, including per-field type resolution that is especially
+        /// expensive for shared generic instantiations). On large processes (hundreds of thousands
+        /// of loaded types) the majority have no statics at all, so this filter is the dominant
+        /// savings; callers that walk static roots should prefer this over manually iterating
+        /// <see cref="EnumerateTypeDefToMethodTableMap"/>.
+        ///
+        /// Note: like <see cref="EnumerateTypeDefToMethodTableMap"/>, this returns one MethodTable
+        /// per typedef defined in this module and therefore does not include closed generic
+        /// instantiations (e.g. <c>Foo&lt;int&gt;</c> and <c>Foo&lt;string&gt;</c> from a generic
+        /// definition <c>Foo&lt;T&gt;</c>). Callers that need static roots from closed generic
+        /// instantiations must enumerate those separately.
         /// </summary>
         public IEnumerable<ClrType> EnumerateTypesWithStaticFields()
         {
@@ -250,7 +255,13 @@ namespace Microsoft.Diagnostics.Runtime
             {
                 foreach (FieldDefInfo info in metadata.EnumerateFields(typeToken))
                 {
-                    if ((info.Attributes & System.Reflection.FieldAttributes.Static) != 0)
+                    const System.Reflection.FieldAttributes StaticNonStorage =
+                        System.Reflection.FieldAttributes.Static | System.Reflection.FieldAttributes.Literal;
+
+                    // Literal (const) fields have no runtime storage and won't appear in
+                    // ClrType.StaticFields/ThreadStaticFields, so they don't qualify a type for
+                    // the fast path. Require Static set and Literal clear.
+                    if ((info.Attributes & StaticNonStorage) == System.Reflection.FieldAttributes.Static)
                         return true;
                 }
             }

--- a/src/TestTargets/Types/Types.cs
+++ b/src/TestTargets/Types/Types.cs
@@ -23,6 +23,17 @@ class ExplicitImpl : IExplicitTest
     public void RegularMethod() { }
 }
 
+// Type that has ONLY thread-static fields (no regular statics, no instance fields).
+// Used to verify ClrModule.EnumerateTypesWithStaticFields includes thread-static-only types.
+class ThreadStaticsOnly
+{
+    [ThreadStatic]
+    public static string ts_marker;
+
+    [ThreadStatic]
+    public static int ts_counter;
+}
+
 class Types
 {
     [ThreadStatic]
@@ -104,6 +115,11 @@ class Types
         // Set thread-static values on the main thread only
         ts_threadId = Environment.CurrentManagedThreadId;
         ts_threadName = "MainThread";
+
+        // Initialize the thread-static-only type's fields on the main thread so the
+        // type is constructed and the per-thread storage is allocated.
+        ThreadStaticsOnly.ts_marker = "ThreadStaticsOnlyMarker";
+        ThreadStaticsOnly.ts_counter = 7;
 
         // Exercise struct interface dispatch to create unboxing stub + JIT the implementation
         IStructTest structTest = new StructWithInterface();


### PR DESCRIPTION
This pull request adds a new, more efficient method for enumerating types with static fields in a module, along with comprehensive tests to verify its correctness. The main goal is to optimize the process of finding types with static or thread-static fields, which is especially beneficial for large applications with many types. Additionally, new test types and initialization logic are introduced to ensure accurate coverage.