### PR TITLE
Use AppContext.BaseDirectory for default assemblies path for AOT

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/Implementation/DotNetClrInfoProvider.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Implementation/DotNetClrInfoProvider.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
 
         private const string c_cdacContractDescriptorExport = "DotNetRuntimeContractDescriptor";
 
-        private static readonly string s_defaultAssembliesPath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!;
+        private static readonly string s_defaultAssembliesPath = AppContext.BaseDirectory;
 
         public IServiceProvider GetDacServices(ClrInfo clrInfo, string? providedPath, bool ignoreMismatch, bool verifySignature)
         {


### PR DESCRIPTION
Assembly.GetExecutingAssembly().Location returns an empty string for assemblies embedded in a single-file or NativeAOT-published app, which triggers IL3000 under PublishAot=true and would also produce a null path at runtime in those scenarios. AppContext.BaseDirectory is the documented AOT/single-file replacement and resolves to the same directory as Assembly.Location for normal multi-file deployments.