### PR TITLE
Update dependencies and bump .NET SDK to 10.0.107

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,11 +1,11 @@
 {
   "sdk": {
-    "version": "10.0.106",
+    "version": "10.0.107",
     "rollForward": "latestMajor",
     "allowPrerelease": true
   },
   "tools": {
-    "dotnet": "10.0.106"
+    "dotnet": "10.0.107"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "10.0.0-beta.26208.4"

--- a/src/Benchmarks/Benchmarks.csproj
+++ b/src/Benchmarks/Benchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -11,9 +11,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.12.1.1384" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageReference Include="NETStandard.Library" Version="2.0.3" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.7.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Benchmarks/HeapBenchmarks.cs
+++ b/src/Benchmarks/HeapBenchmarks.cs
@@ -42,7 +42,7 @@ namespace Benchmarks
                 UseOSMemoryFeatures = UseOSMemoryFeatures,
             };
 
-            _dataTarget = DataTarget.LoadDump(Program.CrashDump, options);
+            _dataTarget = DataTarget.LoadDump(Program.CrashDump, new DataTargetOptions { CacheOptions = options });
             _runtime = _dataTarget.ClrVersions.Single().CreateRuntime();
         }
 

--- a/src/Benchmarks/ParallelHeapBenchmarks.cs
+++ b/src/Benchmarks/ParallelHeapBenchmarks.cs
@@ -44,7 +44,7 @@ namespace Benchmarks
                 UseOSMemoryFeatures = UseOSMemoryFeatures,
             };
 
-            _dataTarget = DataTarget.LoadDump(Program.CrashDump, options);
+            _dataTarget = DataTarget.LoadDump(Program.CrashDump, new DataTargetOptions { CacheOptions = options });
             _runtime = _dataTarget.ClrVersions.Single().CreateRuntime();
         }
 

--- a/src/Microsoft.Diagnostics.Runtime/Microsoft.Diagnostics.Runtime.csproj
+++ b/src/Microsoft.Diagnostics.Runtime/Microsoft.Diagnostics.Runtime.csproj
@@ -29,12 +29,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.13.2" />
-    <PackageReference Include="Microsoft.Diagnostics.NETCore.Client" Version="0.2.652701" />
+    <PackageReference Include="Azure.Identity" Version="1.21.0" />
+    <PackageReference Include="Microsoft.Diagnostics.NETCore.Client" Version="0.2.721401" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
-    <PackageReference Include="System.Collections.Immutable" Version="9.0.10" />
+    <PackageReference Include="System.Collections.Immutable" Version="10.0.7" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.2" />
   </ItemGroup>
 


### PR DESCRIPTION
- Update Azure.Identity 1.13.2 -> 1.21.0
- Update Microsoft.Diagnostics.NETCore.Client 0.2.652701 -> 0.2.721401
- Update System.Collections.Immutable 9.0.10 -> 10.0.7
- Bump global.json SDK 10.0.106 -> 10.0.107
- Bump Benchmarks project from net6.0 (out of support) to net10.0
- Update BenchmarkDotNet 0.12.1.1384 -> 0.15.8
- Update Microsoft.CodeAnalysis.CSharp 3.7.0 -> 5.3.0
- Fix benchmark LoadDump calls to wrap CacheOptions in DataTargetOptions