### PR TITLE
Fix ReadStruct on primitive statics and IClrStaticField inconsistency

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/StaticFieldTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/StaticFieldTests.cs
@@ -154,6 +154,95 @@ namespace Microsoft.Diagnostics.Runtime.Tests
 
             Assert.True(foundValue, "No thread had the thread static field initialized");
         }
+
+        /// <summary>
+        /// Regression test for issue #1448: ReadStruct on a primitive-typed static must
+        /// return a ClrValueType pointing at the field slot (where the primitive value is
+        /// stored inline), not garbage produced by treating the inline value as a boxed
+        /// pointer. Also verifies the IClrStaticField interface implementation matches the
+        /// concrete ClrStaticField behavior.
+        /// </summary>
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void StaticField_ReadStruct_OnPrimitive_ReturnsSlotAddress(bool singleFile)
+        {
+            using DataTarget dt = TestTargets.NestedTypes.LoadFullDump(singleFile);
+            using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
+
+            ClrModule module = runtime.GetModule(TypeTests.NestedTypesModuleName);
+            ClrType program = module.GetTypeByName("Program");
+            Assert.NotNull(program);
+
+            ClrStaticField field = program.GetStaticFieldByName("s_publicField");
+            Assert.NotNull(field);
+            Assert.True(field.IsPrimitive);
+            Assert.True(field.IsValueType);
+
+            ClrAppDomain domain = runtime.AppDomains.Single();
+            ulong slot = field.GetAddress(domain);
+            Assert.NotEqual(0ul, slot);
+
+            // ReadStruct on a primitive should point at the slot itself, not at a fake boxed
+            // object derived from misinterpreting the inline value as a pointer.
+            ClrValueType cvt = field.ReadStruct(domain);
+            Assert.Equal(slot, cvt.Address);
+
+            // The explicit IClrStaticField.ReadStruct must match the public ReadStruct.
+            Interfaces.IClrStaticField iface = field;
+            Interfaces.IClrValue ifaceCvt = iface.ReadStruct(domain);
+            Assert.Equal(cvt.Address, ifaceCvt.Address);
+
+            // Sanity: Read<int> reads the same memory the ClrValueType points at.
+            int valueRead = field.Read<int>(domain);
+            Assert.True(dt.DataReader.Read(cvt.Address, out int valueAtSlot));
+            Assert.Equal(valueRead, valueAtSlot);
+        }
+
+        /// <summary>
+        /// Regression test for issue #1448: the ClrThreadStaticField.ReadStruct primitive
+        /// path mirrors ClrStaticField.ReadStruct - returns a ClrValueType pointing at the
+        /// inline slot rather than dereferencing the value as a pointer.
+        /// </summary>
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void ThreadStaticField_ReadStruct_OnPrimitive_ReturnsSlotAddress(bool singleFile)
+        {
+            using DataTarget dt = TestTargets.Types.LoadFullDump(singleFile);
+            using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
+
+            ClrModule module = runtime.GetModule("types.dll");
+            ClrType type = module.GetTypeByName("Types");
+            Assert.NotNull(type);
+
+            ClrThreadStaticField idField = type.ThreadStaticFields.Single(f => f.Name == "ts_threadId");
+            Assert.True(idField.IsPrimitive);
+            Assert.True(idField.IsValueType);
+
+            bool foundValue = false;
+            foreach (ClrThread thread in runtime.Threads)
+            {
+                if (!idField.IsInitialized(thread))
+                    continue;
+
+                ulong slot = idField.GetAddress(thread);
+                Assert.NotEqual(0ul, slot);
+
+                ClrValueType cvt = idField.ReadStruct(thread);
+                Assert.Equal(slot, cvt.Address);
+
+                int valueRead = idField.Read<int>(thread);
+                Assert.True(dt.DataReader.Read(cvt.Address, out int valueAtSlot));
+                Assert.Equal(valueRead, valueAtSlot);
+                Assert.NotEqual(0, valueRead);
+
+                foundValue = true;
+                break;
+            }
+
+            Assert.True(foundValue, "No thread had the thread static field initialized");
+        }
         /// <summary>
         /// Verifies that <see cref="ClrModule.EnumerateTypesWithStaticFields"/> yields every type
         /// that has at least one static field according to <c>ClrType.StaticFields</c>, and yields

--- a/src/Microsoft.Diagnostics.Runtime/ClrStaticField.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrStaticField.cs
@@ -96,8 +96,17 @@ namespace Microsoft.Diagnostics.Runtime
         }
 
         /// <summary>
-        /// Reads a ValueType struct from the instance field.
+        /// Reads a ValueType struct (or primitive) from the static field.
         /// </summary>
+        /// <remarks>
+        /// For primitive-typed statics (<see cref="int"/>, <see cref="float"/>, etc.) the
+        /// runtime stores the value inline in the static base, so the returned
+        /// <see cref="ClrValueType"/> points directly at the field slot. For non-primitive
+        /// value types the runtime stores the value as a boxed object referenced by the
+        /// static slot, so the slot is dereferenced and the method-table pointer is skipped
+        /// to reach the struct data. Use <see cref="Read{T}(ClrAppDomain)"/> when you know
+        /// the unmanaged type at compile time.
+        /// </remarks>
         /// <returns>The value read.</returns>
         public ClrValueType ReadStruct(ClrAppDomain appDomain)
         {
@@ -105,8 +114,15 @@ namespace Microsoft.Diagnostics.Runtime
             if (address == 0)
                 return default;
 
+            // Primitive statics are stored inline at the static slot; the slot IS the value.
+            if (ElementType.IsPrimitive())
+                return new ClrValueType(address, Type, interior: true);
+
+            // True struct statics are stored as boxed instances on the GC heap; the slot
+            // contains a pointer to the boxed object. Dereference it and skip the method
+            // table to reach the struct payload.
             IDataReader dataReader = ContainingType.Module.DataReader;
-            if (address == 0 || !dataReader.ReadPointer(address, out ulong obj) || obj == 0)
+            if (!dataReader.ReadPointer(address, out ulong obj) || obj == 0)
                 return default;
 
             return new ClrValueType(obj + (uint)dataReader.PointerSize, Type, interior: true);
@@ -118,7 +134,18 @@ namespace Microsoft.Diagnostics.Runtime
             if (address == 0)
                 return default(ClrValueType);
 
-            return new ClrValueType(address, Type, interior: true);
+            // Primitive statics are stored inline at the slot; the slot IS the value.
+            if (ElementType.IsPrimitive())
+                return new ClrValueType(address, Type, interior: true);
+
+            // Non-primitive value types are stored as boxed instances on the GC heap;
+            // the slot contains a pointer to the boxed object. Dereference and skip the
+            // method table to reach the struct payload.
+            IDataReader dataReader = ContainingType.Module.DataReader;
+            if (!dataReader.ReadPointer(address, out ulong obj) || obj == 0)
+                return default(ClrValueType);
+
+            return new ClrValueType(obj + (uint)dataReader.PointerSize, Type, interior: true);
         }
 
         /// <summary>

--- a/src/Microsoft.Diagnostics.Runtime/ClrThreadStaticField.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrThreadStaticField.cs
@@ -62,8 +62,15 @@ namespace Microsoft.Diagnostics.Runtime
         }
 
         /// <summary>
-        /// Reads a ValueType struct from the instance field.
+        /// Reads a ValueType struct (or primitive) from the thread-static field.
         /// </summary>
+        /// <remarks>
+        /// For primitive-typed thread statics the runtime stores the value inline at the
+        /// field slot. For non-primitive value types the slot contains a pointer to a boxed
+        /// instance and the method-table pointer is skipped to reach the struct payload.
+        /// Use <see cref="Read{T}(ClrThread)"/> when you know the unmanaged type at compile
+        /// time.
+        /// </remarks>
         /// <returns>The value read.</returns>
         public ClrValueType ReadStruct(ClrThread thread)
         {
@@ -71,8 +78,14 @@ namespace Microsoft.Diagnostics.Runtime
             if (address == 0)
                 return default;
 
+            // Primitive thread-statics are stored inline at the slot; the slot IS the value.
+            if (ElementType.IsPrimitive())
+                return new ClrValueType(address, Type, interior: true);
+
+            // Non-primitive value types are stored as boxed instances; dereference the slot
+            // and skip the method table to reach the struct payload.
             IDataReader dataReader = ContainingType.Module.DataReader;
-            if (address == 0 || !dataReader.ReadPointer(address, out ulong obj) || obj == 0)
+            if (!dataReader.ReadPointer(address, out ulong obj) || obj == 0)
                 return default;
 
             return new ClrValueType(obj + (uint)dataReader.PointerSize, Type, interior: true);


### PR DESCRIPTION
ClrStaticField.ReadStruct and ClrThreadStaticField.ReadStruct misinterpreted primitive statics as boxed object references: they ReadPointer'd the inline primitive value as a managed pointer and then offset past a method table, returning a ClrValueType pointing at garbage. Primitive statics are stored inline at the field slot, so ReadStruct now returns a ClrValueType pointing at the slot itself when ElementType.IsPrimitive() is true. The boxed-pointer path is preserved for non-primitive value types.

Also fix IClrStaticField.ReadStruct(IClrAppDomain), which was missed by PR #1216 and still returned new ClrValueType(slot, Type, true) instead of the boxed-deref result; it now delegates to the public ReadStruct(ClrAppDomain) so the interface and concrete implementations cannot drift again.

Adds regression tests in StaticFieldTests for both ClrStaticField and ClrThreadStaticField primitive paths and for IClrStaticField/ClrStaticField consistency.

Fixes #1448.