### PR TITLE
Return 0 from sos14 static field address when class .cctor has not run

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/StaticFieldTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/StaticFieldTests.cs
@@ -156,6 +156,41 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         }
 
         /// <summary>
+        /// Regression test for issue #1448 follow-up: ClrStaticField.IsInitialized must return
+        /// false (and GetAddress must return 0) for a type whose .cctor has not yet run. With
+        /// the new sos14-based static base APIs the per-type static area is allocated up front,
+        /// so naively returning <c>base + field.Offset</c> produces a non-zero slot pointing at
+        /// zeroed memory. That caused callers to believe their statics were initialized and
+        /// to silently read 0 / null for every primitive and reference static.
+        /// </summary>
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void StaticField_UninitializedClass_ReportsNotInitialized(bool singleFile)
+        {
+            using DataTarget dt = TestTargets.NestedTypes.LoadFullDump(singleFile);
+            using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
+
+            ClrModule module = runtime.GetModule(TypeTests.NestedTypesModuleName);
+            ClrType type = module.GetTypeByName("UninitializedStatics");
+            Assert.NotNull(type);
+
+            ClrAppDomain domain = runtime.AppDomains.Single();
+
+            ClrStaticField intField = type.GetStaticFieldByName("Int32Static");
+            Assert.NotNull(intField);
+            Assert.False(intField.IsInitialized(domain));
+            Assert.Equal(0ul, intField.GetAddress(domain));
+            Assert.Equal(0, intField.Read<int>(domain));
+
+            ClrStaticField stringField = type.GetStaticFieldByName("StringStatic");
+            Assert.NotNull(stringField);
+            Assert.False(stringField.IsInitialized(domain));
+            Assert.Equal(0ul, stringField.GetAddress(domain));
+            Assert.True(stringField.ReadObject(domain).IsNull);
+        }
+
+        /// <summary>
         /// Regression test for issue #1448: ReadStruct on a primitive-typed static must
         /// return a ClrValueType pointing at the field slot (where the primitive value is
         /// stored inline), not garbage produced by treating the inline value as a boxed

--- a/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacTypeHelpers.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacTypeHelpers.cs
@@ -235,6 +235,14 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
         {
             if (_sos14 is not null)
             {
+                // The static base for a type is allocated up front, but the .cctor may not
+                // have run yet (e.g. for beforefieldinit types whose statics have not been
+                // touched). Returning a non-zero slot address in that case would let callers
+                // read garbage/zero and believe it was a real field value. Match the legacy
+                // DomainLocalModuleData path, which returns 0 when the class is not initialized.
+                if (_sos14.GetMethodTableInitializationFlags(ClrDataAddress.FromTargetAddress(type.MethodTable, _target)) != MethodTableInitializationFlags.MethodTableInitialized)
+                    return 0;
+
                 (ClrDataAddress nonGcBase, ClrDataAddress gcBase) = _sos14.GetStaticBaseAddress(ClrDataAddress.FromTargetAddress(type.MethodTable, _target));
                 if (field.ElementType.IsPrimitive())
                     return !nonGcBase.IsNull ? nonGcBase.ToAddress(_target) + (uint)field.Offset : 0;
@@ -277,6 +285,12 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
 
             if (_sos14 is not null)
             {
+                // See GetStaticFieldAddress: the per-type static bases are allocated even
+                // when the .cctor hasn't run. Match the legacy ThreadLocalModuleData path,
+                // which only returns an address once the class is initialized.
+                if (_sos14.GetMethodTableInitializationFlags(ClrDataAddress.FromTargetAddress(type.MethodTable, _target)) != MethodTableInitializationFlags.MethodTableInitialized)
+                    return 0;
+
                 (ClrDataAddress nonGcBase, ClrDataAddress gcBase) = _sos14.GetThreadStaticBaseAddress(ClrDataAddress.FromTargetAddress(type.MethodTable, _target), ClrDataAddress.FromTargetAddress(threadAddress, _target));
                 if (field.ElementType.IsPrimitive())
                     return !nonGcBase.IsNull ? nonGcBase.ToAddress(_target) + (uint)field.Offset : 0;

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/SosDac14.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/SosDac14.cs
@@ -35,6 +35,12 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             return hr ? (nonGCThreadStaticsBase, gcThreadStaticsBase) : (ClrDataAddress.Null, ClrDataAddress.Null);
         }
 
+        public MethodTableInitializationFlags GetMethodTableInitializationFlags(ClrDataAddress methodTable)
+        {
+            HResult hr = VTable.GetMethodTableInitializationFlags(Self, methodTable.ToInteropAddress(), out MethodTableInitializationFlags flags);
+            return hr ? flags : MethodTableInitializationFlags.Unknown;
+        }
+
         [StructLayout(LayoutKind.Sequential)]
         private readonly unsafe struct ISOSDac14VTable
         {

--- a/src/TestTargets/NestedTypes/NestedTypes.cs
+++ b/src/TestTargets/NestedTypes/NestedTypes.cs
@@ -6,6 +6,16 @@ using System.Collections.Generic;
 using System.IO;
 using System.Runtime.CompilerServices;
 
+// A type whose .cctor is never triggered by the test target. Used by the StaticFieldTests
+// regression test for issue #1448 to verify that ClrMD reports IsInitialized==false (and
+// GetAddress==0) for statics whose class constructor has not run, rather than reporting
+// IsInitialized==true with a slot address pointing at zeroed memory.
+public class UninitializedStatics
+{
+    public static int Int32Static = 100;
+    public static string StringStatic = "uninitialized class string";
+}
+
 public class Program
 {
     public static readonly int s_publicField;
@@ -34,6 +44,11 @@ public class Program
 
     private static void Main()
     {
+        // Force the runtime to load UninitializedStatics' MethodTable (via typeof) without
+        // running its .cctor, so the regression test for issue #1448 can find the type but
+        // observe IsInitialized==false on its statics.
+        GC.KeepAlive(typeof(UninitializedStatics));
+
         RuntimeHelpers.RunClassConstructor(typeof(PublicClass).TypeHandle);
         RuntimeHelpers.RunClassConstructor(typeof(PrivateClass).TypeHandle);
         RuntimeHelpers.RunClassConstructor(typeof(InternalClass).TypeHandle);


### PR DESCRIPTION
When the runtime exposes ISOSDac14 (.NET 9+), the per-type static base is allocated as soon as the type loads, independent of whether the class constructor has executed. DacTypeHelpers.GetStaticFieldAddress and GetThreadStaticFieldAddress were happily returning `base + field.Offset` in that case, so:

* IClrStaticField.IsInitialized(domain) returned true (because GetAddress returned a non-zero slot address).
* Read<T>/ReadObject/ReadStruct read zeroed memory and silently returned 0 for primitives and null for references.

This is a regression versus the legacy DomainLocalModuleData path, which checks the per-class init bit and returns 0 from GetStaticFieldAddress until the .cctor has actually run. Issue #1448 reported this for net10.0 dumps where new ClassWithStatics() never triggers the beforefieldinit .cctor on its own.

Fix: query ISOSDac14::GetMethodTableInitializationFlags and return 0 from both Get(Thread)StaticFieldAddress when the flag is not MethodTableInitialized. IsInitialized, Read<T>, ReadObject, and ReadStruct now consistently observe `not initialized` until the cctor actually runs.

Adds a regression test (NestedTypes.UninitializedStatics) plus a typeof() anchor in the test target so the type's MethodTable is loaded but its .cctor is never triggered.

Fixes #1448