### PR TITLE
Add stresslog support

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/DumpGenerator.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/DumpGenerator.cs
@@ -83,11 +83,11 @@ namespace Microsoft.Diagnostics.Runtime.Tests
                 string processOutput = null;
                 if (highBit && isFramework)
                 {
-                    GenerateHighBitFrameworkDump(exePath, dumpPath, gcMode, full, architecture);
+                    GenerateHighBitFrameworkDump(exePath, dumpPath, gcMode, full, architecture, extraEnv);
                 }
                 else if (highBit)
                 {
-                    processOutput = GenerateHighBitCoreDump(exePath, dumpPath, gcMode, full, architecture);
+                    processOutput = GenerateHighBitCoreDump(exePath, dumpPath, gcMode, full, architecture, extraEnv);
                 }
                 else if (isFramework && RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 {
@@ -373,7 +373,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         /// runs the target .exe's entry point. When the target throws, DbgEng captures
         /// the dump just as it does in the non-HighBit Framework path.
         /// </summary>
-        private static void GenerateHighBitFrameworkDump(string exePath, string dumpPath, GCMode gcMode, bool full, string architecture)
+        private static void GenerateHighBitFrameworkDump(string exePath, string dumpPath, GCMode gcMode, bool full, string architecture, IReadOnlyDictionary<string, string> extraEnv = null)
         {
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 throw new PlatformNotSupportedException("High-bit dump generation is only supported on Windows.");
@@ -392,6 +392,12 @@ namespace Microsoft.Diagnostics.Runtime.Tests
                 info.SetEnvironmentVariable("COMPlus_BuildFlavor", "SVR");
             }
 
+            if (extraEnv != null)
+            {
+                foreach (KeyValuePair<string, string> kvp in extraEnv)
+                    info.SetEnvironmentVariable(kvp.Key, kvp.Value);
+            }
+
             string commandLine = $"\"{host}\" --mode=framework \"{exePath}\"";
             LaunchAndCaptureDump(info, commandLine, workingDirectory: Path.GetDirectoryName(exePath), dumpPath, full, ClrExceptionCode);
         }
@@ -401,7 +407,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         /// before starting the CLR, forcing heap allocations into the upper 2 GB of the 32-bit
         /// address space. Windows x86 only.
         /// </summary>
-        private static string GenerateHighBitCoreDump(string exePath, string dumpPath, GCMode gcMode, bool full, string architecture)
+        private static string GenerateHighBitCoreDump(string exePath, string dumpPath, GCMode gcMode, bool full, string architecture, IReadOnlyDictionary<string, string> extraEnv = null)
         {
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 throw new PlatformNotSupportedException("High-bit dump generation is only supported on Windows.");
@@ -448,6 +454,12 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             {
                 psi.Environment["DOTNET_gcServer"] = "1";
                 psi.Environment["COMPlus_gcServer"] = "1";
+            }
+
+            if (extraEnv != null)
+            {
+                foreach (KeyValuePair<string, string> kvp in extraEnv)
+                    psi.Environment[kvp.Key] = kvp.Value;
             }
 
             using Process process = Process.Start(psi);

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/DumpGenerator.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/DumpGenerator.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         public static string GetBuildOutputDir(string binDir, bool isFramework)
             => Path.Combine(binDir, GetTfm(isFramework));
 
-        public static void EnsureDump(string name, string projectDir, string dumpPath, string architecture, bool isFramework, GCMode gcMode, bool full, bool singleFile = false, bool highBit = false, string[] companionTargets = null)
+        public static void EnsureDump(string name, string projectDir, string dumpPath, string architecture, bool isFramework, GCMode gcMode, bool full, bool singleFile = false, bool highBit = false, string[] companionTargets = null, IReadOnlyDictionary<string, string> extraEnv = null)
         {
             if (File.Exists(dumpPath))
                 return;
@@ -91,17 +91,17 @@ namespace Microsoft.Diagnostics.Runtime.Tests
                 }
                 else if (isFramework && RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 {
-                    GenerateFrameworkDump(exePath, dumpPath, gcMode, full);
+                    GenerateFrameworkDump(exePath, dumpPath, gcMode, full, extraEnv);
                 }
                 else if (singleFile && RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 {
                     // Single-file self-contained apps don't include createdump, so
                     // DOTNET_DbgEnableMiniDump won't work. Use DbgEng instead.
-                    GenerateDbgEngDump(exePath, dumpPath, gcMode, full);
+                    GenerateDbgEngDump(exePath, dumpPath, gcMode, full, extraEnv);
                 }
                 else
                 {
-                    processOutput = GenerateCoreDump(exePath, dumpPath, gcMode, full, singleFile);
+                    processOutput = GenerateCoreDump(exePath, dumpPath, gcMode, full, singleFile, extraEnv);
                 }
 
                 if (!File.Exists(dumpPath))
@@ -750,7 +750,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         /// Generates a dump for a .NET Core target using DOTNET_DbgEnableMiniDump environment variables.
         /// The target is expected to crash with an unhandled exception.
         /// </summary>
-        private static string GenerateCoreDump(string exePath, string dumpPath, GCMode gcMode, bool full, bool singleFile = false)
+        private static string GenerateCoreDump(string exePath, string dumpPath, GCMode gcMode, bool full, bool singleFile = false, IReadOnlyDictionary<string, string> extraEnv = null)
         {
             bool isDll = exePath.EndsWith(".dll", StringComparison.OrdinalIgnoreCase);
 
@@ -815,6 +815,14 @@ namespace Microsoft.Diagnostics.Runtime.Tests
                 psi.Environment["COMPlus_gcServer"] = "1";
             }
 
+            if (extraEnv != null)
+            {
+                foreach (KeyValuePair<string, string> kvp in extraEnv)
+                {
+                    psi.Environment[kvp.Key] = kvp.Value;
+                }
+            }
+
             using Process process = Process.Start(psi);
             string stdout = process.StandardOutput.ReadToEnd();
             string stderr = process.StandardError.ReadToEnd();
@@ -832,7 +840,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         /// Generates a dump for a .NET Framework target using DbgEng on Windows.
         /// Launches the target under the debugger and captures a dump on the unhandled CLR exception.
         /// </summary>
-        private static void GenerateFrameworkDump(string exePath, string dumpPath, GCMode gcMode, bool full)
+        private static void GenerateFrameworkDump(string exePath, string dumpPath, GCMode gcMode, bool full, IReadOnlyDictionary<string, string> extraEnv = null)
         {
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 throw new PlatformNotSupportedException("Framework dump generation is only supported on Windows.");
@@ -845,6 +853,14 @@ namespace Microsoft.Diagnostics.Runtime.Tests
                 info.SetEnvironmentVariable("COMPlus_BuildFlavor", "SVR");
             }
 
+            if (extraEnv != null)
+            {
+                foreach (KeyValuePair<string, string> kvp in extraEnv)
+                {
+                    info.SetEnvironmentVariable(kvp.Key, kvp.Value);
+                }
+            }
+
             LaunchAndCaptureDump(info, exePath, dumpPath, full, ClrExceptionCode);
         }
 
@@ -852,7 +868,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         /// Generates a dump for a .NET Core single-file target using DbgEng on Windows.
         /// Single-file apps don't include createdump, so DOTNET_DbgEnableMiniDump won't work.
         /// </summary>
-        private static void GenerateDbgEngDump(string exePath, string dumpPath, GCMode gcMode, bool full)
+        private static void GenerateDbgEngDump(string exePath, string dumpPath, GCMode gcMode, bool full, IReadOnlyDictionary<string, string> extraEnv = null)
         {
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 throw new PlatformNotSupportedException("DbgEng dump generation is only supported on Windows.");
@@ -864,6 +880,14 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             {
                 info.SetEnvironmentVariable("DOTNET_gcServer", "1");
                 info.SetEnvironmentVariable("COMPlus_gcServer", "1");
+            }
+
+            if (extraEnv != null)
+            {
+                foreach (KeyValuePair<string, string> kvp in extraEnv)
+                {
+                    info.SetEnvironmentVariable(kvp.Key, kvp.Value);
+                }
             }
 
             LaunchAndCaptureDump(info, exePath, dumpPath, full, ClrExceptionCode);

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/StressLog/SyntheticDataReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/StressLog/SyntheticDataReader.cs
@@ -1,0 +1,69 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.Diagnostics.Runtime.Tests
+{
+    /// <summary>
+    /// An <see cref="IDataReader"/> backed by an in-memory address-to-bytes
+    /// dictionary. Reads return however many bytes are available starting at
+    /// the requested address, up to the buffer length, mimicking
+    /// <c>ReadProcessMemory</c> semantics for short reads.
+    /// </summary>
+    internal sealed class SyntheticDataReader : IDataReader
+    {
+        private readonly Dictionary<ulong, byte[]> _segments;
+
+        public SyntheticDataReader(Dictionary<ulong, byte[]> segments)
+        {
+            _segments = segments;
+        }
+
+        public string DisplayName => "synthetic";
+        public bool IsThreadSafe => true;
+        public OSPlatform TargetPlatform => OSPlatform.Windows;
+        public Architecture Architecture => Architecture.X64;
+        public int ProcessId => 0;
+        public IEnumerable<ModuleInfo> EnumerateModules() => Array.Empty<ModuleInfo>();
+        public bool GetThreadContext(uint threadID, uint contextFlags, Span<byte> context) => false;
+        public IEnumerable<uint> EnumerateAllThreads() => Array.Empty<uint>();
+        public void FlushCachedData() { }
+        public int PointerSize => 8;
+
+        public int Read(ulong address, Span<byte> buffer)
+        {
+            foreach (KeyValuePair<ulong, byte[]> kv in _segments)
+            {
+                ulong start = kv.Key;
+                ulong end = start + (ulong)kv.Value.Length;
+                if (address >= start && address < end)
+                {
+                    int srcOffset = (int)(address - start);
+                    int avail = kv.Value.Length - srcOffset;
+                    int copy = Math.Min(avail, buffer.Length);
+                    kv.Value.AsSpan(srcOffset, copy).CopyTo(buffer);
+                    return copy;
+                }
+            }
+            return 0;
+        }
+
+        public bool Read<T>(ulong address, out T value) where T : unmanaged
+        {
+            Span<byte> buf = stackalloc byte[Marshal.SizeOf<T>()];
+            int got = Read(address, buf);
+            if (got != buf.Length) { value = default; return false; }
+            value = MemoryMarshal.Read<T>(buf);
+            return true;
+        }
+
+        public T Read<T>(ulong address) where T : unmanaged
+            => Read(address, out T value) ? value : default;
+
+        public bool ReadPointer(ulong address, out ulong value) => Read(address, out value);
+        public ulong ReadPointer(ulong address) => Read<ulong>(address);
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/StressLog/SyntheticDataReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/StressLog/SyntheticDataReader.cs
@@ -18,20 +18,27 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         private readonly Dictionary<ulong, byte[]> _segments;
 
         public SyntheticDataReader(Dictionary<ulong, byte[]> segments)
+            : this(segments, pointerSize: 8, architecture: Architecture.X64)
+        {
+        }
+
+        public SyntheticDataReader(Dictionary<ulong, byte[]> segments, int pointerSize, Architecture architecture)
         {
             _segments = segments;
+            PointerSize = pointerSize;
+            Architecture = architecture;
         }
 
         public string DisplayName => "synthetic";
         public bool IsThreadSafe => true;
         public OSPlatform TargetPlatform => OSPlatform.Windows;
-        public Architecture Architecture => Architecture.X64;
+        public Architecture Architecture { get; }
         public int ProcessId => 0;
         public IEnumerable<ModuleInfo> EnumerateModules() => Array.Empty<ModuleInfo>();
         public bool GetThreadContext(uint threadID, uint contextFlags, Span<byte> context) => false;
         public IEnumerable<uint> EnumerateAllThreads() => Array.Empty<uint>();
         public void FlushCachedData() { }
-        public int PointerSize => 8;
+        public int PointerSize { get; }
 
         public int Read(ulong address, Span<byte> buffer)
         {
@@ -63,7 +70,15 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         public T Read<T>(ulong address) where T : unmanaged
             => Read(address, out T value) ? value : default;
 
-        public bool ReadPointer(ulong address, out ulong value) => Read(address, out value);
-        public ulong ReadPointer(ulong address) => Read<ulong>(address);
+        public bool ReadPointer(ulong address, out ulong value)
+        {
+            if (PointerSize == 4)
+            {
+                if (Read(address, out uint v32)) { value = v32; return true; }
+                value = 0; return false;
+            }
+            return Read(address, out value);
+        }
+        public ulong ReadPointer(ulong address) => ReadPointer(address, out ulong v) ? v : 0UL;
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/StressLog/SyntheticStressLogBuilder.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/StressLog/SyntheticStressLogBuilder.cs
@@ -55,23 +55,25 @@ namespace Microsoft.Diagnostics.Runtime.Tests
 
             Memory[ChunkAddr] = chunk;
 
-            // Construct the ThreadStressLog (80 bytes).
+            // Construct the ThreadStressLog (80 bytes, Core layout).
             byte[] thread = new byte[StressLogLayout.Thread_HeaderSize];
             // next = 0 (no further threads)
-            BinaryPrimitives.WriteUInt64LittleEndian(thread.AsSpan(StressLogLayout.Thread_ThreadId), ThreadId);
+            BinaryPrimitives.WriteUInt64LittleEndian(thread.AsSpan(StressLogLayout.CoreThread_ThreadId), ThreadId);
             // isDead = readHasWrapped = writeHasWrapped = 0
             ulong msgAddr = ChunkAddr + (ulong)StressLogLayout.Chunk_Buf;
-            BinaryPrimitives.WriteUInt64LittleEndian(thread.AsSpan(StressLogLayout.Thread_CurPtr), msgAddr);
-            BinaryPrimitives.WriteUInt64LittleEndian(thread.AsSpan(StressLogLayout.Thread_ReadPtr), msgAddr);
-            BinaryPrimitives.WriteUInt64LittleEndian(thread.AsSpan(StressLogLayout.Thread_ChunkListHead), ChunkAddr);
-            BinaryPrimitives.WriteUInt64LittleEndian(thread.AsSpan(StressLogLayout.Thread_ChunkListTail), ChunkAddr);
-            BinaryPrimitives.WriteUInt64LittleEndian(thread.AsSpan(StressLogLayout.Thread_CurReadChunk), ChunkAddr);
-            BinaryPrimitives.WriteUInt64LittleEndian(thread.AsSpan(StressLogLayout.Thread_CurWriteChunk), ChunkAddr);
+            BinaryPrimitives.WriteUInt64LittleEndian(thread.AsSpan(StressLogLayout.CoreThread_CurPtr), msgAddr);
+            BinaryPrimitives.WriteUInt64LittleEndian(thread.AsSpan(StressLogLayout.CoreThread_ReadPtr), msgAddr);
+            BinaryPrimitives.WriteUInt64LittleEndian(thread.AsSpan(StressLogLayout.CoreThread_ChunkListHead), ChunkAddr);
+            BinaryPrimitives.WriteUInt64LittleEndian(thread.AsSpan(StressLogLayout.CoreThread_ChunkListTail), ChunkAddr);
+            BinaryPrimitives.WriteUInt64LittleEndian(thread.AsSpan(StressLogLayout.CoreThread_CurReadChunk), ChunkAddr);
+            BinaryPrimitives.WriteUInt64LittleEndian(thread.AsSpan(StressLogLayout.CoreThread_CurWriteChunk), ChunkAddr);
             Memory[ThreadAddr] = thread;
 
-            // Construct the StressLog header (160 bytes).
+            // Construct the StressLog header (160 bytes, Core layout).
             byte[] header = new byte[StressLogLayout.InProc_HeaderSize];
             BinaryPrimitives.WriteUInt64LittleEndian(header.AsSpan(StressLogLayout.InProc_Logs), ThreadAddr);
+            // padding sentinel (0xFFFFFFFF) marks this as a Core in-process StressLog.
+            BinaryPrimitives.WriteUInt32LittleEndian(header.AsSpan(StressLogLayout.InProc_Padding), 0xFFFFFFFFu);
             BinaryPrimitives.WriteUInt64LittleEndian(header.AsSpan(StressLogLayout.InProc_TickFrequency), TickFrequency);
             BinaryPrimitives.WriteUInt64LittleEndian(header.AsSpan(StressLogLayout.InProc_StartTimeStamp), StartTimeStamp);
             // StartTime: leave 0 (no FILETIME)

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/StressLog/SyntheticStressLogBuilder.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/StressLog/SyntheticStressLogBuilder.cs
@@ -1,0 +1,84 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Buffers.Binary;
+using System.Collections.Generic;
+using Microsoft.Diagnostics.Runtime.StressLogs.Internal;
+
+namespace Microsoft.Diagnostics.Runtime.Tests
+{
+    /// <summary>
+    /// Builds a minimal but valid in-process stress log image for end-to-end
+    /// tests. The image consists of one <c>StressLog</c> header, one
+    /// <c>ThreadStressLog</c>, and one <c>StressLogChunk</c> containing a
+    /// single zero-argument message.
+    /// </summary>
+    internal sealed class SyntheticStressLogBuilder
+    {
+        public const ulong StressLogAddr = 0x100000;
+        public const ulong ThreadAddr    = 0x200000;
+        public const ulong ChunkAddr     = 0x300000;
+        public const ulong ThreadId      = 0x42;
+        public const uint  Facility      = 0xABCDEF01;
+        public const ulong TickFrequency = 10_000_000UL; // 10 MHz
+        public const ulong StartTimeStamp = 1_000_000UL;
+        public const ulong MessageTimeStamp = 1_500_000UL;
+
+        public Dictionary<ulong, byte[]> Memory { get; } = new();
+
+        public ulong Build(out ulong threadAddr, out ulong chunkAddr)
+        {
+            threadAddr = ThreadAddr;
+            chunkAddr = ChunkAddr;
+
+            // Construct a chunk with one V4 message at the start, followed by zeros.
+            byte[] chunk = new byte[StressLogLayout.Chunk_TotalSize];
+
+            // prev = next = self (single-element ring)
+            BinaryPrimitives.WriteUInt64LittleEndian(chunk.AsSpan(StressLogLayout.Chunk_Prev), ChunkAddr);
+            BinaryPrimitives.WriteUInt64LittleEndian(chunk.AsSpan(StressLogLayout.Chunk_Next), ChunkAddr);
+
+            // Write a single message with 0 args at the start of the buffer.
+            // V4 header layout (little-endian, 16 bytes):
+            //   word0 = facility(32) | numberOfArgs(6) | formatOffsetLow(26)
+            //   word1 = formatOffsetHigh(13) | timeStamp(51)
+            int msgOffset = StressLogLayout.Chunk_Buf;
+            ulong word0 = Facility; // numberOfArgs = 0, formatOffsetLow = 0
+            ulong word1 = MessageTimeStamp << StressLogConstants.FormatOffsetHighBits;
+            BinaryPrimitives.WriteUInt64LittleEndian(chunk.AsSpan(msgOffset), word0);
+            BinaryPrimitives.WriteUInt64LittleEndian(chunk.AsSpan(msgOffset + 8), word1);
+
+            // Signatures.
+            BinaryPrimitives.WriteUInt32LittleEndian(chunk.AsSpan(StressLogLayout.Chunk_DwSig1Offset), StressLogConstants.ChunkSignature);
+            BinaryPrimitives.WriteUInt32LittleEndian(chunk.AsSpan(StressLogLayout.Chunk_DwSig2Offset), StressLogConstants.ChunkSignature);
+
+            Memory[ChunkAddr] = chunk;
+
+            // Construct the ThreadStressLog (80 bytes).
+            byte[] thread = new byte[StressLogLayout.Thread_HeaderSize];
+            // next = 0 (no further threads)
+            BinaryPrimitives.WriteUInt64LittleEndian(thread.AsSpan(StressLogLayout.Thread_ThreadId), ThreadId);
+            // isDead = readHasWrapped = writeHasWrapped = 0
+            ulong msgAddr = ChunkAddr + (ulong)StressLogLayout.Chunk_Buf;
+            BinaryPrimitives.WriteUInt64LittleEndian(thread.AsSpan(StressLogLayout.Thread_CurPtr), msgAddr);
+            BinaryPrimitives.WriteUInt64LittleEndian(thread.AsSpan(StressLogLayout.Thread_ReadPtr), msgAddr);
+            BinaryPrimitives.WriteUInt64LittleEndian(thread.AsSpan(StressLogLayout.Thread_ChunkListHead), ChunkAddr);
+            BinaryPrimitives.WriteUInt64LittleEndian(thread.AsSpan(StressLogLayout.Thread_ChunkListTail), ChunkAddr);
+            BinaryPrimitives.WriteUInt64LittleEndian(thread.AsSpan(StressLogLayout.Thread_CurReadChunk), ChunkAddr);
+            BinaryPrimitives.WriteUInt64LittleEndian(thread.AsSpan(StressLogLayout.Thread_CurWriteChunk), ChunkAddr);
+            Memory[ThreadAddr] = thread;
+
+            // Construct the StressLog header (160 bytes).
+            byte[] header = new byte[StressLogLayout.InProc_HeaderSize];
+            BinaryPrimitives.WriteUInt64LittleEndian(header.AsSpan(StressLogLayout.InProc_Logs), ThreadAddr);
+            BinaryPrimitives.WriteUInt64LittleEndian(header.AsSpan(StressLogLayout.InProc_TickFrequency), TickFrequency);
+            BinaryPrimitives.WriteUInt64LittleEndian(header.AsSpan(StressLogLayout.InProc_StartTimeStamp), StartTimeStamp);
+            // StartTime: leave 0 (no FILETIME)
+            // ModuleOffset = 0 (no module table; format addresses won't resolve)
+            Memory[StressLogAddr] = header;
+
+            return StressLogAddr;
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/StressLog/SyntheticStressLogBuilder.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/StressLog/SyntheticStressLogBuilder.cs
@@ -28,59 +28,74 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         public Dictionary<ulong, byte[]> Memory { get; } = new();
 
         public ulong Build(out ulong threadAddr, out ulong chunkAddr)
+            => Build(StressLogLayout.CoreX64, out threadAddr, out chunkAddr);
+
+        public ulong Build(StressLogLayout layout, out ulong threadAddr, out ulong chunkAddr)
         {
             threadAddr = ThreadAddr;
             chunkAddr = ChunkAddr;
 
             // Construct a chunk with one V4 message at the start, followed by zeros.
-            byte[] chunk = new byte[StressLogLayout.Chunk_TotalSize];
+            byte[] chunk = new byte[layout.ChunkTotalSize];
 
             // prev = next = self (single-element ring)
-            BinaryPrimitives.WriteUInt64LittleEndian(chunk.AsSpan(StressLogLayout.Chunk_Prev), ChunkAddr);
-            BinaryPrimitives.WriteUInt64LittleEndian(chunk.AsSpan(StressLogLayout.Chunk_Next), ChunkAddr);
+            WritePointer(layout, chunk.AsSpan(layout.ChunkPrevOffset), ChunkAddr);
+            WritePointer(layout, chunk.AsSpan(layout.ChunkNextOffset), ChunkAddr);
 
-            // Write a single message with 0 args at the start of the buffer.
-            // V4 header layout (little-endian, 16 bytes):
+            // Write a single message at the start of the buffer.
+            // For Core (V4) layout (little-endian, 16 bytes):
             //   word0 = facility(32) | numberOfArgs(6) | formatOffsetLow(26)
             //   word1 = formatOffsetHigh(13) | timeStamp(51)
-            int msgOffset = StressLogLayout.Chunk_Buf;
+            int msgOffset = layout.ChunkBufOffset;
             ulong word0 = Facility; // numberOfArgs = 0, formatOffsetLow = 0
             ulong word1 = MessageTimeStamp << StressLogConstants.FormatOffsetHighBits;
             BinaryPrimitives.WriteUInt64LittleEndian(chunk.AsSpan(msgOffset), word0);
             BinaryPrimitives.WriteUInt64LittleEndian(chunk.AsSpan(msgOffset + 8), word1);
 
             // Signatures.
-            BinaryPrimitives.WriteUInt32LittleEndian(chunk.AsSpan(StressLogLayout.Chunk_DwSig1Offset), StressLogConstants.ChunkSignature);
-            BinaryPrimitives.WriteUInt32LittleEndian(chunk.AsSpan(StressLogLayout.Chunk_DwSig2Offset), StressLogConstants.ChunkSignature);
+            BinaryPrimitives.WriteUInt32LittleEndian(chunk.AsSpan(layout.ChunkSig1Offset), StressLogConstants.ChunkSignature);
+            BinaryPrimitives.WriteUInt32LittleEndian(chunk.AsSpan(layout.ChunkSig2Offset), StressLogConstants.ChunkSignature);
 
             Memory[ChunkAddr] = chunk;
 
-            // Construct the ThreadStressLog (80 bytes, Core layout).
-            byte[] thread = new byte[StressLogLayout.Thread_HeaderSize];
+            // Construct the ThreadStressLog.
+            byte[] thread = new byte[layout.ThreadHeaderSize];
             // next = 0 (no further threads)
-            BinaryPrimitives.WriteUInt64LittleEndian(thread.AsSpan(StressLogLayout.CoreThread_ThreadId), ThreadId);
+            // threadId
+            if (layout.ThreadIdSize == 8)
+                BinaryPrimitives.WriteUInt64LittleEndian(thread.AsSpan(layout.ThreadIdOffset), ThreadId);
+            else
+                BinaryPrimitives.WriteUInt32LittleEndian(thread.AsSpan(layout.ThreadIdOffset), (uint)ThreadId);
             // isDead = readHasWrapped = writeHasWrapped = 0
-            ulong msgAddr = ChunkAddr + (ulong)StressLogLayout.Chunk_Buf;
-            BinaryPrimitives.WriteUInt64LittleEndian(thread.AsSpan(StressLogLayout.CoreThread_CurPtr), msgAddr);
-            BinaryPrimitives.WriteUInt64LittleEndian(thread.AsSpan(StressLogLayout.CoreThread_ReadPtr), msgAddr);
-            BinaryPrimitives.WriteUInt64LittleEndian(thread.AsSpan(StressLogLayout.CoreThread_ChunkListHead), ChunkAddr);
-            BinaryPrimitives.WriteUInt64LittleEndian(thread.AsSpan(StressLogLayout.CoreThread_ChunkListTail), ChunkAddr);
-            BinaryPrimitives.WriteUInt64LittleEndian(thread.AsSpan(StressLogLayout.CoreThread_CurReadChunk), ChunkAddr);
-            BinaryPrimitives.WriteUInt64LittleEndian(thread.AsSpan(StressLogLayout.CoreThread_CurWriteChunk), ChunkAddr);
+            ulong msgAddr = ChunkAddr + (ulong)layout.ChunkBufOffset;
+            WritePointer(layout, thread.AsSpan(layout.ThreadCurPtrOffset), msgAddr);
+            WritePointer(layout, thread.AsSpan(layout.ThreadReadPtrOffset), msgAddr);
+            WritePointer(layout, thread.AsSpan(layout.ThreadChunkListHeadOffset), ChunkAddr);
+            WritePointer(layout, thread.AsSpan(layout.ThreadChunkListTailOffset), ChunkAddr);
+            WritePointer(layout, thread.AsSpan(layout.ThreadCurReadChunkOffset), ChunkAddr);
+            WritePointer(layout, thread.AsSpan(layout.ThreadCurWriteChunkOffset), ChunkAddr);
             Memory[ThreadAddr] = thread;
 
-            // Construct the StressLog header (160 bytes, Core layout).
-            byte[] header = new byte[StressLogLayout.InProc_HeaderSize];
-            BinaryPrimitives.WriteUInt64LittleEndian(header.AsSpan(StressLogLayout.InProc_Logs), ThreadAddr);
+            // Construct the StressLog header.
+            byte[] header = new byte[layout.InProcHeaderSize];
+            WritePointer(layout, header.AsSpan(layout.InProcLogsOffset), ThreadAddr);
             // padding sentinel (0xFFFFFFFF) marks this as a Core in-process StressLog.
-            BinaryPrimitives.WriteUInt32LittleEndian(header.AsSpan(StressLogLayout.InProc_Padding), 0xFFFFFFFFu);
-            BinaryPrimitives.WriteUInt64LittleEndian(header.AsSpan(StressLogLayout.InProc_TickFrequency), TickFrequency);
-            BinaryPrimitives.WriteUInt64LittleEndian(header.AsSpan(StressLogLayout.InProc_StartTimeStamp), StartTimeStamp);
+            BinaryPrimitives.WriteUInt32LittleEndian(header.AsSpan(layout.InProcPaddingOffset), 0xFFFFFFFFu);
+            BinaryPrimitives.WriteUInt64LittleEndian(header.AsSpan(layout.InProcTickFrequencyOffset), TickFrequency);
+            BinaryPrimitives.WriteUInt64LittleEndian(header.AsSpan(layout.InProcStartTimeStampOffset), StartTimeStamp);
             // StartTime: leave 0 (no FILETIME)
             // ModuleOffset = 0 (no module table; format addresses won't resolve)
             Memory[StressLogAddr] = header;
 
             return StressLogAddr;
+        }
+
+        private static void WritePointer(StressLogLayout layout, Span<byte> dst, ulong value)
+        {
+            if (layout.PointerSize == 8)
+                BinaryPrimitives.WriteUInt64LittleEndian(dst, value);
+            else
+                BinaryPrimitives.WriteUInt32LittleEndian(dst, (uint)value);
         }
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/StressLogIntegrationTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/StressLogIntegrationTests.cs
@@ -88,11 +88,11 @@ namespace Microsoft.Diagnostics.Runtime.Tests
 
             using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
 
-            bool opened = StressLog.TryOpen(runtime, out StressLog? stressLog);
-            Assert.True(opened, BuildDiagnosticMessage("StressLog.TryOpen returned false", runtime, stressLog: null));
+            bool opened = runtime.TryGetStressLog(out StressLog? stressLog, out string? failureReason);
+            Assert.True(opened, BuildDiagnosticMessage($"runtime.TryGetStressLog returned false: {failureReason}", runtime, stressLog: null));
             Assert.NotNull(stressLog);
 
-            using (stressLog)
+            // The stress log is owned by the runtime; do not dispose it here.
             {
                 List<StressLogMessage> messages = new();
                 Dictionary<StressLogKnownFormat, int> knownCounts = new();

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/StressLogIntegrationTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/StressLogIntegrationTests.cs
@@ -1,0 +1,211 @@
+#nullable enable
+
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using Microsoft.Diagnostics.Runtime.StressLogs;
+using Xunit;
+
+namespace Microsoft.Diagnostics.Runtime.Tests
+{
+    public class StressLogIntegrationTests
+    {
+        // The runtime's stress log is enabled by environment variable. We set both
+        // the DOTNET_ and COMPlus_ prefixes so this works for .NET 5+ (DOTNET_) and
+        // older runtimes / .NET Framework (COMPlus_).
+        //
+        // LogFacility=0xFFFFFFFF turns on every subsystem; the per-thread buffer
+        // is sized large enough (1 MB) that a couple of forced compacting
+        // collections won't be wrapped out by other chatter.
+        //
+        // LogLevel=10 == LL_INFO100000, which is the most permissive level the
+        // GC writers check against.
+        private static readonly Dictionary<string, string> s_stressLogEnv = new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["DOTNET_StressLog"] = "1",
+            ["COMPlus_StressLog"] = "1",
+            ["DOTNET_LogFacility"] = "0xFFFFFFFF",
+            ["COMPlus_LogFacility"] = "0xFFFFFFFF",
+            ["DOTNET_LogLevel"] = "10",
+            ["COMPlus_LogLevel"] = "10",
+            ["DOTNET_StressLogSize"] = "0x100000",
+            ["COMPlus_StressLogSize"] = "0x100000",
+            ["DOTNET_TotalStressLogSize"] = "0x4000000",
+            ["COMPlus_TotalStressLogSize"] = "0x4000000",
+        };
+
+        // Suffix bumps when the environment changes so old cached dumps don't
+        // satisfy a new test that needs different GC behavior.
+        private const string DumpSuffix = "stresslog_v2";
+
+        [Fact]
+        public void CanOpenStressLog_Core_Workstation()
+        {
+            RunAssertions(GCMode.Workstation, isFramework: false, singleFile: false, requireGcStartEnd: true);
+        }
+
+        [Fact]
+        public void CanOpenStressLog_Core_Server()
+        {
+            RunAssertions(GCMode.Server, isFramework: false, singleFile: false, requireGcStartEnd: true);
+        }
+
+        [WindowsFact]
+        public void CanOpenStressLog_Core_SingleFile()
+        {
+            // Smoke-only: self-contained single-file publishes can include a
+            // runtime whose internal format strings differ enough that we don't
+            // recognize them; we only assert that the parser opens cleanly and
+            // produces messages.
+            RunAssertions(GCMode.Workstation, isFramework: false, singleFile: true, requireGcStartEnd: false);
+        }
+
+        [FrameworkFact]
+        public void CanOpenStressLog_Framework_Workstation()
+        {
+            // Smoke-only: .NET Framework's GC stress format strings drift across
+            // patch releases enough that we don't pin them.
+            RunAssertions(GCMode.Workstation, isFramework: true, singleFile: false, requireGcStartEnd: false);
+        }
+
+        [FrameworkFact]
+        public void CanOpenStressLog_Framework_Server()
+        {
+            RunAssertions(GCMode.Server, isFramework: true, singleFile: false, requireGcStartEnd: false);
+        }
+
+        private static void RunAssertions(GCMode gcMode, bool isFramework, bool singleFile, bool requireGcStartEnd)
+        {
+            using DataTarget dt = TestTargets.StressLog.LoadFullDumpWithEnvironment(
+                extraEnv: s_stressLogEnv,
+                dumpNameSuffix: DumpSuffix,
+                gc: gcMode,
+                isFramework: isFramework,
+                singleFile: singleFile);
+
+            using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
+
+            bool opened = StressLog.TryOpen(runtime, out StressLog? stressLog);
+            Assert.True(opened, BuildDiagnosticMessage("StressLog.TryOpen returned false", runtime, stressLog: null));
+            Assert.NotNull(stressLog);
+
+            using (stressLog)
+            {
+                List<StressLogMessage> messages = new();
+                Dictionary<StressLogKnownFormat, int> knownCounts = new();
+                List<StressLogDiagnostic> diagnostics = new();
+
+                stressLog!.Diagnostic += d =>
+                {
+                    lock (diagnostics)
+                    {
+                        if (diagnostics.Count < 32)
+                            diagnostics.Add(d);
+                    }
+                };
+
+                foreach (StressLogMessage msg in stressLog.EnumerateMessages())
+                {
+                    messages.Add(msg);
+                    if (msg.KnownFormat != StressLogKnownFormat.None)
+                    {
+                        knownCounts.TryGetValue(msg.KnownFormat, out int n);
+                        knownCounts[msg.KnownFormat] = n + 1;
+                    }
+
+                    // Cap the enumeration to keep the test bounded even if the
+                    // dump is unexpectedly large; we only need a representative
+                    // sample for the assertions below.
+                    if (messages.Count >= 200_000)
+                        break;
+                }
+
+                if (requireGcStartEnd)
+                {
+                    Assert.True(
+                        messages.Count > 0,
+                        BuildDiagnosticMessage("Stress log was opened but yielded zero messages", runtime, stressLog, messages, knownCounts, diagnostics));
+                }
+
+                // Per-format arg-count sanity. The format strings come from the
+                // runtime's gcmsg.inl and have stable arities; if a format is
+                // observed it must have the documented argument count.
+                AssertArgCount(messages, StressLogKnownFormat.GcStart, expected: 3);
+                AssertArgCount(messages, StressLogKnownFormat.GcEnd, expected: 3);
+                AssertArgCount(messages, StressLogKnownFormat.GcRoot, expected: 4);
+                AssertArgCount(messages, StressLogKnownFormat.GcRootPromote, expected: 3);
+                AssertArgCount(messages, StressLogKnownFormat.GcPlugMove, expected: 3);
+
+                if (requireGcStartEnd)
+                {
+                    // The test target forces two compacting GCs, so GcStart/GcEnd
+                    // are expected to appear. Other known formats are best-effort:
+                    // they depend on whether the GC actually had relocations to
+                    // emit, which can vary by runtime version and GC mode.
+                    Assert.True(
+                        knownCounts.GetValueOrDefault(StressLogKnownFormat.GcStart, 0) > 0,
+                        BuildDiagnosticMessage("GcStart not observed", runtime, stressLog, messages, knownCounts, diagnostics));
+                    Assert.True(
+                        knownCounts.GetValueOrDefault(StressLogKnownFormat.GcEnd, 0) > 0,
+                        BuildDiagnosticMessage("GcEnd not observed", runtime, stressLog, messages, knownCounts, diagnostics));
+                }
+            }
+        }
+
+        private static void AssertArgCount(IEnumerable<StressLogMessage> messages, StressLogKnownFormat format, int expected)
+        {
+            foreach (StressLogMessage msg in messages)
+            {
+                if (msg.KnownFormat == format)
+                {
+                    Assert.True(
+                        msg.ArgumentCount == expected,
+                        $"{format} message had ArgumentCount={msg.ArgumentCount}, expected {expected}.");
+                }
+            }
+        }
+
+        private static string BuildDiagnosticMessage(
+            string headline,
+            ClrRuntime runtime,
+            StressLog? stressLog,
+            IReadOnlyList<StressLogMessage>? messages = null,
+            IReadOnlyDictionary<StressLogKnownFormat, int>? knownCounts = null,
+            IReadOnlyList<StressLogDiagnostic>? diagnostics = null)
+        {
+            System.Text.StringBuilder sb = new();
+            sb.AppendLine(headline);
+            sb.AppendLine($"  OS: {RuntimeInformation.OSDescription}");
+            sb.AppendLine($"  Architecture: {RuntimeInformation.ProcessArchitecture}");
+            sb.AppendLine($"  ClrVersion: {runtime.ClrInfo.Version} flavor={runtime.ClrInfo.Flavor}");
+            sb.AppendLine($"  StressLog opened: {stressLog is not null}");
+            if (messages is not null)
+            {
+                sb.AppendLine($"  Total messages parsed: {messages.Count}");
+                int unknown = 0;
+                foreach (StressLogMessage m in messages)
+                    if (m.KnownFormat == StressLogKnownFormat.None) unknown++;
+                sb.AppendLine($"  Unknown-format messages: {unknown}");
+            }
+
+            if (knownCounts is not null)
+            {
+                foreach (KeyValuePair<StressLogKnownFormat, int> kvp in knownCounts)
+                    sb.AppendLine($"  {kvp.Key}: {kvp.Value}");
+            }
+
+            if (diagnostics is not null && diagnostics.Count > 0)
+            {
+                sb.AppendLine($"  Diagnostics ({diagnostics.Count}):");
+                foreach (StressLogDiagnostic d in diagnostics)
+                    sb.AppendLine($"    {d}");
+            }
+
+            return sb.ToString();
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/StressLogIntegrationTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/StressLogIntegrationTests.cs
@@ -57,25 +57,24 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         [WindowsFact]
         public void CanOpenStressLog_Core_SingleFile()
         {
-            // Smoke-only: self-contained single-file publishes can include a
-            // runtime whose internal format strings differ enough that we don't
-            // recognize them; we only assert that the parser opens cleanly and
-            // produces messages.
-            RunAssertions(GCMode.Workstation, isFramework: false, singleFile: true, requireGcStartEnd: false);
+            // Self-contained single-file publishes use the same Core format
+            // strings as a framework-dependent publish; the stress log content
+            // is identical and we can assert the same set of known formats.
+            RunAssertions(GCMode.Workstation, isFramework: false, singleFile: true, requireGcStartEnd: true);
         }
 
         [FrameworkFact]
         public void CanOpenStressLog_Framework_Workstation()
         {
-            // Smoke-only: .NET Framework's GC stress format strings drift across
-            // patch releases enough that we don't pin them.
-            RunAssertions(GCMode.Workstation, isFramework: true, singleFile: false, requireGcStartEnd: false);
+            // .NET Framework's gcmsg.inl shares the GcStart/GcEnd/GcRoot
+            // format strings with Core, so they are recognized by the parser.
+            RunAssertions(GCMode.Workstation, isFramework: true, singleFile: false, requireGcStartEnd: true);
         }
 
         [FrameworkFact]
         public void CanOpenStressLog_Framework_Server()
         {
-            RunAssertions(GCMode.Server, isFramework: true, singleFile: false, requireGcStartEnd: false);
+            RunAssertions(GCMode.Server, isFramework: true, singleFile: false, requireGcStartEnd: true);
         }
 
         private static void RunAssertions(GCMode gcMode, bool isFramework, bool singleFile, bool requireGcStartEnd)
@@ -124,12 +123,9 @@ namespace Microsoft.Diagnostics.Runtime.Tests
                         break;
                 }
 
-                if (requireGcStartEnd)
-                {
-                    Assert.True(
-                        messages.Count > 0,
-                        BuildDiagnosticMessage("Stress log was opened but yielded zero messages", runtime, stressLog, messages, knownCounts, diagnostics));
-                }
+                Assert.True(
+                    messages.Count > 0,
+                    BuildDiagnosticMessage("Stress log was opened but yielded zero messages", runtime, stressLog, messages, knownCounts, diagnostics));
 
                 // Per-format arg-count sanity. The format strings come from the
                 // runtime's gcmsg.inl and have stable arities; if a format is

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/StressLogTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/StressLogTests.cs
@@ -318,16 +318,20 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         // ---- Fuzz: random format strings + random args must not crash ----
 
         [Theory]
-        [InlineData(0xC0FFEE)]
-        [InlineData(unchecked((int)0xDEADBEEF))]
-        [InlineData(0x12345678)]
-        public void Parser_FuzzNeverThrowsAndStaysBounded(int seed)
+        [InlineData(0xC0FFEE, 8)]
+        [InlineData(unchecked((int)0xDEADBEEF), 8)]
+        [InlineData(0x12345678, 8)]
+        [InlineData(0xC0FFEE, 4)]
+        [InlineData(unchecked((int)0xDEADBEEF), 4)]
+        [InlineData(0x12345678, 4)]
+        public void Parser_FuzzNeverThrowsAndStaysBounded(int seed, int pointerSize)
         {
             // Feed random bytes (including 0x25 '%' to ensure many specifier
             // attempts) into the parser. The parser must always terminate
             // and never throw an unhandled exception. This exercises every
             // combination of length modifier, width/precision overflow,
-            // truncated specifier at end-of-string, etc.
+            // truncated specifier at end-of-string, etc., for both pointer
+            // sizes so the x86 64-bit-arg-combining path is covered.
             Random rng = new(seed);
             for (int trial = 0; trial < 250; trial++)
             {
@@ -350,7 +354,10 @@ namespace Microsoft.Diagnostics.Runtime.Tests
                     args[i] = (ulong)rng.NextInt64();
 
                 CaptureReceiver receiver = CaptureReceiver.Create();
-                ArgumentResolver resolver = new ArgumentResolver(new SyntheticDataReader(new()));
+                SyntheticDataReader reader = pointerSize == 4
+                    ? new SyntheticDataReader(new(), pointerSize: 4, architecture: System.Runtime.InteropServices.Architecture.X86)
+                    : new SyntheticDataReader(new());
+                ArgumentResolver resolver = new ArgumentResolver(reader, maxStringBytes: 256, pointerSize: pointerSize);
 
                 // Must not throw.
                 FormatStringParser.Parse<CaptureReceiver>(format, args, resolver, ref receiver);

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/StressLogTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/StressLogTests.cs
@@ -133,10 +133,14 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         }
 
         private static void Parse(string format, ulong[] args, out CaptureReceiver receiver,
-                                  Dictionary<ulong, byte[]>? memory = null)
+                                  Dictionary<ulong, byte[]>? memory = null,
+                                  int pointerSize = 8)
         {
             receiver = CaptureReceiver.Create();
-            ArgumentResolver resolver = new ArgumentResolver(new SyntheticDataReader(memory ?? new()));
+            SyntheticDataReader reader = pointerSize == 4
+                ? new SyntheticDataReader(memory ?? new(), pointerSize: 4, architecture: System.Runtime.InteropServices.Architecture.X86)
+                : new SyntheticDataReader(memory ?? new());
+            ArgumentResolver resolver = new ArgumentResolver(reader, maxStringBytes: 256, pointerSize: pointerSize);
             FormatStringParser.Parse(Encoding.ASCII.GetBytes(format), args, resolver, ref receiver);
         }
 
@@ -233,6 +237,157 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             foreach (char c in output)
                 Assert.True(c >= 0x20 && c <= 0x7E, $"Output contains non-printable byte 0x{(int)c:X} ('{output}')");
             Assert.Contains(".[31m!", output);
+        }
+
+        // ---- 32-bit printf semantics: sign extension and 64-bit length modifier ----
+
+        [Fact]
+        public void Parser_X86_DecimalSpecSignExtendsInt()
+        {
+            // The runtime stores `int -1` as the 32-bit value 0xFFFFFFFF on a
+            // 32-bit target; when read into a ulong slot it is zero-extended
+            // to 0x00000000FFFFFFFF. %d must reinterpret the low 32 bits as a
+            // signed int and emit -1, not 4294967295.
+            Parse("%d", new ulong[] { 0xFFFFFFFFUL }, out CaptureReceiver r, pointerSize: 4);
+            Assert.Equal(1, r.IntegerCalls);
+            Assert.Contains("[Decimal:-1]", r.Output.ToString());
+        }
+
+        [Fact]
+        public void Parser_X86_UnsignedSpecZeroExtendsUint()
+        {
+            // %u of 0xFFFFFFFF on x86 is 4294967295 (unsigned int max), not -1.
+            Parse("%u", new ulong[] { 0xFFFFFFFFUL }, out CaptureReceiver r, pointerSize: 4);
+            Assert.Equal(1, r.IntegerCalls);
+            Assert.Contains("[Unsigned:4294967295]", r.Output.ToString());
+        }
+
+        [Fact]
+        public void Parser_X86_I64UnsignedConsumesTwoSlots()
+        {
+            // On 32-bit, fprintf's %I64u/%llu takes 8 bytes of arg storage,
+            // i.e. two consecutive size_t-wide slots: low dword first.
+            // 0x00000000_FFFFFFFF (low=0xFFFFFFFF, high=0) -> 4294967295.
+            Parse("%I64u", new ulong[] { 0xFFFFFFFFUL, 0UL }, out CaptureReceiver r, pointerSize: 4);
+            Assert.Equal(1, r.IntegerCalls);
+            Assert.Contains("[Unsigned:4294967295]", r.Output.ToString());
+        }
+
+        [Fact]
+        public void Parser_X86_I64UnsignedHighBitsCombined()
+        {
+            // 0x00000001_00000000 = low=0, high=1 -> 4294967296.
+            Parse("%I64u", new ulong[] { 0UL, 1UL }, out CaptureReceiver r, pointerSize: 4);
+            Assert.Equal(1, r.IntegerCalls);
+            Assert.Contains("[Unsigned:4294967296]", r.Output.ToString());
+        }
+
+        [Fact]
+        public void Parser_X86_LongLongHexConsumesTwoSlots()
+        {
+            // %llx on 32-bit: low=0xCAFEBABE, high=0xDEADBEEF -> 0xDEADBEEFCAFEBABE.
+            Parse("%llx", new ulong[] { 0xCAFEBABEUL, 0xDEADBEEFUL }, out CaptureReceiver r, pointerSize: 4);
+            Assert.Equal(1, r.IntegerCalls);
+            // CaptureReceiver formats Integer values as decimal, so just check call count and value.
+            Assert.Contains("[Hex:" + unchecked((long)0xDEADBEEFCAFEBABEUL) + "]", r.Output.ToString());
+        }
+
+        [Fact]
+        public void Parser_X86_I64UnsignedRunsOutOfArgs()
+        {
+            // Only one slot supplied for an %I64u that wants two. Must not
+            // throw, must not read out of bounds: parser sees the low slot
+            // as the value (high defaulted to 0) and emits the integer
+            // without crashing.
+            Parse("%I64u", new ulong[] { 0xFFFFFFFFUL }, out CaptureReceiver r, pointerSize: 4);
+            // Either Integer with low value, or MissingArgument -- both are
+            // acceptable so long as the parser stays bounded.
+            Assert.True(r.IntegerCalls + r.MissingCalls >= 1);
+        }
+
+        [Fact]
+        public void Parser_X64_DecimalSpecRoundTripsNegative()
+        {
+            // On 64-bit, `int -1` is sign-extended at store time to
+            // 0xFFFFFFFFFFFFFFFF; %d must still emit -1.
+            Parse("%d", new ulong[] { 0xFFFFFFFFFFFFFFFFUL }, out CaptureReceiver r, pointerSize: 8);
+            Assert.Equal(1, r.IntegerCalls);
+            Assert.Contains("[Decimal:-1]", r.Output.ToString());
+        }
+
+        // ---- Fuzz: random format strings + random args must not crash ----
+
+        [Theory]
+        [InlineData(0xC0FFEE)]
+        [InlineData(unchecked((int)0xDEADBEEF))]
+        [InlineData(0x12345678)]
+        public void Parser_FuzzNeverThrowsAndStaysBounded(int seed)
+        {
+            // Feed random bytes (including 0x25 '%' to ensure many specifier
+            // attempts) into the parser. The parser must always terminate
+            // and never throw an unhandled exception. This exercises every
+            // combination of length modifier, width/precision overflow,
+            // truncated specifier at end-of-string, etc.
+            Random rng = new(seed);
+            for (int trial = 0; trial < 250; trial++)
+            {
+                int len = rng.Next(1, 256);
+                byte[] format = new byte[len];
+                for (int i = 0; i < len; i++)
+                {
+                    int r = rng.Next(0, 100);
+                    if (r < 25)
+                        format[i] = (byte)'%';
+                    else if (r < 35)
+                        format[i] = (byte)"diuxXpsScnhlLjztI*0123456789. -+#"[rng.Next(33)];
+                    else
+                        format[i] = (byte)rng.Next(0x20, 0x7F); // printable ASCII
+                }
+
+                int argCount = rng.Next(0, 16);
+                ulong[] args = new ulong[argCount];
+                for (int i = 0; i < argCount; i++)
+                    args[i] = (ulong)rng.NextInt64();
+
+                CaptureReceiver receiver = CaptureReceiver.Create();
+                ArgumentResolver resolver = new ArgumentResolver(new SyntheticDataReader(new()));
+
+                // Must not throw.
+                FormatStringParser.Parse<CaptureReceiver>(format, args, resolver, ref receiver);
+
+                // Must not advance past argCount + a small bound (per-spec
+                // 64-bit consumes 2; rough upper bound is 2 * format.Length).
+                Assert.True(receiver.LiteralCalls + receiver.IntegerCalls + receiver.PointerCalls
+                            + receiver.StringCalls + receiver.MissingCalls <= 2 * format.Length + 8,
+                    "Parser emitted unbounded tokens for input.");
+            }
+        }
+
+        [Fact]
+        public void Parser_FuzzPercentNeverInterpreted()
+        {
+            // Stress the parser with format strings full of '%' and length
+            // modifiers but no valid conversion specifier. Verifies that
+            // %n, positional %1$, etc. never get treated as a real specifier.
+            string[] danger = {
+                "%n", "%hn", "%ln", "%lln", "%hhn",
+                "%1$d", "%99$s",
+                "%*d", "%.*d", "%-1d",
+                "%2147483648d", "%.2147483648s",
+                "%llz", "%I63d", "%qd",
+                "%pZ", "%pX", "%phM",
+            };
+            foreach (string f in danger)
+            {
+                Parse(f, new ulong[] { 1, 2, 3, 4 }, out CaptureReceiver r);
+                // %n family must never be interpreted (no Pointer, no Integer
+                // for those specs; for the others we simply require the
+                // parser to terminate cleanly and not throw).
+                if (f.Contains("%n", System.StringComparison.Ordinal) || f.Contains("$", System.StringComparison.Ordinal))
+                {
+                    Assert.Equal(0, r.PointerCalls);
+                }
+            }
         }
 
         // ---- StressLogModuleTable ----------------------------------------

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/StressLogTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/StressLogTests.cs
@@ -306,7 +306,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             foreach (StressLogMessage msg in log.EnumerateMessages())
             {
                 count++;
-                Assert.Equal(SyntheticStressLogBuilder.ThreadId, msg.ThreadId);
+                Assert.Equal(SyntheticStressLogBuilder.ThreadId, msg.OSThreadId);
                 Assert.Equal((StressLogFacility)SyntheticStressLogBuilder.Facility, msg.Facility);
                 Assert.Equal(0, msg.ArgumentCount);
                 if (count > 100) break;

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/StressLogTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/StressLogTests.cs
@@ -57,6 +57,22 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         }
 
         [Fact]
+        public void Sanitizer_PreservesWhitespaceControlBytes()
+        {
+            // \t \n \r are legitimate (format strings commonly end in \n);
+            // \v (0x0B) and \f (0x0C) are not whitespace we need to preserve.
+            byte[] input = { (byte)'\t', (byte)'\n', (byte)'\r', 0x0B, 0x0C };
+            byte[] dst = new byte[input.Length];
+            int written = StressLogSanitizer.SanitizeAscii(input, dst);
+            Assert.Equal(input.Length, written);
+            Assert.Equal((byte)'\t', dst[0]);
+            Assert.Equal((byte)'\n', dst[1]);
+            Assert.Equal((byte)'\r', dst[2]);
+            Assert.Equal((byte)'.', dst[3]);
+            Assert.Equal((byte)'.', dst[4]);
+        }
+
+        [Fact]
         public void Sanitizer_Utf16TerminatesAtNull()
         {
             // 'A' 0x00 'B' 0x00 0x00 0x00 'C' 0x00
@@ -378,5 +394,214 @@ namespace Microsoft.Diagnostics.Runtime.Tests
                 Assert.Equal(50, countB);
             }
         }
+
+        // ---- 32-bit (Win-x86) ---------------------------------------------
+
+        [Fact]
+        public void Layout_x86_RoundTripSingleMessage()
+        {
+            SyntheticStressLogBuilder builder = new();
+            ulong addr = builder.Build(StressLogLayout.CoreWinX86, out _, out _);
+            SyntheticDataReader reader = new(builder.Memory, pointerSize: 4, architecture: System.Runtime.InteropServices.Architecture.X86);
+
+            Assert.True(StressLog.TryOpen(reader, addr, out StressLog? log));
+            Assert.NotNull(log);
+            Assert.Equal(4, log!.PointerSize);
+
+            int count = 0;
+            foreach (StressLogMessage msg in log.EnumerateMessages())
+            {
+                count++;
+                Assert.Equal(SyntheticStressLogBuilder.ThreadId, msg.OSThreadId);
+                Assert.Equal((StressLogFacility)SyntheticStressLogBuilder.Facility, msg.Facility);
+                Assert.Equal(0, msg.ArgumentCount);
+                if (count > 10) break;
+            }
+
+            Assert.Equal(1, count);
+            log.Dispose();
+        }
+
+        [Fact]
+        public void Layout_x86_HighBitPointersZeroExtend()
+        {
+            // Place the StressLog header at a high address (>= 0x80000000).
+            // If any pointer-sized read inadvertently sign-extended, the
+            // resulting ulong would be 0xFFFFFFFF80000000... and the chunk
+            // walk would fail. Successful enumeration confirms zero-extension.
+            HighBitBuilder builder = new(stressLogAddr: 0x80100000, threadAddr: 0x80200000, chunkAddr: 0x80300000);
+            ulong addr = builder.Build(StressLogLayout.CoreWinX86, out _, out _);
+            SyntheticDataReader reader = new(builder.Memory, pointerSize: 4, architecture: System.Runtime.InteropServices.Architecture.X86);
+
+            Assert.True(StressLog.TryOpen(reader, addr, out StressLog? log));
+            Assert.NotNull(log);
+
+            int count = 0;
+            foreach (StressLogMessage msg in log!.EnumerateMessages())
+            {
+                count++;
+                Assert.Equal(0x42UL, msg.OSThreadId);
+                if (count > 10) break;
+            }
+
+            Assert.Equal(1, count);
+            log.Dispose();
+        }
+
+        [Fact]
+        public void Layout_x86_AddressOverflowRejected()
+        {
+            // A chunk whose end address would exceed uint.MaxValue must be
+            // rejected; otherwise downstream offset arithmetic could wrap.
+            // Place a ThreadStressLog whose chunkListHead points just below
+            // 4 GiB so that adding ChunkTotalSize (16400) overflows.
+            SyntheticStressLogBuilder builder = new();
+            // Override the chunk address to one that overflows 32-bit.
+            ulong nearMax = 0xFFFFC000UL;
+            HighBitBuilder hb = new(stressLogAddr: 0x100000, threadAddr: 0x200000, chunkAddr: nearMax);
+            ulong addr = hb.Build(StressLogLayout.CoreWinX86, out _, out _);
+            SyntheticDataReader reader = new(hb.Memory, pointerSize: 4, architecture: System.Runtime.InteropServices.Architecture.X86);
+
+            Assert.True(StressLog.TryOpen(reader, addr, out StressLog? log));
+            Assert.NotNull(log);
+
+            int count = 0;
+            foreach (StressLogMessage _ in log!.EnumerateMessages())
+            {
+                count++;
+                if (count > 10) break;
+            }
+
+            // Chunk overflows 32-bit address space; iterator must reject it.
+            Assert.Equal(0, count);
+            log.Dispose();
+        }
+
+        [Fact]
+        public void Layout_x86_RejectsNonWindows()
+        {
+            SyntheticStressLogBuilder builder = new();
+            ulong addr = builder.Build(StressLogLayout.CoreWinX86, out _, out _);
+            NonWindowsX86Reader reader = new(builder.Memory);
+
+            Assert.False(StressLog.TryOpen(reader, addr, out StressLog? log, out string? reason));
+            Assert.Null(log);
+            Assert.NotNull(reason);
+            Assert.Contains("32-bit", reason!, System.StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void ModuleTable_x86_EntryStrideIs8Bytes()
+        {
+            // x86 module table: 8 bytes per entry (4 base + 4 size).
+            byte[] bytes = new byte[5 * 8];
+            // Entry 0: base=0x10000000, size=0x100000 (valid, >= 1 MiB).
+            BitConverter.GetBytes((uint)0x10000000).CopyTo(bytes, 0);
+            BitConverter.GetBytes((uint)0x100000).CopyTo(bytes, 4);
+            // Entries 1..4: zero-filled => skipped.
+            StressLogModuleTable table = StressLogModuleTable.BuildInProcess(
+                StressLogLayout.CoreWinX86,
+                bytes,
+                legacyModuleOffset: 0x10000000,
+                hasModuleTable: true,
+                maxOffset: 1UL << 39);
+
+            Assert.True(table.TryResolveFormatOffset(formatOffset: 0x100, out ulong addr));
+            Assert.Equal(0x10000100UL, addr);
+        }
+    }
+
+    internal sealed class HighBitBuilder
+    {
+        private readonly SyntheticStressLogBuilder _inner = new();
+        private readonly ulong _stressLogAddr;
+        private readonly ulong _threadAddr;
+        private readonly ulong _chunkAddr;
+
+        public HighBitBuilder(ulong stressLogAddr, ulong threadAddr, ulong chunkAddr)
+        {
+            _stressLogAddr = stressLogAddr;
+            _threadAddr = threadAddr;
+            _chunkAddr = chunkAddr;
+        }
+
+        public Dictionary<ulong, byte[]> Memory => _inner.Memory;
+
+        public ulong Build(StressLogLayout layout, out ulong threadAddr, out ulong chunkAddr)
+        {
+            threadAddr = _threadAddr;
+            chunkAddr = _chunkAddr;
+
+            byte[] chunk = new byte[layout.ChunkTotalSize];
+            WritePtr(layout, chunk.AsSpan(layout.ChunkPrevOffset), _chunkAddr);
+            WritePtr(layout, chunk.AsSpan(layout.ChunkNextOffset), _chunkAddr);
+
+            int msgOffset = layout.ChunkBufOffset;
+            ulong word0 = 0xABCDEF01UL;
+            ulong word1 = 1_500_000UL << StressLogConstants.FormatOffsetHighBits;
+            System.Buffers.Binary.BinaryPrimitives.WriteUInt64LittleEndian(chunk.AsSpan(msgOffset), word0);
+            System.Buffers.Binary.BinaryPrimitives.WriteUInt64LittleEndian(chunk.AsSpan(msgOffset + 8), word1);
+
+            System.Buffers.Binary.BinaryPrimitives.WriteUInt32LittleEndian(chunk.AsSpan(layout.ChunkSig1Offset), StressLogConstants.ChunkSignature);
+            System.Buffers.Binary.BinaryPrimitives.WriteUInt32LittleEndian(chunk.AsSpan(layout.ChunkSig2Offset), StressLogConstants.ChunkSignature);
+
+            Memory[_chunkAddr] = chunk;
+
+            byte[] thread = new byte[layout.ThreadHeaderSize];
+            if (layout.ThreadIdSize == 8)
+                System.Buffers.Binary.BinaryPrimitives.WriteUInt64LittleEndian(thread.AsSpan(layout.ThreadIdOffset), 0x42UL);
+            else
+                System.Buffers.Binary.BinaryPrimitives.WriteUInt32LittleEndian(thread.AsSpan(layout.ThreadIdOffset), 0x42u);
+
+            ulong msgAddr = _chunkAddr + (ulong)layout.ChunkBufOffset;
+            WritePtr(layout, thread.AsSpan(layout.ThreadCurPtrOffset), msgAddr);
+            WritePtr(layout, thread.AsSpan(layout.ThreadReadPtrOffset), msgAddr);
+            WritePtr(layout, thread.AsSpan(layout.ThreadChunkListHeadOffset), _chunkAddr);
+            WritePtr(layout, thread.AsSpan(layout.ThreadChunkListTailOffset), _chunkAddr);
+            WritePtr(layout, thread.AsSpan(layout.ThreadCurReadChunkOffset), _chunkAddr);
+            WritePtr(layout, thread.AsSpan(layout.ThreadCurWriteChunkOffset), _chunkAddr);
+            Memory[_threadAddr] = thread;
+
+            byte[] header = new byte[layout.InProcHeaderSize];
+            WritePtr(layout, header.AsSpan(layout.InProcLogsOffset), _threadAddr);
+            System.Buffers.Binary.BinaryPrimitives.WriteUInt32LittleEndian(header.AsSpan(layout.InProcPaddingOffset), 0xFFFFFFFFu);
+            System.Buffers.Binary.BinaryPrimitives.WriteUInt64LittleEndian(header.AsSpan(layout.InProcTickFrequencyOffset), 10_000_000UL);
+            System.Buffers.Binary.BinaryPrimitives.WriteUInt64LittleEndian(header.AsSpan(layout.InProcStartTimeStampOffset), 1_000_000UL);
+            Memory[_stressLogAddr] = header;
+
+            return _stressLogAddr;
+        }
+
+        private static void WritePtr(StressLogLayout layout, Span<byte> dst, ulong value)
+        {
+            if (layout.PointerSize == 8)
+                System.Buffers.Binary.BinaryPrimitives.WriteUInt64LittleEndian(dst, value);
+            else
+                System.Buffers.Binary.BinaryPrimitives.WriteUInt32LittleEndian(dst, (uint)value);
+        }
+    }
+
+    internal sealed class NonWindowsX86Reader : IDataReader
+    {
+        private readonly SyntheticDataReader _inner;
+        public NonWindowsX86Reader(Dictionary<ulong, byte[]> segments)
+        {
+            _inner = new SyntheticDataReader(segments, pointerSize: 4, architecture: System.Runtime.InteropServices.Architecture.X86);
+        }
+        public string DisplayName => "synthetic-linux-x86";
+        public bool IsThreadSafe => true;
+        public System.Runtime.InteropServices.OSPlatform TargetPlatform => System.Runtime.InteropServices.OSPlatform.Linux;
+        public System.Runtime.InteropServices.Architecture Architecture => System.Runtime.InteropServices.Architecture.X86;
+        public int ProcessId => 0;
+        public IEnumerable<ModuleInfo> EnumerateModules() => Array.Empty<ModuleInfo>();
+        public bool GetThreadContext(uint threadID, uint contextFlags, Span<byte> context) => false;
+        public IEnumerable<uint> EnumerateAllThreads() => Array.Empty<uint>();
+        public void FlushCachedData() { }
+        public int PointerSize => 4;
+        public int Read(ulong address, Span<byte> buffer) => _inner.Read(address, buffer);
+        public bool Read<T>(ulong address, out T value) where T : unmanaged => _inner.Read(address, out value);
+        public T Read<T>(ulong address) where T : unmanaged => _inner.Read<T>(address);
+        public bool ReadPointer(ulong address, out ulong value) => _inner.ReadPointer(address, out value);
+        public ulong ReadPointer(ulong address) => _inner.ReadPointer(address);
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/StressLogTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/StressLogTests.cs
@@ -230,6 +230,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             BitConverter.GetBytes(StressLogConstants.FormatOffsetMax + 1).CopyTo(entries, 8); // size, too big
 
             StressLogModuleTable table = StressLogModuleTable.BuildInProcess(
+                StressLogLayout.CoreX64,
                 entries,
                 legacyModuleOffset: 0x100,
                 hasModuleTable: true,
@@ -249,6 +250,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             BitConverter.GetBytes(size).CopyTo(entries, 8);
 
             StressLogModuleTable table = StressLogModuleTable.BuildInProcess(
+                StressLogLayout.CoreX64,
                 entries,
                 legacyModuleOffset: baseAddr,
                 hasModuleTable: true,

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/StressLogTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/StressLogTests.cs
@@ -1,0 +1,319 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Diagnostics.Runtime.StressLogs;
+using Microsoft.Diagnostics.Runtime.StressLogs.Internal;
+using Xunit;
+
+namespace Microsoft.Diagnostics.Runtime.Tests
+{
+    /// <summary>
+    /// Unit tests for the stress log reader. The tests cover the parser,
+    /// sanitizer, module table, allocation budget, and end-to-end open/iterate
+    /// path with deliberately malformed inputs to confirm the reader stays
+    /// bounded and never produces unsanitized output.
+    /// </summary>
+    public class StressLogTests
+    {
+        private const ulong FormatAddrSimple = 0x10000;
+        private const ulong FormatAddrPercentN = 0x10100;
+        private const ulong FormatAddrPositional = 0x10200;
+        private const ulong FormatAddrStarWidth = 0x10300;
+        private const ulong FormatAddrLong = 0x10400;
+        private const ulong StringArgAddr = 0x20000;
+        private const ulong StringArgAnsi = 0x20100;
+        private const ulong StringArgUtf16 = 0x20200;
+
+        // ---- FormatStringSanitizer ---------------------------------------
+
+        [Fact]
+        public void Sanitizer_PreservesPrintableAscii()
+        {
+            ReadOnlySpan<byte> input = Encoding.ASCII.GetBytes("Hello %d World").AsSpan();
+            byte[] dst = new byte[input.Length];
+            int written = StressLogSanitizer.SanitizeAscii(input, dst);
+            Assert.Equal(input.Length, written);
+            Assert.Equal(Encoding.ASCII.GetString(input.ToArray()), Encoding.ASCII.GetString(dst));
+        }
+
+        [Fact]
+        public void Sanitizer_ReplacesControlAndAnsiBytes()
+        {
+            // ESC [ 3 1 m   "Hi"   \x07 (BEL)   \x00
+            byte[] input = { 0x1B, (byte)'[', (byte)'3', (byte)'1', (byte)'m', (byte)'H', (byte)'i', 0x07 };
+            byte[] dst = new byte[input.Length];
+            int written = StressLogSanitizer.SanitizeAscii(input, dst);
+            Assert.Equal(input.Length, written);
+            Assert.Equal((byte)'.', dst[0]); // ESC
+            Assert.Equal((byte)'[', dst[1]); // printable
+            Assert.Equal((byte)'H', dst[5]);
+            Assert.Equal((byte)'i', dst[6]);
+            Assert.Equal((byte)'.', dst[7]); // BEL
+        }
+
+        [Fact]
+        public void Sanitizer_Utf16TerminatesAtNull()
+        {
+            // 'A' 0x00 'B' 0x00 0x00 0x00 'C' 0x00
+            byte[] input = { 0x41, 0, 0x42, 0, 0, 0, 0x43, 0 };
+            byte[] dst = new byte[8];
+            int written = StressLogSanitizer.SanitizeUtf16(input, dst);
+            Assert.Equal(2, written); // stops at the third pair which is NUL
+            Assert.Equal((byte)'A', dst[0]);
+            Assert.Equal((byte)'B', dst[1]);
+        }
+
+        // ---- FormatStringParser ------------------------------------------
+
+        private struct CaptureReceiver : IStressLogFormatReceiver
+        {
+            public StringBuilder Output;
+            public int IntegerCalls;
+            public int PointerCalls;
+            public int StringCalls;
+            public int LiteralCalls;
+            public int MissingCalls;
+
+            public static CaptureReceiver Create() => new() { Output = new StringBuilder() };
+
+            public void Literal(ReadOnlySpan<byte> ascii)
+            {
+                LiteralCalls++;
+#if NET10_0_OR_GREATER
+                Output.Append(Encoding.ASCII.GetString(ascii));
+#else
+                Output.Append(Encoding.ASCII.GetString(ascii.ToArray()));
+#endif
+            }
+            public void Integer(StressLogIntegerKind kind, int width, int precision, long value)
+            {
+                IntegerCalls++;
+                Output.Append('[').Append(kind).Append(':').Append(value).Append(']');
+            }
+            public void Pointer(StressLogPointerKind kind, ulong address)
+            {
+                PointerCalls++;
+                Output.Append("[P:").Append(kind).Append(':').Append(address.ToString("x")).Append(']');
+            }
+            public void String(StressLogStringEncoding encoding, ReadOnlySpan<byte> sanitized)
+            {
+                StringCalls++;
+#if NET10_0_OR_GREATER
+                Output.Append("[S:").Append(Encoding.ASCII.GetString(sanitized)).Append(']');
+#else
+                Output.Append("[S:").Append(Encoding.ASCII.GetString(sanitized.ToArray())).Append(']');
+#endif
+            }
+            public void MissingArgument()
+            {
+                MissingCalls++;
+                Output.Append("<missing>");
+            }
+        }
+
+        private static void Parse(string format, ulong[] args, out CaptureReceiver receiver,
+                                  Dictionary<ulong, byte[]>? memory = null)
+        {
+            receiver = CaptureReceiver.Create();
+            ArgumentResolver resolver = new ArgumentResolver(new SyntheticDataReader(memory ?? new()));
+            FormatStringParser.Parse(Encoding.ASCII.GetBytes(format), args, resolver, ref receiver);
+        }
+
+        [Fact]
+        public void Parser_BasicIntegerHexPointer()
+        {
+            Parse("%d %x %p", new ulong[] { 42, 0xDEAD, 0xCAFEBABE }, out CaptureReceiver r);
+            Assert.Equal(2, r.IntegerCalls);
+            Assert.Equal(1, r.PointerCalls);
+            Assert.Equal(0, r.MissingCalls);
+        }
+
+        [Fact]
+        public void Parser_DoublePercentEmitsLiteral()
+        {
+            Parse("100%% done", Array.Empty<ulong>(), out CaptureReceiver r);
+            string output = r.Output.ToString();
+            Assert.Equal("100% done", output);
+            Assert.Equal(0, r.IntegerCalls);
+        }
+
+        [Fact]
+        public void Parser_RejectsPercentN()
+        {
+            Parse("before %n after", new ulong[] { 0x1234 }, out CaptureReceiver r);
+            // %n must not be invoked as Pointer or Integer; the rejected
+            // specifier is rendered as a literal.
+            Assert.Equal(0, r.PointerCalls);
+            Assert.Equal(0, r.IntegerCalls);
+            Assert.Contains("%n", r.Output.ToString());
+        }
+
+        [Fact]
+        public void Parser_RejectsPositionalSpecifier()
+        {
+            Parse("%1$s and %2$d", new ulong[] { StringArgAddr, 99 }, out CaptureReceiver r);
+            Assert.Equal(0, r.StringCalls);
+            Assert.Equal(0, r.IntegerCalls);
+        }
+
+        [Fact]
+        public void Parser_RejectsIndirectWidth()
+        {
+            Parse("%*d", new ulong[] { 5, 42 }, out CaptureReceiver r);
+            Assert.Equal(0, r.IntegerCalls);
+        }
+
+        [Fact]
+        public void Parser_MissingArgumentEmitsToken()
+        {
+            Parse("%d %d %d", new ulong[] { 1 }, out CaptureReceiver r);
+            Assert.Equal(1, r.IntegerCalls);
+            Assert.Equal(2, r.MissingCalls);
+        }
+
+        [Fact]
+        public void Parser_ClampsHugeWidthAndPrecision()
+        {
+            // Width/precision are clamped before being surfaced. The
+            // important thing is that the parser does not allocate or read
+            // 2 GB of memory; we just verify that exactly one integer was
+            // emitted.
+            Parse("%2147483647.2147483647d", new ulong[] { 7 }, out CaptureReceiver r);
+            Assert.Equal(1, r.IntegerCalls);
+        }
+
+        [Fact]
+        public void Parser_LengthModifiersAreStripped()
+        {
+            Parse("%lu %hd %lld %I64x %zd", new ulong[] { 1, 2, 3, 4, 5 }, out CaptureReceiver r);
+            Assert.Equal(5, r.IntegerCalls);
+        }
+
+        [Fact]
+        public void Parser_TypedPointerSpecifiers()
+        {
+            Parse("%pM %pT %pV %pK %p", new ulong[] { 1, 2, 3, 4, 5 }, out CaptureReceiver r);
+            Assert.Equal(5, r.PointerCalls);
+        }
+
+        [Fact]
+        public void Parser_StringReadsAndSanitizes()
+        {
+            // Backing memory carries control bytes and ANSI escapes; the
+            // parser must hand the receiver only sanitized ASCII.
+            byte[] withControlBytes = { 0x1B, (byte)'[', (byte)'3', (byte)'1', (byte)'m', (byte)'!', 0 };
+            Dictionary<ulong, byte[]> mem = new() { { StringArgAnsi, withControlBytes } };
+            Parse("hello %s end", new ulong[] { StringArgAnsi }, out CaptureReceiver r, mem);
+            Assert.Equal(1, r.StringCalls);
+            string output = r.Output.ToString();
+            // Every char should be printable. The ESC byte must have been
+            // replaced with '.' before reaching the receiver.
+            foreach (char c in output)
+                Assert.True(c >= 0x20 || c == '\n' || c == '\t', $"Output contains control byte 0x{(int)c:X} ('{output}')");
+            Assert.Contains(".[31m!", output);
+        }
+
+        // ---- StressLogModuleTable ----------------------------------------
+
+        [Fact]
+        public void ModuleTable_FallsBackWhenSizeOutOfRange()
+        {
+            // First module's size is bigger than maxOffset → table rejected.
+            byte[] entries = new byte[StressLogConstants.MaxModules * 16];
+            BitConverter.GetBytes((ulong)0x100).CopyTo(entries, 0);                    // baseAddress
+            BitConverter.GetBytes(StressLogConstants.FormatOffsetMax + 1).CopyTo(entries, 8); // size, too big
+
+            StressLogModuleTable table = StressLogModuleTable.BuildInProcess(
+                entries,
+                legacyModuleOffset: 0x100,
+                hasModuleTable: true,
+                maxOffset: StressLogConstants.FormatOffsetMax);
+
+            // Falls back to single-module mode (count == 0).
+            Assert.Equal(0, table.Count);
+        }
+
+        [Fact]
+        public void ModuleTable_ResolvesOffsetWhenValid()
+        {
+            byte[] entries = new byte[StressLogConstants.MaxModules * 16];
+            ulong baseAddr = 0x7FF000;
+            ulong size = 4UL * 1024 * 1024;
+            BitConverter.GetBytes(baseAddr).CopyTo(entries, 0);
+            BitConverter.GetBytes(size).CopyTo(entries, 8);
+
+            StressLogModuleTable table = StressLogModuleTable.BuildInProcess(
+                entries,
+                legacyModuleOffset: baseAddr,
+                hasModuleTable: true,
+                maxOffset: StressLogConstants.FormatOffsetMax);
+
+            Assert.Equal(1, table.Count);
+            Assert.True(table.TryResolveFormatOffset(0x123, out ulong resolved));
+            Assert.Equal(baseAddr + 0x123, resolved);
+        }
+
+        // ---- AllocationBudget --------------------------------------------
+
+        [Fact]
+        public void AllocationBudget_RefusesBeyondCap()
+        {
+            AllocationBudget budget = new(1024);
+            Assert.True(budget.TryReserve(512));
+            Assert.True(budget.TryReserve(512));
+            Assert.False(budget.TryReserve(1));
+            budget.Release(512);
+            Assert.True(budget.TryReserve(512));
+        }
+
+        // ---- End-to-end with a synthetic stress log ----------------------
+
+        [Fact]
+        public void EndToEnd_TruncatedHeaderFailsTryOpen()
+        {
+            // Reader returns 0 bytes for any address.
+            SyntheticDataReader reader = new(new());
+            Assert.False(StressLog.TryOpen(reader, 0x1000, out StressLog? log));
+            Assert.Null(log);
+        }
+
+        [Fact]
+        public void EndToEnd_NullAddressFailsTryOpen()
+        {
+            SyntheticDataReader reader = new(new());
+            Assert.False(StressLog.TryOpen(reader, 0, out StressLog? log));
+            Assert.Null(log);
+        }
+
+        [Fact]
+        public void EndToEnd_SingleMessageRoundTrip()
+        {
+            SyntheticStressLogBuilder builder = new SyntheticStressLogBuilder();
+            ulong stressLogAddr = builder.Build(out _, out _);
+            SyntheticDataReader reader = new(builder.Memory);
+
+            Assert.True(StressLog.TryOpen(reader, stressLogAddr, out StressLog? log));
+            Assert.NotNull(log);
+
+            int count = 0;
+            int diagnosticCount = 0;
+            log!.Diagnostic += _ => diagnosticCount++;
+            foreach (StressLogMessage msg in log.EnumerateMessages())
+            {
+                count++;
+                Assert.Equal(SyntheticStressLogBuilder.ThreadId, msg.ThreadId);
+                Assert.Equal((StressLogFacility)SyntheticStressLogBuilder.Facility, msg.Facility);
+                Assert.Equal(0, msg.ArgumentCount);
+                if (count > 100) break;
+            }
+
+            Assert.Equal(1, count);
+            log.Dispose();
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/StressLogTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/StressLogTests.cs
@@ -211,10 +211,11 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             Parse("hello %s end", new ulong[] { StringArgAnsi }, out CaptureReceiver r, mem);
             Assert.Equal(1, r.StringCalls);
             string output = r.Output.ToString();
-            // Every char should be printable. The ESC byte must have been
-            // replaced with '.' before reaching the receiver.
+            // Every byte must be printable 7-bit ASCII. The ESC byte must
+            // have been replaced before reaching the receiver, and tab/
+            // newline bytes from anywhere in the input must also be replaced.
             foreach (char c in output)
-                Assert.True(c >= 0x20 || c == '\n' || c == '\t', $"Output contains control byte 0x{(int)c:X} ('{output}')");
+                Assert.True(c >= 0x20 && c <= 0x7E, $"Output contains non-printable byte 0x{(int)c:X} ('{output}')");
             Assert.Contains(".[31m!", output);
         }
 
@@ -314,6 +315,66 @@ namespace Microsoft.Diagnostics.Runtime.Tests
 
             Assert.Equal(1, count);
             log.Dispose();
+        }
+
+        [Fact]
+        public void EndToEnd_ConcurrentEnumerationsDoNotInterfere()
+        {
+            // Two threads enumerating the same StressLog instance must each
+            // see exactly the messages they were yielded; the per-enumeration
+            // context isolates argument scratch / current iterator from the
+            // shared instance.
+            SyntheticStressLogBuilder builder = new SyntheticStressLogBuilder();
+            ulong stressLogAddr = builder.Build(out _, out _);
+            SyntheticDataReader reader = new(builder.Memory);
+
+            Assert.True(StressLog.TryOpen(reader, stressLogAddr, out StressLog? log));
+            Assert.NotNull(log);
+
+            using (log)
+            {
+                int countA = 0;
+                int countB = 0;
+                Exception? errorA = null;
+                Exception? errorB = null;
+
+                System.Threading.Thread tA = new(() =>
+                {
+                    try
+                    {
+                        for (int loop = 0; loop < 50; loop++)
+                            foreach (StressLogMessage msg in log!.EnumerateMessages())
+                            {
+                                Assert.Equal(SyntheticStressLogBuilder.ThreadId, msg.OSThreadId);
+                                countA++;
+                            }
+                    }
+                    catch (Exception ex) { errorA = ex; }
+                });
+                System.Threading.Thread tB = new(() =>
+                {
+                    try
+                    {
+                        for (int loop = 0; loop < 50; loop++)
+                            foreach (StressLogMessage msg in log!.EnumerateMessages())
+                            {
+                                Assert.Equal(SyntheticStressLogBuilder.ThreadId, msg.OSThreadId);
+                                countB++;
+                            }
+                    }
+                    catch (Exception ex) { errorB = ex; }
+                });
+
+                tA.Start();
+                tB.Start();
+                tA.Join();
+                tB.Join();
+
+                Assert.Null(errorA);
+                Assert.Null(errorB);
+                Assert.Equal(50, countA);
+                Assert.Equal(50, countB);
+            }
         }
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/StressLogTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/StressLogTests.cs
@@ -459,7 +459,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         {
             // Reader returns 0 bytes for any address.
             SyntheticDataReader reader = new(new());
-            Assert.False(StressLog.TryOpen(reader, 0x1000, out StressLog? log));
+            Assert.False(StressLog.TryOpen(reader, 0x1000, out StressLog? log, out _));
             Assert.Null(log);
         }
 
@@ -467,7 +467,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         public void EndToEnd_NullAddressFailsTryOpen()
         {
             SyntheticDataReader reader = new(new());
-            Assert.False(StressLog.TryOpen(reader, 0, out StressLog? log));
+            Assert.False(StressLog.TryOpen(reader, 0, out StressLog? log, out _));
             Assert.Null(log);
         }
 
@@ -478,7 +478,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             ulong stressLogAddr = builder.Build(out _, out _);
             SyntheticDataReader reader = new(builder.Memory);
 
-            Assert.True(StressLog.TryOpen(reader, stressLogAddr, out StressLog? log));
+            Assert.True(StressLog.TryOpen(reader, stressLogAddr, out StressLog? log, out _));
             Assert.NotNull(log);
 
             int count = 0;
@@ -508,7 +508,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             ulong stressLogAddr = builder.Build(out _, out _);
             SyntheticDataReader reader = new(builder.Memory);
 
-            Assert.True(StressLog.TryOpen(reader, stressLogAddr, out StressLog? log));
+            Assert.True(StressLog.TryOpen(reader, stressLogAddr, out StressLog? log, out _));
             Assert.NotNull(log);
 
             using (log)
@@ -566,7 +566,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             ulong addr = builder.Build(StressLogLayout.CoreWinX86, out _, out _);
             SyntheticDataReader reader = new(builder.Memory, pointerSize: 4, architecture: System.Runtime.InteropServices.Architecture.X86);
 
-            Assert.True(StressLog.TryOpen(reader, addr, out StressLog? log));
+            Assert.True(StressLog.TryOpen(reader, addr, out StressLog? log, out _));
             Assert.NotNull(log);
             Assert.Equal(4, log!.PointerSize);
 
@@ -595,7 +595,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             ulong addr = builder.Build(StressLogLayout.CoreWinX86, out _, out _);
             SyntheticDataReader reader = new(builder.Memory, pointerSize: 4, architecture: System.Runtime.InteropServices.Architecture.X86);
 
-            Assert.True(StressLog.TryOpen(reader, addr, out StressLog? log));
+            Assert.True(StressLog.TryOpen(reader, addr, out StressLog? log, out _));
             Assert.NotNull(log);
 
             int count = 0;
@@ -624,7 +624,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             ulong addr = hb.Build(StressLogLayout.CoreWinX86, out _, out _);
             SyntheticDataReader reader = new(hb.Memory, pointerSize: 4, architecture: System.Runtime.InteropServices.Architecture.X86);
 
-            Assert.True(StressLog.TryOpen(reader, addr, out StressLog? log));
+            Assert.True(StressLog.TryOpen(reader, addr, out StressLog? log, out _));
             Assert.NotNull(log);
 
             int count = 0;

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/TestTargets.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/TestTargets.cs
@@ -4,6 +4,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Runtime.InteropServices;
 using Microsoft.Diagnostics.Runtime.Implementation;
@@ -38,6 +39,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         private static readonly Lazy<TestTarget> _appDomains = new(() => new TestTarget("AppDomains", supportedFlavors: TargetFlavors.Framework, companionTargets: ["NestedException"]));
         private static readonly Lazy<TestTarget> _finalizationQueue = new(() => new TestTarget("FinalizationQueue"));
         private static readonly Lazy<TestTarget> _byReference = new(() => new TestTarget("ByReference"));
+        private static readonly Lazy<TestTarget> _stressLog = new(() => new TestTarget("StressLog"));
 
         public static TestTarget GCRoot => _gcroot.Value;
         public static TestTarget GCRoot2 => _gcroot2.Value;
@@ -51,6 +53,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         public static TestTarget ClrObjects => _clrObjects.Value;
         public static TestTarget Arrays => _arrays.Value;
         public static TestTarget ByReference => _byReference.Value;
+        public static TestTarget StressLog => _stressLog.Value;
     }
 
     public class TestTarget
@@ -310,6 +313,47 @@ namespace Microsoft.Diagnostics.Runtime.Tests
 
             Utilities.DbgEng.DbgEngIDataReader dbgengReader = new(dumpPath);
             return new DataTarget(dbgengReader, options ?? new DataTargetOptions() { VerifyDacOnWindows = false });
+        }
+
+        /// <summary>
+        /// Loads a full dump where the target process is launched with the supplied
+        /// environment variables in addition to the standard dump-collection env.
+        /// <paramref name="dumpNameSuffix"/> is mixed into the dump filename so a
+        /// dump generated with one environment is not silently reused by a test
+        /// expecting a different environment.
+        /// </summary>
+        public DataTarget LoadFullDumpWithEnvironment(
+            IReadOnlyDictionary<string, string> extraEnv,
+            string dumpNameSuffix,
+            GCMode gc = GCMode.Workstation,
+            bool isFramework = false,
+            bool singleFile = false,
+            DataTargetOptions? options = null)
+        {
+            if (extraEnv is null) throw new ArgumentNullException(nameof(extraEnv));
+            if (string.IsNullOrEmpty(dumpNameSuffix)) throw new ArgumentException("Suffix must be non-empty.", nameof(dumpNameSuffix));
+
+            string architecture = DumpGenerator.GetArchitecture();
+            string baseDumpPath = BuildDumpName(gc, full: true, architecture: architecture, isFramework: isFramework, singleFile: singleFile);
+
+            // Append the suffix before the .dmp extension so a dump generated with
+            // one environment can't be reused by a test that expects a different one.
+            string dumpPath = Path.Combine(
+                Path.GetDirectoryName(baseDumpPath)!,
+                Path.GetFileNameWithoutExtension(baseDumpPath) + "_" + dumpNameSuffix + Path.GetExtension(baseDumpPath));
+
+            DumpGenerator.EnsureDump(
+                Name,
+                ProjectDir,
+                dumpPath,
+                architecture,
+                isFramework: isFramework,
+                gc,
+                full: true,
+                singleFile: singleFile,
+                companionTargets: CompanionTargets,
+                extraEnv: extraEnv);
+            return LoadDump(dumpPath, options);
         }
 
         // ---------------------------------------------------------------------

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/TestTargets.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/TestTargets.cs
@@ -356,6 +356,47 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             return LoadDump(dumpPath, options);
         }
 
+        /// <summary>
+        /// Loads a full dump for a specific <see cref="DumpVariant"/> (which
+        /// may include the HighBit harness) with extra environment variables.
+        /// </summary>
+        public DataTarget LoadFullDumpWithEnvironment(
+            DumpVariant variant,
+            IReadOnlyDictionary<string, string> extraEnv,
+            string dumpNameSuffix,
+            GCMode gc = GCMode.Workstation,
+            bool singleFile = false,
+            DataTargetOptions? options = null)
+        {
+            if (extraEnv is null) throw new ArgumentNullException(nameof(extraEnv));
+            if (string.IsNullOrEmpty(dumpNameSuffix)) throw new ArgumentException("Suffix must be non-empty.", nameof(dumpNameSuffix));
+            if (singleFile && variant.HighBit) throw new InvalidOperationException("Single-file is not supported with HighBit.");
+            if (!Supports(variant.Flavor, variant.HighBit))
+                throw new InvalidOperationException($"Target {Name} does not support variant {variant}.");
+
+            string architecture = DumpGenerator.GetArchitecture();
+            bool isFramework = variant.Flavor == DumpFlavor.Framework;
+            string baseDumpPath = BuildDumpName(gc, full: true, architecture: architecture, isFramework: isFramework, singleFile: singleFile, highBit: variant.HighBit);
+
+            string dumpPath = Path.Combine(
+                Path.GetDirectoryName(baseDumpPath)!,
+                Path.GetFileNameWithoutExtension(baseDumpPath) + "_" + dumpNameSuffix + Path.GetExtension(baseDumpPath));
+
+            DumpGenerator.EnsureDump(
+                Name,
+                ProjectDir,
+                dumpPath,
+                architecture,
+                isFramework: isFramework,
+                gc,
+                full: true,
+                singleFile: singleFile,
+                highBit: variant.HighBit,
+                companionTargets: CompanionTargets,
+                extraEnv: extraEnv);
+            return LoadDump(dumpPath, options);
+        }
+
         // ---------------------------------------------------------------------
         // Variant-based dump loading (primary API used by matrixed [Theory] tests).
         // ---------------------------------------------------------------------

--- a/src/Microsoft.Diagnostics.Runtime/ClrRuntime.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrRuntime.cs
@@ -5,12 +5,14 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Collections.ObjectModel;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Threading;
 using Microsoft.Diagnostics.Runtime.AbstractDac;
 using Microsoft.Diagnostics.Runtime.DacImplementation;
 using Microsoft.Diagnostics.Runtime.Interfaces;
+using Microsoft.Diagnostics.Runtime.StressLogs;
 
 namespace Microsoft.Diagnostics.Runtime
 {
@@ -29,6 +31,11 @@ namespace Microsoft.Diagnostics.Runtime
         private IAbstractComHelpers? _comHelpers;
         private IAbstractMethodLocator? _methodLocator;
         private IAbstractDacController? _controller;
+
+        private StressLog? _stressLog;
+        private string? _stressLogFailureReason;
+        private bool _stressLogProbed;
+        private readonly object _stressLogGate = new();
 
         internal ClrRuntime(ClrInfo clrInfo, IServiceProvider services)
         {
@@ -55,6 +62,14 @@ namespace Microsoft.Diagnostics.Runtime
             _domainAndModules = null;
             _threads = default;
             _heap = null;
+
+            lock (_stressLogGate)
+            {
+                _stressLog?.Dispose();
+                _stressLog = null;
+                _stressLogFailureReason = null;
+                _stressLogProbed = false;
+            }
         }
 
         /// <summary>
@@ -82,6 +97,54 @@ namespace Microsoft.Diagnostics.Runtime
             if (svc is DacImplementation.DacRuntime dacRuntime)
                 return dacRuntime.GetStressLogAddress();
             return 0;
+        }
+
+        /// <summary>
+        /// The runtime's stress log, or <see langword="null"/> if stress
+        /// logging is disabled, the DAC does not provide a stress log
+        /// address, or the log fails validation. Use
+        /// <see cref="TryGetStressLog"/> if you need a description of the
+        /// failure. The returned instance is owned by this runtime and is
+        /// disposed when <see cref="FlushCachedData"/> is called; callers
+        /// should not dispose it themselves.
+        /// </summary>
+        public StressLog? StressLog
+        {
+            get
+            {
+                EnsureStressLogProbed();
+                return _stressLog;
+            }
+        }
+
+        /// <summary>
+        /// Try to get the runtime's stress log. On success, <paramref name="stressLog"/>
+        /// is populated; on failure, <paramref name="failureReason"/> contains
+        /// a human-readable explanation. The returned instance is owned by
+        /// this runtime and is disposed when <see cref="FlushCachedData"/> is
+        /// called; callers should not dispose it themselves.
+        /// </summary>
+        public bool TryGetStressLog([NotNullWhen(true)] out StressLog? stressLog,
+                                    [NotNullWhen(false)] out string? failureReason)
+        {
+            EnsureStressLogProbed();
+            stressLog = _stressLog;
+            failureReason = stressLog is null
+                ? (_stressLogFailureReason ?? "Stress log is unavailable.")
+                : null;
+            return stressLog is not null;
+        }
+
+        private void EnsureStressLogProbed()
+        {
+            if (_stressLogProbed) return;
+            lock (_stressLogGate)
+            {
+                if (_stressLogProbed) return;
+
+                StressLogs.StressLog.TryOpen(this, out _stressLog, out _stressLogFailureReason);
+                _stressLogProbed = true;
+            }
         }
 
         private IAbstractComHelpers? TryGetComHelpers() => _comHelpers ??= GetServiceOrThrow<IAbstractComHelpers>();

--- a/src/Microsoft.Diagnostics.Runtime/ClrRuntime.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrRuntime.cs
@@ -67,6 +67,23 @@ namespace Microsoft.Diagnostics.Runtime
 
         private IAbstractRuntime GetDacRuntime() => _runtime ??= (IAbstractRuntime?)_services.GetService(typeof(IAbstractRuntime)) ?? throw new NotSupportedException($"Could not construct an {nameof(IAbstractRuntime)} for this runtime.");
 
+        /// <summary>
+        /// Returns the target-space address of this runtime's stress log,
+        /// or 0 if stress logging is not enabled or the DAC does not support
+        /// the lookup.
+        /// </summary>
+        internal ulong GetStressLogAddress()
+        {
+            // The stress-log address only flows through the SOS DAC, not the
+            // abstract runtime contract. Reach into the DAC implementation
+            // directly when present; return 0 otherwise so callers get a
+            // consistent "stress log unavailable" signal.
+            object? svc = _services.GetService(typeof(IAbstractRuntime));
+            if (svc is DacImplementation.DacRuntime dacRuntime)
+                return dacRuntime.GetStressLogAddress();
+            return 0;
+        }
+
         private IAbstractComHelpers? TryGetComHelpers() => _comHelpers ??= GetServiceOrThrow<IAbstractComHelpers>();
 
         private IAbstractMethodLocator? TryGetMethodLocator() => _methodLocator ??= GetService<IAbstractMethodLocator>();

--- a/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacRuntime.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacRuntime.cs
@@ -41,7 +41,10 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
 
         internal ulong GetStressLogAddress()
         {
-            return _sos.TryGetStressLogAddress(out ulong addr) ? addr : 0;
+            // Translate the wire-format ClrDataAddress to a target-process
+            // pointer; ToAddress un-sign-extends the high 32 bits on 32-bit
+            // targets so the address can be used directly with IDataReader.
+            return _sos.TryGetStressLogAddress(out ClrDataAddress addr) ? addr.ToAddress(_target) : 0;
         }
 
         public IEnumerable<ClrThreadInfo> EnumerateThreads()

--- a/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacRuntime.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacRuntime.cs
@@ -39,6 +39,11 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
             _sos.DacVersion = version;
         }
 
+        internal ulong GetStressLogAddress()
+        {
+            return _sos.TryGetStressLogAddress(out ulong addr) ? addr : 0;
+        }
+
         public IEnumerable<ClrThreadInfo> EnumerateThreads()
         {
             if (!_sos.GetThreadStoreData(out ThreadStoreData threadStore))

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/SosDac.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/SosDac.cs
@@ -394,19 +394,21 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             return VTable.GetUsefulGlobals(Self, out commonMTs);
         }
 
-        public bool TryGetStressLogAddress(out ulong stressLogAddress)
+        public bool TryGetStressLogAddress(out ClrDataAddress stressLogAddress)
         {
             HResult hr = VTable.GetStressLogAddress(Self, out ClrDataAddress addr);
             if (!hr)
             {
-                stressLogAddress = 0;
+                stressLogAddress = ClrDataAddress.Null;
                 return false;
             }
 
-            // The StressLog parser only supports 64-bit targets, so we don't
-            // need to handle the 32-bit sign-extension transform here.
-            stressLogAddress = addr.ToInteropAddress();
-            return stressLogAddress != 0;
+            // Return the raw wire value the same way the rest of this file
+            // does. The caller is responsible for translating it to a target
+            // pointer via ClrDataAddress.ToAddress(target), which un-sign-
+            // extends on 32-bit targets.
+            stressLogAddress = addr;
+            return !addr.IsNull;
         }
 
         public ClrDataAddress[] GetAssemblyList(ClrDataAddress appDomain) => GetAssemblyList(appDomain, 0);

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/SosDac.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/SosDac.cs
@@ -394,6 +394,21 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             return VTable.GetUsefulGlobals(Self, out commonMTs);
         }
 
+        public bool TryGetStressLogAddress(out ulong stressLogAddress)
+        {
+            HResult hr = VTable.GetStressLogAddress(Self, out ClrDataAddress addr);
+            if (!hr)
+            {
+                stressLogAddress = 0;
+                return false;
+            }
+
+            // The StressLog parser only supports 64-bit targets, so we don't
+            // need to handle the 32-bit sign-extension transform here.
+            stressLogAddress = addr.ToInteropAddress();
+            return stressLogAddress != 0;
+        }
+
         public ClrDataAddress[] GetAssemblyList(ClrDataAddress appDomain) => GetAssemblyList(appDomain, 0);
 
         public ClrDataAddress[] GetAssemblyList(ClrDataAddress appDomain, int count) => GetModuleOrAssembly(appDomain, count, VTable.GetAssemblyList);
@@ -897,7 +912,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
         private readonly IntPtr GetNestedExceptionData;
 
         // StressLog
-        public readonly IntPtr GetStressLogAddress;
+        public readonly delegate* unmanaged[Stdcall]<IntPtr, out ClrDataAddress, int> GetStressLogAddress;
 
         // Heaps
         public readonly delegate* unmanaged[Stdcall]<IntPtr, ulong /*ClrDataAddress*/, IntPtr, int> TraverseLoaderHeap;

--- a/src/Microsoft.Diagnostics.Runtime/StressLog/IStressLogFormatReceiver.cs
+++ b/src/Microsoft.Diagnostics.Runtime/StressLog/IStressLogFormatReceiver.cs
@@ -1,0 +1,67 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace Microsoft.Diagnostics.Runtime.StressLogs
+{
+    /// <summary>
+    /// Receives a sequence of typed tokens describing a single stress log
+    /// message, produced by <see cref="StressLogMessage.Format{T}"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The reader parses, validates, and sanitizes the log-supplied format
+    /// bytes and emits a sequence of typed tokens to the receiver. Receivers
+    /// never see raw format bytes; the indirection means consumers cannot
+    /// accidentally hand log-controlled bytes to a printf-family or
+    /// <see cref="string.Format(string, object)"/> API.
+    /// </para>
+    /// <para>
+    /// Implementations should be value types declared with <see langword="struct"/>
+    /// to avoid boxing when invoked through
+    /// <c>Format&lt;T&gt;(ref T) where T : struct, IStressLogFormatReceiver</c>.
+    /// </para>
+    /// </remarks>
+    public interface IStressLogFormatReceiver
+    {
+        /// <summary>
+        /// Receives a literal run of bytes from the format string.
+        /// The bytes are guaranteed to be 7-bit printable ASCII; control
+        /// characters and ANSI escape sequences are replaced with
+        /// <c>'.'</c> before being passed.
+        /// </summary>
+        void Literal(ReadOnlySpan<byte> ascii);
+
+        /// <summary>
+        /// Receives an integer-typed argument.
+        /// </summary>
+        /// <param name="kind">Numeric format requested by the format specifier.</param>
+        /// <param name="width">Minimum width, or <c>-1</c> if not specified. Clamped to <c>[0, 256]</c>.</param>
+        /// <param name="precision">Precision, or <c>-1</c> if not specified. Clamped to <c>[0, 256]</c>.</param>
+        /// <param name="value">The integer value. Sign-extended for signed kinds, zero-extended otherwise.</param>
+        void Integer(StressLogIntegerKind kind, int width, int precision, long value);
+
+        /// <summary>
+        /// Receives a pointer-typed argument.
+        /// </summary>
+        /// <param name="kind">Whether the pointer is plain or runtime-typed (MethodDesc/MethodTable/...).</param>
+        /// <param name="address">The pointer value as it appeared in the message arguments.</param>
+        void Pointer(StressLogPointerKind kind, ulong address);
+
+        /// <summary>
+        /// Receives a string-typed argument whose bytes have already been read
+        /// from the target, decoded, and sanitized into 7-bit printable ASCII.
+        /// </summary>
+        /// <param name="encoding">Encoding of the string in the target before sanitization.</param>
+        /// <param name="sanitized">The sanitized string bytes. Length is bounded by the reader's options.</param>
+        void String(StressLogStringEncoding encoding, ReadOnlySpan<byte> sanitized);
+
+        /// <summary>
+        /// Indicates that the format string requested an argument the message
+        /// did not carry. Receivers typically render this as <c>&lt;missing&gt;</c>
+        /// or similar.
+        /// </summary>
+        void MissingArgument();
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/StressLog/Internal/AllocationBudget.cs
+++ b/src/Microsoft.Diagnostics.Runtime/StressLog/Internal/AllocationBudget.cs
@@ -1,0 +1,47 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
+{
+    /// <summary>
+    /// Tracks bytes allocated against a configured cap. Returns <see langword="false"/>
+    /// from <see cref="TryReserve"/> once the cap is hit so that callers can stop
+    /// growing buffers and surface a <c>LimitExceeded</c> diagnostic, bounding
+    /// peak working-set while parsing arbitrarily large stress logs.
+    /// </summary>
+    internal sealed class AllocationBudget
+    {
+        private readonly long _cap;
+        private long _consumed;
+
+        public AllocationBudget(long capBytes)
+        {
+            _cap = capBytes;
+        }
+
+        public bool TryReserve(int bytes)
+        {
+            if (bytes < 0)
+                return false;
+
+            long next = _consumed + bytes;
+            if (next < _consumed || next > _cap)
+                return false;
+
+            _consumed = next;
+            return true;
+        }
+
+        public void Release(int bytes)
+        {
+            if (bytes <= 0)
+                return;
+
+            long next = _consumed - bytes;
+            _consumed = next < 0 ? 0 : next;
+        }
+
+        public long Consumed => _consumed;
+        public long Cap => _cap;
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/StressLog/Internal/ArgumentResolver.cs
+++ b/src/Microsoft.Diagnostics.Runtime/StressLog/Internal/ArgumentResolver.cs
@@ -14,10 +14,10 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
     /// <remarks>
     /// <para>
     /// The number of bytes read from the target for any single string
-    /// argument is bounded by <see cref="MaxStringBytes"/>. NUL termination
-    /// is honored; bytes past the first NUL are dropped. Read failures
-    /// (truncated <see cref="IMemoryReader.Read"/>, address 0) yield an
-    /// empty span.
+    /// argument is bounded by the configured maximum string length. NUL
+    /// termination is honored; bytes past the first NUL are dropped. Read
+    /// failures (truncated <see cref="IMemoryReader.Read"/>, address 0)
+    /// yield an empty span.
     /// </para>
     /// <para>
     /// All bytes returned have been passed through
@@ -28,15 +28,31 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
     /// </remarks>
     internal sealed class ArgumentResolver
     {
-        public const int MaxStringBytes = 256;
+        public const int DefaultMaxStringBytes = 256;
 
         private readonly IMemoryReader _reader;
-        private readonly byte[] _readScratch = new byte[MaxStringBytes * 2]; // *2 for UTF-16
-        private readonly byte[] _sanitizeScratch = new byte[MaxStringBytes];
+        private readonly int _maxStringBytes;
+        private readonly byte[] _readScratch;
+        private readonly byte[] _sanitizeScratch;
 
         public ArgumentResolver(IMemoryReader reader)
+            : this(reader, DefaultMaxStringBytes)
+        {
+        }
+
+        public ArgumentResolver(IMemoryReader reader, int maxStringBytes)
         {
             _reader = reader;
+            // Clamp to a sane range so a misconfigured option cannot drive
+            // the parser into a zero-byte read or a many-MB allocation.
+            if (maxStringBytes < 16)
+                maxStringBytes = 16;
+            else if (maxStringBytes > 64 * 1024)
+                maxStringBytes = 64 * 1024;
+
+            _maxStringBytes = maxStringBytes;
+            _readScratch = new byte[maxStringBytes * 2]; // *2 for UTF-16
+            _sanitizeScratch = new byte[maxStringBytes];
         }
 
         public ReadOnlySpan<byte> ResolveString(ulong address, StressLogStringEncoding encoding)
@@ -46,7 +62,7 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
 
             if (encoding == StressLogStringEncoding.Utf8)
             {
-                Span<byte> read = _readScratch.AsSpan(0, MaxStringBytes);
+                Span<byte> read = _readScratch.AsSpan(0, _maxStringBytes);
                 int got = _reader.Read(address, read);
                 if (got <= 0)
                     return default;
@@ -58,7 +74,7 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
             }
             else
             {
-                Span<byte> read = _readScratch.AsSpan(0, MaxStringBytes * 2);
+                Span<byte> read = _readScratch.AsSpan(0, _maxStringBytes * 2);
                 int got = _reader.Read(address, read);
                 if (got <= 0)
                     return default;

--- a/src/Microsoft.Diagnostics.Runtime/StressLog/Internal/ArgumentResolver.cs
+++ b/src/Microsoft.Diagnostics.Runtime/StressLog/Internal/ArgumentResolver.cs
@@ -1,0 +1,72 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Microsoft.Diagnostics.Runtime;
+
+namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
+{
+    /// <summary>
+    /// Resolves <c>%s</c>/<c>%S</c> argument addresses to sanitized byte
+    /// spans. Ownership of the returned span is the resolver's, and it is
+    /// only valid until the next call.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The number of bytes read from the target for any single string
+    /// argument is bounded by <see cref="MaxStringBytes"/>. NUL termination
+    /// is honored; bytes past the first NUL are dropped. Read failures
+    /// (truncated <see cref="IMemoryReader.Read"/>, address 0) yield an
+    /// empty span.
+    /// </para>
+    /// <para>
+    /// All bytes returned have been passed through
+    /// <see cref="StressLogSanitizer"/>, so they are guaranteed to be 7-bit
+    /// printable ASCII. Receivers can write them straight to a console,
+    /// file, or other byte sink without further escaping.
+    /// </para>
+    /// </remarks>
+    internal sealed class ArgumentResolver
+    {
+        public const int MaxStringBytes = 256;
+
+        private readonly IMemoryReader _reader;
+        private readonly byte[] _readScratch = new byte[MaxStringBytes * 2]; // *2 for UTF-16
+        private readonly byte[] _sanitizeScratch = new byte[MaxStringBytes];
+
+        public ArgumentResolver(IMemoryReader reader)
+        {
+            _reader = reader;
+        }
+
+        public ReadOnlySpan<byte> ResolveString(ulong address, StressLogStringEncoding encoding)
+        {
+            if (address == 0)
+                return default;
+
+            if (encoding == StressLogStringEncoding.Utf8)
+            {
+                Span<byte> read = _readScratch.AsSpan(0, MaxStringBytes);
+                int got = _reader.Read(address, read);
+                if (got <= 0)
+                    return default;
+
+                ReadOnlySpan<byte> raw = read.Slice(0, got);
+                int len = StressLogSanitizer.LengthToFirstNull(raw);
+                int written = StressLogSanitizer.SanitizeAscii(raw.Slice(0, len), _sanitizeScratch);
+                return _sanitizeScratch.AsSpan(0, written);
+            }
+            else
+            {
+                Span<byte> read = _readScratch.AsSpan(0, MaxStringBytes * 2);
+                int got = _reader.Read(address, read);
+                if (got <= 0)
+                    return default;
+
+                ReadOnlySpan<byte> raw = read.Slice(0, got & ~1); // drop a stray trailing byte
+                int written = StressLogSanitizer.SanitizeUtf16(raw, _sanitizeScratch);
+                return _sanitizeScratch.AsSpan(0, written);
+            }
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/StressLog/Internal/ArgumentResolver.cs
+++ b/src/Microsoft.Diagnostics.Runtime/StressLog/Internal/ArgumentResolver.cs
@@ -34,13 +34,19 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
         private readonly int _maxStringBytes;
         private readonly byte[] _readScratch;
         private readonly byte[] _sanitizeScratch;
+        private readonly int _pointerSize;
 
         public ArgumentResolver(IMemoryReader reader)
-            : this(reader, DefaultMaxStringBytes)
+            : this(reader, DefaultMaxStringBytes, pointerSize: 8)
         {
         }
 
         public ArgumentResolver(IMemoryReader reader, int maxStringBytes)
+            : this(reader, maxStringBytes, pointerSize: 8)
+        {
+        }
+
+        public ArgumentResolver(IMemoryReader reader, int maxStringBytes, int pointerSize)
         {
             _reader = reader;
             // Clamp to a sane range so a misconfigured option cannot drive
@@ -53,7 +59,16 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
             _maxStringBytes = maxStringBytes;
             _readScratch = new byte[maxStringBytes * 2]; // *2 for UTF-16
             _sanitizeScratch = new byte[maxStringBytes];
+            _pointerSize = pointerSize == 4 ? 4 : 8;
         }
+
+        /// <summary>
+        /// Pointer size of the target, in bytes. Used by the format parser
+        /// to decide whether 64-bit length-modified arguments occupy one
+        /// slot (8-byte pointer target) or two consecutive slots (4-byte
+        /// pointer target, low dword first).
+        /// </summary>
+        public int PointerSize => _pointerSize;
 
         public ReadOnlySpan<byte> ResolveString(ulong address, StressLogStringEncoding encoding)
         {

--- a/src/Microsoft.Diagnostics.Runtime/StressLog/Internal/ChunkReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/StressLog/Internal/ChunkReader.cs
@@ -9,7 +9,7 @@ using Microsoft.Diagnostics.Runtime;
 namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
 {
     /// <summary>
-    /// Reads a 64-bit stress log chunk into a pooled byte buffer and exposes
+    /// Reads a stress log chunk into a pooled byte buffer and exposes
     /// validated views of its prev/next pointers and message body. Construction
     /// fails (returns <see langword="false"/>) on truncated reads, mismatched
     /// signatures, or when the allocation budget is exhausted.
@@ -17,6 +17,7 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
     internal struct ChunkReader
     {
         private byte[]? _buffer;
+        private readonly StressLogLayout _layout;
         private readonly AllocationBudget _budget;
 
         public ulong Address { get; private set; }
@@ -25,8 +26,9 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
 
         public bool IsLoaded => _buffer is not null;
 
-        public ChunkReader(AllocationBudget budget)
+        public ChunkReader(StressLogLayout layout, AllocationBudget budget)
         {
+            _layout = layout;
             _budget = budget;
             _buffer = null;
             Address = 0;
@@ -41,25 +43,24 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
         public bool TryLoad(IDataReader reader, ulong address)
         {
             // Reject addresses whose chunk range cannot be represented in
-            // 64 bits. Without this guard the BufferStart/BufferEnd accessors
-            // and the message-address arithmetic in the iterator can wrap.
-            const ulong totalSize = (ulong)StressLogLayout.Chunk_Buf
-                                  + (ulong)StressLogConstants.ChunkBufferSize64;
-            if (address > ulong.MaxValue - totalSize)
+            // the target's address space. Without this guard the
+            // BufferStart/BufferEnd accessors and the message-address
+            // arithmetic in the iterator can wrap.
+            if (!_layout.ChunkFits(address))
                 return false;
 
             Address = address;
             if (_buffer is null)
             {
-                if (!_budget.TryReserve(StressLogLayout.Chunk_TotalSize))
+                if (!_budget.TryReserve(_layout.ChunkTotalSize))
                     return false;
 
-                _buffer = ArrayPool<byte>.Shared.Rent(StressLogLayout.Chunk_TotalSize);
+                _buffer = ArrayPool<byte>.Shared.Rent(_layout.ChunkTotalSize);
             }
 
-            Span<byte> dst = _buffer.AsSpan(0, StressLogLayout.Chunk_TotalSize);
+            Span<byte> dst = _buffer.AsSpan(0, _layout.ChunkTotalSize);
             int got = reader.Read(address, dst);
-            if (got < StressLogLayout.Chunk_TotalSize)
+            if (got < _layout.ChunkTotalSize)
             {
                 Address = 0;
                 Prev = 0;
@@ -67,8 +68,8 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
                 return false;
             }
 
-            uint sig1 = BinaryPrimitives.ReadUInt32LittleEndian(dst.Slice(StressLogLayout.Chunk_DwSig1Offset));
-            uint sig2 = BinaryPrimitives.ReadUInt32LittleEndian(dst.Slice(StressLogLayout.Chunk_DwSig2Offset));
+            uint sig1 = BinaryPrimitives.ReadUInt32LittleEndian(dst.Slice(_layout.ChunkSig1Offset));
+            uint sig2 = BinaryPrimitives.ReadUInt32LittleEndian(dst.Slice(_layout.ChunkSig2Offset));
             if (sig1 != StressLogConstants.ChunkSignature || sig2 != StressLogConstants.ChunkSignature)
             {
                 Prev = 0;
@@ -76,16 +77,16 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
                 return false;
             }
 
-            Prev = BinaryPrimitives.ReadUInt64LittleEndian(dst.Slice(StressLogLayout.Chunk_Prev));
-            Next = BinaryPrimitives.ReadUInt64LittleEndian(dst.Slice(StressLogLayout.Chunk_Next));
+            Prev = _layout.ReadTargetPointer(dst, _layout.ChunkPrevOffset);
+            Next = _layout.ReadTargetPointer(dst, _layout.ChunkNextOffset);
             return true;
         }
 
-        /// <summary>The chunk's message buffer, addresses 0 .. ChunkBufferSize64 - 1.</summary>
+        /// <summary>The chunk's message buffer.</summary>
         public ReadOnlySpan<byte> Buffer
             => _buffer is null
                 ? default
-                : _buffer.AsSpan(StressLogLayout.Chunk_Buf, StressLogConstants.ChunkBufferSize64);
+                : _buffer.AsSpan(_layout.ChunkBufOffset, _layout.ChunkBufferSize);
 
         /// <summary>Translate a target message address into an offset within <see cref="Buffer"/>.</summary>
         public bool TryAddressToOffset(ulong address, out int offset)
@@ -93,16 +94,14 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
             offset = -1;
 
             // Reject chunk addresses whose buffer range cannot be represented
-            // in 64 bits. A malformed dump can put Address near ulong.MaxValue;
-            // the additions below would otherwise wrap and let an out-of-range
-            // address pass the in-range check.
-            const ulong totalSize = (ulong)StressLogLayout.Chunk_Buf
-                                  + (ulong)StressLogConstants.ChunkBufferSize64;
-            if (Address > ulong.MaxValue - totalSize)
+            // in the target's address space. A malformed dump can put Address
+            // near MaxAddress; the additions below would otherwise wrap and
+            // let an out-of-range address pass the in-range check.
+            if (!_layout.ChunkFits(Address))
                 return false;
 
-            ulong start = Address + (ulong)StressLogLayout.Chunk_Buf;
-            ulong end = start + (ulong)StressLogConstants.ChunkBufferSize64;
+            ulong start = Address + (ulong)_layout.ChunkBufOffset;
+            ulong end = start + (ulong)_layout.ChunkBufferSize;
             if (address < start || address >= end)
                 return false;
 
@@ -110,15 +109,15 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
             return true;
         }
 
-        public ulong BufferStartAddress => Address + (ulong)StressLogLayout.Chunk_Buf;
-        public ulong BufferEndAddress => BufferStartAddress + (ulong)StressLogConstants.ChunkBufferSize64;
+        public ulong BufferStartAddress => Address + (ulong)_layout.ChunkBufOffset;
+        public ulong BufferEndAddress => BufferStartAddress + (ulong)_layout.ChunkBufferSize;
 
         public void Release()
         {
             if (_buffer is not null)
             {
                 ArrayPool<byte>.Shared.Return(_buffer);
-                _budget.Release(StressLogLayout.Chunk_TotalSize);
+                _budget.Release(_layout.ChunkTotalSize);
                 _buffer = null;
             }
         }

--- a/src/Microsoft.Diagnostics.Runtime/StressLog/Internal/ChunkReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/StressLog/Internal/ChunkReader.cs
@@ -1,0 +1,110 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Buffers;
+using System.Buffers.Binary;
+using Microsoft.Diagnostics.Runtime;
+
+namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
+{
+    /// <summary>
+    /// Reads a 64-bit stress log chunk into a pooled byte buffer and exposes
+    /// validated views of its prev/next pointers and message body. Construction
+    /// fails (returns <see langword="false"/>) on truncated reads, mismatched
+    /// signatures, or when the allocation budget is exhausted.
+    /// </summary>
+    internal struct ChunkReader
+    {
+        private byte[]? _buffer;
+        private readonly AllocationBudget _budget;
+
+        public ulong Address { get; private set; }
+        public ulong Prev { get; private set; }
+        public ulong Next { get; private set; }
+
+        public bool IsLoaded => _buffer is not null;
+
+        public ChunkReader(AllocationBudget budget)
+        {
+            _budget = budget;
+            _buffer = null;
+            Address = 0;
+            Prev = 0;
+            Next = 0;
+        }
+
+        /// <summary>
+        /// Read and validate the chunk located at <paramref name="address"/>.
+        /// On success the chunk's body is accessible via <see cref="Buffer"/>.
+        /// </summary>
+        public bool TryLoad(IDataReader reader, ulong address)
+        {
+            Address = address;
+            if (_buffer is null)
+            {
+                if (!_budget.TryReserve(StressLogLayout.Chunk_TotalSize))
+                    return false;
+
+                _buffer = ArrayPool<byte>.Shared.Rent(StressLogLayout.Chunk_TotalSize);
+            }
+
+            Span<byte> dst = _buffer.AsSpan(0, StressLogLayout.Chunk_TotalSize);
+            int got = reader.Read(address, dst);
+            if (got < StressLogLayout.Chunk_TotalSize)
+            {
+                Address = 0;
+                Prev = 0;
+                Next = 0;
+                return false;
+            }
+
+            uint sig1 = BinaryPrimitives.ReadUInt32LittleEndian(dst.Slice(StressLogLayout.Chunk_DwSig1Offset));
+            uint sig2 = BinaryPrimitives.ReadUInt32LittleEndian(dst.Slice(StressLogLayout.Chunk_DwSig2Offset));
+            if (sig1 != StressLogConstants.ChunkSignature || sig2 != StressLogConstants.ChunkSignature)
+            {
+                Prev = 0;
+                Next = 0;
+                return false;
+            }
+
+            Prev = BinaryPrimitives.ReadUInt64LittleEndian(dst.Slice(StressLogLayout.Chunk_Prev));
+            Next = BinaryPrimitives.ReadUInt64LittleEndian(dst.Slice(StressLogLayout.Chunk_Next));
+            return true;
+        }
+
+        /// <summary>The chunk's message buffer, addresses 0 .. ChunkBufferSize64 - 1.</summary>
+        public ReadOnlySpan<byte> Buffer
+            => _buffer is null
+                ? default
+                : _buffer.AsSpan(StressLogLayout.Chunk_Buf, StressLogConstants.ChunkBufferSize64);
+
+        /// <summary>Translate a target message address into an offset within <see cref="Buffer"/>.</summary>
+        public bool TryAddressToOffset(ulong address, out int offset)
+        {
+            ulong start = Address + (ulong)StressLogLayout.Chunk_Buf;
+            ulong end = start + (ulong)StressLogConstants.ChunkBufferSize64;
+            if (address < start || address >= end)
+            {
+                offset = -1;
+                return false;
+            }
+
+            offset = (int)(address - start);
+            return true;
+        }
+
+        public ulong BufferStartAddress => Address + (ulong)StressLogLayout.Chunk_Buf;
+        public ulong BufferEndAddress => BufferStartAddress + (ulong)StressLogConstants.ChunkBufferSize64;
+
+        public void Release()
+        {
+            if (_buffer is not null)
+            {
+                ArrayPool<byte>.Shared.Return(_buffer);
+                _budget.Release(StressLogLayout.Chunk_TotalSize);
+                _buffer = null;
+            }
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/StressLog/Internal/ChunkReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/StressLog/Internal/ChunkReader.cs
@@ -40,6 +40,14 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
         /// </summary>
         public bool TryLoad(IDataReader reader, ulong address)
         {
+            // Reject addresses whose chunk range cannot be represented in
+            // 64 bits. Without this guard the BufferStart/BufferEnd accessors
+            // and the message-address arithmetic in the iterator can wrap.
+            const ulong totalSize = (ulong)StressLogLayout.Chunk_Buf
+                                  + (ulong)StressLogConstants.ChunkBufferSize64;
+            if (address > ulong.MaxValue - totalSize)
+                return false;
+
             Address = address;
             if (_buffer is null)
             {
@@ -82,13 +90,21 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
         /// <summary>Translate a target message address into an offset within <see cref="Buffer"/>.</summary>
         public bool TryAddressToOffset(ulong address, out int offset)
         {
+            offset = -1;
+
+            // Reject chunk addresses whose buffer range cannot be represented
+            // in 64 bits. A malformed dump can put Address near ulong.MaxValue;
+            // the additions below would otherwise wrap and let an out-of-range
+            // address pass the in-range check.
+            const ulong totalSize = (ulong)StressLogLayout.Chunk_Buf
+                                  + (ulong)StressLogConstants.ChunkBufferSize64;
+            if (Address > ulong.MaxValue - totalSize)
+                return false;
+
             ulong start = Address + (ulong)StressLogLayout.Chunk_Buf;
             ulong end = start + (ulong)StressLogConstants.ChunkBufferSize64;
             if (address < start || address >= end)
-            {
-                offset = -1;
                 return false;
-            }
 
             offset = (int)(address - start);
             return true;

--- a/src/Microsoft.Diagnostics.Runtime/StressLog/Internal/FormatStringCache.cs
+++ b/src/Microsoft.Diagnostics.Runtime/StressLog/Internal/FormatStringCache.cs
@@ -1,0 +1,133 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Diagnostics.Runtime;
+
+namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
+{
+    /// <summary>
+    /// Caches the bytes of a format string keyed on the resolved target
+    /// address from which they were read. Format strings appear repeatedly
+    /// across messages; reading and sanitizing them once amortizes the cost
+    /// and keeps the per-message critical path allocation-free.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The cache is bounded in entry count and total bytes so that a
+    /// pathological log cannot turn this into an unbounded allocation
+    /// primitive. When the cap is hit the oldest entries are dropped (FIFO).
+    /// </para>
+    /// <para>
+    /// Each cached entry stores both the sanitized format bytes (with a
+    /// trailing NUL stripped) and the recognized
+    /// <see cref="StressLogKnownFormat"/>, so identification is O(1) after
+    /// the first read.
+    /// </para>
+    /// </remarks>
+    internal sealed class FormatStringCache
+    {
+        private readonly Dictionary<ulong, Entry> _entries = new();
+        private readonly Queue<ulong> _insertionOrder = new();
+        private readonly IMemoryReader _reader;
+        private readonly AllocationBudget _budget;
+        private readonly int _maxLength;
+        private readonly int _maxEntries;
+
+        private byte[] _readScratch;
+
+        public FormatStringCache(IMemoryReader reader, AllocationBudget budget, int maxFormatLength, int maxEntries)
+        {
+            _reader = reader;
+            _budget = budget;
+            _maxLength = maxFormatLength;
+            _maxEntries = maxEntries;
+            _readScratch = new byte[maxFormatLength];
+        }
+
+        public bool TryGet(ulong address, out ReadOnlyMemory<byte> sanitized, out StressLogKnownFormat known)
+        {
+            if (address == 0)
+            {
+                sanitized = default;
+                known = StressLogKnownFormat.None;
+                return false;
+            }
+
+            if (_entries.TryGetValue(address, out Entry e))
+            {
+                sanitized = e.Sanitized;
+                known = e.Known;
+                return e.Sanitized.Length > 0;
+            }
+
+            return TryReadAndCache(address, out sanitized, out known);
+        }
+
+        private bool TryReadAndCache(ulong address, out ReadOnlyMemory<byte> sanitized, out StressLogKnownFormat known)
+        {
+            int read = _reader.Read(address, _readScratch);
+            if (read <= 0)
+            {
+                Insert(address, Array.Empty<byte>(), StressLogKnownFormat.None);
+                sanitized = default;
+                known = StressLogKnownFormat.None;
+                return false;
+            }
+
+            ReadOnlySpan<byte> raw = _readScratch.AsSpan(0, read);
+            int len = StressLogSanitizer.LengthToFirstNull(raw);
+
+            // Identify against the original (unsanitized) bytes, since the
+            // known format constants are themselves printf format strings
+            // containing '%' specifiers that the sanitizer would not change.
+            StressLogKnownFormat k = StressLogKnownFormats.Identify(raw.Slice(0, len));
+
+            byte[] copy;
+            if (!_budget.TryReserve(len))
+            {
+                Insert(address, Array.Empty<byte>(), k);
+                sanitized = default;
+                known = k;
+                return false;
+            }
+
+            copy = new byte[len];
+            StressLogSanitizer.SanitizeAscii(raw.Slice(0, len), copy);
+            Insert(address, copy, k);
+
+            sanitized = copy;
+            known = k;
+            return true;
+        }
+
+        private void Insert(ulong address, byte[] sanitized, StressLogKnownFormat known)
+        {
+            while (_entries.Count >= _maxEntries && _insertionOrder.Count > 0)
+            {
+                ulong oldest = _insertionOrder.Dequeue();
+                if (_entries.TryGetValue(oldest, out Entry victim))
+                {
+                    _budget.Release(victim.Sanitized.Length);
+                    _entries.Remove(oldest);
+                }
+            }
+
+            _entries[address] = new Entry(sanitized, known);
+            _insertionOrder.Enqueue(address);
+        }
+
+        private readonly struct Entry
+        {
+            public Entry(byte[] sanitized, StressLogKnownFormat known)
+            {
+                Sanitized = sanitized;
+                Known = known;
+            }
+
+            public byte[] Sanitized { get; }
+            public StressLogKnownFormat Known { get; }
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/StressLog/Internal/FormatStringCache.cs
+++ b/src/Microsoft.Diagnostics.Runtime/StressLog/Internal/FormatStringCache.cs
@@ -102,6 +102,18 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
 
             copy = new byte[len];
             StressLogSanitizer.SanitizeAscii(raw.Slice(0, len), copy);
+            // Stress logs are emitted in reverse time order; runtime format
+            // strings use '{' to mark a region's start and '}' to mark its
+            // end. When the log is read newest-first these read backwards,
+            // so we swap '{' <-> '}' here so that the resulting display is
+            // bracket-balanced when read top-to-bottom. Native SOS does the
+            // same in stressLogDump.cpp.
+            for (int idx = 0; idx < copy.Length; idx++)
+            {
+                byte b = copy[idx];
+                if (b == (byte)'{') copy[idx] = (byte)'}';
+                else if (b == (byte)'}') copy[idx] = (byte)'{';
+            }
             Insert(address, copy, k);
 
             sanitized = copy;

--- a/src/Microsoft.Diagnostics.Runtime/StressLog/Internal/FormatStringCache.cs
+++ b/src/Microsoft.Diagnostics.Runtime/StressLog/Internal/FormatStringCache.cs
@@ -34,6 +34,7 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
         private readonly AllocationBudget _budget;
         private readonly int _maxLength;
         private readonly int _maxEntries;
+        private readonly object _gate = new();
 
         private byte[] _readScratch;
 
@@ -55,14 +56,20 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
                 return false;
             }
 
-            if (_entries.TryGetValue(address, out Entry e))
+            // The cache is shared across concurrent enumerations on the same
+            // StressLog; serialize reads/inserts so the dictionary, FIFO
+            // queue, and shared scratch buffer stay consistent.
+            lock (_gate)
             {
-                sanitized = e.Sanitized;
-                known = e.Known;
-                return e.Sanitized.Length > 0;
-            }
+                if (_entries.TryGetValue(address, out Entry e))
+                {
+                    sanitized = e.Sanitized;
+                    known = e.Known;
+                    return e.Sanitized.Length > 0;
+                }
 
-            return TryReadAndCache(address, out sanitized, out known);
+                return TryReadAndCache(address, out sanitized, out known);
+            }
         }
 
         private bool TryReadAndCache(ulong address, out ReadOnlyMemory<byte> sanitized, out StressLogKnownFormat known)

--- a/src/Microsoft.Diagnostics.Runtime/StressLog/Internal/FormatStringParser.cs
+++ b/src/Microsoft.Diagnostics.Runtime/StressLog/Internal/FormatStringParser.cs
@@ -168,8 +168,13 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
                     precision = MaxPrecision;
             }
 
-            // Length modifiers (recognized and ignored).
-            // h, hh, l, ll, z, j, t, L, I, I32, I64
+            // Length modifiers (recognized).
+            // h, hh, l, ll, z, j, t, L, I, I32, I64.
+            // ll, j, L, I64 indicate 64-bit args; on 32-bit targets this
+            // means the argument occupies two consecutive arg slots (low
+            // dword followed by high dword), so we record the modifier so
+            // that DispatchSpec can combine slots when needed.
+            bool is64Bit = false;
             if (i < format.Length)
             {
                 byte b = format[i];
@@ -181,10 +186,19 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
                 else if (b == (byte)'l')
                 {
                     i++;
-                    if (i < format.Length && format[i] == (byte)'l') i++;
+                    if (i < format.Length && format[i] == (byte)'l')
+                    {
+                        is64Bit = true;
+                        i++;
+                    }
                 }
-                else if (b is (byte)'z' or (byte)'j' or (byte)'t' or (byte)'L')
+                else if (b is (byte)'z' or (byte)'t')
                 {
+                    i++;
+                }
+                else if (b is (byte)'j' or (byte)'L')
+                {
+                    is64Bit = true;
                     i++;
                 }
                 else if (b == (byte)'I')
@@ -193,7 +207,10 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
                     if (i + 1 < format.Length && format[i] == (byte)'3' && format[i + 1] == (byte)'2')
                         i += 2;
                     else if (i + 1 < format.Length && format[i] == (byte)'6' && format[i + 1] == (byte)'4')
+                    {
+                        is64Bit = true;
                         i += 2;
+                    }
                 }
             }
 
@@ -208,19 +225,19 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
             {
                 case (byte)'d':
                 case (byte)'i':
-                    spec = new FormatSpec(SpecKind.Integer, StressLogIntegerKind.Decimal, default, default, width, precision);
+                    spec = new FormatSpec(SpecKind.Integer, StressLogIntegerKind.Decimal, default, default, width, precision, is64Bit);
                     return true;
                 case (byte)'u':
-                    spec = new FormatSpec(SpecKind.Integer, StressLogIntegerKind.Unsigned, default, default, width, precision);
+                    spec = new FormatSpec(SpecKind.Integer, StressLogIntegerKind.Unsigned, default, default, width, precision, is64Bit);
                     return true;
                 case (byte)'x':
-                    spec = new FormatSpec(SpecKind.Integer, StressLogIntegerKind.Hex, default, default, width, precision);
+                    spec = new FormatSpec(SpecKind.Integer, StressLogIntegerKind.Hex, default, default, width, precision, is64Bit);
                     return true;
                 case (byte)'X':
-                    spec = new FormatSpec(SpecKind.Integer, StressLogIntegerKind.HexUpper, default, default, width, precision);
+                    spec = new FormatSpec(SpecKind.Integer, StressLogIntegerKind.HexUpper, default, default, width, precision, is64Bit);
                     return true;
                 case (byte)'c':
-                    spec = new FormatSpec(SpecKind.Integer, StressLogIntegerKind.Char, default, default, width, precision);
+                    spec = new FormatSpec(SpecKind.Integer, StressLogIntegerKind.Char, default, default, width, precision, is64Bit);
                     return true;
 
                 case (byte)'p':
@@ -239,14 +256,14 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
                             default: break;
                         }
                     }
-                    spec = new FormatSpec(SpecKind.Pointer, default, ptrKind, default, width, precision);
+                    spec = new FormatSpec(SpecKind.Pointer, default, ptrKind, default, width, precision, false);
                     return true;
 
                 case (byte)'s':
-                    spec = new FormatSpec(SpecKind.String, default, default, StressLogStringEncoding.Utf8, width, precision);
+                    spec = new FormatSpec(SpecKind.String, default, default, StressLogStringEncoding.Utf8, width, precision, false);
                     return true;
                 case (byte)'S':
-                    spec = new FormatSpec(SpecKind.String, default, default, StressLogStringEncoding.Utf16, width, precision);
+                    spec = new FormatSpec(SpecKind.String, default, default, StressLogStringEncoding.Utf16, width, precision, false);
                     return true;
 
                 default:
@@ -272,11 +289,48 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
 
             ulong raw = args[argIndex++];
 
+            // On 32-bit targets, a 64-bit length-modified argument
+            // (ll/I64/j/L) occupies two pointer-sized slots: low dword
+            // first, then high dword. Combine them so the receiver sees
+            // the full 64-bit value. On 64-bit targets each slot is
+            // already 8 bytes wide so no combination is needed.
+            if (spec.Is64Bit && argumentResolver.PointerSize == 4)
+            {
+                if ((uint)argIndex < (uint)args.Length)
+                {
+                    ulong hi = args[argIndex++];
+                    raw = (raw & 0xFFFFFFFFUL) | (hi << 32);
+                }
+            }
+
             switch (spec.Kind)
             {
                 case SpecKind.Integer:
-                    receiver.Integer(spec.IntegerKind, spec.Width, spec.Precision, unchecked((long)raw));
-                    break;
+                    {
+                        // Apply the printf rule that an unmodified %d/%i/%u/%x
+                        // refers to a 32-bit int. The runtime stores each
+                        // argument size_t-wide; on 32-bit targets that's
+                        // already 4 bytes (zero-extended into the 8-byte
+                        // slot), and on 64-bit targets a 32-bit value was
+                        // sign- or zero-extended via implicit conversion at
+                        // store time. Truncate-then-extend through int/uint
+                        // to recover the value the caller wrote.
+                        long signedValue;
+                        if (spec.Is64Bit)
+                        {
+                            signedValue = unchecked((long)raw);
+                        }
+                        else if (spec.IntegerKind == StressLogIntegerKind.Decimal)
+                        {
+                            signedValue = unchecked((int)raw);
+                        }
+                        else
+                        {
+                            signedValue = unchecked((long)(uint)raw);
+                        }
+                        receiver.Integer(spec.IntegerKind, spec.Width, spec.Precision, signedValue);
+                        break;
+                    }
 
                 case SpecKind.Pointer:
                     receiver.Pointer(spec.PointerKind, raw);
@@ -305,7 +359,8 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
                               StressLogPointerKind pointerKind,
                               StressLogStringEncoding stringEncoding,
                               int width,
-                              int precision)
+                              int precision,
+                              bool is64Bit)
             {
                 Kind = kind;
                 IntegerKind = integerKind;
@@ -313,6 +368,7 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
                 StringEncoding = stringEncoding;
                 Width = width;
                 Precision = precision;
+                Is64Bit = is64Bit;
             }
 
             public SpecKind Kind { get; }
@@ -321,6 +377,7 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
             public StressLogStringEncoding StringEncoding { get; }
             public int Width { get; }
             public int Precision { get; }
+            public bool Is64Bit { get; }
         }
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/StressLog/Internal/FormatStringParser.cs
+++ b/src/Microsoft.Diagnostics.Runtime/StressLog/Internal/FormatStringParser.cs
@@ -291,9 +291,17 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
 
             // On 32-bit targets, a 64-bit length-modified argument
             // (ll/I64/j/L) occupies two pointer-sized slots: low dword
-            // first, then high dword. Combine them so the receiver sees
-            // the full 64-bit value. On 64-bit targets each slot is
-            // already 8 bytes wide so no combination is needed.
+            // first, then high dword. This matches the canonical SOS
+            // consumer ABI: stressLogDump.cpp:formatOutput passes raw
+            // void* args to fprintf, which on 32-bit reads 8 bytes
+            // (i.e. two adjacent slots) for each %I64u / %llu. The
+            // runtime's STRESS_LOG macros store one size_t-wide slot
+            // per argument regardless of the source type, so on a
+            // 32-bit target a 64-bit value is effectively truncated at
+            // store time and the high dword we read here is whatever
+            // happens to be in the next slot. We deliberately preserve
+            // this behavior so our output matches `!dumplog`. On 64-bit
+            // each slot is already 8 bytes so no combination is needed.
             if (spec.Is64Bit && argumentResolver.PointerSize == 4)
             {
                 if ((uint)argIndex < (uint)args.Length)

--- a/src/Microsoft.Diagnostics.Runtime/StressLog/Internal/FormatStringParser.cs
+++ b/src/Microsoft.Diagnostics.Runtime/StressLog/Internal/FormatStringParser.cs
@@ -1,0 +1,326 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
+{
+    /// <summary>
+    /// Parses a sanitized printf-style format string and dispatches typed
+    /// tokens to a <see cref="IStressLogFormatReceiver"/>. The parser
+    /// recognizes a strict allow-list of conversion specifiers and rejects
+    /// every other specifier including <c>%n</c>, positional specifiers
+    /// (<c>%1$s</c>), and indirect width/precision (<c>%*d</c>).
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The input is bytes that have already been read and sanitized via
+    /// <see cref="StressLogSanitizer"/>. Sanitization preserves <c>%</c>
+    /// (since <c>%</c> is in the printable ASCII range), so format
+    /// specifiers survive sanitization intact.
+    /// </para>
+    /// <para>
+    /// Width and precision are clamped to a small constant before being
+    /// surfaced. Length modifiers (<c>h</c>, <c>l</c>, <c>ll</c>, <c>z</c>,
+    /// <c>j</c>, <c>t</c>, <c>L</c>, <c>I</c>, <c>I32</c>, <c>I64</c>) are
+    /// recognized and discarded; the runtime stores every argument
+    /// pointer-sized, so the modifier does not affect decoding.
+    /// </para>
+    /// </remarks>
+    internal static class FormatStringParser
+    {
+        private const int MaxWidth = 256;
+        private const int MaxPrecision = 256;
+
+        public static void Parse<TReceiver>(
+            ReadOnlySpan<byte> format,
+            ReadOnlySpan<ulong> args,
+            ArgumentResolver argumentResolver,
+            ref TReceiver receiver)
+            where TReceiver : struct, IStressLogFormatReceiver
+        {
+            int argIndex = 0;
+            int literalStart = 0;
+            int i = 0;
+
+            while (i < format.Length)
+            {
+                byte b = format[i];
+                if (b != (byte)'%')
+                {
+                    i++;
+                    continue;
+                }
+
+                // Flush accumulated literal bytes, if any.
+                if (i > literalStart)
+                    receiver.Literal(format.Slice(literalStart, i - literalStart));
+
+                int specStart = i;
+                i++; // consume '%'
+
+                if (i >= format.Length)
+                {
+                    // Trailing lone '%'. Render as literal '%'.
+                    receiver.Literal(format.Slice(specStart, 1));
+                    literalStart = format.Length;
+                    break;
+                }
+
+                // %% -> literal '%'.
+                if (format[i] == (byte)'%')
+                {
+                    receiver.Literal(format.Slice(specStart + 1, 1));
+                    i++;
+                    literalStart = i;
+                    continue;
+                }
+
+                if (!TryParseSpec(format, ref i, out FormatSpec spec))
+                {
+                    // Unknown / disallowed specifier (incl. %n, positional).
+                    // Render the raw spec bytes as a literal for traceability;
+                    // they were sanitized, so they cannot escape into a
+                    // downstream formatter.
+                    receiver.Literal(format.Slice(specStart, i - specStart));
+                    literalStart = i;
+                    continue;
+                }
+
+                DispatchSpec(spec, args, ref argIndex, argumentResolver, ref receiver);
+                literalStart = i;
+            }
+
+            if (literalStart < format.Length)
+                receiver.Literal(format.Slice(literalStart));
+        }
+
+        private static bool TryParseSpec(ReadOnlySpan<byte> format, ref int i, out FormatSpec spec)
+        {
+            spec = default;
+            int start = i;
+
+            // Reject positional arguments: %<digits>$.
+            int probe = i;
+            while (probe < format.Length && format[probe] is >= (byte)'0' and <= (byte)'9')
+                probe++;
+            if (probe < format.Length && format[probe] == (byte)'$')
+            {
+                i = probe + 1;
+                return false;
+            }
+
+            // Flags.
+            while (i < format.Length)
+            {
+                byte b = format[i];
+                if (b is (byte)'-' or (byte)'+' or (byte)' ' or (byte)'#' or (byte)'0')
+                    i++;
+                else
+                    break;
+            }
+
+            // Width.
+            int width = -1;
+            if (i < format.Length && format[i] == (byte)'*')
+            {
+                // Indirect width pulls from an argument; we do not support this.
+                i++;
+                return false;
+            }
+
+            if (i < format.Length && format[i] is >= (byte)'0' and <= (byte)'9')
+            {
+                width = 0;
+                while (i < format.Length && format[i] is (byte)'0' or (byte)'1' or (byte)'2' or (byte)'3' or (byte)'4'
+                                                       or (byte)'5' or (byte)'6' or (byte)'7' or (byte)'8' or (byte)'9')
+                {
+                    int digit = format[i] - (byte)'0';
+                    if (width <= MaxWidth)
+                        width = width * 10 + digit;
+                    i++;
+                }
+                if (width > MaxWidth)
+                    width = MaxWidth;
+            }
+
+            // Precision.
+            int precision = -1;
+            if (i < format.Length && format[i] == (byte)'.')
+            {
+                i++;
+                if (i < format.Length && format[i] == (byte)'*')
+                {
+                    i++;
+                    return false;
+                }
+
+                precision = 0;
+                while (i < format.Length && format[i] is (byte)'0' or (byte)'1' or (byte)'2' or (byte)'3' or (byte)'4'
+                                                       or (byte)'5' or (byte)'6' or (byte)'7' or (byte)'8' or (byte)'9')
+                {
+                    int digit = format[i] - (byte)'0';
+                    if (precision <= MaxPrecision)
+                        precision = precision * 10 + digit;
+                    i++;
+                }
+                if (precision > MaxPrecision)
+                    precision = MaxPrecision;
+            }
+
+            // Length modifiers (recognized and ignored).
+            // h, hh, l, ll, z, j, t, L, I, I32, I64
+            if (i < format.Length)
+            {
+                byte b = format[i];
+                if (b == (byte)'h')
+                {
+                    i++;
+                    if (i < format.Length && format[i] == (byte)'h') i++;
+                }
+                else if (b == (byte)'l')
+                {
+                    i++;
+                    if (i < format.Length && format[i] == (byte)'l') i++;
+                }
+                else if (b is (byte)'z' or (byte)'j' or (byte)'t' or (byte)'L')
+                {
+                    i++;
+                }
+                else if (b == (byte)'I')
+                {
+                    i++;
+                    if (i + 1 < format.Length && format[i] == (byte)'3' && format[i + 1] == (byte)'2')
+                        i += 2;
+                    else if (i + 1 < format.Length && format[i] == (byte)'6' && format[i + 1] == (byte)'4')
+                        i += 2;
+                }
+            }
+
+            // Conversion specifier.
+            if (i >= format.Length)
+                return false;
+
+            byte conv = format[i];
+            i++;
+
+            switch (conv)
+            {
+                case (byte)'d':
+                case (byte)'i':
+                    spec = new FormatSpec(SpecKind.Integer, StressLogIntegerKind.Decimal, default, default, width, precision);
+                    return true;
+                case (byte)'u':
+                    spec = new FormatSpec(SpecKind.Integer, StressLogIntegerKind.Unsigned, default, default, width, precision);
+                    return true;
+                case (byte)'x':
+                    spec = new FormatSpec(SpecKind.Integer, StressLogIntegerKind.Hex, default, default, width, precision);
+                    return true;
+                case (byte)'X':
+                    spec = new FormatSpec(SpecKind.Integer, StressLogIntegerKind.HexUpper, default, default, width, precision);
+                    return true;
+                case (byte)'c':
+                    spec = new FormatSpec(SpecKind.Integer, StressLogIntegerKind.Char, default, default, width, precision);
+                    return true;
+
+                case (byte)'p':
+                    // %p, optionally followed by a single letter that selects a
+                    // runtime pointer kind: %pM / %pT / %pV / %pK.
+                    StressLogPointerKind ptrKind = StressLogPointerKind.Plain;
+                    if (i < format.Length)
+                    {
+                        byte sub = format[i];
+                        switch (sub)
+                        {
+                            case (byte)'M': ptrKind = StressLogPointerKind.MethodDesc; i++; break;
+                            case (byte)'T': ptrKind = StressLogPointerKind.MethodTable; i++; break;
+                            case (byte)'V': ptrKind = StressLogPointerKind.VTable; i++; break;
+                            case (byte)'K': ptrKind = StressLogPointerKind.CodePointer; i++; break;
+                            default: break;
+                        }
+                    }
+                    spec = new FormatSpec(SpecKind.Pointer, default, ptrKind, default, width, precision);
+                    return true;
+
+                case (byte)'s':
+                    spec = new FormatSpec(SpecKind.String, default, default, StressLogStringEncoding.Utf8, width, precision);
+                    return true;
+                case (byte)'S':
+                    spec = new FormatSpec(SpecKind.String, default, default, StressLogStringEncoding.Utf16, width, precision);
+                    return true;
+
+                default:
+                    // %n, %a, %e, %f, %g, %o, %v, ... all rejected.
+                    _ = start; // start is used only for callers wanting to report the rejected range.
+                    return false;
+            }
+        }
+
+        private static void DispatchSpec<TReceiver>(
+            FormatSpec spec,
+            ReadOnlySpan<ulong> args,
+            ref int argIndex,
+            ArgumentResolver argumentResolver,
+            ref TReceiver receiver)
+            where TReceiver : struct, IStressLogFormatReceiver
+        {
+            if ((uint)argIndex >= (uint)args.Length)
+            {
+                receiver.MissingArgument();
+                return;
+            }
+
+            ulong raw = args[argIndex++];
+
+            switch (spec.Kind)
+            {
+                case SpecKind.Integer:
+                    receiver.Integer(spec.IntegerKind, spec.Width, spec.Precision, unchecked((long)raw));
+                    break;
+
+                case SpecKind.Pointer:
+                    receiver.Pointer(spec.PointerKind, raw);
+                    break;
+
+                case SpecKind.String:
+                    {
+                        ReadOnlySpan<byte> sanitized = argumentResolver.ResolveString(raw, spec.StringEncoding);
+                        receiver.String(spec.StringEncoding, sanitized);
+                        break;
+                    }
+            }
+        }
+
+        private enum SpecKind
+        {
+            Integer,
+            Pointer,
+            String,
+        }
+
+        private readonly struct FormatSpec
+        {
+            public FormatSpec(SpecKind kind,
+                              StressLogIntegerKind integerKind,
+                              StressLogPointerKind pointerKind,
+                              StressLogStringEncoding stringEncoding,
+                              int width,
+                              int precision)
+            {
+                Kind = kind;
+                IntegerKind = integerKind;
+                PointerKind = pointerKind;
+                StringEncoding = stringEncoding;
+                Width = width;
+                Precision = precision;
+            }
+
+            public SpecKind Kind { get; }
+            public StressLogIntegerKind IntegerKind { get; }
+            public StressLogPointerKind PointerKind { get; }
+            public StressLogStringEncoding StringEncoding { get; }
+            public int Width { get; }
+            public int Precision { get; }
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/StressLog/Internal/StressLogConstants.cs
+++ b/src/Microsoft.Diagnostics.Runtime/StressLog/Internal/StressLogConstants.cs
@@ -50,5 +50,13 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
 
         /// <summary>Maximum length of a format string read from the target.</summary>
         public const int MaxFormatStringLength = 256;
+
+        /// <summary>
+        /// Upper bound on bytes ever read for a <c>ThreadStressLog</c>
+        /// header. Sized for the largest variant we support so callers can
+        /// stack-allocate a buffer once and slice. Must be kept in sync
+        /// with <see cref="StressLogLayout.ThreadHeaderSize"/>.
+        /// </summary>
+        public const int MaxThreadHeaderBytes = 80;
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/StressLog/Internal/StressLogConstants.cs
+++ b/src/Microsoft.Diagnostics.Runtime/StressLog/Internal/StressLogConstants.cs
@@ -1,0 +1,54 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
+{
+    /// <summary>
+    /// Wire-protocol constants for the runtime stress log. These match the
+    /// values in <c>src/coreclr/inc/stresslog.h</c> in dotnet/runtime and
+    /// the in-tree mirror in dotnet/diagnostics. They are part of the
+    /// runtime's documented binary interface; values here must not be
+    /// changed without coordinating with the runtime.
+    /// </summary>
+    internal static class StressLogConstants
+    {
+        /// <summary>The "STRL" magic at the head of a memory-mapped stress log.</summary>
+        public const uint MemoryMappedMagic = 0x4C525453; // 'STRL' little-endian
+
+        /// <summary>Legacy memory-mapped layout (small format offset).</summary>
+        public const uint MemoryMappedVersionV1 = 0x00010001;
+
+        /// <summary>Memory-mapped layout introduced in .NET 8 (large format offset).</summary>
+        public const uint MemoryMappedVersionV2 = 0x00010002;
+
+        /// <summary>The signature word that brackets every <c>StressLogChunk</c>.</summary>
+        public const uint ChunkSignature = 0xCFCFCFCFu;
+
+        /// <summary>Size of a stress log chunk on a 64-bit target.</summary>
+        public const int ChunkBufferSize64 = 32 * 1024;
+
+        /// <summary>Size of a stress log chunk on a 32-bit target.</summary>
+        public const int ChunkBufferSize32 = 16 * 1024;
+
+        /// <summary>Maximum number of modules tracked by the runtime's module table.</summary>
+        public const int MaxModules = 5;
+
+        /// <summary>Maximum number of arguments any message may carry. The 6-bit field caps it at 63.</summary>
+        public const int MaxArgumentCount = 63;
+
+        /// <summary>Number of bits used to encode the low half of <c>formatOffset</c> in V4.</summary>
+        public const int FormatOffsetLowBits = 26;
+
+        /// <summary>Number of bits used to encode the high half of <c>formatOffset</c> in V4.</summary>
+        public const int FormatOffsetHighBits = 13;
+
+        /// <summary>Total number of bits used to encode <c>formatOffset</c> in V4.</summary>
+        public const int FormatOffsetTotalBits = FormatOffsetLowBits + FormatOffsetHighBits;
+
+        /// <summary>Maximum value of a V4 <c>formatOffset</c>: <c>1 &lt;&lt; 39</c>.</summary>
+        public const ulong FormatOffsetMax = 1UL << FormatOffsetTotalBits;
+
+        /// <summary>Maximum length of a format string read from the target.</summary>
+        public const int MaxFormatStringLength = 256;
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/StressLog/Internal/StressLogEnumerationContext.cs
+++ b/src/Microsoft.Diagnostics.Runtime/StressLog/Internal/StressLogEnumerationContext.cs
@@ -1,0 +1,78 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
+{
+    /// <summary>
+    /// Per-enumeration state for <see cref="StressLog.EnumerateMessages"/>.
+    /// Each call to <c>EnumerateMessages</c> allocates a fresh context, so
+    /// two concurrent enumerations of the same <see cref="StressLog"/> do
+    /// not share argument scratch buffers, the active iterator, or the
+    /// generation counter that invalidates stale <see cref="StressLogMessage"/>
+    /// instances.
+    /// </summary>
+    internal sealed class StressLogEnumerationContext
+    {
+        private readonly StressLog _log;
+        private readonly ulong[] _argScratch = new ulong[StressLogConstants.MaxArgumentCount];
+        private readonly ArgumentResolver _argResolver;
+
+        private int _generationCounter;
+        private ThreadIterator? _currentIterator;
+
+        public StressLogEnumerationContext(StressLog log, ArgumentResolver argResolver)
+        {
+            _log = log;
+            _argResolver = argResolver;
+        }
+
+        public StressLog Log => _log;
+
+        public ThreadIterator? CurrentIterator
+        {
+            get => _currentIterator;
+            set => _currentIterator = value;
+        }
+
+        /// <summary>
+        /// Bump the generation counter and copy the active iterator's
+        /// arguments into our scratch buffer. Returns the new generation,
+        /// which the corresponding <see cref="StressLogMessage"/> stamps so
+        /// later access through the message can detect that iteration has
+        /// since advanced and refuse to read stale buffers.
+        /// </summary>
+        public int CaptureFromIterator(ThreadIterator iter)
+        {
+            _currentIterator = iter;
+            int gen = ++_generationCounter;
+            int n = iter.ArgumentCount;
+            for (int i = 0; i < n; i++)
+                _argScratch[i] = iter.GetArgument(i);
+            return gen;
+        }
+
+        public void Clear()
+        {
+            _currentIterator = null;
+            // Do not reset _generationCounter; outstanding StressLogMessage
+            // instances rely on the counter never returning to a previously
+            // valid value.
+        }
+
+        public ulong GetArgument(int generation, int index, int argCount)
+        {
+            if (generation != _generationCounter || _currentIterator is null) return 0;
+            if ((uint)index >= (uint)argCount) return 0;
+            return _argScratch[index];
+        }
+
+        public void FormatMessage<T>(int generation, ulong formatAddress, int argCount, ref T receiver)
+            where T : struct, IStressLogFormatReceiver
+        {
+            if (generation != _generationCounter || _currentIterator is null) return;
+            _log.FormatMessage(_argScratch, _argResolver, formatAddress, argCount, ref receiver);
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/StressLog/Internal/StressLogKnownFormats.cs
+++ b/src/Microsoft.Diagnostics.Runtime/StressLog/Internal/StressLogKnownFormats.cs
@@ -1,0 +1,51 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Text;
+
+namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
+{
+    /// <summary>
+    /// Well-known format strings shipped by the runtime. We byte-compare
+    /// against these to identify GC-history messages without parsing the
+    /// format string text.
+    /// </summary>
+    /// <remarks>
+    /// The constants here mirror <c>src/coreclr/inc/gcmsg.inl</c> and the
+    /// <c>TaskSwitchMsg</c> string in <c>stresslog.h</c>. They are part of
+    /// the runtime's stable wire format; do not rewrap or retype the strings
+    /// without coordinating with the runtime team.
+    /// </remarks>
+    internal static class StressLogKnownFormats
+    {
+        public static readonly byte[] GcStart =
+            Encoding.ASCII.GetBytes("{ =========== BEGINGC %d, (requested generation = %lu, collect_classes = %lu) ==========\n");
+
+        public static readonly byte[] GcEnd =
+            Encoding.ASCII.GetBytes("========== ENDGC %d (gen = %lu, collect_classes = %lu) ===========}\n");
+
+        public static readonly byte[] GcRoot =
+            Encoding.ASCII.GetBytes("    GC Root %p RELOCATED %p -> %p  MT = %pT\n");
+
+        public static readonly byte[] GcRootPromote =
+            Encoding.ASCII.GetBytes("    IGCHeap::Promote: Promote GC Root *%p = %p MT = %pT\n");
+
+        public static readonly byte[] GcPlugMove =
+            Encoding.ASCII.GetBytes("GC_HEAP RELOCATING Objects in heap within range [%p %p) by -0x%x bytes\n");
+
+        public static readonly byte[] TaskSwitch =
+            Encoding.ASCII.GetBytes("StressLog TaskSwitch Marker\n");
+
+        public static StressLogKnownFormat Identify(ReadOnlySpan<byte> formatBytes)
+        {
+            if (formatBytes.SequenceEqual(GcStart))       return StressLogKnownFormat.GcStart;
+            if (formatBytes.SequenceEqual(GcEnd))         return StressLogKnownFormat.GcEnd;
+            if (formatBytes.SequenceEqual(GcRoot))        return StressLogKnownFormat.GcRoot;
+            if (formatBytes.SequenceEqual(GcRootPromote)) return StressLogKnownFormat.GcRootPromote;
+            if (formatBytes.SequenceEqual(GcPlugMove))    return StressLogKnownFormat.GcPlugMove;
+            if (formatBytes.SequenceEqual(TaskSwitch))    return StressLogKnownFormat.TaskSwitch;
+            return StressLogKnownFormat.None;
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/StressLog/Internal/StressLogLayout.cs
+++ b/src/Microsoft.Diagnostics.Runtime/StressLog/Internal/StressLogLayout.cs
@@ -3,134 +3,398 @@
 
 using System;
 using System.Buffers.Binary;
+using Microsoft.Diagnostics.Runtime;
 
 namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
 {
     /// <summary>
-    /// Field offsets within the on-target structures we read. Only 64-bit
-    /// targets are supported; 32-bit targets are rejected during open.
+    /// Per-target description of the on-disk struct layouts that make up a
+    /// runtime stress log. A single instance captures pointer size, OS, and
+    /// runtime variant (Core vs .NET Framework V1) so that consumers can
+    /// read fields by symbolic name regardless of the target.
     /// </summary>
     /// <remarks>
-    /// The runtime's <c>StressLog</c> class layout is documented at
-    /// <c>src/coreclr/inc/stresslog.h</c> and mirrored in this repo's
-    /// adjacent dotnet/diagnostics tree. These offsets must move in
-    /// lockstep with that header.
+    /// <para>
+    /// The bit-field decoders (<see cref="DecodeMessageV3"/>,
+    /// <see cref="DecodeMessageV4"/>, <see cref="DecodeMessageFxV1"/>) are
+    /// independent of pointer size and remain static methods on this type.
+    /// </para>
+    /// <para>
+    /// All pointer-sized field reads MUST go through
+    /// <see cref="ReadTargetPointer"/>. Reads done with
+    /// <c>BinaryPrimitives.ReadInt32LittleEndian</c> would sign-extend a
+    /// high-bit (≥ 0x80000000) 32-bit pointer, producing a malformed
+    /// 64-bit address; reads done with <c>ReadUInt64LittleEndian</c> on a
+    /// 32-bit target would consume four bytes of an unrelated adjacent
+    /// field. Centralizing in a single helper avoids both classes of bug.
+    /// </para>
     /// </remarks>
-    internal static class StressLogLayout
+    internal sealed class StressLogLayout
     {
-        // -----------------------------------------------------------------
-        // In-process StressLog (64-bit target)
-        // -----------------------------------------------------------------
+        /// <summary>Pointer size on the target, in bytes (4 or 8).</summary>
+        public int PointerSize { get; }
 
-        public const int InProc_FacilitiesToLog   = 0;     // uint
-        public const int InProc_LevelToLog        = 4;     // uint
-        public const int InProc_MaxSizePerThread  = 8;     // uint
-        public const int InProc_MaxSizeTotal      = 12;    // uint
-        public const int InProc_TotalChunk        = 16;    // int (Volatile<LONG>)
-        // 4 bytes padding for 8-byte alignment of the next pointer
-        public const int InProc_Logs              = 24;    // ThreadStressLog*
-        public const int InProc_Padding           = 32;    // uint (named 'padding' in the header)
-        public const int InProc_DeadCount         = 36;    // int (Volatile<LONG>)
-        public const int InProc_Lock              = 40;    // CRITSEC_COOKIE (pointer)
-        public const int InProc_TickFrequency     = 48;    // uint64
-        public const int InProc_StartTimeStamp    = 56;    // uint64
-        public const int InProc_StartTime         = 64;    // FILETIME (uint64)
-        public const int InProc_ModuleOffset      = 72;    // size_t
-        public const int InProc_Modules           = 80;    // ModuleDesc[5]
-        public const int InProc_ModuleEntrySize   = 16;    // baseAddress + size on 64-bit
-        public const int InProc_ModulesEnd        = InProc_Modules + StressLogConstants.MaxModules * InProc_ModuleEntrySize;
+        /// <summary>
+        /// Largest valid target address. <c>uint.MaxValue</c> on 32-bit;
+        /// <c>ulong.MaxValue</c> on 64-bit. Use this as the upper bound on
+        /// all address arithmetic to reject overflow that would otherwise
+        /// wrap a malformed dump's pointers back into the legal range.
+        /// </summary>
+        public ulong MaxAddress { get; }
 
-        /// <summary>Bytes we read from the target for the in-process header.</summary>
-        public const int InProc_HeaderSize        = InProc_ModulesEnd; // 160
+        /// <summary>True if the target is a 64-bit target.</summary>
+        public bool Is64Bit => PointerSize == 8;
+
+        /// <summary>True if the target is the legacy .NET Framework runtime.</summary>
+        public bool IsFramework { get; }
 
         // -----------------------------------------------------------------
-        // Memory-mapped StressLogHeader (64-bit only)
+        // StressLog struct (in-process). Fields up through 'totalChunk'
+        // share offsets with both pointer sizes; everything past 'logs'
+        // shifts because the pointer size changes.
         // -----------------------------------------------------------------
 
-        public const int Mm_HeaderSize            = 0;     // size_t
-        public const int Mm_Magic                 = 8;     // uint32 'STRL'
-        public const int Mm_Version               = 12;    // uint32
-        public const int Mm_MemoryBase            = 16;    // uint8*
-        public const int Mm_MemoryCur             = 24;    // uint8*
-        public const int Mm_MemoryLimit           = 32;    // uint8*
-        public const int Mm_Logs                  = 40;    // ThreadStressLog*
-        public const int Mm_TickFrequency         = 48;    // uint64
-        public const int Mm_StartTimeStamp        = 56;    // uint64
-        public const int Mm_ThreadsWithNoLog      = 64;    // uint32
-        public const int Mm_Reserved1             = 68;    // uint32
-        public const int Mm_Reserved2             = 72;    // uint64[15] (15 * 8 = 120 bytes)
-        public const int Mm_Modules               = 192;   // ModuleDesc[5]
-        public const int Mm_ModulesEnd            = Mm_Modules + StressLogConstants.MaxModules * InProc_ModuleEntrySize;
-        public const int Mm_ModuleImage           = Mm_ModulesEnd;  // 272
+        public int InProcFacilitiesToLogOffset => 0;   // uint
+        public int InProcLevelToLogOffset      => 4;   // uint
+        public int InProcMaxSizePerThreadOffset => 8;  // uint
+        public int InProcMaxSizeTotalOffset    => 12;  // uint
+        public int InProcTotalChunkOffset      => 16;  // int (Volatile<LONG>)
 
-        /// <summary>Bytes we read from the target for the memory-mapped header.</summary>
-        public const int Mm_HeaderReadSize        = Mm_ModulesEnd; // 272
-
-        // -----------------------------------------------------------------
-        // ThreadStressLog (Core, 64-bit target)
-        // -----------------------------------------------------------------
-
-        public const int Thread_Next              = 0;     // ThreadStressLog*
-        public const int CoreThread_ThreadId      = 8;     // uint64
-        public const int CoreThread_IsDead        = 16;    // uint8
-        public const int CoreThread_ReadHasWrapped  = 17;  // uint8 (uninitialized in the live writer; we never trust this byte)
-        public const int CoreThread_WriteHasWrapped = 18;  // uint8
-        // 5 bytes padding for 8-byte alignment of the next pointer
-        public const int CoreThread_CurPtr        = 24;    // StressMsg*
-        public const int CoreThread_ReadPtr       = 32;    // StressMsg*
-        public const int CoreThread_ChunkListHead = 40;    // StressLogChunk*
-        public const int CoreThread_ChunkListTail = 48;    // StressLogChunk*
-        public const int CoreThread_CurReadChunk  = 56;    // StressLogChunk*
-        public const int CoreThread_CurWriteChunk = 64;    // StressLogChunk*
-        public const int CoreThread_ChunkListLength = 72;  // long (4 bytes)
+        // 'logs' is the first pointer-sized field. On x86 there's no
+        // pre-padding (totalChunk is 4 bytes, naturally aligned for a
+        // 4-byte pointer); on x64 there are 4 bytes of padding inserted
+        // for 8-byte alignment.
+        public int InProcLogsOffset { get; }
+        public int InProcPaddingOffset { get; }
+        public int InProcDeadCountOffset { get; }
+        public int InProcLockOffset { get; }
+        public int InProcTickFrequencyOffset { get; }
+        public int InProcStartTimeStampOffset { get; }
+        public int InProcStartTimeOffset { get; }
+        public int InProcModuleOffsetOffset { get; }
+        public int InProcModulesOffset { get; }
+        public int InProcHeaderSize { get; }
 
         // -----------------------------------------------------------------
-        // ThreadStressLog (.NET Framework V1, 64-bit target)
+        // Memory-mapped StressLogHeader. Memory-mapped logs only exist on
+        // 64-bit hosts; on 32-bit the offsets here are unused but we keep
+        // them populated for symmetry. TryOpen rejects MM logs when
+        // <see cref="PointerSize"/> != 8 by checking the magic.
         // -----------------------------------------------------------------
+
+        public int MmHeaderSizeOffset       => 0;
+        public int MmMagicOffset            => 8;
+        public int MmVersionOffset          => 12;
+        public int MmMemoryBaseOffset       { get; }
+        public int MmMemoryCurOffset        { get; }
+        public int MmMemoryLimitOffset      { get; }
+        public int MmLogsOffset             { get; }
+        public int MmTickFrequencyOffset    { get; }
+        public int MmStartTimeStampOffset   { get; }
+        public int MmThreadsWithNoLogOffset { get; }
+        public int MmModulesOffset          { get; }
+        public int MmHeaderReadSize         { get; }
+
+        // -----------------------------------------------------------------
+        // ThreadStressLog struct.
         //
-        // Framework's ThreadStressLog uses a 4-byte threadId and 4-byte
-        // isDead/readHasWrapped/writeHasWrapped fields, shifting curPtr,
-        // readPtr earlier in the layout. Verified against
-        // .NET Framework 4.8.9325 dumps via the cdb dt extension.
+        // Core layout:
+        //   [P]   next                    pointer
+        //   [8]   threadId                always uint64
+        //   [1]   isDead
+        //   [1]   readHasWrapped (junk in writer)
+        //   [1]   writeHasWrapped
+        //   pad to pointer alignment
+        //   [P]   curPtr
+        //   [P]   readPtr
+        //   [P]   chunkListHead
+        //   [P]   chunkListTail
+        //   [P]   curReadChunk
+        //   [P]   curWriteChunk
+        //   [4]   chunkListLength (long)
+        //
+        // Framework layout (pre-Core; threadId is uint32, the write-wrapped
+        // flag is a full uint32, etc.):
+        //   [P]   next
+        //   [4]   threadId
+        //   [4]   isDead
+        //   [P]   curPtr
+        //   [P]   readPtr
+        //   [4]   readHasWrapped
+        //   [4]   writeHasWrapped
+        //   [P]   chunkListHead
+        //   [P]   chunkListTail
+        //   [P]   curReadChunk
+        //   [P]   curWriteChunk
+        //   [4]   chunkListLength
+        // -----------------------------------------------------------------
 
-        public const int FxThread_ThreadId        = 8;     // uint32
-        public const int FxThread_IsDead          = 12;    // uint32
-        public const int FxThread_CurPtr          = 16;    // StressMsg*
-        public const int FxThread_ReadPtr         = 24;    // StressMsg*
-        public const int FxThread_ReadHasWrapped  = 32;    // uint32 (uninitialized in the live writer)
-        public const int FxThread_WriteHasWrapped = 36;    // uint32
-        public const int FxThread_ChunkListHead   = 40;    // StressLogChunk*
-        public const int FxThread_ChunkListTail   = 48;    // StressLogChunk*
-        public const int FxThread_CurReadChunk    = 56;    // StressLogChunk*
-        public const int FxThread_CurWriteChunk   = 64;    // StressLogChunk*
-        public const int FxThread_ChunkListLength = 72;    // long (4 bytes)
-
-        // Both layouts use the same 80-byte struct size (the differences are
-        // a rearrangement of fields within those bytes), so we always read
-        // 80 bytes for the thread header regardless of variant.
-        public const int Thread_HeaderSize        = 80;
+        public int ThreadNextOffset           => 0;
+        public int ThreadIdOffset             { get; }
+        public int ThreadIdSize               { get; }   // 8 on Core, 4 on Framework
+        public int ThreadIsDeadOffset         { get; }
+        public int ThreadReadHasWrappedOffset { get; }   // never trusted; see remarks
+        public int ThreadWriteHasWrappedOffset { get; }
+        public int ThreadCurPtrOffset         { get; }
+        public int ThreadReadPtrOffset        { get; }
+        public int ThreadChunkListHeadOffset  { get; }
+        public int ThreadChunkListTailOffset  { get; }
+        public int ThreadCurReadChunkOffset   { get; }
+        public int ThreadCurWriteChunkOffset  { get; }
+        public int ThreadChunkListLengthOffset { get; }
+        public int ThreadHeaderSize           { get; }
 
         // -----------------------------------------------------------------
-        // StressLogChunk (64-bit target, 32 KB body)
+        // StressLogChunk
         // -----------------------------------------------------------------
 
-        public const int Chunk_Prev               = 0;     // StressLogChunk*
-        public const int Chunk_Next               = 8;     // StressLogChunk*
-        public const int Chunk_Buf                = 16;    // char[ChunkBufferSize64]
-        public const int Chunk_DwSig1Offset       = Chunk_Buf + StressLogConstants.ChunkBufferSize64;     // 32784
-        public const int Chunk_DwSig2Offset       = Chunk_DwSig1Offset + 4;                              // 32788
-        public const int Chunk_TotalSize          = Chunk_DwSig2Offset + 4;                              // 32792
+        public int ChunkPrevOffset       => 0;
+        public int ChunkNextOffset       { get; }
+        public int ChunkBufOffset        { get; }
+        public int ChunkBufferSize       { get; }
+        public int ChunkSig1Offset       => ChunkBufOffset + ChunkBufferSize;
+        public int ChunkSig2Offset       => ChunkSig1Offset + 4;
+        public int ChunkTotalSize        => ChunkSig2Offset + 4;
 
         // -----------------------------------------------------------------
         // StressMsg
         // -----------------------------------------------------------------
 
-        public const int Msg_HeaderSize           = 16;    // sizeof(StressMsg) without args (Core V3/V4)
-        public const int Msg_HeaderSizeFxV1       = 24;    // .NET Framework: each header field is qword-aligned
-        public const int Msg_ArgSize              = 8;     // pointer-sized
+        /// <summary>Bytes consumed by the <c>StressMsg</c> header (without args).</summary>
+        public int MessageHeaderSize { get; }
+
+        /// <summary>
+        /// Stride in bytes between consecutive arguments. Always equals
+        /// <see cref="PointerSize"/>: arguments are <c>void*</c> on the
+        /// target.
+        /// </summary>
+        public int ArgStride => PointerSize;
+
+        /// <summary>Number of hex digits to emit for a <c>%p</c> on this target (8 or 16).</summary>
+        public int PointerHexDigits => PointerSize * 2;
+
+        /// <summary>Number of bytes occupied by a single module-table entry (baseAddress + size, both pointer-sized).</summary>
+        public int ModuleEntrySize => PointerSize * 2;
 
         // -----------------------------------------------------------------
-        // Bit-field decoders
+        // Static factories
+        // -----------------------------------------------------------------
+
+        /// <summary>
+        /// Layout for a 64-bit Core target. Matches modern CoreCLR.
+        /// </summary>
+        public static StressLogLayout CoreX64 { get; } = new StressLogLayout(pointerSize: 8, isFramework: false);
+
+        /// <summary>
+        /// Layout for a 64-bit .NET Framework V1 target. Same chunk and
+        /// module-table sizes as Core x64; ThreadStressLog and StressMsg
+        /// layouts differ.
+        /// </summary>
+        public static StressLogLayout FrameworkX64 { get; } = new StressLogLayout(pointerSize: 8, isFramework: true);
+
+        /// <summary>
+        /// Layout for a 32-bit Core target on Windows. .NET Core has not
+        /// shipped a 32-bit Linux runtime in a supported configuration,
+        /// so only Windows-x86 layout is defined.
+        /// </summary>
+        public static StressLogLayout CoreWinX86 { get; } = new StressLogLayout(pointerSize: 4, isFramework: false);
+
+        /// <summary>
+        /// Layout for a 32-bit .NET Framework V1 target on Windows.
+        /// </summary>
+        public static StressLogLayout FrameworkWinX86 { get; } = new StressLogLayout(pointerSize: 4, isFramework: true);
+
+        /// <summary>
+        /// Pick a layout for the given pointer size. The returned layout
+        /// initially assumes Core; callers must call <see cref="WithFramework"/>
+        /// after variant detection if the target is Framework.
+        /// </summary>
+        public static StressLogLayout ForCore(int pointerSize) => pointerSize switch
+        {
+            8 => CoreX64,
+            4 => CoreWinX86,
+            _ => throw new ArgumentOutOfRangeException(nameof(pointerSize), pointerSize, "Pointer size must be 4 or 8."),
+        };
+
+        /// <summary>
+        /// Returns the Framework V1 sibling of the supplied layout,
+        /// preserving pointer size.
+        /// </summary>
+        public StressLogLayout WithFramework() => PointerSize switch
+        {
+            8 => FrameworkX64,
+            4 => FrameworkWinX86,
+            _ => throw new InvalidOperationException(),
+        };
+
+        private StressLogLayout(int pointerSize, bool isFramework)
+        {
+            PointerSize = pointerSize;
+            IsFramework = isFramework;
+            MaxAddress = pointerSize == 8 ? ulong.MaxValue : uint.MaxValue;
+
+            // Field offsets in the StressLog struct.
+            //
+            // The first pointer-sized field is 'logs'. On x86 it follows
+            // totalChunk (offset 16) directly with no padding. On x64 there
+            // are 4 bytes of padding for 8-byte alignment.
+            int p = pointerSize;
+            int afterTotalChunk = 20;                      // x86: align(20, 4) = 20
+            if (p == 8) afterTotalChunk = AlignUp(20, 8); // x64: 24
+            InProcLogsOffset = afterTotalChunk;
+            InProcPaddingOffset = InProcLogsOffset + p;            // uint padding (or fwk's TLS slot)
+            InProcDeadCountOffset = InProcPaddingOffset + 4;       // int
+            InProcLockOffset = InProcDeadCountOffset + 4;          // pointer (CRITSEC_COOKIE)
+            // tickFrequency is uint64; on x86 MSVC __int64 is 8-byte aligned,
+            // so there are 4 bytes of padding between lock and tickFrequency.
+            int afterLock = InProcLockOffset + p;
+            InProcTickFrequencyOffset = AlignUp(afterLock, 8);
+            InProcStartTimeStampOffset = InProcTickFrequencyOffset + 8;
+            InProcStartTimeOffset = InProcStartTimeStampOffset + 8;
+            InProcModuleOffsetOffset = InProcStartTimeOffset + 8;  // size_t
+            InProcModulesOffset = InProcModuleOffsetOffset + p;
+            InProcHeaderSize = InProcModulesOffset
+                             + StressLogConstants.MaxModules * ModuleEntrySize;
+
+            // Memory-mapped header offsets. These are only valid on 64-bit
+            // hosts (the runtime guards memory-mapped stress logs behind
+            // HOST_64BIT). On 32-bit we still compute defensible numbers
+            // but the magic check in TryOpen prevents this path from running.
+            MmMemoryBaseOffset = 16;
+            MmMemoryCurOffset = MmMemoryBaseOffset + p;            // 24 on x64
+            MmMemoryLimitOffset = MmMemoryCurOffset + p;           // 32
+            MmLogsOffset = MmMemoryLimitOffset + p;                // 40
+            MmTickFrequencyOffset = MmLogsOffset + p;              // 48
+            MmStartTimeStampOffset = MmTickFrequencyOffset + 8;    // 56
+            MmThreadsWithNoLogOffset = MmStartTimeStampOffset + 8; // 64
+            // Reserved1 (uint32) at +68, Reserved2[15] (uint64*15) at +72,
+            // Modules at +192. We jump straight to Modules.
+            MmModulesOffset = MmThreadsWithNoLogOffset + 4 + 4 + 15 * 8;  // 192 on x64
+            MmHeaderReadSize = MmModulesOffset
+                             + StressLogConstants.MaxModules * ModuleEntrySize;
+
+            // ThreadStressLog field offsets.
+            ChunkNextOffset = p;
+            if (isFramework)
+            {
+                // Framework's ThreadStressLog lays out:
+                //   next:P, threadId:4, isDead:4, curPtr:P, readPtr:P,
+                //   readHasWrapped:4, writeHasWrapped:4, chunkListHead:P,
+                //   chunkListTail:P, curReadChunk:P, curWriteChunk:P,
+                //   chunkListLength:4.
+                ThreadIdOffset = p;
+                ThreadIdSize = 4;
+                ThreadIsDeadOffset = ThreadIdOffset + 4;
+                ThreadCurPtrOffset = ThreadIsDeadOffset + 4;
+                ThreadReadPtrOffset = ThreadCurPtrOffset + p;
+                ThreadReadHasWrappedOffset = ThreadReadPtrOffset + p;
+                ThreadWriteHasWrappedOffset = ThreadReadHasWrappedOffset + 4;
+                ThreadChunkListHeadOffset = ThreadWriteHasWrappedOffset + 4;
+                ThreadChunkListTailOffset = ThreadChunkListHeadOffset + p;
+                ThreadCurReadChunkOffset = ThreadChunkListTailOffset + p;
+                ThreadCurWriteChunkOffset = ThreadCurReadChunkOffset + p;
+                ThreadChunkListLengthOffset = ThreadCurWriteChunkOffset + p;
+                // Round up to pointer alignment to match the C++ sizeof,
+                // matching the existing 80-byte read on x64.
+                ThreadHeaderSize = AlignUp(ThreadChunkListLengthOffset + 4, p);
+            }
+            else
+            {
+                // Core layout:
+                //   next:P, threadId:8 (8-byte aligned), isDead:1,
+                //   readHasWrapped:1, writeHasWrapped:1, pad to P,
+                //   curPtr:P, readPtr:P, chunkListHead:P, chunkListTail:P,
+                //   curReadChunk:P, curWriteChunk:P, chunkListLength:4.
+                int afterNext = p;
+                ThreadIdOffset = AlignUp(afterNext, 8);          // 8 on both bitness
+                ThreadIdSize = 8;
+                ThreadIsDeadOffset = ThreadIdOffset + 8;          // 16
+                ThreadReadHasWrappedOffset = ThreadIsDeadOffset + 1;
+                ThreadWriteHasWrappedOffset = ThreadReadHasWrappedOffset + 1;
+                int afterFlags = ThreadWriteHasWrappedOffset + 1;
+                ThreadCurPtrOffset = AlignUp(afterFlags, p);
+                ThreadReadPtrOffset = ThreadCurPtrOffset + p;
+                ThreadChunkListHeadOffset = ThreadReadPtrOffset + p;
+                ThreadChunkListTailOffset = ThreadChunkListHeadOffset + p;
+                ThreadCurReadChunkOffset = ThreadChunkListTailOffset + p;
+                ThreadCurWriteChunkOffset = ThreadCurReadChunkOffset + p;
+                ThreadChunkListLengthOffset = ThreadCurWriteChunkOffset + p;
+                ThreadHeaderSize = AlignUp(ThreadChunkListLengthOffset + 4, p);
+            }
+
+            // Chunk: prev (P), next (P), buf[ChunkBufferSize], sig1, sig2
+            ChunkBufOffset = 2 * p;
+            ChunkBufferSize = p == 8
+                ? StressLogConstants.ChunkBufferSize64
+                : StressLogConstants.ChunkBufferSize32;
+
+            // StressMsg header.
+            //   Core (V3/V4):       fmtOffsCArgs:DWORD_PTR + facility:DWORD_PTR(?) + timestamp:uint64
+            //                       Both x64 and x86 collapse to 16 bytes.
+            //                       Wait — that's NOT what the existing code says for x64 Fwk.
+            //   Framework V1 x64:   fmtOffsCArgs:size_t + facility:size_t + timeStamp:uint64
+            //                       = 8 + 8 + 8 = 24 bytes (qword-aligned).
+            //   Framework V1 x86:   fmtOffsCArgs:size_t + facility:size_t + timeStamp:uint64
+            //                       = 4 + 4 + 8 = 16 bytes (no padding).
+            //   Core V3/V4 (both):  packed bitfield + uint32 facility + uint64 timeStamp = 16 bytes.
+            if (isFramework && p == 8)
+                MessageHeaderSize = 24;
+            else
+                MessageHeaderSize = 16;
+        }
+
+        private static int AlignUp(int value, int alignment)
+            => (value + alignment - 1) & ~(alignment - 1);
+
+        // -----------------------------------------------------------------
+        // Pointer reads
+        // -----------------------------------------------------------------
+
+        /// <summary>
+        /// Read a pointer-sized field from <paramref name="span"/> at
+        /// <paramref name="offset"/>, zero-extending to <see cref="ulong"/>
+        /// on 32-bit targets.
+        /// </summary>
+        /// <remarks>
+        /// 32-bit pointer fields stored in target memory are exactly four
+        /// raw bytes. Treating them as <c>uint</c> (zero-extended to
+        /// <c>ulong</c>) is correct: any sign-extension would conflate a
+        /// high-bit pointer such as <c>0x90000000</c> with the bogus
+        /// <c>0xFFFFFFFF90000000</c>. (DAC-returned addresses are a
+        /// separate concern: <c>CLRDATA_ADDRESS</c> is sign-extended by
+        /// the DAC ABI; we un-extend at the SOSDac boundary.)
+        /// </remarks>
+        public ulong ReadTargetPointer(ReadOnlySpan<byte> span, int offset)
+        {
+            if (PointerSize == 8)
+                return BinaryPrimitives.ReadUInt64LittleEndian(span.Slice(offset));
+            return BinaryPrimitives.ReadUInt32LittleEndian(span.Slice(offset));
+        }
+
+        /// <summary>
+        /// Read the threadId field. Width depends on the runtime variant:
+        /// 8 bytes on Core (always uint64), 4 bytes on Framework.
+        /// </summary>
+        public ulong ReadThreadId(ReadOnlySpan<byte> threadHeader)
+        {
+            if (ThreadIdSize == 8)
+                return BinaryPrimitives.ReadUInt64LittleEndian(threadHeader.Slice(ThreadIdOffset));
+            return BinaryPrimitives.ReadUInt32LittleEndian(threadHeader.Slice(ThreadIdOffset));
+        }
+
+        /// <summary>
+        /// True if a chunk's address can be added to its total size without
+        /// exceeding the target's <see cref="MaxAddress"/>. Use this before
+        /// computing any per-chunk address arithmetic.
+        /// </summary>
+        public bool ChunkFits(ulong address)
+        {
+            ulong totalSize = (ulong)ChunkTotalSize;
+            return address <= MaxAddress - totalSize;
+        }
+
+        // -----------------------------------------------------------------
+        // Bit-field decoders. These are independent of pointer size.
         // -----------------------------------------------------------------
 
         /// <summary>
@@ -184,29 +448,41 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
         }
 
         /// <summary>
-        /// Decode a Framework V1 <c>StressMsg</c> header from a 24-byte
-        /// little-endian span. Layout differs from Core's V3/V4: each field
-        /// is qword-aligned, so <c>fmtOffsCArgs</c>, <c>facility</c>, and
-        /// <c>timeStamp</c> each occupy 8 bytes (with the upper 4 bytes of
-        /// the first two being unused padding). The bit-field is also
-        /// (numArgs:3 | formatOffset:29) without the V3 high-bits split.
+        /// Decode a Framework V1 <c>StressMsg</c> header. On x64 the header
+        /// is 24 bytes (each scalar qword-aligned); on x86 it is 16 bytes.
+        /// In either case the bit-field is (numArgs:3 | formatOffset:29).
         /// </summary>
-        public static void DecodeMessageFxV1(ReadOnlySpan<byte> header24,
+        public static void DecodeMessageFxV1(ReadOnlySpan<byte> headerBytes,
+                                             int pointerSize,
                                              out uint facility,
                                              out int numberOfArgs,
                                              out ulong formatOffset,
                                              out ulong timeStamp)
         {
-            uint w0Low = BinaryPrimitives.ReadUInt32LittleEndian(header24);
-            // header24[4..8] is padding/uninitialized — never read.
-            uint w1Low = BinaryPrimitives.ReadUInt32LittleEndian(header24.Slice(8));
-            // header24[12..16] is padding.
-            ulong ts = BinaryPrimitives.ReadUInt64LittleEndian(header24.Slice(16));
+            if (pointerSize == 8)
+            {
+                uint w0Low = BinaryPrimitives.ReadUInt32LittleEndian(headerBytes);
+                // headerBytes[4..8] is padding/uninitialized — never read.
+                uint w1Low = BinaryPrimitives.ReadUInt32LittleEndian(headerBytes.Slice(8));
+                // headerBytes[12..16] is padding.
+                ulong ts = BinaryPrimitives.ReadUInt64LittleEndian(headerBytes.Slice(16));
 
-            numberOfArgs = (int)(w0Low & 0x7u);
-            formatOffset = (w0Low >> 3) & ((1u << 29) - 1);
-            facility = w1Low;
-            timeStamp = ts;
+                numberOfArgs = (int)(w0Low & 0x7u);
+                formatOffset = (w0Low >> 3) & ((1u << 29) - 1);
+                facility = w1Low;
+                timeStamp = ts;
+            }
+            else
+            {
+                uint w0 = BinaryPrimitives.ReadUInt32LittleEndian(headerBytes);
+                uint w1 = BinaryPrimitives.ReadUInt32LittleEndian(headerBytes.Slice(4));
+                ulong ts = BinaryPrimitives.ReadUInt64LittleEndian(headerBytes.Slice(8));
+
+                numberOfArgs = (int)(w0 & 0x7u);
+                formatOffset = (w0 >> 3) & ((1u << 29) - 1);
+                facility = w1;
+                timeStamp = ts;
+            }
         }
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/StressLog/Internal/StressLogLayout.cs
+++ b/src/Microsoft.Diagnostics.Runtime/StressLog/Internal/StressLogLayout.cs
@@ -186,11 +186,11 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
         public static StressLogLayout CoreX64 { get; } = new StressLogLayout(pointerSize: 8, isFramework: false);
 
         /// <summary>
-        /// Layout for a 64-bit .NET Framework V1 target. Same chunk and
-        /// module-table sizes as Core x64; ThreadStressLog and StressMsg
-        /// layouts differ.
+        /// Layout for a 64-bit .NET Framework V1 target on Windows. .NET
+        /// Framework only ships on Windows. Same chunk and module-table
+        /// sizes as Core x64; ThreadStressLog and StressMsg layouts differ.
         /// </summary>
-        public static StressLogLayout FrameworkX64 { get; } = new StressLogLayout(pointerSize: 8, isFramework: true);
+        public static StressLogLayout FrameworkWinX64 { get; } = new StressLogLayout(pointerSize: 8, isFramework: true);
 
         /// <summary>
         /// Layout for a 32-bit Core target on Windows. .NET Core has not
@@ -222,7 +222,7 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
         /// </summary>
         public StressLogLayout WithFramework() => PointerSize switch
         {
-            8 => FrameworkX64,
+            8 => FrameworkWinX64,
             4 => FrameworkWinX86,
             _ => throw new InvalidOperationException(),
         };

--- a/src/Microsoft.Diagnostics.Runtime/StressLog/Internal/StressLogLayout.cs
+++ b/src/Microsoft.Diagnostics.Runtime/StressLog/Internal/StressLogLayout.cs
@@ -67,24 +67,48 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
         public const int Mm_HeaderReadSize        = Mm_ModulesEnd; // 272
 
         // -----------------------------------------------------------------
-        // ThreadStressLog (64-bit target)
+        // ThreadStressLog (Core, 64-bit target)
         // -----------------------------------------------------------------
 
         public const int Thread_Next              = 0;     // ThreadStressLog*
-        public const int Thread_ThreadId          = 8;     // uint64
-        public const int Thread_IsDead            = 16;    // uint8
-        public const int Thread_ReadHasWrapped    = 17;    // uint8
-        public const int Thread_WriteHasWrapped   = 18;    // uint8
+        public const int CoreThread_ThreadId      = 8;     // uint64
+        public const int CoreThread_IsDead        = 16;    // uint8
+        public const int CoreThread_ReadHasWrapped  = 17;  // uint8 (uninitialized in the live writer; we never trust this byte)
+        public const int CoreThread_WriteHasWrapped = 18;  // uint8
         // 5 bytes padding for 8-byte alignment of the next pointer
-        public const int Thread_CurPtr            = 24;    // StressMsg*
-        public const int Thread_ReadPtr           = 32;    // StressMsg*
-        public const int Thread_ChunkListHead     = 40;    // StressLogChunk*
-        public const int Thread_ChunkListTail     = 48;    // StressLogChunk*
-        public const int Thread_CurReadChunk      = 56;    // StressLogChunk*
-        public const int Thread_CurWriteChunk     = 64;    // StressLogChunk*
-        public const int Thread_ChunkListLength   = 72;    // long (4 bytes)
+        public const int CoreThread_CurPtr        = 24;    // StressMsg*
+        public const int CoreThread_ReadPtr       = 32;    // StressMsg*
+        public const int CoreThread_ChunkListHead = 40;    // StressLogChunk*
+        public const int CoreThread_ChunkListTail = 48;    // StressLogChunk*
+        public const int CoreThread_CurReadChunk  = 56;    // StressLogChunk*
+        public const int CoreThread_CurWriteChunk = 64;    // StressLogChunk*
+        public const int CoreThread_ChunkListLength = 72;  // long (4 bytes)
 
-        public const int Thread_HeaderSize        = 80;    // 4 bytes trailing pad to 8-byte align
+        // -----------------------------------------------------------------
+        // ThreadStressLog (.NET Framework V1, 64-bit target)
+        // -----------------------------------------------------------------
+        //
+        // Framework's ThreadStressLog uses a 4-byte threadId and 4-byte
+        // isDead/readHasWrapped/writeHasWrapped fields, shifting curPtr,
+        // readPtr earlier in the layout. Verified against
+        // .NET Framework 4.8.9325 dumps via the cdb dt extension.
+
+        public const int FxThread_ThreadId        = 8;     // uint32
+        public const int FxThread_IsDead          = 12;    // uint32
+        public const int FxThread_CurPtr          = 16;    // StressMsg*
+        public const int FxThread_ReadPtr         = 24;    // StressMsg*
+        public const int FxThread_ReadHasWrapped  = 32;    // uint32 (uninitialized in the live writer)
+        public const int FxThread_WriteHasWrapped = 36;    // uint32
+        public const int FxThread_ChunkListHead   = 40;    // StressLogChunk*
+        public const int FxThread_ChunkListTail   = 48;    // StressLogChunk*
+        public const int FxThread_CurReadChunk    = 56;    // StressLogChunk*
+        public const int FxThread_CurWriteChunk   = 64;    // StressLogChunk*
+        public const int FxThread_ChunkListLength = 72;    // long (4 bytes)
+
+        // Both layouts use the same 80-byte struct size (the differences are
+        // a rearrangement of fields within those bytes), so we always read
+        // 80 bytes for the thread header regardless of variant.
+        public const int Thread_HeaderSize        = 80;
 
         // -----------------------------------------------------------------
         // StressLogChunk (64-bit target, 32 KB body)
@@ -101,7 +125,8 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
         // StressMsg
         // -----------------------------------------------------------------
 
-        public const int Msg_HeaderSize           = 16;    // sizeof(StressMsg) without args
+        public const int Msg_HeaderSize           = 16;    // sizeof(StressMsg) without args (Core V3/V4)
+        public const int Msg_HeaderSizeFxV1       = 24;    // .NET Framework: each header field is qword-aligned
         public const int Msg_ArgSize              = 8;     // pointer-sized
 
         // -----------------------------------------------------------------
@@ -156,6 +181,32 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
             formatOffset = formatOffset26;
             facility = w1;
             timeStamp = w2;
+        }
+
+        /// <summary>
+        /// Decode a Framework V1 <c>StressMsg</c> header from a 24-byte
+        /// little-endian span. Layout differs from Core's V3/V4: each field
+        /// is qword-aligned, so <c>fmtOffsCArgs</c>, <c>facility</c>, and
+        /// <c>timeStamp</c> each occupy 8 bytes (with the upper 4 bytes of
+        /// the first two being unused padding). The bit-field is also
+        /// (numArgs:3 | formatOffset:29) without the V3 high-bits split.
+        /// </summary>
+        public static void DecodeMessageFxV1(ReadOnlySpan<byte> header24,
+                                             out uint facility,
+                                             out int numberOfArgs,
+                                             out ulong formatOffset,
+                                             out ulong timeStamp)
+        {
+            uint w0Low = BinaryPrimitives.ReadUInt32LittleEndian(header24);
+            // header24[4..8] is padding/uninitialized — never read.
+            uint w1Low = BinaryPrimitives.ReadUInt32LittleEndian(header24.Slice(8));
+            // header24[12..16] is padding.
+            ulong ts = BinaryPrimitives.ReadUInt64LittleEndian(header24.Slice(16));
+
+            numberOfArgs = (int)(w0Low & 0x7u);
+            formatOffset = (w0Low >> 3) & ((1u << 29) - 1);
+            facility = w1Low;
+            timeStamp = ts;
         }
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/StressLog/Internal/StressLogLayout.cs
+++ b/src/Microsoft.Diagnostics.Runtime/StressLog/Internal/StressLogLayout.cs
@@ -1,0 +1,161 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Buffers.Binary;
+
+namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
+{
+    /// <summary>
+    /// Field offsets within the on-target structures we read. Only 64-bit
+    /// targets are supported; 32-bit targets are rejected during open.
+    /// </summary>
+    /// <remarks>
+    /// The runtime's <c>StressLog</c> class layout is documented at
+    /// <c>src/coreclr/inc/stresslog.h</c> and mirrored in this repo's
+    /// adjacent dotnet/diagnostics tree. These offsets must move in
+    /// lockstep with that header.
+    /// </remarks>
+    internal static class StressLogLayout
+    {
+        // -----------------------------------------------------------------
+        // In-process StressLog (64-bit target)
+        // -----------------------------------------------------------------
+
+        public const int InProc_FacilitiesToLog   = 0;     // uint
+        public const int InProc_LevelToLog        = 4;     // uint
+        public const int InProc_MaxSizePerThread  = 8;     // uint
+        public const int InProc_MaxSizeTotal      = 12;    // uint
+        public const int InProc_TotalChunk        = 16;    // int (Volatile<LONG>)
+        // 4 bytes padding for 8-byte alignment of the next pointer
+        public const int InProc_Logs              = 24;    // ThreadStressLog*
+        public const int InProc_Padding           = 32;    // uint (named 'padding' in the header)
+        public const int InProc_DeadCount         = 36;    // int (Volatile<LONG>)
+        public const int InProc_Lock              = 40;    // CRITSEC_COOKIE (pointer)
+        public const int InProc_TickFrequency     = 48;    // uint64
+        public const int InProc_StartTimeStamp    = 56;    // uint64
+        public const int InProc_StartTime         = 64;    // FILETIME (uint64)
+        public const int InProc_ModuleOffset      = 72;    // size_t
+        public const int InProc_Modules           = 80;    // ModuleDesc[5]
+        public const int InProc_ModuleEntrySize   = 16;    // baseAddress + size on 64-bit
+        public const int InProc_ModulesEnd        = InProc_Modules + StressLogConstants.MaxModules * InProc_ModuleEntrySize;
+
+        /// <summary>Bytes we read from the target for the in-process header.</summary>
+        public const int InProc_HeaderSize        = InProc_ModulesEnd; // 160
+
+        // -----------------------------------------------------------------
+        // Memory-mapped StressLogHeader (64-bit only)
+        // -----------------------------------------------------------------
+
+        public const int Mm_HeaderSize            = 0;     // size_t
+        public const int Mm_Magic                 = 8;     // uint32 'STRL'
+        public const int Mm_Version               = 12;    // uint32
+        public const int Mm_MemoryBase            = 16;    // uint8*
+        public const int Mm_MemoryCur             = 24;    // uint8*
+        public const int Mm_MemoryLimit           = 32;    // uint8*
+        public const int Mm_Logs                  = 40;    // ThreadStressLog*
+        public const int Mm_TickFrequency         = 48;    // uint64
+        public const int Mm_StartTimeStamp        = 56;    // uint64
+        public const int Mm_ThreadsWithNoLog      = 64;    // uint32
+        public const int Mm_Reserved1             = 68;    // uint32
+        public const int Mm_Reserved2             = 72;    // uint64[15] (15 * 8 = 120 bytes)
+        public const int Mm_Modules               = 192;   // ModuleDesc[5]
+        public const int Mm_ModulesEnd            = Mm_Modules + StressLogConstants.MaxModules * InProc_ModuleEntrySize;
+        public const int Mm_ModuleImage           = Mm_ModulesEnd;  // 272
+
+        /// <summary>Bytes we read from the target for the memory-mapped header.</summary>
+        public const int Mm_HeaderReadSize        = Mm_ModulesEnd; // 272
+
+        // -----------------------------------------------------------------
+        // ThreadStressLog (64-bit target)
+        // -----------------------------------------------------------------
+
+        public const int Thread_Next              = 0;     // ThreadStressLog*
+        public const int Thread_ThreadId          = 8;     // uint64
+        public const int Thread_IsDead            = 16;    // uint8
+        public const int Thread_ReadHasWrapped    = 17;    // uint8
+        public const int Thread_WriteHasWrapped   = 18;    // uint8
+        // 5 bytes padding for 8-byte alignment of the next pointer
+        public const int Thread_CurPtr            = 24;    // StressMsg*
+        public const int Thread_ReadPtr           = 32;    // StressMsg*
+        public const int Thread_ChunkListHead     = 40;    // StressLogChunk*
+        public const int Thread_ChunkListTail     = 48;    // StressLogChunk*
+        public const int Thread_CurReadChunk      = 56;    // StressLogChunk*
+        public const int Thread_CurWriteChunk     = 64;    // StressLogChunk*
+        public const int Thread_ChunkListLength   = 72;    // long (4 bytes)
+
+        public const int Thread_HeaderSize        = 80;    // 4 bytes trailing pad to 8-byte align
+
+        // -----------------------------------------------------------------
+        // StressLogChunk (64-bit target, 32 KB body)
+        // -----------------------------------------------------------------
+
+        public const int Chunk_Prev               = 0;     // StressLogChunk*
+        public const int Chunk_Next               = 8;     // StressLogChunk*
+        public const int Chunk_Buf                = 16;    // char[ChunkBufferSize64]
+        public const int Chunk_DwSig1Offset       = Chunk_Buf + StressLogConstants.ChunkBufferSize64;     // 32784
+        public const int Chunk_DwSig2Offset       = Chunk_DwSig1Offset + 4;                              // 32788
+        public const int Chunk_TotalSize          = Chunk_DwSig2Offset + 4;                              // 32792
+
+        // -----------------------------------------------------------------
+        // StressMsg
+        // -----------------------------------------------------------------
+
+        public const int Msg_HeaderSize           = 16;    // sizeof(StressMsg) without args
+        public const int Msg_ArgSize              = 8;     // pointer-sized
+
+        // -----------------------------------------------------------------
+        // Bit-field decoders
+        // -----------------------------------------------------------------
+
+        /// <summary>
+        /// Decode a V4 <c>StressMsg</c> header from a 16-byte little-endian span.
+        /// </summary>
+        public static void DecodeMessageV4(ReadOnlySpan<byte> header16,
+                                           out uint facility,
+                                           out int numberOfArgs,
+                                           out ulong formatOffset,
+                                           out ulong timeStamp)
+        {
+            ulong w0 = BinaryPrimitives.ReadUInt64LittleEndian(header16);
+            ulong w1 = BinaryPrimitives.ReadUInt64LittleEndian(header16.Slice(8));
+
+            // word 0: facility (32) | numberOfArgs (6) | formatOffsetLow (26)
+            facility = (uint)(w0 & 0xFFFFFFFFu);
+            numberOfArgs = (int)((w0 >> 32) & 0x3F);
+            ulong formatOffsetLow = (w0 >> 38) & ((1UL << StressLogConstants.FormatOffsetLowBits) - 1);
+
+            // word 1: formatOffsetHigh (13) | timeStamp (51)
+            ulong formatOffsetHigh = w1 & ((1UL << StressLogConstants.FormatOffsetHighBits) - 1);
+            timeStamp = w1 >> StressLogConstants.FormatOffsetHighBits;
+
+            formatOffset = (formatOffsetHigh << StressLogConstants.FormatOffsetLowBits) | formatOffsetLow;
+        }
+
+        /// <summary>
+        /// Decode a V3 <c>StressMsg</c> header from a 16-byte little-endian span.
+        /// V3 uses a separate 32-bit facility field and a single 26-bit
+        /// <c>formatOffset</c> with a 3+3 split <c>numberOfArgs</c>.
+        /// </summary>
+        public static void DecodeMessageV3(ReadOnlySpan<byte> header16,
+                                           out uint facility,
+                                           out int numberOfArgs,
+                                           out ulong formatOffset,
+                                           out ulong timeStamp)
+        {
+            uint w0 = BinaryPrimitives.ReadUInt32LittleEndian(header16);
+            uint w1 = BinaryPrimitives.ReadUInt32LittleEndian(header16.Slice(4));
+            ulong w2 = BinaryPrimitives.ReadUInt64LittleEndian(header16.Slice(8));
+
+            // word 0: numberOfArgsLow (3) | formatOffset (26) | numberOfArgsHigh (3)
+            uint argsLow = w0 & 0x7u;
+            uint formatOffset26 = (w0 >> 3) & ((1u << 26) - 1);
+            uint argsHigh = (w0 >> 29) & 0x7u;
+
+            numberOfArgs = (int)(argsLow | (argsHigh << 3));
+            formatOffset = formatOffset26;
+            facility = w1;
+            timeStamp = w2;
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/StressLog/Internal/StressLogLayoutKind.cs
+++ b/src/Microsoft.Diagnostics.Runtime/StressLog/Internal/StressLogLayoutKind.cs
@@ -1,0 +1,49 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
+{
+    /// <summary>
+    /// The on-disk layout we are reading. Chosen during open based on the
+    /// header bytes; controls how subsequent fields are interpreted.
+    /// </summary>
+    internal enum StressLogLayoutKind
+    {
+        /// <summary>
+        /// In-process layout from before the module table was added. Format
+        /// offsets are interpreted relative to the single <c>moduleOffset</c>
+        /// field in the header. Recognized only as a fallback when the module
+        /// table looks unusable.
+        /// </summary>
+        InProcessLegacy,
+
+        /// <summary>
+        /// In-process layout with the module table. Used when the header's
+        /// module table appears valid and the runtime version reports
+        /// stress-log version &gt;= 3.
+        /// </summary>
+        InProcessV3,
+
+        /// <summary>
+        /// In-process layout with the V4 <c>StressMsg</c> bit packing
+        /// (split <c>formatOffset</c>). Distinguished from V3 by the
+        /// runtime version reported by the DAC; the structural layout
+        /// of the header itself is unchanged.
+        /// </summary>
+        InProcessV4,
+
+        /// <summary>
+        /// Memory-mapped log, version <c>0x00010001</c>: <c>StressLogHeader</c>
+        /// followed by an embedded module image. Format offsets index into
+        /// the module image rather than into target memory. Uses the legacy
+        /// 26-bit <c>formatOffset</c>.
+        /// </summary>
+        MemoryMappedV1,
+
+        /// <summary>
+        /// Memory-mapped log, version <c>0x00010002</c>: same shape as V1
+        /// but with the V4 39-bit <c>formatOffset</c>.
+        /// </summary>
+        MemoryMappedV2,
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/StressLog/Internal/StressLogModuleTable.cs
+++ b/src/Microsoft.Diagnostics.Runtime/StressLog/Internal/StressLogModuleTable.cs
@@ -1,0 +1,171 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Buffers.Binary;
+
+namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
+{
+    /// <summary>
+    /// Read-only view over the up-to-five module descriptors carried in a
+    /// stress log. Used to translate the bit-packed <c>formatOffset</c>
+    /// stored in each message back into a target-memory address that the
+    /// reader can read to recover the format string bytes.
+    /// </summary>
+    /// <remarks>
+    /// Both in-process and memory-mapped logs resolve offsets to addresses
+    /// in the target's address space. For memory-mapped logs taken inside
+    /// a process dump, the runtime keeps the file mapped at capture time
+    /// so those addresses are still backed in the dump; for standalone
+    /// <c>.stl</c> files (no surrounding process), the format strings are
+    /// in the embedded <c>moduleImage</c> region and target-address
+    /// resolution will fail. Consumers must read via the dump's
+    /// <see cref="IMemoryReader"/>.
+    /// </remarks>
+    internal sealed class StressLogModuleTable
+    {
+        private readonly Module[] _modules;
+        private readonly ulong _legacyModuleOffset;
+        private readonly ulong _maxOffset;
+
+        /// <summary>Number of module entries that passed validation.</summary>
+        public int Count { get; }
+
+        private StressLogModuleTable(Module[] modules,
+                                     int count,
+                                     ulong legacyModuleOffset,
+                                     ulong maxOffset)
+        {
+            _modules = modules;
+            Count = count;
+            _legacyModuleOffset = legacyModuleOffset;
+            _maxOffset = maxOffset;
+        }
+
+        /// <summary>
+        /// Build a module table for an in-process layout. The module entries
+        /// occupy <c>StressLogConstants.MaxModules</c> 16-byte slots in
+        /// <paramref name="entries16"/>.
+        /// </summary>
+        public static StressLogModuleTable BuildInProcess(ReadOnlySpan<byte> entries16,
+                                                          ulong legacyModuleOffset,
+                                                          bool hasModuleTable,
+                                                          ulong maxOffset)
+        {
+            Module[] modules = ParseEntries(entries16, maxOffset, out int count);
+
+            // Mirror the existing C++ heuristic: only use the module table
+            // if the first entry's baseAddress matches legacyModuleOffset
+            // and its size is in a sane range. Otherwise fall back to
+            // single-module mode.
+            if (!hasModuleTable
+                || count == 0
+                || modules[0].BaseAddress != legacyModuleOffset
+                || modules[0].Size < 1024 * 1024
+                || modules[0].Size >= maxOffset)
+            {
+                count = 0;
+            }
+
+            return new StressLogModuleTable(modules, count, legacyModuleOffset, maxOffset);
+        }
+
+        /// <summary>
+        /// Build a module table for a memory-mapped layout.
+        /// </summary>
+        public static StressLogModuleTable BuildMemoryMapped(ReadOnlySpan<byte> entries16, ulong maxOffset)
+        {
+            Module[] modules = ParseEntries(entries16, maxOffset, out int count);
+            return new StressLogModuleTable(modules, count, legacyModuleOffset: 0, maxOffset);
+        }
+
+        private static Module[] ParseEntries(ReadOnlySpan<byte> entries16, ulong maxOffset, out int count)
+        {
+            Module[] modules = new Module[StressLogConstants.MaxModules];
+            count = 0;
+
+            ulong cumulative = 0;
+            for (int i = 0; i < StressLogConstants.MaxModules; i++)
+            {
+                int o = i * StressLogLayout.InProc_ModuleEntrySize;
+                if (o + StressLogLayout.InProc_ModuleEntrySize > entries16.Length)
+                    break;
+
+                ulong baseAddress = BinaryPrimitives.ReadUInt64LittleEndian(entries16.Slice(o));
+                ulong size = BinaryPrimitives.ReadUInt64LittleEndian(entries16.Slice(o + 8));
+
+                if (baseAddress == 0)
+                    break;
+
+                if (size == 0 || size >= maxOffset)
+                    break;
+
+                ulong nextCumulative = cumulative + size;
+                if (nextCumulative < cumulative || nextCumulative >= maxOffset)
+                    break;
+
+                modules[i] = new Module(baseAddress, size, cumulative);
+                cumulative = nextCumulative;
+                count++;
+            }
+
+            return modules;
+        }
+
+        /// <summary>
+        /// Translate a bit-packed format offset into either a target address
+        /// (for in-process logs) or an address inside the embedded module
+        /// image (for memory-mapped logs). Returns false if the offset is
+        /// out of range.
+        /// </summary>
+        public bool TryResolveFormatOffset(ulong formatOffset, out ulong address)
+        {
+            if (formatOffset == 0 || formatOffset >= _maxOffset)
+            {
+                address = 0;
+                return false;
+            }
+
+            if (Count == 0)
+            {
+                // Legacy single-module mode (in-process only).
+                if (_legacyModuleOffset == 0)
+                {
+                    address = 0;
+                    return false;
+                }
+
+                address = _legacyModuleOffset + formatOffset;
+                return address >= _legacyModuleOffset; // overflow guard
+            }
+
+            for (int i = 0; i < Count; i++)
+            {
+                Module m = _modules[i];
+                if (formatOffset < m.CumulativeOffset + m.Size && formatOffset >= m.CumulativeOffset)
+                {
+                    ulong relative = formatOffset - m.CumulativeOffset;
+                    address = m.BaseAddress + relative;
+                    return address >= m.BaseAddress; // overflow guard
+                }
+            }
+
+            address = 0;
+            return false;
+        }
+
+        private readonly struct Module
+        {
+            public Module(ulong baseAddress, ulong size, ulong cumulativeOffset)
+            {
+                BaseAddress = baseAddress;
+                Size = size;
+                CumulativeOffset = cumulativeOffset;
+            }
+
+            public ulong BaseAddress { get; }
+            public ulong Size { get; }
+            public ulong CumulativeOffset { get; }
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/StressLog/Internal/StressLogModuleTable.cs
+++ b/src/Microsoft.Diagnostics.Runtime/StressLog/Internal/StressLogModuleTable.cs
@@ -27,6 +27,7 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
         private readonly Module[] _modules;
         private readonly ulong _legacyModuleOffset;
         private readonly ulong _maxOffset;
+        private readonly ulong _maxAddress;
 
         /// <summary>Number of module entries that passed validation.</summary>
         public int Count { get; }
@@ -34,25 +35,28 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
         private StressLogModuleTable(Module[] modules,
                                      int count,
                                      ulong legacyModuleOffset,
-                                     ulong maxOffset)
+                                     ulong maxOffset,
+                                     ulong maxAddress)
         {
             _modules = modules;
             Count = count;
             _legacyModuleOffset = legacyModuleOffset;
             _maxOffset = maxOffset;
+            _maxAddress = maxAddress;
         }
 
         /// <summary>
         /// Build a module table for an in-process layout. The module entries
-        /// occupy <c>StressLogConstants.MaxModules</c> 16-byte slots in
-        /// <paramref name="entries16"/>.
+        /// occupy <c>StressLogConstants.MaxModules</c> slots in
+        /// <paramref name="entries"/>, each <c>2 * pointerSize</c> bytes wide.
         /// </summary>
-        public static StressLogModuleTable BuildInProcess(ReadOnlySpan<byte> entries16,
+        public static StressLogModuleTable BuildInProcess(StressLogLayout layout,
+                                                          ReadOnlySpan<byte> entries,
                                                           ulong legacyModuleOffset,
                                                           bool hasModuleTable,
                                                           ulong maxOffset)
         {
-            Module[] modules = ParseEntries(entries16, maxOffset, out int count);
+            Module[] modules = ParseEntries(layout, entries, maxOffset, out int count);
 
             // Mirror the existing C++ heuristic: only use the module table
             // if the first entry's baseAddress matches legacyModuleOffset
@@ -67,32 +71,35 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
                 count = 0;
             }
 
-            return new StressLogModuleTable(modules, count, legacyModuleOffset, maxOffset);
+            return new StressLogModuleTable(modules, count, legacyModuleOffset, maxOffset, layout.MaxAddress);
         }
 
         /// <summary>
-        /// Build a module table for a memory-mapped layout.
+        /// Build a module table for a memory-mapped layout. Memory-mapped
+        /// stress logs are 64-bit only, so the entry size is fixed at 16.
         /// </summary>
-        public static StressLogModuleTable BuildMemoryMapped(ReadOnlySpan<byte> entries16, ulong maxOffset)
+        public static StressLogModuleTable BuildMemoryMapped(StressLogLayout layout, ReadOnlySpan<byte> entries, ulong maxOffset)
         {
-            Module[] modules = ParseEntries(entries16, maxOffset, out int count);
-            return new StressLogModuleTable(modules, count, legacyModuleOffset: 0, maxOffset);
+            Module[] modules = ParseEntries(layout, entries, maxOffset, out int count);
+            return new StressLogModuleTable(modules, count, legacyModuleOffset: 0, maxOffset, layout.MaxAddress);
         }
 
-        private static Module[] ParseEntries(ReadOnlySpan<byte> entries16, ulong maxOffset, out int count)
+        private static Module[] ParseEntries(StressLogLayout layout, ReadOnlySpan<byte> entries, ulong maxOffset, out int count)
         {
             Module[] modules = new Module[StressLogConstants.MaxModules];
             count = 0;
 
+            int entrySize = layout.ModuleEntrySize;
+            int p = layout.PointerSize;
             ulong cumulative = 0;
             for (int i = 0; i < StressLogConstants.MaxModules; i++)
             {
-                int o = i * StressLogLayout.InProc_ModuleEntrySize;
-                if (o + StressLogLayout.InProc_ModuleEntrySize > entries16.Length)
+                int o = i * entrySize;
+                if (o + entrySize > entries.Length)
                     break;
 
-                ulong baseAddress = BinaryPrimitives.ReadUInt64LittleEndian(entries16.Slice(o));
-                ulong size = BinaryPrimitives.ReadUInt64LittleEndian(entries16.Slice(o + 8));
+                ulong baseAddress = layout.ReadTargetPointer(entries, o);
+                ulong size = layout.ReadTargetPointer(entries, o + p);
 
                 if (baseAddress == 0)
                     break;
@@ -102,6 +109,13 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
 
                 ulong nextCumulative = cumulative + size;
                 if (nextCumulative < cumulative || nextCumulative >= maxOffset)
+                    break;
+
+                // Reject modules whose base+size cannot be represented in
+                // the target's address space (matters on 32-bit, where a
+                // malformed dump can otherwise produce addresses > 4GB).
+                ulong endAddress = baseAddress + size;
+                if (endAddress < baseAddress || endAddress - 1 > layout.MaxAddress)
                     break;
 
                 modules[i] = new Module(baseAddress, size, cumulative);
@@ -136,7 +150,12 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
                 }
 
                 address = _legacyModuleOffset + formatOffset;
-                return address >= _legacyModuleOffset; // overflow guard
+                if (address < _legacyModuleOffset || address > _maxAddress)
+                {
+                    address = 0;
+                    return false;
+                }
+                return true;
             }
 
             for (int i = 0; i < Count; i++)
@@ -146,7 +165,12 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
                 {
                     ulong relative = formatOffset - m.CumulativeOffset;
                     address = m.BaseAddress + relative;
-                    return address >= m.BaseAddress; // overflow guard
+                    if (address < m.BaseAddress || address > _maxAddress)
+                    {
+                        address = 0;
+                        return false;
+                    }
+                    return true;
                 }
             }
 

--- a/src/Microsoft.Diagnostics.Runtime/StressLog/Internal/StressLogOptions.cs
+++ b/src/Microsoft.Diagnostics.Runtime/StressLog/Internal/StressLogOptions.cs
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
+{
+    /// <summary>
+    /// Internal limits. The public API intentionally hides these for now;
+    /// the values are conservative defaults that bound CPU and memory while
+    /// parsing arbitrarily large or malformed stress logs.
+    /// </summary>
+    internal sealed class StressLogOptions
+    {
+        public static StressLogOptions Default { get; } = new();
+
+        /// <summary>Maximum number of threads enumerated. Cycles in the thread list are also bounded by this.</summary>
+        public int MaxThreads { get; init; } = 100_000;
+
+        /// <summary>Maximum number of chunks per thread. Cycles in the chunk list are bounded by this.</summary>
+        public int MaxChunksPerThread { get; init; } = 65_536;
+
+        /// <summary>Maximum number of messages emitted per thread.</summary>
+        public int MaxMessagesPerThread { get; init; } = 10_000_000;
+
+        /// <summary>Maximum length of a format string read from the target.</summary>
+        public int MaxFormatStringLength { get; init; } = StressLogConstants.MaxFormatStringLength;
+
+        /// <summary>Maximum length of a string argument (<c>%s</c>/<c>%S</c>) read from the target.</summary>
+        public int MaxStringArgumentLength { get; init; } = 256;
+
+        /// <summary>Total bytes the parser may rent from the array pool while open.</summary>
+        public long MaxTotalBytesAllocated { get; init; } = 256L * 1024 * 1024;
+
+        /// <summary>
+        /// Maximum number of distinct format strings cached. Bounded so a
+        /// pathological log cannot force an entry per message.
+        /// </summary>
+        public int MaxFormatStringCacheEntries { get; init; } = 100_000;
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/StressLog/Internal/StressLogSanitizer.cs
+++ b/src/Microsoft.Diagnostics.Runtime/StressLog/Internal/StressLogSanitizer.cs
@@ -7,18 +7,24 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
 {
     /// <summary>
     /// Byte-level sanitization for any text byte read from the target.
-    /// Replaces anything that is not 7-bit printable ASCII (<c>0x20</c>
-    /// through <c>0x7E</c>) with <c>'.'</c>. Used both for format strings
-    /// and for <c>%s</c>/<c>%S</c> argument bytes before they are handed to
-    /// a receiver.
+    /// Allows printable 7-bit ASCII (<c>0x20</c>..<c>0x7E</c>) plus the
+    /// whitespace control bytes <c>\t</c> (0x09), <c>\n</c> (0x0A), and
+    /// <c>\r</c> (0x0D). Everything else — including the ANSI escape
+    /// introducer (0x1B), other C0 control bytes, DEL (0x7F), and all
+    /// non-ASCII bytes — is replaced with <c>'.'</c>. Used both for format
+    /// strings and for <c>%s</c>/<c>%S</c> argument bytes before they are
+    /// handed to a receiver.
     /// </summary>
     /// <remarks>
-    /// The replacement character is deliberately chosen to be benign and to
-    /// not be misinterpreted as part of a printf-family format specifier
-    /// (e.g., <c>%</c>) or as an ANSI escape introducer (e.g., <c>\u001B</c>)
-    /// in any downstream consumer. Tab and newline bytes are also replaced
-    /// so that target-controlled bytes cannot inject visual line breaks
-    /// into the rendered output of a single message.
+    /// The replacement byte is deliberately chosen to be benign and to not
+    /// be misinterpreted as part of a printf-family format specifier
+    /// (e.g., <c>%</c>) or as an ANSI escape introducer (e.g.,
+    /// <c>\u001B</c>) in any downstream consumer. Tab/newline/carriage
+    /// return are allowed through because legitimate runtime format strings
+    /// commonly terminate with <c>\n</c>, and stripping or replacing those
+    /// alters output content rather than addressing a meaningful threat;
+    /// terminal escape injection is prevented by replacing the actual
+    /// escape byte (0x1B).
     /// </remarks>
     internal static class StressLogSanitizer
     {
@@ -76,12 +82,15 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
 
         private static byte SanitizeByte(byte b)
         {
-            // Allow only printable 7-bit ASCII (0x20..0x7E). Everything else,
-            // including 0x00 / control / DEL / non-ASCII, is collapsed to the
-            // replacement byte. Tabs and newlines are deliberately replaced
-            // so that target-derived bytes cannot inject what looks like a
-            // line break in the rendered output.
+            // Allow printable 7-bit ASCII (0x20..0x7E) plus the whitespace
+            // control bytes \t, \n, \r. Everything else, including 0x00,
+            // other C0 control bytes, the ANSI escape introducer (0x1B),
+            // DEL (0x7F), and non-ASCII bytes, is collapsed to the
+            // replacement byte to prevent terminal escape injection from
+            // target-controlled bytes.
             if (b is >= 0x20 and <= 0x7E)
+                return b;
+            if (b == (byte)'\t' || b == (byte)'\n' || b == (byte)'\r')
                 return b;
 
             return Replacement;

--- a/src/Microsoft.Diagnostics.Runtime/StressLog/Internal/StressLogSanitizer.cs
+++ b/src/Microsoft.Diagnostics.Runtime/StressLog/Internal/StressLogSanitizer.cs
@@ -1,0 +1,84 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
+{
+    /// <summary>
+    /// Byte-level sanitization for any text byte read from the target.
+    /// Replaces anything that is not 7-bit printable ASCII (plus space and
+    /// newline/tab) with <c>'.'</c>. Used both for format strings and for
+    /// <c>%s</c>/<c>%S</c> argument bytes before they are handed to a
+    /// receiver.
+    /// </summary>
+    /// <remarks>
+    /// The replacement character is deliberately chosen to be benign and to
+    /// not be misinterpreted as part of a printf-family format specifier
+    /// (e.g., <c>%</c>) or as an ANSI escape introducer (e.g., <c>\u001B</c>)
+    /// in any downstream consumer.
+    /// </remarks>
+    internal static class StressLogSanitizer
+    {
+        public const byte Replacement = (byte)'.';
+
+        /// <summary>
+        /// Returns the length of <paramref name="src"/> up to the first NUL byte
+        /// (or the full length if there is none). Used because the runtime
+        /// stores format strings null-terminated in their original module.
+        /// </summary>
+        public static int LengthToFirstNull(ReadOnlySpan<byte> src)
+        {
+            int idx = src.IndexOf((byte)0);
+            return idx < 0 ? src.Length : idx;
+        }
+
+        /// <summary>
+        /// Sanitize <paramref name="src"/> into <paramref name="dst"/>:
+        /// non-printable bytes become <c>'.'</c>. Returns the number of bytes
+        /// written. <paramref name="dst"/> must be at least as long as
+        /// <paramref name="src"/>.
+        /// </summary>
+        public static int SanitizeAscii(ReadOnlySpan<byte> src, Span<byte> dst)
+        {
+            if (dst.Length < src.Length)
+                throw new ArgumentException("destination buffer is too small", nameof(dst));
+
+            for (int i = 0; i < src.Length; i++)
+                dst[i] = SanitizeByte(src[i]);
+
+            return src.Length;
+        }
+
+        /// <summary>
+        /// Sanitize a UTF-16LE byte sequence into ASCII <paramref name="dst"/>.
+        /// Returns the number of bytes written.
+        /// </summary>
+        public static int SanitizeUtf16(ReadOnlySpan<byte> src, Span<byte> dst)
+        {
+            int srcCount = src.Length / 2;
+            if (dst.Length < srcCount)
+                throw new ArgumentException("destination buffer is too small", nameof(dst));
+
+            for (int i = 0; i < srcCount; i++)
+            {
+                ushort u = (ushort)(src[i * 2] | (src[i * 2 + 1] << 8));
+                if (u == 0)
+                    return i;
+
+                dst[i] = u <= 0x7F ? SanitizeByte((byte)u) : Replacement;
+            }
+
+            return srcCount;
+        }
+
+        private static byte SanitizeByte(byte b)
+        {
+            // Allow space (0x20) through tilde (0x7E), plus tab and LF.
+            if (b is (>= 0x20 and <= 0x7E) or (byte)'\t' or (byte)'\n')
+                return b;
+
+            return Replacement;
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/StressLog/Internal/StressLogSanitizer.cs
+++ b/src/Microsoft.Diagnostics.Runtime/StressLog/Internal/StressLogSanitizer.cs
@@ -74,6 +74,12 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
                 if (u == 0)
                     return i;
 
+                // ASCII-range code units (<= 0x7F) are forwarded to
+                // SanitizeByte so the same whitelist (\t, \n, \r) and the
+                // 0x7F -> Replacement collapse defined for the ASCII path
+                // also apply here. Code units >= 0x80 cannot be any of
+                // those special bytes and are mapped directly to
+                // Replacement without going through SanitizeByte.
                 dst[i] = u <= 0x7F ? SanitizeByte((byte)u) : Replacement;
             }
 

--- a/src/Microsoft.Diagnostics.Runtime/StressLog/Internal/StressLogSanitizer.cs
+++ b/src/Microsoft.Diagnostics.Runtime/StressLog/Internal/StressLogSanitizer.cs
@@ -7,16 +7,18 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
 {
     /// <summary>
     /// Byte-level sanitization for any text byte read from the target.
-    /// Replaces anything that is not 7-bit printable ASCII (plus space and
-    /// newline/tab) with <c>'.'</c>. Used both for format strings and for
-    /// <c>%s</c>/<c>%S</c> argument bytes before they are handed to a
-    /// receiver.
+    /// Replaces anything that is not 7-bit printable ASCII (<c>0x20</c>
+    /// through <c>0x7E</c>) with <c>'.'</c>. Used both for format strings
+    /// and for <c>%s</c>/<c>%S</c> argument bytes before they are handed to
+    /// a receiver.
     /// </summary>
     /// <remarks>
     /// The replacement character is deliberately chosen to be benign and to
     /// not be misinterpreted as part of a printf-family format specifier
     /// (e.g., <c>%</c>) or as an ANSI escape introducer (e.g., <c>\u001B</c>)
-    /// in any downstream consumer.
+    /// in any downstream consumer. Tab and newline bytes are also replaced
+    /// so that target-controlled bytes cannot inject visual line breaks
+    /// into the rendered output of a single message.
     /// </remarks>
     internal static class StressLogSanitizer
     {
@@ -74,8 +76,12 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
 
         private static byte SanitizeByte(byte b)
         {
-            // Allow space (0x20) through tilde (0x7E), plus tab and LF.
-            if (b is (>= 0x20 and <= 0x7E) or (byte)'\t' or (byte)'\n')
+            // Allow only printable 7-bit ASCII (0x20..0x7E). Everything else,
+            // including 0x00 / control / DEL / non-ASCII, is collapsed to the
+            // replacement byte. Tabs and newlines are deliberately replaced
+            // so that target-derived bytes cannot inject what looks like a
+            // line break in the rendered output.
+            if (b is >= 0x20 and <= 0x7E)
                 return b;
 
             return Replacement;

--- a/src/Microsoft.Diagnostics.Runtime/StressLog/Internal/StressLogVariant.cs
+++ b/src/Microsoft.Diagnostics.Runtime/StressLog/Internal/StressLogVariant.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
+{
+    /// <summary>
+    /// Identifies which on-target struct layout the parser should use when
+    /// decoding a <c>ThreadStressLog</c>. The two variants differ in field
+    /// sizes and ordering between the .NET Framework runtime and modern
+    /// .NET Core / .NET 5+ runtimes.
+    /// </summary>
+    internal enum StressLogVariant
+    {
+        /// <summary>Modern CoreCLR / .NET 5+. 8-byte threadId, 1-byte isDead/wrap flags.</summary>
+        Core,
+
+        /// <summary>.NET Framework 4.x. 4-byte threadId, 4-byte wrap flags, curPtr at offset 16.</summary>
+        FrameworkV1,
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/StressLog/Internal/ThreadIterator.cs
+++ b/src/Microsoft.Diagnostics.Runtime/StressLog/Internal/ThreadIterator.cs
@@ -46,6 +46,7 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
         private readonly bool _writeHasWrapped;
 
         private bool _readHasWrapped;
+        private bool _revisitedWriteChunk;
         private int _messagesEmitted;
         private int _readOffset;
 
@@ -197,21 +198,26 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
             ArgumentCount = numArgs;
             _argsOffset = _readOffset + _msgHeaderSize;
 
-            // Termination: read pointer reached the write pointer.
+            // Termination: read pointer reached the write pointer. Mirrors
+            // the runtime's CompletedDump check (stresslog.h): once
+            // readHasWrapped, stopping happens when we re-enter curWriteChunk
+            // and reach curPtr. Do NOT emit this final message: in the
+            // wrapped case we already emitted the one at curPtr on the very
+            // first decode, and re-emitting it would duplicate. In the
+            // non-wrapped case _readHasWrapped is false so this branch is
+            // not taken at all.
             ulong messageAddr = _chunk.BufferStartAddress + (ulong)_readOffset;
-            bool atWriteHead = _chunk.Address == _curWriteChunk
-                               && messageAddr >= _curPtr
-                               && _readHasWrapped;
+            if (_chunk.Address == _curWriteChunk
+                && messageAddr >= _curPtr
+                && _readHasWrapped)
+            {
+                Exhausted = true;
+                return false;
+            }
 
             // Advance read offset past this message.
             _readOffset += totalSize;
             _messagesEmitted++;
-
-            if (atWriteHead)
-            {
-                Exhausted = true;
-                // Still emit this final message (it was at curPtr, valid).
-            }
 
             return true;
         }
@@ -246,16 +252,11 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
                 return false;
             }
 
-            // Natural full-circle termination: we've returned to the chunk we
-            // started at, and we already observed the read-wrap sentinel. The
-            // writer's curPtr-anchored termination test will be evaluated
-            // against the next message we decode.
-            if (nextAddr == _curWriteChunk && _readHasWrapped)
-            {
-                Exhausted = true;
-                return false;
-            }
-
+            // Allow re-entry to _curWriteChunk exactly once after wrapping.
+            // The runtime's chunk list is circular; after walking around the
+            // ring we re-enter curWriteChunk at offset 0 to read the messages
+            // written from buffer-start up to curPtr. The per-message
+            // termination above stops us before crossing curPtr a second time.
             if (!LoadChunk(nextAddr))
                 return false;
 
@@ -285,8 +286,22 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
 
             if (!_visitedChunks.Add(address))
             {
-                _diag?.Invoke(new StressLogDiagnostic(StressLogDiagnosticKind.CorruptChunk, address));
-                return false;
+                // The legitimate case for re-visiting a chunk is re-entering
+                // _curWriteChunk after the read pointer has wrapped all the
+                // way around the ring. Allow this exactly once; any other
+                // duplicate is treated as a cycle in the chunk list.
+                if (address == _curWriteChunk
+                    && _readHasWrapped
+                    && _writeHasWrapped
+                    && !_revisitedWriteChunk)
+                {
+                    _revisitedWriteChunk = true;
+                }
+                else
+                {
+                    _diag?.Invoke(new StressLogDiagnostic(StressLogDiagnosticKind.CorruptChunk, address));
+                    return false;
+                }
             }
 
             if (!_chunk.TryLoad(_reader, address))

--- a/src/Microsoft.Diagnostics.Runtime/StressLog/Internal/ThreadIterator.cs
+++ b/src/Microsoft.Diagnostics.Runtime/StressLog/Internal/ThreadIterator.cs
@@ -31,10 +31,12 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
     internal sealed class ThreadIterator : IDisposable
     {
         private readonly IDataReader _reader;
+        private readonly StressLogLayout _layout;
         private readonly StressLogOptions _options;
         private readonly bool _isV4;
         private readonly StressLogVariant _variant;
         private readonly int _msgHeaderSize;
+        private readonly int _argStride;
         private readonly Action<StressLogDiagnostic>? _diag;
 
         private ChunkReader _chunk;
@@ -61,6 +63,7 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
         private int _argsOffset;
 
         public ThreadIterator(IDataReader reader,
+                              StressLogLayout layout,
                               StressLogOptions options,
                               AllocationBudget budget,
                               Action<StressLogDiagnostic>? diagnostic,
@@ -70,39 +73,34 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
                               StressLogVariant variant)
         {
             _reader = reader;
+            _layout = layout;
             _options = options;
             _diag = diagnostic;
             _isV4 = isV4;
             _variant = variant;
-            _msgHeaderSize = variant == StressLogVariant.FrameworkV1
-                ? StressLogLayout.Msg_HeaderSizeFxV1
-                : StressLogLayout.Msg_HeaderSize;
-            _chunk = new ChunkReader(budget);
+            _msgHeaderSize = layout.MessageHeaderSize;
+            _argStride = layout.ArgStride;
+            _chunk = new ChunkReader(layout, budget);
 
-            ulong curReadChunk;
-            ulong readPtr;
             byte writeWrapped;
+
+            OSThreadId = layout.ReadThreadId(threadHeader);
+            _curPtr = layout.ReadTargetPointer(threadHeader, layout.ThreadCurPtrOffset);
+            ulong readPtr = layout.ReadTargetPointer(threadHeader, layout.ThreadReadPtrOffset);
+            _chunkListTail = layout.ReadTargetPointer(threadHeader, layout.ThreadChunkListTailOffset);
+            ulong curReadChunk = layout.ReadTargetPointer(threadHeader, layout.ThreadCurReadChunkOffset);
+            _curWriteChunk = layout.ReadTargetPointer(threadHeader, layout.ThreadCurWriteChunkOffset);
 
             if (variant == StressLogVariant.FrameworkV1)
             {
-                OSThreadId = BinaryPrimitives.ReadUInt32LittleEndian(threadHeader.Slice(StressLogLayout.FxThread_ThreadId));
-                _curPtr = BinaryPrimitives.ReadUInt64LittleEndian(threadHeader.Slice(StressLogLayout.FxThread_CurPtr));
-                readPtr = BinaryPrimitives.ReadUInt64LittleEndian(threadHeader.Slice(StressLogLayout.FxThread_ReadPtr));
-                uint writeWrapped32 = BinaryPrimitives.ReadUInt32LittleEndian(threadHeader.Slice(StressLogLayout.FxThread_WriteHasWrapped));
+                // Framework's writeHasWrapped flag is a full uint32.
+                uint writeWrapped32 = BinaryPrimitives.ReadUInt32LittleEndian(threadHeader.Slice(layout.ThreadWriteHasWrappedOffset));
                 writeWrapped = (byte)(writeWrapped32 != 0 ? 1 : 0);
-                _chunkListTail = BinaryPrimitives.ReadUInt64LittleEndian(threadHeader.Slice(StressLogLayout.FxThread_ChunkListTail));
-                curReadChunk = BinaryPrimitives.ReadUInt64LittleEndian(threadHeader.Slice(StressLogLayout.FxThread_CurReadChunk));
-                _curWriteChunk = BinaryPrimitives.ReadUInt64LittleEndian(threadHeader.Slice(StressLogLayout.FxThread_CurWriteChunk));
             }
             else
             {
-                OSThreadId = BinaryPrimitives.ReadUInt64LittleEndian(threadHeader.Slice(StressLogLayout.CoreThread_ThreadId));
-                writeWrapped = threadHeader[StressLogLayout.CoreThread_WriteHasWrapped];
-                _curPtr = BinaryPrimitives.ReadUInt64LittleEndian(threadHeader.Slice(StressLogLayout.CoreThread_CurPtr));
-                readPtr = BinaryPrimitives.ReadUInt64LittleEndian(threadHeader.Slice(StressLogLayout.CoreThread_ReadPtr));
-                _chunkListTail = BinaryPrimitives.ReadUInt64LittleEndian(threadHeader.Slice(StressLogLayout.CoreThread_ChunkListTail));
-                curReadChunk = BinaryPrimitives.ReadUInt64LittleEndian(threadHeader.Slice(StressLogLayout.CoreThread_CurReadChunk));
-                _curWriteChunk = BinaryPrimitives.ReadUInt64LittleEndian(threadHeader.Slice(StressLogLayout.CoreThread_CurWriteChunk));
+                // Core's writeHasWrapped flag is a single byte.
+                writeWrapped = threadHeader[layout.ThreadWriteHasWrappedOffset];
             }
 
             // The runtime writer never initializes readHasWrapped (it is only
@@ -162,7 +160,7 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
             ulong formatOffset;
             ulong timeStamp;
             if (_variant == StressLogVariant.FrameworkV1)
-                StressLogLayout.DecodeMessageFxV1(header, out facility, out numArgs, out formatOffset, out timeStamp);
+                StressLogLayout.DecodeMessageFxV1(header, _layout.PointerSize, out facility, out numArgs, out formatOffset, out timeStamp);
             else if (_isV4)
                 StressLogLayout.DecodeMessageV4(header, out facility, out numArgs, out formatOffset, out timeStamp);
             else
@@ -184,7 +182,7 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
                 return false;
             }
 
-            int totalSize = _msgHeaderSize + numArgs * StressLogLayout.Msg_ArgSize;
+            int totalSize = _msgHeaderSize + numArgs * _argStride;
             if (_readOffset + totalSize > body.Length)
             {
                 _diag?.Invoke(new StressLogDiagnostic(StressLogDiagnosticKind.CorruptMessage, _chunk.BufferStartAddress + (ulong)_readOffset));
@@ -226,9 +224,9 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
         {
             if ((uint)index >= (uint)ArgumentCount) return 0;
             ReadOnlySpan<byte> body = _chunk.Buffer;
-            int offset = _argsOffset + index * StressLogLayout.Msg_ArgSize;
-            if (offset + StressLogLayout.Msg_ArgSize > body.Length) return 0;
-            return BinaryPrimitives.ReadUInt64LittleEndian(body.Slice(offset));
+            int offset = _argsOffset + index * _argStride;
+            if (offset + _argStride > body.Length) return 0;
+            return _layout.ReadTargetPointer(body, offset);
         }
 
         private bool CrossChunkBoundary()
@@ -262,14 +260,15 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
 
             // Skip leading zero pointer-words up to maxMsgSize() words. The
             // writer pads unused space at the start of chunks with NULs.
+            // Word size is pointer-sized: 8 bytes on x64, 4 bytes on x86.
             ReadOnlySpan<byte> body = _chunk.Buffer;
-            int maxSkipWords = (_msgHeaderSize + StressLogConstants.MaxArgumentCount * StressLogLayout.Msg_ArgSize) / StressLogLayout.Msg_ArgSize;
+            int maxSkipWords = (_msgHeaderSize + StressLogConstants.MaxArgumentCount * _argStride) / _argStride;
             int offset = 0;
-            for (int w = 0; w < maxSkipWords && offset + StressLogLayout.Msg_ArgSize <= body.Length; w++)
+            for (int w = 0; w < maxSkipWords && offset + _argStride <= body.Length; w++)
             {
-                ulong word = BinaryPrimitives.ReadUInt64LittleEndian(body.Slice(offset));
+                ulong word = _layout.ReadTargetPointer(body, offset);
                 if (word != 0) break;
-                offset += StressLogLayout.Msg_ArgSize;
+                offset += _argStride;
             }
 
             _readOffset = offset;

--- a/src/Microsoft.Diagnostics.Runtime/StressLog/Internal/ThreadIterator.cs
+++ b/src/Microsoft.Diagnostics.Runtime/StressLog/Internal/ThreadIterator.cs
@@ -1,0 +1,272 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Buffers.Binary;
+using System.Collections.Generic;
+using Microsoft.Diagnostics.Runtime;
+
+namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
+{
+    /// <summary>
+    /// Per-thread iterator that walks the chunked, circular message buffer of
+    /// a single <c>ThreadStressLog</c>. Yields raw decoded messages in
+    /// reverse-chronological order (newest first).
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// All linked-list and address arithmetic in this file validates each
+    /// byte before using it: every chunk transition is bounded by
+    /// <see cref="StressLogOptions.MaxChunksPerThread"/> and visited-address
+    /// tracking, every per-message advance is validated against chunk bounds,
+    /// and every <c>Read</c> is checked for short returns. Failures stop the
+    /// iterator and surface a <see cref="StressLogDiagnostic"/> to the
+    /// owning <see cref="StressLog"/>; they never throw.
+    /// </para>
+    /// <para>
+    /// The decoded message exposes only validated metadata. Argument bytes
+    /// remain in the chunk buffer; consumers extract them via <see cref="GetArgument"/>.
+    /// </para>
+    /// </remarks>
+    internal sealed class ThreadIterator : IDisposable
+    {
+        private readonly IDataReader _reader;
+        private readonly StressLogOptions _options;
+        private readonly bool _isV4;
+        private readonly Action<StressLogDiagnostic>? _diag;
+
+        private ChunkReader _chunk;
+        private readonly HashSet<ulong> _visitedChunks = new();
+
+        private readonly ulong _curWriteChunk;
+        private readonly ulong _curPtr;
+        private readonly ulong _chunkListTail;
+        private readonly bool _writeHasWrapped;
+
+        private bool _readHasWrapped;
+        private int _messagesEmitted;
+        private int _readOffset;
+
+        public ulong ThreadId { get; }
+        public bool Exhausted { get; private set; }
+
+        // Latest decoded message fields; consumer reads via accessors after each Advance().
+        public uint Facility { get; private set; }
+        public ulong TimeStamp { get; private set; }
+        public ulong FormatOffset { get; private set; }
+        public int ArgumentCount { get; private set; }
+        private int _argsOffset;
+
+        public ThreadIterator(IDataReader reader,
+                              StressLogOptions options,
+                              AllocationBudget budget,
+                              Action<StressLogDiagnostic>? diagnostic,
+                              ulong threadAddress,
+                              ReadOnlySpan<byte> threadHeader,
+                              bool isV4)
+        {
+            _reader = reader;
+            _options = options;
+            _diag = diagnostic;
+            _isV4 = isV4;
+            _chunk = new ChunkReader(budget);
+
+            ThreadId = BinaryPrimitives.ReadUInt64LittleEndian(threadHeader.Slice(StressLogLayout.Thread_ThreadId));
+            byte readWrapped = threadHeader[StressLogLayout.Thread_ReadHasWrapped];
+            byte writeWrapped = threadHeader[StressLogLayout.Thread_WriteHasWrapped];
+            _readHasWrapped = readWrapped != 0;
+            _writeHasWrapped = writeWrapped != 0;
+            _curPtr = BinaryPrimitives.ReadUInt64LittleEndian(threadHeader.Slice(StressLogLayout.Thread_CurPtr));
+            ulong readPtr = BinaryPrimitives.ReadUInt64LittleEndian(threadHeader.Slice(StressLogLayout.Thread_ReadPtr));
+            _chunkListTail = BinaryPrimitives.ReadUInt64LittleEndian(threadHeader.Slice(StressLogLayout.Thread_ChunkListTail));
+            ulong curReadChunk = BinaryPrimitives.ReadUInt64LittleEndian(threadHeader.Slice(StressLogLayout.Thread_CurReadChunk));
+            _curWriteChunk = BinaryPrimitives.ReadUInt64LittleEndian(threadHeader.Slice(StressLogLayout.Thread_CurWriteChunk));
+
+            // Replicate the ReadOnly-mode constructor: start reading at curWriteChunk/curPtr.
+            // Many real-world dumps have curReadChunk/readPtr not set; trust curWriteChunk/curPtr.
+            ulong startChunk = _curWriteChunk != 0 ? _curWriteChunk : curReadChunk;
+            ulong startPtr = _curPtr != 0 ? _curPtr : readPtr;
+
+            if (startChunk == 0 || !LoadChunk(startChunk))
+            {
+                Exhausted = true;
+                return;
+            }
+
+            if (!_chunk.TryAddressToOffset(startPtr, out _readOffset))
+            {
+                _diag?.Invoke(new StressLogDiagnostic(StressLogDiagnosticKind.CorruptThread, threadAddress));
+                Exhausted = true;
+                return;
+            }
+
+            _ = threadAddress; // address kept for diagnostics only; not referenced afterwards
+        }
+
+        /// <summary>
+        /// Advance to the next message. Returns <see langword="false"/> if the
+        /// log has been fully drained (or terminated due to corruption).
+        /// </summary>
+        public bool Advance()
+        {
+            if (Exhausted) return false;
+            if (_messagesEmitted >= _options.MaxMessagesPerThread)
+            {
+                _diag?.Invoke(new StressLogDiagnostic(StressLogDiagnosticKind.LimitExceeded, _chunk.Address));
+                Exhausted = true;
+                return false;
+            }
+
+            ReadOnlySpan<byte> body = _chunk.Buffer;
+            if (_readOffset < 0 || _readOffset + StressLogLayout.Msg_HeaderSize > body.Length)
+            {
+                if (!CrossChunkBoundary())
+                    return false;
+                body = _chunk.Buffer;
+            }
+
+            // Decode the message header.
+            ReadOnlySpan<byte> header = body.Slice(_readOffset, StressLogLayout.Msg_HeaderSize);
+            uint facility;
+            int numArgs;
+            ulong formatOffset;
+            ulong timeStamp;
+            if (_isV4)
+                StressLogLayout.DecodeMessageV4(header, out facility, out numArgs, out formatOffset, out timeStamp);
+            else
+                StressLogLayout.DecodeMessageV3(header, out facility, out numArgs, out formatOffset, out timeStamp);
+
+            // Termination: timeStamp == 0 means we've reached the zero-padded region
+            // at the start of the current chunk that the writer skipped.
+            if (timeStamp == 0)
+            {
+                Exhausted = true;
+                return false;
+            }
+
+            // Validate numberOfArgs and chunk bounds.
+            if ((uint)numArgs > StressLogConstants.MaxArgumentCount)
+            {
+                _diag?.Invoke(new StressLogDiagnostic(StressLogDiagnosticKind.CorruptMessage, _chunk.BufferStartAddress + (ulong)_readOffset));
+                Exhausted = true;
+                return false;
+            }
+
+            int totalSize = StressLogLayout.Msg_HeaderSize + numArgs * StressLogLayout.Msg_ArgSize;
+            if (_readOffset + totalSize > body.Length)
+            {
+                _diag?.Invoke(new StressLogDiagnostic(StressLogDiagnosticKind.CorruptMessage, _chunk.BufferStartAddress + (ulong)_readOffset));
+                Exhausted = true;
+                return false;
+            }
+
+            Facility = facility;
+            TimeStamp = timeStamp;
+            FormatOffset = formatOffset;
+            ArgumentCount = numArgs;
+            _argsOffset = _readOffset + StressLogLayout.Msg_HeaderSize;
+
+            // Termination: read pointer reached the write pointer.
+            ulong messageAddr = _chunk.BufferStartAddress + (ulong)_readOffset;
+            bool atWriteHead = _chunk.Address == _curWriteChunk
+                               && messageAddr >= _curPtr
+                               && _readHasWrapped;
+
+            // Advance read offset past this message.
+            _readOffset += totalSize;
+            _messagesEmitted++;
+
+            if (atWriteHead)
+            {
+                Exhausted = true;
+                // Still emit this final message (it was at curPtr, valid).
+            }
+
+            return true;
+        }
+
+        public ulong GetArgument(int index)
+        {
+            if ((uint)index >= (uint)ArgumentCount) return 0;
+            ReadOnlySpan<byte> body = _chunk.Buffer;
+            int offset = _argsOffset + index * StressLogLayout.Msg_ArgSize;
+            if (offset + StressLogLayout.Msg_ArgSize > body.Length) return 0;
+            return BinaryPrimitives.ReadUInt64LittleEndian(body.Slice(offset));
+        }
+
+        private bool CrossChunkBoundary()
+        {
+            // Mirror AdvReadPastBoundary: if we just exhausted chunkListTail and
+            // write hasn't wrapped, we've read everything the writer left valid.
+            if (_chunk.Address == _chunkListTail)
+            {
+                _readHasWrapped = true;
+                if (!_writeHasWrapped)
+                {
+                    Exhausted = true;
+                    return false;
+                }
+            }
+
+            ulong nextAddr = _chunk.Next;
+            if (nextAddr == 0)
+            {
+                Exhausted = true;
+                return false;
+            }
+
+            // Natural full-circle termination: we've returned to the chunk we
+            // started at, and we already observed the read-wrap sentinel. The
+            // writer's curPtr-anchored termination test will be evaluated
+            // against the next message we decode.
+            if (nextAddr == _curWriteChunk && _readHasWrapped)
+            {
+                Exhausted = true;
+                return false;
+            }
+
+            if (!LoadChunk(nextAddr))
+                return false;
+
+            // Skip leading zero pointer-words up to maxMsgSize() words. The
+            // writer pads unused space at the start of chunks with NULs.
+            ReadOnlySpan<byte> body = _chunk.Buffer;
+            int maxSkipWords = (StressLogLayout.Msg_HeaderSize + StressLogConstants.MaxArgumentCount * StressLogLayout.Msg_ArgSize) / StressLogLayout.Msg_ArgSize;
+            int offset = 0;
+            for (int w = 0; w < maxSkipWords && offset + StressLogLayout.Msg_ArgSize <= body.Length; w++)
+            {
+                ulong word = BinaryPrimitives.ReadUInt64LittleEndian(body.Slice(offset));
+                if (word != 0) break;
+                offset += StressLogLayout.Msg_ArgSize;
+            }
+
+            _readOffset = offset;
+            return true;
+        }
+
+        private bool LoadChunk(ulong address)
+        {
+            if (_visitedChunks.Count >= _options.MaxChunksPerThread)
+            {
+                _diag?.Invoke(new StressLogDiagnostic(StressLogDiagnosticKind.LimitExceeded, address));
+                return false;
+            }
+
+            if (!_visitedChunks.Add(address))
+            {
+                _diag?.Invoke(new StressLogDiagnostic(StressLogDiagnosticKind.CorruptChunk, address));
+                return false;
+            }
+
+            if (!_chunk.TryLoad(_reader, address))
+            {
+                _diag?.Invoke(new StressLogDiagnostic(StressLogDiagnosticKind.CorruptChunk, address));
+                return false;
+            }
+
+            return true;
+        }
+
+        public void Dispose() => _chunk.Release();
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/StressLog/Internal/ThreadIterator.cs
+++ b/src/Microsoft.Diagnostics.Runtime/StressLog/Internal/ThreadIterator.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
         private int _messagesEmitted;
         private int _readOffset;
 
-        public ulong ThreadId { get; }
+        public ulong OSThreadId { get; }
         public bool Exhausted { get; private set; }
 
         // Latest decoded message fields; consumer reads via accessors after each Advance().
@@ -84,7 +84,7 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
 
             if (variant == StressLogVariant.FrameworkV1)
             {
-                ThreadId = BinaryPrimitives.ReadUInt32LittleEndian(threadHeader.Slice(StressLogLayout.FxThread_ThreadId));
+                OSThreadId = BinaryPrimitives.ReadUInt32LittleEndian(threadHeader.Slice(StressLogLayout.FxThread_ThreadId));
                 _curPtr = BinaryPrimitives.ReadUInt64LittleEndian(threadHeader.Slice(StressLogLayout.FxThread_CurPtr));
                 readPtr = BinaryPrimitives.ReadUInt64LittleEndian(threadHeader.Slice(StressLogLayout.FxThread_ReadPtr));
                 uint writeWrapped32 = BinaryPrimitives.ReadUInt32LittleEndian(threadHeader.Slice(StressLogLayout.FxThread_WriteHasWrapped));
@@ -95,7 +95,7 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
             }
             else
             {
-                ThreadId = BinaryPrimitives.ReadUInt64LittleEndian(threadHeader.Slice(StressLogLayout.CoreThread_ThreadId));
+                OSThreadId = BinaryPrimitives.ReadUInt64LittleEndian(threadHeader.Slice(StressLogLayout.CoreThread_ThreadId));
                 writeWrapped = threadHeader[StressLogLayout.CoreThread_WriteHasWrapped];
                 _curPtr = BinaryPrimitives.ReadUInt64LittleEndian(threadHeader.Slice(StressLogLayout.CoreThread_CurPtr));
                 readPtr = BinaryPrimitives.ReadUInt64LittleEndian(threadHeader.Slice(StressLogLayout.CoreThread_ReadPtr));

--- a/src/Microsoft.Diagnostics.Runtime/StressLog/Internal/ThreadIterator.cs
+++ b/src/Microsoft.Diagnostics.Runtime/StressLog/Internal/ThreadIterator.cs
@@ -33,6 +33,8 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
         private readonly IDataReader _reader;
         private readonly StressLogOptions _options;
         private readonly bool _isV4;
+        private readonly StressLogVariant _variant;
+        private readonly int _msgHeaderSize;
         private readonly Action<StressLogDiagnostic>? _diag;
 
         private ChunkReader _chunk;
@@ -63,27 +65,54 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
                               Action<StressLogDiagnostic>? diagnostic,
                               ulong threadAddress,
                               ReadOnlySpan<byte> threadHeader,
-                              bool isV4)
+                              bool isV4,
+                              StressLogVariant variant)
         {
             _reader = reader;
             _options = options;
             _diag = diagnostic;
             _isV4 = isV4;
+            _variant = variant;
+            _msgHeaderSize = variant == StressLogVariant.FrameworkV1
+                ? StressLogLayout.Msg_HeaderSizeFxV1
+                : StressLogLayout.Msg_HeaderSize;
             _chunk = new ChunkReader(budget);
 
-            ThreadId = BinaryPrimitives.ReadUInt64LittleEndian(threadHeader.Slice(StressLogLayout.Thread_ThreadId));
-            byte readWrapped = threadHeader[StressLogLayout.Thread_ReadHasWrapped];
-            byte writeWrapped = threadHeader[StressLogLayout.Thread_WriteHasWrapped];
-            _readHasWrapped = readWrapped != 0;
-            _writeHasWrapped = writeWrapped != 0;
-            _curPtr = BinaryPrimitives.ReadUInt64LittleEndian(threadHeader.Slice(StressLogLayout.Thread_CurPtr));
-            ulong readPtr = BinaryPrimitives.ReadUInt64LittleEndian(threadHeader.Slice(StressLogLayout.Thread_ReadPtr));
-            _chunkListTail = BinaryPrimitives.ReadUInt64LittleEndian(threadHeader.Slice(StressLogLayout.Thread_ChunkListTail));
-            ulong curReadChunk = BinaryPrimitives.ReadUInt64LittleEndian(threadHeader.Slice(StressLogLayout.Thread_CurReadChunk));
-            _curWriteChunk = BinaryPrimitives.ReadUInt64LittleEndian(threadHeader.Slice(StressLogLayout.Thread_CurWriteChunk));
+            ulong curReadChunk;
+            ulong readPtr;
+            byte writeWrapped;
 
-            // Replicate the ReadOnly-mode constructor: start reading at curWriteChunk/curPtr.
-            // Many real-world dumps have curReadChunk/readPtr not set; trust curWriteChunk/curPtr.
+            if (variant == StressLogVariant.FrameworkV1)
+            {
+                ThreadId = BinaryPrimitives.ReadUInt32LittleEndian(threadHeader.Slice(StressLogLayout.FxThread_ThreadId));
+                _curPtr = BinaryPrimitives.ReadUInt64LittleEndian(threadHeader.Slice(StressLogLayout.FxThread_CurPtr));
+                readPtr = BinaryPrimitives.ReadUInt64LittleEndian(threadHeader.Slice(StressLogLayout.FxThread_ReadPtr));
+                uint writeWrapped32 = BinaryPrimitives.ReadUInt32LittleEndian(threadHeader.Slice(StressLogLayout.FxThread_WriteHasWrapped));
+                writeWrapped = (byte)(writeWrapped32 != 0 ? 1 : 0);
+                _chunkListTail = BinaryPrimitives.ReadUInt64LittleEndian(threadHeader.Slice(StressLogLayout.FxThread_ChunkListTail));
+                curReadChunk = BinaryPrimitives.ReadUInt64LittleEndian(threadHeader.Slice(StressLogLayout.FxThread_CurReadChunk));
+                _curWriteChunk = BinaryPrimitives.ReadUInt64LittleEndian(threadHeader.Slice(StressLogLayout.FxThread_CurWriteChunk));
+            }
+            else
+            {
+                ThreadId = BinaryPrimitives.ReadUInt64LittleEndian(threadHeader.Slice(StressLogLayout.CoreThread_ThreadId));
+                writeWrapped = threadHeader[StressLogLayout.CoreThread_WriteHasWrapped];
+                _curPtr = BinaryPrimitives.ReadUInt64LittleEndian(threadHeader.Slice(StressLogLayout.CoreThread_CurPtr));
+                readPtr = BinaryPrimitives.ReadUInt64LittleEndian(threadHeader.Slice(StressLogLayout.CoreThread_ReadPtr));
+                _chunkListTail = BinaryPrimitives.ReadUInt64LittleEndian(threadHeader.Slice(StressLogLayout.CoreThread_ChunkListTail));
+                curReadChunk = BinaryPrimitives.ReadUInt64LittleEndian(threadHeader.Slice(StressLogLayout.CoreThread_CurReadChunk));
+                _curWriteChunk = BinaryPrimitives.ReadUInt64LittleEndian(threadHeader.Slice(StressLogLayout.CoreThread_CurWriteChunk));
+            }
+
+            // The runtime writer never initializes readHasWrapped (it is only
+            // set by the readonly Activate() and by AdvReadPastBoundary in the
+            // SOS DAC code path). Treat the dump's bytes as junk and start from
+            // the readonly initial state described in stresslog.h.
+            _readHasWrapped = false;
+            _writeHasWrapped = writeWrapped != 0;
+
+            // Replicate the readonly Activate() seed: read from curWriteChunk/
+            // curPtr. If curWriteChunk is zero, fall back to curReadChunk/readPtr.
             ulong startChunk = _curWriteChunk != 0 ? _curWriteChunk : curReadChunk;
             ulong startPtr = _curPtr != 0 ? _curPtr : readPtr;
 
@@ -118,7 +147,7 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
             }
 
             ReadOnlySpan<byte> body = _chunk.Buffer;
-            if (_readOffset < 0 || _readOffset + StressLogLayout.Msg_HeaderSize > body.Length)
+            if (_readOffset < 0 || _readOffset + _msgHeaderSize > body.Length)
             {
                 if (!CrossChunkBoundary())
                     return false;
@@ -126,12 +155,14 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
             }
 
             // Decode the message header.
-            ReadOnlySpan<byte> header = body.Slice(_readOffset, StressLogLayout.Msg_HeaderSize);
+            ReadOnlySpan<byte> header = body.Slice(_readOffset, _msgHeaderSize);
             uint facility;
             int numArgs;
             ulong formatOffset;
             ulong timeStamp;
-            if (_isV4)
+            if (_variant == StressLogVariant.FrameworkV1)
+                StressLogLayout.DecodeMessageFxV1(header, out facility, out numArgs, out formatOffset, out timeStamp);
+            else if (_isV4)
                 StressLogLayout.DecodeMessageV4(header, out facility, out numArgs, out formatOffset, out timeStamp);
             else
                 StressLogLayout.DecodeMessageV3(header, out facility, out numArgs, out formatOffset, out timeStamp);
@@ -152,7 +183,7 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
                 return false;
             }
 
-            int totalSize = StressLogLayout.Msg_HeaderSize + numArgs * StressLogLayout.Msg_ArgSize;
+            int totalSize = _msgHeaderSize + numArgs * StressLogLayout.Msg_ArgSize;
             if (_readOffset + totalSize > body.Length)
             {
                 _diag?.Invoke(new StressLogDiagnostic(StressLogDiagnosticKind.CorruptMessage, _chunk.BufferStartAddress + (ulong)_readOffset));
@@ -164,7 +195,7 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
             TimeStamp = timeStamp;
             FormatOffset = formatOffset;
             ArgumentCount = numArgs;
-            _argsOffset = _readOffset + StressLogLayout.Msg_HeaderSize;
+            _argsOffset = _readOffset + _msgHeaderSize;
 
             // Termination: read pointer reached the write pointer.
             ulong messageAddr = _chunk.BufferStartAddress + (ulong)_readOffset;
@@ -231,7 +262,7 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
             // Skip leading zero pointer-words up to maxMsgSize() words. The
             // writer pads unused space at the start of chunks with NULs.
             ReadOnlySpan<byte> body = _chunk.Buffer;
-            int maxSkipWords = (StressLogLayout.Msg_HeaderSize + StressLogConstants.MaxArgumentCount * StressLogLayout.Msg_ArgSize) / StressLogLayout.Msg_ArgSize;
+            int maxSkipWords = (_msgHeaderSize + StressLogConstants.MaxArgumentCount * StressLogLayout.Msg_ArgSize) / StressLogLayout.Msg_ArgSize;
             int offset = 0;
             for (int w = 0; w < maxSkipWords && offset + StressLogLayout.Msg_ArgSize <= body.Length; w++)
             {

--- a/src/Microsoft.Diagnostics.Runtime/StressLog/StressLog.cs
+++ b/src/Microsoft.Diagnostics.Runtime/StressLog/StressLog.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Buffers.Binary;
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
 using System.Threading;
 using Microsoft.Diagnostics.Runtime;
 using Microsoft.Diagnostics.Runtime.DacInterface;
@@ -36,6 +37,7 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs
     public sealed class StressLog : IDisposable
     {
         private readonly IDataReader _reader;
+        private readonly StressLogLayout _layout;
         private readonly StressLogOptions _options;
         private readonly AllocationBudget _budget;
         private readonly StressLogModuleTable _modules;
@@ -51,6 +53,7 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs
         private bool _disposed;
 
         private StressLog(IDataReader reader,
+                          StressLogLayout layout,
                           StressLogOptions options,
                           AllocationBudget budget,
                           StressLogModuleTable modules,
@@ -62,6 +65,7 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs
                           StressLogVariant variant)
         {
             _reader = reader;
+            _layout = layout;
             _options = options;
             _budget = budget;
             _modules = modules;
@@ -141,9 +145,17 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs
                 failureReason = "Data reader is null.";
                 return false;
             }
-            if (reader.PointerSize != 8)
+            if (reader.PointerSize != 8 && reader.PointerSize != 4)
             {
-                failureReason = $"Stress logs on a {reader.PointerSize * 8}-bit target are not supported; only 64-bit targets are.";
+                failureReason = $"Stress logs on a {reader.PointerSize * 8}-bit target are not supported; only 32-bit and 64-bit targets are.";
+                return false;
+            }
+            if (reader.PointerSize == 4 && reader.TargetPlatform != OSPlatform.Windows)
+            {
+                // 32-bit Linux/macOS .NET runtimes have not shipped in a
+                // supported configuration in years; we have no reference
+                // dumps to validate the layout against. Reject explicitly.
+                failureReason = "Stress logs on a 32-bit non-Windows target are not supported.";
                 return false;
             }
             if (address == 0)
@@ -151,34 +163,54 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs
                 failureReason = "Stress log address is 0.";
                 return false;
             }
+
+            // Choose a preliminary Core layout based on pointer size; if
+            // variant detection identifies a Framework target later, we
+            // swap to the matching Framework layout.
+            StressLogLayout layout = StressLogLayout.ForCore(reader.PointerSize);
             StressLogOptions options = StressLogOptions.Default;
             AllocationBudget budget = new AllocationBudget(options.MaxTotalBytesAllocated);
 
             // Speculatively read the larger memory-mapped header. If the magic
             // does not match, treat as in-process and use only the first
-            // InProc_HeaderSize bytes.
-            Span<byte> header = stackalloc byte[StressLogLayout.Mm_HeaderReadSize];
-            int got = reader.Read(address, header);
-            if (got < StressLogLayout.InProc_HeaderSize)
+            // InProcHeaderSize bytes. Memory-mapped logs are 64-bit only;
+            // on 32-bit the magic check will always fail.
+            int speculativeReadSize = layout.Is64Bit
+                ? Math.Max(layout.MmHeaderReadSize, layout.InProcHeaderSize)
+                : layout.InProcHeaderSize;
+            Span<byte> header = stackalloc byte[512]; // upper bound for any layout
+            if (speculativeReadSize > header.Length)
             {
-                failureReason = $"Could not read the stress log header at 0x{address:x} (got {got} bytes, expected at least {StressLogLayout.InProc_HeaderSize}).";
+                // Defensive: any future layout change that bloats the header
+                // beyond 512 bytes would land here. Today the worst case is
+                // 272 (Mm x64).
+                failureReason = "Speculative header read size exceeds the preallocated buffer.";
+                return false;
+            }
+            header = header.Slice(0, speculativeReadSize);
+
+            int got = reader.Read(address, header);
+            if (got < layout.InProcHeaderSize)
+            {
+                failureReason = $"Could not read the stress log header at 0x{address:x} (got {got} bytes, expected at least {layout.InProcHeaderSize}).";
                 return false;
             }
 
-            uint maybeMagic = got >= StressLogLayout.Mm_Version
-                ? BinaryPrimitives.ReadUInt32LittleEndian(header.Slice(StressLogLayout.Mm_Magic))
+            uint maybeMagic = layout.Is64Bit && got >= layout.MmVersionOffset
+                ? BinaryPrimitives.ReadUInt32LittleEndian(header.Slice(layout.MmMagicOffset))
                 : 0;
 
-            bool isMemoryMapped = got >= StressLogLayout.Mm_HeaderReadSize
+            bool isMemoryMapped = layout.Is64Bit
+                                  && got >= layout.MmHeaderReadSize
                                   && maybeMagic == StressLogConstants.MemoryMappedMagic;
 
             if (isMemoryMapped)
             {
-                stressLog = OpenMemoryMapped(reader, options, budget, header);
+                stressLog = OpenMemoryMapped(reader, layout, options, budget, header);
             }
             else
             {
-                stressLog = OpenInProcess(reader, options, budget, header.Slice(0, StressLogLayout.InProc_HeaderSize));
+                stressLog = OpenInProcess(reader, layout, options, budget, header.Slice(0, layout.InProcHeaderSize));
             }
 
             if (stressLog is null)
@@ -190,25 +222,31 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs
         }
 
         private static StressLog? OpenInProcess(IDataReader reader,
+                                                StressLogLayout layout,
                                                 StressLogOptions options,
                                                 AllocationBudget budget,
                                                 ReadOnlySpan<byte> header)
         {
             // Variant detection. Modern CoreCLR initializes the 'padding'
-            // field at StressLog offset 32 to UINT_MAX (0xFFFFFFFF) as a
+            // field at StressLog InProcPaddingOffset to UINT_MAX (0xFFFFFFFF) as a
             // sentinel; the .NET Framework runtime stores its TLS slot index
             // there (a small positive integer). This is a stable signal we
             // verified across all five integration-test dump variants.
-            uint sentinel = BinaryPrimitives.ReadUInt32LittleEndian(header.Slice(StressLogLayout.InProc_Padding));
+            uint sentinel = BinaryPrimitives.ReadUInt32LittleEndian(header.Slice(layout.InProcPaddingOffset));
             StressLogVariant variant = sentinel == 0xFFFFFFFFu
                 ? StressLogVariant.Core
                 : StressLogVariant.FrameworkV1;
 
-            ulong logs = BinaryPrimitives.ReadUInt64LittleEndian(header.Slice(StressLogLayout.InProc_Logs));
-            ulong tickFreq = BinaryPrimitives.ReadUInt64LittleEndian(header.Slice(StressLogLayout.InProc_TickFrequency));
-            ulong startTs = BinaryPrimitives.ReadUInt64LittleEndian(header.Slice(StressLogLayout.InProc_StartTimeStamp));
-            ulong startFiletime = BinaryPrimitives.ReadUInt64LittleEndian(header.Slice(StressLogLayout.InProc_StartTime));
-            ulong moduleOffset = BinaryPrimitives.ReadUInt64LittleEndian(header.Slice(StressLogLayout.InProc_ModuleOffset));
+            // Swap to the Framework layout if needed; ThreadStressLog and
+            // StressMsg layouts differ from Core.
+            if (variant == StressLogVariant.FrameworkV1)
+                layout = layout.WithFramework();
+
+            ulong logs = layout.ReadTargetPointer(header, layout.InProcLogsOffset);
+            ulong tickFreq = BinaryPrimitives.ReadUInt64LittleEndian(header.Slice(layout.InProcTickFrequencyOffset));
+            ulong startTs = BinaryPrimitives.ReadUInt64LittleEndian(header.Slice(layout.InProcStartTimeStampOffset));
+            ulong startFiletime = BinaryPrimitives.ReadUInt64LittleEndian(header.Slice(layout.InProcStartTimeOffset));
+            ulong moduleOffset = layout.ReadTargetPointer(header, layout.InProcModuleOffsetOffset);
 
             DateTime? startTimeUtc = null;
             try
@@ -222,62 +260,66 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs
             }
 
             // Framework's StressLog struct has no module table appended; the
-            // bytes we speculatively read at offset 80..160 are unrelated heap
-            // memory. Restrict module table parsing to Core, and let Framework
-            // fall through to the single-module path keyed off moduleOffset.
+            // bytes we speculatively read past the header end are unrelated
+            // heap memory. Restrict module table parsing to Core, and let
+            // Framework fall through to the single-module path keyed off
+            // moduleOffset.
             StressLogModuleTable modules;
             if (variant == StressLogVariant.Core)
             {
-                ReadOnlySpan<byte> entries = header.Slice(StressLogLayout.InProc_Modules,
-                                                          StressLogConstants.MaxModules * StressLogLayout.InProc_ModuleEntrySize);
+                int entriesByteCount = StressLogConstants.MaxModules * layout.ModuleEntrySize;
+                ReadOnlySpan<byte> entries = header.Slice(layout.InProcModulesOffset, entriesByteCount);
                 modules = StressLogModuleTable.BuildInProcess(
-                    entries16: entries,
-                    moduleOffset,
+                    layout: layout,
+                    entries: entries,
+                    legacyModuleOffset: moduleOffset,
                     hasModuleTable: true,
-                    StressLogConstants.FormatOffsetMax);
+                    maxOffset: StressLogConstants.FormatOffsetMax);
             }
             else
             {
                 modules = StressLogModuleTable.BuildInProcess(
-                    entries16: ReadOnlySpan<byte>.Empty,
-                    moduleOffset,
+                    layout: layout,
+                    entries: ReadOnlySpan<byte>.Empty,
+                    legacyModuleOffset: moduleOffset,
                     hasModuleTable: false,
-                    StressLogConstants.FormatOffsetMax);
+                    maxOffset: StressLogConstants.FormatOffsetMax);
             }
 
             // V4 message decoding has been used since the addition of the
             // module table in CoreCLR; Framework V1 predates it and uses V3.
             bool isV4 = variant == StressLogVariant.Core;
 
-            return new StressLog(reader, options, budget, modules, logs, tickFreq, startTs, startTimeUtc, isV4: isV4, variant: variant);
+            return new StressLog(reader, layout, options, budget, modules, logs, tickFreq, startTs, startTimeUtc, isV4: isV4, variant: variant);
         }
 
         private static StressLog? OpenMemoryMapped(IDataReader reader,
+                                                   StressLogLayout layout,
                                                    StressLogOptions options,
                                                    AllocationBudget budget,
                                                    ReadOnlySpan<byte> header)
         {
-            uint version = BinaryPrimitives.ReadUInt32LittleEndian(header.Slice(StressLogLayout.Mm_Version));
+            uint version = BinaryPrimitives.ReadUInt32LittleEndian(header.Slice(layout.MmVersionOffset));
             if (version != StressLogConstants.MemoryMappedVersionV1
                 && version != StressLogConstants.MemoryMappedVersionV2)
             {
                 return null;
             }
 
-            ulong logs = BinaryPrimitives.ReadUInt64LittleEndian(header.Slice(StressLogLayout.Mm_Logs));
-            ulong tickFreq = BinaryPrimitives.ReadUInt64LittleEndian(header.Slice(StressLogLayout.Mm_TickFrequency));
-            ulong startTs = BinaryPrimitives.ReadUInt64LittleEndian(header.Slice(StressLogLayout.Mm_StartTimeStamp));
+            ulong logs = layout.ReadTargetPointer(header, layout.MmLogsOffset);
+            ulong tickFreq = BinaryPrimitives.ReadUInt64LittleEndian(header.Slice(layout.MmTickFrequencyOffset));
+            ulong startTs = BinaryPrimitives.ReadUInt64LittleEndian(header.Slice(layout.MmStartTimeStampOffset));
 
-            ReadOnlySpan<byte> entries = header.Slice(StressLogLayout.Mm_Modules,
-                                                      StressLogConstants.MaxModules * StressLogLayout.InProc_ModuleEntrySize);
+            int entriesByteCount = StressLogConstants.MaxModules * layout.ModuleEntrySize;
+            ReadOnlySpan<byte> entries = header.Slice(layout.MmModulesOffset, entriesByteCount);
 
             ulong maxOffset = version == StressLogConstants.MemoryMappedVersionV1
                 ? (1UL << StressLogConstants.FormatOffsetLowBits)
                 : StressLogConstants.FormatOffsetMax;
 
-            StressLogModuleTable modules = StressLogModuleTable.BuildMemoryMapped(entries, maxOffset);
+            StressLogModuleTable modules = StressLogModuleTable.BuildMemoryMapped(layout, entries, maxOffset);
 
-            return new StressLog(reader, options, budget, modules, logs, tickFreq, startTs, startTimeUtc: null, isV4: true, variant: StressLogVariant.Core);
+            return new StressLog(reader, layout, options, budget, modules, logs, tickFreq, startTs, startTimeUtc: null, isV4: true, variant: StressLogVariant.Core);
         }
 
         /// <summary>
@@ -365,7 +407,8 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs
             HashSet<ulong> visited = new();
             ulong addr = _firstThreadAddr;
 
-            Span<byte> threadHeader = stackalloc byte[StressLogLayout.Thread_HeaderSize];
+            Span<byte> threadHeader = stackalloc byte[StressLogConstants.MaxThreadHeaderBytes];
+            threadHeader = threadHeader.Slice(0, _layout.ThreadHeaderSize);
             Action<StressLogDiagnostic> raiseDiagnostic = d => Diagnostic?.Invoke(d);
 
             while (addr != 0)
@@ -383,14 +426,14 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs
                 }
 
                 int got = _reader.Read(addr, threadHeader);
-                if (got < StressLogLayout.Thread_HeaderSize)
+                if (got < _layout.ThreadHeaderSize)
                 {
                     Diagnostic?.Invoke(new StressLogDiagnostic(StressLogDiagnosticKind.ReadMemoryFailed, addr));
                     break;
                 }
 
-                ulong nextAddr = BinaryPrimitives.ReadUInt64LittleEndian(threadHeader.Slice(StressLogLayout.Thread_Next));
-                ThreadIterator iter = new ThreadIterator(_reader, _options, _budget,
+                ulong nextAddr = _layout.ReadTargetPointer(threadHeader, _layout.ThreadNextOffset);
+                ThreadIterator iter = new ThreadIterator(_reader, _layout, _options, _budget,
                     diagnostic: raiseDiagnostic,
                     threadAddress: addr,
                     threadHeader: threadHeader,

--- a/src/Microsoft.Diagnostics.Runtime/StressLog/StressLog.cs
+++ b/src/Microsoft.Diagnostics.Runtime/StressLog/StressLog.cs
@@ -93,6 +93,14 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs
         public DateTime? StartTimeUtc => _startTimeUtc;
 
         /// <summary>
+        /// Pointer size of the target the log was captured from, in bytes.
+        /// 4 for a 32-bit target, 8 for a 64-bit target. Receivers should
+        /// format <c>%p</c> arguments with <c>2 * PointerSize</c> hex digits
+        /// to match the target's native pointer width.
+        /// </summary>
+        public int PointerSize => _layout.PointerSize;
+
+        /// <summary>
         /// Try to open the stress log for the given <paramref name="runtime"/>.
         /// Looks up the stress log address through the runtime's DAC and
         /// reads from the runtime's data target. Returns <see langword="false"/>

--- a/src/Microsoft.Diagnostics.Runtime/StressLog/StressLog.cs
+++ b/src/Microsoft.Diagnostics.Runtime/StressLog/StressLog.cs
@@ -103,16 +103,32 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs
         /// not support <c>GetStressLogAddress</c>, or the resulting log fails
         /// validation.
         /// </summary>
-        public static bool TryOpen(ClrRuntime runtime, out StressLog? stressLog)
+        internal static bool TryOpen(ClrRuntime runtime, out StressLog? stressLog)
+            => TryOpen(runtime, out stressLog, out _);
+
+        /// <summary>
+        /// Try to open the stress log for the given <paramref name="runtime"/>,
+        /// returning a human-readable explanation in
+        /// <paramref name="failureReason"/> when the open fails.
+        /// </summary>
+        internal static bool TryOpen(ClrRuntime runtime, out StressLog? stressLog, out string? failureReason)
         {
             stressLog = null;
-            if (runtime is null) return false;
+            failureReason = null;
+            if (runtime is null)
+            {
+                failureReason = "Runtime is null.";
+                return false;
+            }
 
             ulong address = runtime.GetStressLogAddress();
             if (address == 0)
+            {
+                failureReason = "Stress logging is not enabled for this runtime, or the DAC does not expose the stress log address.";
                 return false;
+            }
 
-            return TryOpen(runtime.DataTarget.DataReader, address, out stressLog);
+            return TryOpen(runtime.DataTarget.DataReader, address, out stressLog, out failureReason);
         }
 
         /// <summary>
@@ -120,12 +136,28 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs
         /// target. Returns <see langword="false"/> on any structural
         /// validation failure.
         /// </summary>
-        public static bool TryOpen(IDataReader reader, ulong address, out StressLog? stressLog)
+        internal static bool TryOpen(IDataReader reader, ulong address, out StressLog? stressLog)
+            => TryOpen(reader, address, out stressLog, out _);
+
+        internal static bool TryOpen(IDataReader reader, ulong address, out StressLog? stressLog, out string? failureReason)
         {
             stressLog = null;
-            if (reader is null) return false;
-            if (reader.PointerSize != 8) return false;
-            if (address == 0) return false;
+            failureReason = null;
+            if (reader is null)
+            {
+                failureReason = "Data reader is null.";
+                return false;
+            }
+            if (reader.PointerSize != 8)
+            {
+                failureReason = $"Stress logs on a {reader.PointerSize * 8}-bit target are not supported; only 64-bit targets are.";
+                return false;
+            }
+            if (address == 0)
+            {
+                failureReason = "Stress log address is 0.";
+                return false;
+            }
             StressLogOptions options = StressLogOptions.Default;
             AllocationBudget budget = new AllocationBudget(options.MaxTotalBytesAllocated);
 
@@ -135,7 +167,10 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs
             Span<byte> header = stackalloc byte[StressLogLayout.Mm_HeaderReadSize];
             int got = reader.Read(address, header);
             if (got < StressLogLayout.InProc_HeaderSize)
+            {
+                failureReason = $"Could not read the stress log header at 0x{address:x} (got {got} bytes, expected at least {StressLogLayout.InProc_HeaderSize}).";
                 return false;
+            }
 
             uint maybeMagic = got >= StressLogLayout.Mm_Version
                 ? BinaryPrimitives.ReadUInt32LittleEndian(header.Slice(StressLogLayout.Mm_Magic))
@@ -153,7 +188,12 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs
                 stressLog = OpenInProcess(reader, options, budget, header.Slice(0, StressLogLayout.InProc_HeaderSize));
             }
 
-            return stressLog is not null;
+            if (stressLog is null)
+            {
+                failureReason = "Stress log header failed validation.";
+                return false;
+            }
+            return true;
         }
 
         private static StressLog? OpenInProcess(IDataReader reader,

--- a/src/Microsoft.Diagnostics.Runtime/StressLog/StressLog.cs
+++ b/src/Microsoft.Diagnostics.Runtime/StressLog/StressLog.cs
@@ -295,7 +295,7 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs
                     yield return new StressLogMessage(
                         log: this,
                         generation: gen,
-                        threadId: iter.ThreadId,
+                        threadId: iter.OSThreadId,
                         facility: iter.Facility,
                         timeStampTicks: iter.TimeStamp,
                         formatAddress: ResolveFormatAddress(iter.FormatOffset),

--- a/src/Microsoft.Diagnostics.Runtime/StressLog/StressLog.cs
+++ b/src/Microsoft.Diagnostics.Runtime/StressLog/StressLog.cs
@@ -47,6 +47,7 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs
         private readonly ulong _startTimeStamp;
         private readonly DateTime? _startTimeUtc;
         private readonly bool _isV4;
+        private readonly StressLogVariant _variant;
 
         private readonly ulong[] _argScratch = new ulong[StressLogConstants.MaxArgumentCount];
 
@@ -63,7 +64,8 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs
                           ulong tickFrequency,
                           ulong startTimeStamp,
                           DateTime? startTimeUtc,
-                          bool isV4)
+                          bool isV4,
+                          StressLogVariant variant)
         {
             _reader = reader;
             _options = options;
@@ -74,6 +76,7 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs
             _startTimeStamp = startTimeStamp;
             _startTimeUtc = startTimeUtc;
             _isV4 = isV4;
+            _variant = variant;
             _formatCache = new FormatStringCache(reader, budget, options.MaxFormatStringLength, options.MaxFormatStringCacheEntries);
             _argResolver = new ArgumentResolver(reader);
         }
@@ -158,6 +161,16 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs
                                                 AllocationBudget budget,
                                                 ReadOnlySpan<byte> header)
         {
+            // Variant detection. Modern CoreCLR initializes the 'padding'
+            // field at StressLog offset 32 to UINT_MAX (0xFFFFFFFF) as a
+            // sentinel; the .NET Framework runtime stores its TLS slot index
+            // there (a small positive integer). This is a stable signal we
+            // verified across all five integration-test dump variants.
+            uint sentinel = BinaryPrimitives.ReadUInt32LittleEndian(header.Slice(StressLogLayout.InProc_Padding));
+            StressLogVariant variant = sentinel == 0xFFFFFFFFu
+                ? StressLogVariant.Core
+                : StressLogVariant.FrameworkV1;
+
             ulong logs = BinaryPrimitives.ReadUInt64LittleEndian(header.Slice(StressLogLayout.InProc_Logs));
             ulong tickFreq = BinaryPrimitives.ReadUInt64LittleEndian(header.Slice(StressLogLayout.InProc_TickFrequency));
             ulong startTs = BinaryPrimitives.ReadUInt64LittleEndian(header.Slice(StressLogLayout.InProc_StartTimeStamp));
@@ -175,18 +188,35 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs
                 // Malformed FILETIME; leave null.
             }
 
-            ReadOnlySpan<byte> entries = header.Slice(StressLogLayout.InProc_Modules,
-                                                      StressLogConstants.MaxModules * StressLogLayout.InProc_ModuleEntrySize);
-            // Use the module table only when at least one module entry's base
-            // address matches moduleOffset; otherwise fall back to single-module
-            // mode so a malformed log cannot remap addresses arbitrarily.
-            StressLogModuleTable modules = StressLogModuleTable.BuildInProcess(
-                entries,
-                moduleOffset,
-                hasModuleTable: true,
-                StressLogConstants.FormatOffsetMax);
+            // Framework's StressLog struct has no module table appended; the
+            // bytes we speculatively read at offset 80..160 are unrelated heap
+            // memory. Restrict module table parsing to Core, and let Framework
+            // fall through to the single-module path keyed off moduleOffset.
+            StressLogModuleTable modules;
+            if (variant == StressLogVariant.Core)
+            {
+                ReadOnlySpan<byte> entries = header.Slice(StressLogLayout.InProc_Modules,
+                                                          StressLogConstants.MaxModules * StressLogLayout.InProc_ModuleEntrySize);
+                modules = StressLogModuleTable.BuildInProcess(
+                    entries16: entries,
+                    moduleOffset,
+                    hasModuleTable: true,
+                    StressLogConstants.FormatOffsetMax);
+            }
+            else
+            {
+                modules = StressLogModuleTable.BuildInProcess(
+                    entries16: ReadOnlySpan<byte>.Empty,
+                    moduleOffset,
+                    hasModuleTable: false,
+                    StressLogConstants.FormatOffsetMax);
+            }
 
-            return new StressLog(reader, options, budget, modules, logs, tickFreq, startTs, startTimeUtc, isV4: true);
+            // V4 message decoding has been used since the addition of the
+            // module table in CoreCLR; Framework V1 predates it and uses V3.
+            bool isV4 = variant == StressLogVariant.Core;
+
+            return new StressLog(reader, options, budget, modules, logs, tickFreq, startTs, startTimeUtc, isV4: isV4, variant: variant);
         }
 
         private static StressLog? OpenMemoryMapped(IDataReader reader,
@@ -214,7 +244,7 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs
 
             StressLogModuleTable modules = StressLogModuleTable.BuildMemoryMapped(entries, maxOffset);
 
-            return new StressLog(reader, options, budget, modules, logs, tickFreq, startTs, startTimeUtc: null, isV4: true);
+            return new StressLog(reader, options, budget, modules, logs, tickFreq, startTs, startTimeUtc: null, isV4: true, variant: StressLogVariant.Core);
         }
 
         /// <summary>
@@ -320,7 +350,8 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs
                     diagnostic: raiseDiagnostic,
                     threadAddress: addr,
                     threadHeader: threadHeader,
-                    isV4: _isV4);
+                    isV4: _isV4,
+                    variant: _variant);
 
                 iterators.Add(iter);
                 addr = nextAddr;

--- a/src/Microsoft.Diagnostics.Runtime/StressLog/StressLog.cs
+++ b/src/Microsoft.Diagnostics.Runtime/StressLog/StressLog.cs
@@ -1,0 +1,382 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Buffers.Binary;
+using System.Collections.Generic;
+using System.Threading;
+using Microsoft.Diagnostics.Runtime;
+using Microsoft.Diagnostics.Runtime.StressLogs.Internal;
+
+namespace Microsoft.Diagnostics.Runtime.StressLogs
+{
+    /// <summary>
+    /// Reads a runtime stress log from a target process or dump. The
+    /// implementation validates every input byte: every linked-list walk
+    /// is bounded and cycle-detected, every memory read is checked against
+    /// the requested length, and no log-derived bytes are ever passed to
+    /// a runtime formatter.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is the public entry point for stress-log analysis. Callers open
+    /// a log via <see cref="TryOpen"/>, then enumerate messages with
+    /// <see cref="EnumerateMessages"/>. Each yielded
+    /// <see cref="StressLogMessage"/> is valid only for the body of the
+    /// iteration step that produced it.
+    /// </para>
+    /// <para>
+    /// Format string bytes are sanitized and decoded inside the
+    /// <see cref="StressLog"/> instance. Consumers receive only typed,
+    /// sanitized tokens through <see cref="IStressLogFormatReceiver"/>; the
+    /// raw bytes never escape this assembly.
+    /// </para>
+    /// </remarks>
+    public sealed class StressLog : IDisposable
+    {
+        private readonly IDataReader _reader;
+        private readonly StressLogOptions _options;
+        private readonly AllocationBudget _budget;
+        private readonly StressLogModuleTable _modules;
+        private readonly FormatStringCache _formatCache;
+        private readonly ArgumentResolver _argResolver;
+
+        private readonly ulong _firstThreadAddr;
+        private readonly ulong _tickFrequency;
+        private readonly ulong _startTimeStamp;
+        private readonly DateTime? _startTimeUtc;
+        private readonly bool _isV4;
+
+        private readonly ulong[] _argScratch = new ulong[StressLogConstants.MaxArgumentCount];
+
+        private ThreadIterator? _currentIterator;
+        private int _generationCounter;
+
+        private bool _disposed;
+
+        private StressLog(IDataReader reader,
+                          StressLogOptions options,
+                          AllocationBudget budget,
+                          StressLogModuleTable modules,
+                          ulong firstThreadAddr,
+                          ulong tickFrequency,
+                          ulong startTimeStamp,
+                          DateTime? startTimeUtc,
+                          bool isV4)
+        {
+            _reader = reader;
+            _options = options;
+            _budget = budget;
+            _modules = modules;
+            _firstThreadAddr = firstThreadAddr;
+            _tickFrequency = tickFrequency;
+            _startTimeStamp = startTimeStamp;
+            _startTimeUtc = startTimeUtc;
+            _isV4 = isV4;
+            _formatCache = new FormatStringCache(reader, budget, options.MaxFormatStringLength, options.MaxFormatStringCacheEntries);
+            _argResolver = new ArgumentResolver(reader);
+        }
+
+        /// <summary>
+        /// Raised when the parser detects malformed input. Diagnostics are
+        /// best-effort and may be raised before the corresponding
+        /// <see cref="EnumerateMessages"/> sequence terminates.
+        /// </summary>
+        public event Action<StressLogDiagnostic>? Diagnostic;
+
+        /// <summary>
+        /// Approximate wall-clock time at which the runtime initialized the
+        /// stress log. Available only for in-process logs; memory-mapped
+        /// logs do not record an absolute time and report <see langword="null"/>.
+        /// </summary>
+        public DateTime? StartTimeUtc => _startTimeUtc;
+
+        /// <summary>
+        /// Try to open the stress log at <paramref name="address"/> in the
+        /// target. Returns <see langword="false"/> on any structural
+        /// validation failure.
+        /// </summary>
+        public static bool TryOpen(IDataReader reader, ulong address, out StressLog? stressLog)
+        {
+            stressLog = null;
+            if (reader is null) return false;
+            if (reader.PointerSize != 8) return false;
+            if (address == 0) return false;
+
+            StressLogOptions options = StressLogOptions.Default;
+            AllocationBudget budget = new AllocationBudget(options.MaxTotalBytesAllocated);
+
+            // Speculatively read the larger memory-mapped header. If the magic
+            // does not match, treat as in-process and use only the first
+            // InProc_HeaderSize bytes.
+            Span<byte> header = stackalloc byte[StressLogLayout.Mm_HeaderReadSize];
+            int got = reader.Read(address, header);
+            if (got < StressLogLayout.InProc_HeaderSize)
+                return false;
+
+            uint maybeMagic = got >= StressLogLayout.Mm_Version
+                ? BinaryPrimitives.ReadUInt32LittleEndian(header.Slice(StressLogLayout.Mm_Magic))
+                : 0;
+
+            bool isMemoryMapped = got >= StressLogLayout.Mm_HeaderReadSize
+                                  && maybeMagic == StressLogConstants.MemoryMappedMagic;
+
+            if (isMemoryMapped)
+            {
+                stressLog = OpenMemoryMapped(reader, options, budget, header);
+            }
+            else
+            {
+                stressLog = OpenInProcess(reader, options, budget, header.Slice(0, StressLogLayout.InProc_HeaderSize));
+            }
+
+            return stressLog is not null;
+        }
+
+        private static StressLog? OpenInProcess(IDataReader reader,
+                                                StressLogOptions options,
+                                                AllocationBudget budget,
+                                                ReadOnlySpan<byte> header)
+        {
+            ulong logs = BinaryPrimitives.ReadUInt64LittleEndian(header.Slice(StressLogLayout.InProc_Logs));
+            ulong tickFreq = BinaryPrimitives.ReadUInt64LittleEndian(header.Slice(StressLogLayout.InProc_TickFrequency));
+            ulong startTs = BinaryPrimitives.ReadUInt64LittleEndian(header.Slice(StressLogLayout.InProc_StartTimeStamp));
+            ulong startFiletime = BinaryPrimitives.ReadUInt64LittleEndian(header.Slice(StressLogLayout.InProc_StartTime));
+            ulong moduleOffset = BinaryPrimitives.ReadUInt64LittleEndian(header.Slice(StressLogLayout.InProc_ModuleOffset));
+
+            DateTime? startTimeUtc = null;
+            try
+            {
+                if (startFiletime != 0)
+                    startTimeUtc = DateTime.FromFileTimeUtc((long)startFiletime);
+            }
+            catch (ArgumentOutOfRangeException)
+            {
+                // Malformed FILETIME; leave null.
+            }
+
+            ReadOnlySpan<byte> entries = header.Slice(StressLogLayout.InProc_Modules,
+                                                      StressLogConstants.MaxModules * StressLogLayout.InProc_ModuleEntrySize);
+            // Use the module table only when at least one module entry's base
+            // address matches moduleOffset; otherwise fall back to single-module
+            // mode so a malformed log cannot remap addresses arbitrarily.
+            StressLogModuleTable modules = StressLogModuleTable.BuildInProcess(
+                entries,
+                moduleOffset,
+                hasModuleTable: true,
+                StressLogConstants.FormatOffsetMax);
+
+            return new StressLog(reader, options, budget, modules, logs, tickFreq, startTs, startTimeUtc, isV4: true);
+        }
+
+        private static StressLog? OpenMemoryMapped(IDataReader reader,
+                                                   StressLogOptions options,
+                                                   AllocationBudget budget,
+                                                   ReadOnlySpan<byte> header)
+        {
+            uint version = BinaryPrimitives.ReadUInt32LittleEndian(header.Slice(StressLogLayout.Mm_Version));
+            if (version != StressLogConstants.MemoryMappedVersionV1
+                && version != StressLogConstants.MemoryMappedVersionV2)
+            {
+                return null;
+            }
+
+            ulong logs = BinaryPrimitives.ReadUInt64LittleEndian(header.Slice(StressLogLayout.Mm_Logs));
+            ulong tickFreq = BinaryPrimitives.ReadUInt64LittleEndian(header.Slice(StressLogLayout.Mm_TickFrequency));
+            ulong startTs = BinaryPrimitives.ReadUInt64LittleEndian(header.Slice(StressLogLayout.Mm_StartTimeStamp));
+
+            ReadOnlySpan<byte> entries = header.Slice(StressLogLayout.Mm_Modules,
+                                                      StressLogConstants.MaxModules * StressLogLayout.InProc_ModuleEntrySize);
+
+            ulong maxOffset = version == StressLogConstants.MemoryMappedVersionV1
+                ? (1UL << StressLogConstants.FormatOffsetLowBits)
+                : StressLogConstants.FormatOffsetMax;
+
+            StressLogModuleTable modules = StressLogModuleTable.BuildMemoryMapped(entries, maxOffset);
+
+            return new StressLog(reader, options, budget, modules, logs, tickFreq, startTs, startTimeUtc: null, isV4: true);
+        }
+
+        /// <summary>
+        /// Enumerate messages from all threads in newest-first chronological
+        /// order. Iteration stops cooperatively when
+        /// <paramref name="cancellationToken"/> is canceled or when every
+        /// thread has been drained.
+        /// </summary>
+        public IEnumerable<StressLogMessage> EnumerateMessages(CancellationToken cancellationToken = default)
+        {
+            ThrowIfDisposed();
+
+            List<ThreadIterator> iterators = new();
+            try
+            {
+                if (!LoadThreadIterators(iterators))
+                    yield break;
+
+                // Prime all iterators (each has its first message decoded).
+                for (int i = iterators.Count - 1; i >= 0; i--)
+                {
+                    if (!iterators[i].Advance())
+                    {
+                        iterators[i].Dispose();
+                        iterators.RemoveAt(i);
+                    }
+                }
+
+                // Yield in newest-first order via repeated linear max scan.
+                // Iterator count is bounded by MaxThreads; the linear scan is
+                // O(threads) per message, which is fine for typical numbers.
+                while (iterators.Count > 0)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    int newest = 0;
+                    for (int i = 1; i < iterators.Count; i++)
+                    {
+                        if (iterators[i].TimeStamp > iterators[newest].TimeStamp)
+                            newest = i;
+                    }
+
+                    ThreadIterator iter = iterators[newest];
+                    _currentIterator = iter;
+                    int gen = ++_generationCounter;
+                    CopyArgsToScratch(iter);
+
+                    yield return new StressLogMessage(
+                        log: this,
+                        generation: gen,
+                        threadId: iter.ThreadId,
+                        facility: iter.Facility,
+                        timeStampTicks: iter.TimeStamp,
+                        formatAddress: ResolveFormatAddress(iter.FormatOffset),
+                        argumentCount: (byte)iter.ArgumentCount);
+
+                    if (!iter.Advance())
+                    {
+                        iter.Dispose();
+                        iterators.RemoveAt(newest);
+                    }
+                }
+            }
+            finally
+            {
+                _currentIterator = null;
+                foreach (ThreadIterator iter in iterators)
+                    iter.Dispose();
+            }
+        }
+
+        private bool LoadThreadIterators(List<ThreadIterator> iterators)
+        {
+            HashSet<ulong> visited = new();
+            ulong addr = _firstThreadAddr;
+
+            Span<byte> threadHeader = stackalloc byte[StressLogLayout.Thread_HeaderSize];
+            Action<StressLogDiagnostic> raiseDiagnostic = d => Diagnostic?.Invoke(d);
+
+            while (addr != 0)
+            {
+                if (iterators.Count >= _options.MaxThreads)
+                {
+                    Diagnostic?.Invoke(new StressLogDiagnostic(StressLogDiagnosticKind.LimitExceeded, addr));
+                    break;
+                }
+
+                if (!visited.Add(addr))
+                {
+                    Diagnostic?.Invoke(new StressLogDiagnostic(StressLogDiagnosticKind.CorruptThread, addr));
+                    break;
+                }
+
+                int got = _reader.Read(addr, threadHeader);
+                if (got < StressLogLayout.Thread_HeaderSize)
+                {
+                    Diagnostic?.Invoke(new StressLogDiagnostic(StressLogDiagnosticKind.ReadMemoryFailed, addr));
+                    break;
+                }
+
+                ulong nextAddr = BinaryPrimitives.ReadUInt64LittleEndian(threadHeader.Slice(StressLogLayout.Thread_Next));
+                ThreadIterator iter = new ThreadIterator(_reader, _options, _budget,
+                    diagnostic: raiseDiagnostic,
+                    threadAddress: addr,
+                    threadHeader: threadHeader,
+                    isV4: _isV4);
+
+                iterators.Add(iter);
+                addr = nextAddr;
+            }
+
+            return iterators.Count > 0;
+        }
+
+        private void CopyArgsToScratch(ThreadIterator iter)
+        {
+            int n = iter.ArgumentCount;
+            for (int i = 0; i < n; i++)
+                _argScratch[i] = iter.GetArgument(i);
+        }
+
+        private ulong ResolveFormatAddress(ulong formatOffset)
+        {
+            return _modules.TryResolveFormatOffset(formatOffset, out ulong addr) ? addr : 0;
+        }
+
+        internal double ElapsedSecondsFor(ulong timeStamp)
+        {
+            if (_tickFrequency == 0) return 0;
+            ulong delta = timeStamp >= _startTimeStamp ? timeStamp - _startTimeStamp : 0;
+            return (double)delta / _tickFrequency;
+        }
+
+        internal StressLogKnownFormat LookupKnownFormat(ulong address)
+        {
+            if (address == 0) return StressLogKnownFormat.None;
+            if (_formatCache.TryGet(address, out _, out StressLogKnownFormat known))
+                return known;
+            return StressLogKnownFormat.None;
+        }
+
+        internal ulong GetArgument(int generation, int index, int argCount)
+        {
+            if (generation != _generationCounter || _currentIterator is null) return 0;
+            if ((uint)index >= (uint)argCount) return 0;
+            return _argScratch[index];
+        }
+
+        internal void FormatMessage<T>(int generation, ulong formatAddress, int argCount, ref T receiver)
+            where T : struct, IStressLogFormatReceiver
+        {
+            if (generation != _generationCounter || _currentIterator is null) return;
+            if (formatAddress == 0)
+            {
+                receiver.Literal(s_unresolvedFormat.AsSpan());
+                return;
+            }
+
+            if (!_formatCache.TryGet(formatAddress, out ReadOnlyMemory<byte> formatBytes, out _) || formatBytes.Length == 0)
+            {
+                receiver.Literal(s_unresolvedFormat.AsSpan());
+                return;
+            }
+
+            ReadOnlySpan<ulong> args = _argScratch.AsSpan(0, argCount);
+            FormatStringParser.Parse(formatBytes.Span, args, _argResolver, ref receiver);
+        }
+
+        private static readonly byte[] s_unresolvedFormat =
+            System.Text.Encoding.ASCII.GetBytes("<unresolved-format>");
+
+        private void ThrowIfDisposed()
+        {
+            if (_disposed)
+                throw new ObjectDisposedException(nameof(StressLog));
+        }
+
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _disposed = true;
+            _currentIterator = null;
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/StressLog/StressLog.cs
+++ b/src/Microsoft.Diagnostics.Runtime/StressLog/StressLog.cs
@@ -106,15 +106,8 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs
         /// reads from the runtime's data target. Returns <see langword="false"/>
         /// if the runtime does not have stress logging enabled, the DAC does
         /// not support <c>GetStressLogAddress</c>, or the resulting log fails
-        /// validation.
-        /// </summary>
-        internal static bool TryOpen(ClrRuntime runtime, out StressLog? stressLog)
-            => TryOpen(runtime, out stressLog, out _);
-
-        /// <summary>
-        /// Try to open the stress log for the given <paramref name="runtime"/>,
-        /// returning a human-readable explanation in
-        /// <paramref name="failureReason"/> when the open fails.
+        /// validation; <paramref name="failureReason"/> is a human-readable
+        /// explanation in that case.
         /// </summary>
         internal static bool TryOpen(ClrRuntime runtime, out StressLog? stressLog, out string? failureReason)
         {
@@ -139,11 +132,9 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs
         /// <summary>
         /// Try to open the stress log at <paramref name="address"/> in the
         /// target. Returns <see langword="false"/> on any structural
-        /// validation failure.
+        /// validation failure; <paramref name="failureReason"/> is a
+        /// human-readable explanation in that case.
         /// </summary>
-        internal static bool TryOpen(IDataReader reader, ulong address, out StressLog? stressLog)
-            => TryOpen(reader, address, out stressLog, out _);
-
         internal static bool TryOpen(IDataReader reader, ulong address, out StressLog? stressLog, out string? failureReason)
         {
             stressLog = null;
@@ -370,8 +361,14 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs
                 }
 
                 // Yield in newest-first order via repeated linear max scan.
-                // Iterator count is bounded by MaxThreads; the linear scan is
-                // O(threads) per message, which is fine for typical numbers.
+                // Iterator count is bounded by StressLogOptions.MaxThreads
+                // (100,000), but real dumps typically have tens to hundreds
+                // of threads, where the scan is dwarfed by the per-message
+                // I/O performed by the outer loop. A min-heap would cut the
+                // per-message cost to O(log threads) at the cost of an extra
+                // allocation per enumeration plus reheap-on-advance complexity;
+                // we keep the linear scan because the simplicity wins at the
+                // thread counts we actually see.
                 while (iterators.Count > 0)
                 {
                     cancellationToken.ThrowIfCancellationRequested();

--- a/src/Microsoft.Diagnostics.Runtime/StressLog/StressLog.cs
+++ b/src/Microsoft.Diagnostics.Runtime/StressLog/StressLog.cs
@@ -350,7 +350,7 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs
 
             // Each enumeration owns its own context so concurrent foreach loops
             // do not clobber each other's argument scratch / current iterator.
-            ArgumentResolver argResolver = new ArgumentResolver(_reader, _options.MaxStringArgumentLength);
+            ArgumentResolver argResolver = new ArgumentResolver(_reader, _options.MaxStringArgumentLength, _layout.PointerSize);
             StressLogEnumerationContext context = new StressLogEnumerationContext(this, argResolver);
 
             List<ThreadIterator> iterators = new();

--- a/src/Microsoft.Diagnostics.Runtime/StressLog/StressLog.cs
+++ b/src/Microsoft.Diagnostics.Runtime/StressLog/StressLog.cs
@@ -40,7 +40,6 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs
         private readonly AllocationBudget _budget;
         private readonly StressLogModuleTable _modules;
         private readonly FormatStringCache _formatCache;
-        private readonly ArgumentResolver _argResolver;
 
         private readonly ulong _firstThreadAddr;
         private readonly ulong _tickFrequency;
@@ -48,11 +47,6 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs
         private readonly DateTime? _startTimeUtc;
         private readonly bool _isV4;
         private readonly StressLogVariant _variant;
-
-        private readonly ulong[] _argScratch = new ulong[StressLogConstants.MaxArgumentCount];
-
-        private ThreadIterator? _currentIterator;
-        private int _generationCounter;
 
         private bool _disposed;
 
@@ -78,7 +72,6 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs
             _isV4 = isV4;
             _variant = variant;
             _formatCache = new FormatStringCache(reader, budget, options.MaxFormatStringLength, options.MaxFormatStringCacheEntries);
-            _argResolver = new ArgumentResolver(reader);
         }
 
         /// <summary>
@@ -293,9 +286,22 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs
         /// <paramref name="cancellationToken"/> is canceled or when every
         /// thread has been drained.
         /// </summary>
+        /// <remarks>
+        /// Each call allocates an independent enumeration context. Two
+        /// concurrent enumerations on the same <see cref="StressLog"/> do
+        /// not share argument scratch buffers, so message access through
+        /// <see cref="StressLogMessage.GetArgument"/> and
+        /// <see cref="StressLogMessage.Format{T}"/> remains correct under
+        /// concurrent <c>foreach</c> loops.
+        /// </remarks>
         public IEnumerable<StressLogMessage> EnumerateMessages(CancellationToken cancellationToken = default)
         {
             ThrowIfDisposed();
+
+            // Each enumeration owns its own context so concurrent foreach loops
+            // do not clobber each other's argument scratch / current iterator.
+            ArgumentResolver argResolver = new ArgumentResolver(_reader, _options.MaxStringArgumentLength);
+            StressLogEnumerationContext context = new StressLogEnumerationContext(this, argResolver);
 
             List<ThreadIterator> iterators = new();
             try
@@ -328,12 +334,10 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs
                     }
 
                     ThreadIterator iter = iterators[newest];
-                    _currentIterator = iter;
-                    int gen = ++_generationCounter;
-                    CopyArgsToScratch(iter);
+                    int gen = context.CaptureFromIterator(iter);
 
                     yield return new StressLogMessage(
-                        log: this,
+                        context: context,
                         generation: gen,
                         threadId: iter.OSThreadId,
                         facility: iter.Facility,
@@ -350,7 +354,7 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs
             }
             finally
             {
-                _currentIterator = null;
+                context.Clear();
                 foreach (ThreadIterator iter in iterators)
                     iter.Dispose();
             }
@@ -400,13 +404,6 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs
             return iterators.Count > 0;
         }
 
-        private void CopyArgsToScratch(ThreadIterator iter)
-        {
-            int n = iter.ArgumentCount;
-            for (int i = 0; i < n; i++)
-                _argScratch[i] = iter.GetArgument(i);
-        }
-
         private ulong ResolveFormatAddress(ulong formatOffset)
         {
             return _modules.TryResolveFormatOffset(formatOffset, out ulong addr) ? addr : 0;
@@ -427,17 +424,20 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs
             return StressLogKnownFormat.None;
         }
 
-        internal ulong GetArgument(int generation, int index, int argCount)
-        {
-            if (generation != _generationCounter || _currentIterator is null) return 0;
-            if ((uint)index >= (uint)argCount) return 0;
-            return _argScratch[index];
-        }
-
-        internal void FormatMessage<T>(int generation, ulong formatAddress, int argCount, ref T receiver)
+        /// <summary>
+        /// Render a stress log message into a receiver using the supplied
+        /// per-enumeration argument scratch and resolver. Called by
+        /// <see cref="StressLogEnumerationContext"/> after it has confirmed
+        /// the calling <see cref="StressLogMessage"/> still belongs to the
+        /// current enumeration generation.
+        /// </summary>
+        internal void FormatMessage<T>(ulong[] argScratch,
+                                       ArgumentResolver argResolver,
+                                       ulong formatAddress,
+                                       int argCount,
+                                       ref T receiver)
             where T : struct, IStressLogFormatReceiver
         {
-            if (generation != _generationCounter || _currentIterator is null) return;
             if (formatAddress == 0)
             {
                 receiver.Literal(s_unresolvedFormat.AsSpan());
@@ -450,8 +450,8 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs
                 return;
             }
 
-            ReadOnlySpan<ulong> args = _argScratch.AsSpan(0, argCount);
-            FormatStringParser.Parse(formatBytes.Span, args, _argResolver, ref receiver);
+            ReadOnlySpan<ulong> args = argScratch.AsSpan(0, argCount);
+            FormatStringParser.Parse(formatBytes.Span, args, argResolver, ref receiver);
         }
 
         private static readonly byte[] s_unresolvedFormat =
@@ -467,7 +467,6 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs
         {
             if (_disposed) return;
             _disposed = true;
-            _currentIterator = null;
         }
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/StressLog/StressLog.cs
+++ b/src/Microsoft.Diagnostics.Runtime/StressLog/StressLog.cs
@@ -6,6 +6,7 @@ using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Threading;
 using Microsoft.Diagnostics.Runtime;
+using Microsoft.Diagnostics.Runtime.DacInterface;
 using Microsoft.Diagnostics.Runtime.StressLogs.Internal;
 
 namespace Microsoft.Diagnostics.Runtime.StressLogs
@@ -20,7 +21,7 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs
     /// <remarks>
     /// <para>
     /// This is the public entry point for stress-log analysis. Callers open
-    /// a log via <see cref="TryOpen"/>, then enumerate messages with
+    /// a log via <c>TryOpen</c>, then enumerate messages with
     /// <see cref="EnumerateMessages"/>. Each yielded
     /// <see cref="StressLogMessage"/> is valid only for the body of the
     /// iteration step that produced it.
@@ -92,6 +93,26 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs
         public DateTime? StartTimeUtc => _startTimeUtc;
 
         /// <summary>
+        /// Try to open the stress log for the given <paramref name="runtime"/>.
+        /// Looks up the stress log address through the runtime's DAC and
+        /// reads from the runtime's data target. Returns <see langword="false"/>
+        /// if the runtime does not have stress logging enabled, the DAC does
+        /// not support <c>GetStressLogAddress</c>, or the resulting log fails
+        /// validation.
+        /// </summary>
+        public static bool TryOpen(ClrRuntime runtime, out StressLog? stressLog)
+        {
+            stressLog = null;
+            if (runtime is null) return false;
+
+            ulong address = runtime.GetStressLogAddress();
+            if (address == 0)
+                return false;
+
+            return TryOpen(runtime.DataTarget.DataReader, address, out stressLog);
+        }
+
+        /// <summary>
         /// Try to open the stress log at <paramref name="address"/> in the
         /// target. Returns <see langword="false"/> on any structural
         /// validation failure.
@@ -102,7 +123,6 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs
             if (reader is null) return false;
             if (reader.PointerSize != 8) return false;
             if (address == 0) return false;
-
             StressLogOptions options = StressLogOptions.Default;
             AllocationBudget budget = new AllocationBudget(options.MaxTotalBytesAllocated);
 

--- a/src/Microsoft.Diagnostics.Runtime/StressLog/StressLogDiagnostic.cs
+++ b/src/Microsoft.Diagnostics.Runtime/StressLog/StressLogDiagnostic.cs
@@ -1,0 +1,32 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Diagnostics.Runtime.StressLogs
+{
+    /// <summary>
+    /// A non-fatal diagnostic raised by the stress log reader while enumerating
+    /// a malformed or partially-readable log. Consumers may choose to log these
+    /// or display them to the user; enumeration continues past the offending
+    /// record where possible.
+    /// </summary>
+    public readonly struct StressLogDiagnostic
+    {
+        internal StressLogDiagnostic(StressLogDiagnosticKind kind, ulong address)
+        {
+            Kind = kind;
+            Address = address;
+        }
+
+        /// <summary>Category of the issue.</summary>
+        public StressLogDiagnosticKind Kind { get; }
+
+        /// <summary>
+        /// Address in the target at which the issue was detected, or 0 if not
+        /// associated with a specific address.
+        /// </summary>
+        public ulong Address { get; }
+
+        /// <inheritdoc/>
+        public override string ToString() => $"{Kind} @ 0x{Address:x}";
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/StressLog/StressLogDiagnosticKind.cs
+++ b/src/Microsoft.Diagnostics.Runtime/StressLog/StressLogDiagnosticKind.cs
@@ -1,0 +1,27 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Diagnostics.Runtime.StressLogs
+{
+    /// <summary>
+    /// Categorizes a non-fatal corruption event raised by the stress log reader
+    /// while enumerating a malformed or partially-readable log.
+    /// </summary>
+    public enum StressLogDiagnosticKind
+    {
+        /// <summary>A thread record looked malformed (signature, list cycle, sizes).</summary>
+        CorruptThread,
+
+        /// <summary>A chunk record looked malformed (signature, list cycle).</summary>
+        CorruptChunk,
+
+        /// <summary>A message record looked malformed (arg count, format offset, layout).</summary>
+        CorruptMessage,
+
+        /// <summary>An <see cref="IMemoryReader"/> read returned fewer bytes than requested.</summary>
+        ReadMemoryFailed,
+
+        /// <summary>A configured limit (thread count, chunk count, allocation budget) was hit.</summary>
+        LimitExceeded,
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/StressLog/StressLogFacility.cs
+++ b/src/Microsoft.Diagnostics.Runtime/StressLog/StressLogFacility.cs
@@ -1,0 +1,36 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace Microsoft.Diagnostics.Runtime.StressLogs
+{
+    /// <summary>
+    /// Bit flags identifying which runtime subsystem emitted a stress log message.
+    /// Mirrors the runtime's <c>loglf.h</c> facility values.
+    /// </summary>
+    [Flags]
+    public enum StressLogFacility : uint
+    {
+        /// <summary>No facility.</summary>
+        None        = 0x00000000,
+
+        /// <summary>Garbage collector.</summary>
+        GC          = 0x00000001,
+
+        /// <summary>Garbage collector roots.</summary>
+        GCRoots     = 0x00000002,
+
+        /// <summary>Garbage collector allocation.</summary>
+        GCAlloc     = 0x00000100,
+
+        /// <summary>GC information / detailed tracing.</summary>
+        GCInfo      = 0x00010000,
+
+        /// <summary>EE memory subsystem.</summary>
+        EEMem       = 0x00020000,
+
+        /// <summary>Always logged regardless of facility filter.</summary>
+        Always      = 0x80000000,
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/StressLog/StressLogIntegerKind.cs
+++ b/src/Microsoft.Diagnostics.Runtime/StressLog/StressLogIntegerKind.cs
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Diagnostics.Runtime.StressLogs
+{
+    /// <summary>
+    /// The numeric format requested by an integer-typed stress log argument.
+    /// </summary>
+    public enum StressLogIntegerKind
+    {
+        /// <summary>Signed decimal (printf <c>%d</c>, <c>%i</c>).</summary>
+        Decimal,
+
+        /// <summary>Unsigned decimal (printf <c>%u</c>).</summary>
+        Unsigned,
+
+        /// <summary>Lowercase hexadecimal (printf <c>%x</c>).</summary>
+        Hex,
+
+        /// <summary>Uppercase hexadecimal (printf <c>%X</c>).</summary>
+        HexUpper,
+
+        /// <summary>Single character (printf <c>%c</c>).</summary>
+        Char,
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/StressLog/StressLogKnownFormat.cs
+++ b/src/Microsoft.Diagnostics.Runtime/StressLog/StressLogKnownFormat.cs
@@ -1,0 +1,34 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Diagnostics.Runtime.StressLogs
+{
+    /// <summary>
+    /// Identifies a stress log message that uses one of the well-known
+    /// runtime format strings. Consumers (notably the GC history commands)
+    /// use this in lieu of pattern-matching the format string text.
+    /// </summary>
+    public enum StressLogKnownFormat
+    {
+        /// <summary>Not a recognized well-known message.</summary>
+        None,
+
+        /// <summary>Beginning of a GC.</summary>
+        GcStart,
+
+        /// <summary>End of a GC.</summary>
+        GcEnd,
+
+        /// <summary>A GC root that was relocated during compaction.</summary>
+        GcRoot,
+
+        /// <summary>A GC root that was promoted (kept alive).</summary>
+        GcRootPromote,
+
+        /// <summary>A plug of objects that was relocated.</summary>
+        GcPlugMove,
+
+        /// <summary>A task switch marker.</summary>
+        TaskSwitch,
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/StressLog/StressLogMessage.cs
+++ b/src/Microsoft.Diagnostics.Runtime/StressLog/StressLogMessage.cs
@@ -1,0 +1,105 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Microsoft.Diagnostics.Runtime.StressLogs.Internal;
+
+namespace Microsoft.Diagnostics.Runtime.StressLogs
+{
+    /// <summary>
+    /// A single message decoded from a runtime stress log. The contents of
+    /// the message are validated; argument values and format string bytes
+    /// are accessible only through methods on this struct, which route
+    /// through the owning <see cref="StressLog"/> so that all reads are
+    /// bounded and sanitized.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A <see cref="StressLogMessage"/> is only valid for the body of the
+    /// <c>foreach</c> iteration that yielded it. Once iteration advances
+    /// (or the owning <see cref="StressLog"/> is disposed), accessors that
+    /// resolve back to dump-derived data (<see cref="GetArgument"/>,
+    /// <see cref="Format{T}"/>) return defaults or perform no work.
+    /// </para>
+    /// <para>
+    /// Format string bytes are deliberately not exposed. Use
+    /// <see cref="Format{T}"/> with an
+    /// <see cref="IStressLogFormatReceiver"/> implementation to render the
+    /// message; the parser will hand the receiver only typed, sanitized
+    /// tokens.
+    /// </para>
+    /// </remarks>
+    public readonly struct StressLogMessage
+    {
+        private readonly StressLog? _log;
+        private readonly int _generation;
+        private readonly ulong _formatAddress;
+
+        internal StressLogMessage(StressLog log,
+                                  int generation,
+                                  ulong threadId,
+                                  uint facility,
+                                  ulong timeStampTicks,
+                                  ulong formatAddress,
+                                  byte argumentCount)
+        {
+            _log = log;
+            _generation = generation;
+            _formatAddress = formatAddress;
+            ThreadId = threadId;
+            Facility = (StressLogFacility)facility;
+            TimeStampTicks = timeStampTicks;
+            ArgumentCount = argumentCount;
+        }
+
+        /// <summary>The id of the thread that wrote this message.</summary>
+        public ulong ThreadId { get; }
+
+        /// <summary>Facility bits as encoded in the message header.</summary>
+        public StressLogFacility Facility { get; }
+
+        /// <summary>
+        /// The raw QPC tick value the runtime stamped on the message. Use
+        /// <see cref="ElapsedSeconds"/> for a meaningful comparison across
+        /// messages; the absolute value is only meaningful relative to other
+        /// timestamps from the same log.
+        /// </summary>
+        public ulong TimeStampTicks { get; }
+
+        /// <summary>Seconds elapsed between the start of the log and this message.</summary>
+        public double ElapsedSeconds => _log?.ElapsedSecondsFor(TimeStampTicks) ?? 0.0;
+
+        /// <summary>Number of arguments carried by this message. Bounded to <c>[0, 63]</c>.</summary>
+        public int ArgumentCount { get; }
+
+        /// <summary>
+        /// One of a small set of well-known runtime format strings, or
+        /// <see cref="StressLogKnownFormat.None"/> if this message does not
+        /// match any of them. Useful for GC-history style filtering without
+        /// running the format parser.
+        /// </summary>
+        public StressLogKnownFormat KnownFormat
+            => _log?.LookupKnownFormat(_formatAddress) ?? StressLogKnownFormat.None;
+
+        /// <summary>
+        /// Read the argument at <paramref name="index"/> as a raw 64-bit
+        /// value. Returns <c>0</c> if the index is out of range or the
+        /// message has been invalidated by subsequent iteration.
+        /// </summary>
+        public ulong GetArgument(int index)
+            => _log?.GetArgument(_generation, index, ArgumentCount) ?? 0;
+
+        /// <summary>
+        /// Render the message into a receiver. The format string bytes are
+        /// fetched, sanitized, and parsed into a sequence of typed tokens
+        /// dispatched as method calls on <paramref name="receiver"/>. The
+        /// receiver is constrained to a value type to allow the call chain
+        /// to remain allocation-free.
+        /// </summary>
+        public void Format<T>(ref T receiver) where T : struct, IStressLogFormatReceiver
+        {
+            if (_log is null) return;
+            _log.FormatMessage(_generation, _formatAddress, ArgumentCount, ref receiver);
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/StressLog/StressLogMessage.cs
+++ b/src/Microsoft.Diagnostics.Runtime/StressLog/StressLogMessage.cs
@@ -46,14 +46,19 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs
             _log = log;
             _generation = generation;
             _formatAddress = formatAddress;
-            ThreadId = threadId;
+            OSThreadId = threadId;
             Facility = (StressLogFacility)facility;
             TimeStampTicks = timeStampTicks;
             ArgumentCount = argumentCount;
         }
 
-        /// <summary>The id of the thread that wrote this message.</summary>
-        public ulong ThreadId { get; }
+        /// <summary>
+        /// The OS-level thread id (Windows <c>GetCurrentThreadId</c> / Linux
+        /// <c>gettid</c>) of the thread that wrote this message. To correlate
+        /// with a <see cref="ClrThread"/>, compare with
+        /// <see cref="ClrThread.OSThreadId"/>.
+        /// </summary>
+        public ulong OSThreadId { get; }
 
         /// <summary>Facility bits as encoded in the message header.</summary>
         public StressLogFacility Facility { get; }

--- a/src/Microsoft.Diagnostics.Runtime/StressLog/StressLogMessage.cs
+++ b/src/Microsoft.Diagnostics.Runtime/StressLog/StressLogMessage.cs
@@ -10,8 +10,8 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs
     /// A single message decoded from a runtime stress log. The contents of
     /// the message are validated; argument values and format string bytes
     /// are accessible only through methods on this struct, which route
-    /// through the owning <see cref="StressLog"/> so that all reads are
-    /// bounded and sanitized.
+    /// through the per-enumeration context so that all reads are bounded
+    /// and sanitized.
     /// </summary>
     /// <remarks>
     /// <para>
@@ -31,11 +31,11 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs
     /// </remarks>
     public readonly struct StressLogMessage
     {
-        private readonly StressLog? _log;
+        private readonly StressLogEnumerationContext? _context;
         private readonly int _generation;
         private readonly ulong _formatAddress;
 
-        internal StressLogMessage(StressLog log,
+        internal StressLogMessage(StressLogEnumerationContext context,
                                   int generation,
                                   ulong threadId,
                                   uint facility,
@@ -43,7 +43,7 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs
                                   ulong formatAddress,
                                   byte argumentCount)
         {
-            _log = log;
+            _context = context;
             _generation = generation;
             _formatAddress = formatAddress;
             OSThreadId = threadId;
@@ -72,7 +72,7 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs
         public ulong TimeStampTicks { get; }
 
         /// <summary>Seconds elapsed between the start of the log and this message.</summary>
-        public double ElapsedSeconds => _log?.ElapsedSecondsFor(TimeStampTicks) ?? 0.0;
+        public double ElapsedSeconds => _context?.Log.ElapsedSecondsFor(TimeStampTicks) ?? 0.0;
 
         /// <summary>Number of arguments carried by this message. Bounded to <c>[0, 63]</c>.</summary>
         public int ArgumentCount { get; }
@@ -84,7 +84,7 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs
         /// running the format parser.
         /// </summary>
         public StressLogKnownFormat KnownFormat
-            => _log?.LookupKnownFormat(_formatAddress) ?? StressLogKnownFormat.None;
+            => _context?.Log.LookupKnownFormat(_formatAddress) ?? StressLogKnownFormat.None;
 
         /// <summary>
         /// Read the argument at <paramref name="index"/> as a raw 64-bit
@@ -92,7 +92,7 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs
         /// message has been invalidated by subsequent iteration.
         /// </summary>
         public ulong GetArgument(int index)
-            => _log?.GetArgument(_generation, index, ArgumentCount) ?? 0;
+            => _context?.GetArgument(_generation, index, ArgumentCount) ?? 0;
 
         /// <summary>
         /// Render the message into a receiver. The format string bytes are
@@ -103,8 +103,8 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs
         /// </summary>
         public void Format<T>(ref T receiver) where T : struct, IStressLogFormatReceiver
         {
-            if (_log is null) return;
-            _log.FormatMessage(_generation, _formatAddress, ArgumentCount, ref receiver);
+            if (_context is null) return;
+            _context.FormatMessage(_generation, _formatAddress, ArgumentCount, ref receiver);
         }
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/StressLog/StressLogPointerKind.cs
+++ b/src/Microsoft.Diagnostics.Runtime/StressLog/StressLogPointerKind.cs
@@ -1,0 +1,28 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Diagnostics.Runtime.StressLogs
+{
+    /// <summary>
+    /// Kind of pointer represented by a stress log argument.
+    /// Distinguishes plain pointers from runtime-typed pointers
+    /// that the consumer may want to resolve to method or type names.
+    /// </summary>
+    public enum StressLogPointerKind
+    {
+        /// <summary>Plain pointer (printf <c>%p</c>).</summary>
+        Plain,
+
+        /// <summary>MethodDesc pointer (printf <c>%pM</c>).</summary>
+        MethodDesc,
+
+        /// <summary>MethodTable pointer (printf <c>%pT</c>).</summary>
+        MethodTable,
+
+        /// <summary>C++ vtable pointer (printf <c>%pV</c>).</summary>
+        VTable,
+
+        /// <summary>Code address used in stack traces (printf <c>%pK</c>).</summary>
+        CodePointer,
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/StressLog/StressLogStringEncoding.cs
+++ b/src/Microsoft.Diagnostics.Runtime/StressLog/StressLogStringEncoding.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Diagnostics.Runtime.StressLogs
+{
+    /// <summary>
+    /// Encoding of a string-typed stress log argument as it was stored in the target.
+    /// </summary>
+    public enum StressLogStringEncoding
+    {
+        /// <summary>
+        /// Narrow string in the target. Corresponds to printf <c>%s</c> / <c>%hs</c>.
+        /// The bytes have been interpreted as UTF-8 and any unrepresentable
+        /// or control characters replaced.
+        /// </summary>
+        Utf8,
+
+        /// <summary>
+        /// Wide string in the target. Corresponds to printf <c>%S</c> / <c>%ls</c>.
+        /// The bytes have been interpreted as UTF-16LE and any unrepresentable
+        /// or control characters replaced; the receiver still gets ASCII bytes.
+        /// </summary>
+        Utf16,
+    }
+}

--- a/src/TestTargets/StressLog/StressLog.cs
+++ b/src/TestTargets/StressLog/StressLog.cs
@@ -1,0 +1,63 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+
+// Test target for stress log integration tests. The runtime is launched with
+// the stress log enabled via DOTNET_StressLog / COMPlus_StressLog env vars,
+// then this program forces several full, compacting, blocking GCs. Those GCs
+// emit GcStart/GcEnd plus per-relocation messages into the stress log, which
+// the test then parses out of the dump.
+//
+// The program ends with a deliberate unhandled exception so the test harness
+// (createdump on Linux/macOS, DbgEng on Windows) captures a process dump.
+class Program
+{
+    static void Main()
+    {
+        // Build a graph that has both reachable and unreachable references so
+        // a compacting GC actually has work to relocate. Use varied object
+        // sizes to encourage gen-2 promotion and at least one plug move.
+        const int RootCount = 256;
+        object[] roots = new object[RootCount];
+
+        Random rng = new Random(0x5712);
+        for (int i = 0; i < RootCount; i++)
+        {
+            int size = 16 + rng.Next(0, 256);
+            byte[] payload = new byte[size];
+            rng.NextBytes(payload);
+
+            // Make some roots a small tree so there are interior references
+            // for the GC to walk and (potentially) relocate.
+            List<object> children = new List<object>(4);
+            for (int j = 0; j < 4; j++)
+            {
+                children.Add(new byte[8 + rng.Next(0, 32)]);
+            }
+
+            roots[i] = new object[] { payload, children, "stresslog-" + i };
+        }
+
+        // Drop half of the roots so the next collection has live + dead mix.
+        for (int i = 0; i < RootCount; i += 2)
+        {
+            roots[i] = null;
+        }
+
+        // Force two full, compacting, blocking GCs. Compacting + blocking is
+        // the strongest signal that the GC heap will produce relocate /
+        // plug-move stress log entries.
+        GC.Collect(2, GCCollectionMode.Forced, blocking: true, compacting: true);
+        GC.WaitForPendingFinalizers();
+        GC.Collect(2, GCCollectionMode.Forced, blocking: true, compacting: true);
+
+        // Keep the survivors live across the collection so the JIT cannot
+        // optimize the roots array away.
+        GC.KeepAlive(roots);
+
+        // Throw to trigger a crash dump from the harness.
+        throw new Exception("StressLog test target intentional crash for dump capture.");
+    }
+}

--- a/src/TestTargets/StressLog/StressLog.csproj
+++ b/src/TestTargets/StressLog/StressLog.csproj
@@ -1,0 +1,7 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
This pull request adds comprehensive infrastructure for stress log integration testing in the diagnostics runtime tests. It introduces new synthetic test helpers for stress log data, a suite of integration tests to validate stress log parsing across different runtime configurations, and extends dump generation utilities to allow custom environment variables, enabling more flexible test scenarios.