### PR TITLE
Add IModuleSegmentReader hidden interface

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/DataReaders/Core/CoreDumpReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DataReaders/Core/CoreDumpReader.cs
@@ -12,7 +12,7 @@ using Microsoft.Diagnostics.Runtime.Utilities;
 
 namespace Microsoft.Diagnostics.Runtime
 {
-    internal sealed class CoredumpReader : CommonMemoryReader, IDataReader, IDisposable, IThreadReader, IDumpInfoProvider, IDumpFileMemorySource, IThreadInfoReader, IProcessInfoProvider, IMemoryRegionReader
+    internal sealed class CoredumpReader : CommonMemoryReader, IDataReader, IDisposable, IThreadReader, IDumpInfoProvider, IDumpFileMemorySource, IThreadInfoReader, IProcessInfoProvider, IMemoryRegionReader, IModuleSegmentReader
     {
         private readonly ElfCoreFile _core;
         private readonly DataTargetLimits? _limits;
@@ -318,6 +318,60 @@ namespace Microsoft.Diagnostics.Runtime
                     Protect = protect,
                     AllocationBase = allocBase,
                     AllocationProtect = protect,
+                };
+            }
+        }
+
+        // -- IModuleSegmentReader --
+
+        public IEnumerable<ModuleSegment> EnumerateModuleSegments(ulong moduleBaseAddress)
+        {
+            // Find the loaded image at this base. LoadedImages is keyed by
+            // filename, not address, so a small linear scan is needed —
+            // module count is in the hundreds at worst.
+            ElfLoadedImage? image = null;
+            foreach (ElfLoadedImage candidate in _core.LoadedImages.Values)
+            {
+                if (candidate.BaseAddress == moduleBaseAddress)
+                {
+                    image = candidate;
+                    break;
+                }
+            }
+            if (image is null)
+                yield break;
+
+            using ElfFile? file = image.Open();
+            if (file is null)
+                yield break;
+
+            // Compute load bias: ImageBase - p_vaddr of the lowest PT_LOAD.
+            // For PIE / shared objects the lowest PT_LOAD has p_vaddr == 0,
+            // so load bias == ImageBase. For position-dependent executables
+            // load bias is typically 0.
+            ulong lowestVaddr = ulong.MaxValue;
+            foreach (ElfProgramHeader ph in file.ProgramHeaders)
+            {
+                if (ph.Type != ElfProgramHeaderType.Load || ph.VirtualSize == 0)
+                    continue;
+                if (ph.VirtualAddress < lowestVaddr)
+                    lowestVaddr = ph.VirtualAddress;
+            }
+            if (lowestVaddr == ulong.MaxValue)
+                yield break;
+            ulong loadBias = moduleBaseAddress - lowestVaddr;
+
+            foreach (ElfProgramHeader ph in file.ProgramHeaders)
+            {
+                if (ph.Type != ElfProgramHeaderType.Load || ph.VirtualSize == 0)
+                    continue;
+                yield return new ModuleSegment
+                {
+                    VirtualAddress = ph.VirtualAddress + loadBias,
+                    VirtualSize = ph.VirtualSize,
+                    IsReadable = ph.IsReadable,
+                    IsWritable = ph.IsWritable,
+                    IsExecutable = ph.IsExecutable,
                 };
             }
         }

--- a/src/Microsoft.Diagnostics.Runtime/DataReaders/IModuleSegmentReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DataReaders/IModuleSegmentReader.cs
@@ -1,0 +1,62 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+
+namespace Microsoft.Diagnostics.Runtime.DataReaders.Implementation
+{
+    /// <summary>
+    /// One loadable segment of a module — an ELF PT_LOAD entry on Linux,
+    /// or one PE section header (.text / .data / .rdata / ...) on Windows.
+    ///
+    /// <see cref="VirtualAddress"/> is an absolute address in the target's
+    /// address space (load bias already applied for PIE / shared objects).
+    /// </summary>
+    public readonly struct ModuleSegment
+    {
+        /// <summary>Absolute base address of the segment in the target.</summary>
+        public ulong VirtualAddress { get; init; }
+
+        /// <summary>In-memory size of the segment in bytes (includes BSS).</summary>
+        public ulong VirtualSize { get; init; }
+
+        /// <summary>Whether the segment is mapped readable.</summary>
+        public bool IsReadable { get; init; }
+
+        /// <summary>Whether the segment is mapped writable.</summary>
+        public bool IsWritable { get; init; }
+
+        /// <summary>Whether the segment is mapped executable.</summary>
+        public bool IsExecutable { get; init; }
+    }
+
+    /// <summary>
+    /// Provides per-module loadable-segment layout (ELF PT_LOAD program
+    /// headers, PE section table) so callers can attribute a memory region
+    /// back to a specific segment of the owning module.
+    ///
+    /// This interface is not used by the ClrMD library itself, but is here
+    /// to expose data that <see cref="IDataReader"/> implementations already
+    /// parse — the same ELF program-header walk used to build the module
+    /// list and the <see cref="IMemoryRegionReader"/> output.
+    ///
+    /// This interface must always be requested and not assumed to be there:
+    ///
+    ///     IDataReader reader = ...;
+    ///
+    ///     if (reader is IModuleSegmentReader segments)
+    ///         ...
+    /// </summary>
+    public interface IModuleSegmentReader
+    {
+        /// <summary>
+        /// Enumerates the loadable segments of the module whose
+        /// <see cref="ModuleInfo.ImageBase"/> equals
+        /// <paramref name="moduleBaseAddress"/>. Each returned segment's
+        /// <see cref="ModuleSegment.VirtualAddress"/> is absolute (load bias
+        /// already applied). Returns an empty sequence when the module is
+        /// unknown or its headers cannot be parsed.
+        /// </summary>
+        IEnumerable<ModuleSegment> EnumerateModuleSegments(ulong moduleBaseAddress);
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/DataReaders/LockFreeMmfDataReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DataReaders/LockFreeMmfDataReader.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
     /// to the inner reader, which retains its own access to the dump.
     /// </para>
     /// </summary>
-    internal sealed class LockFreeMmfDataReader : IDataReader, IThreadReader, IDumpInfoProvider, ISegmentedDirectMemoryAccess, IDisposable, IThreadInfoReader, IProcessInfoProvider, IMemoryRegionReader
+    internal sealed class LockFreeMmfDataReader : IDataReader, IThreadReader, IDumpInfoProvider, ISegmentedDirectMemoryAccess, IDisposable, IThreadInfoReader, IProcessInfoProvider, IMemoryRegionReader, IModuleSegmentReader
     {
         private readonly IDataReader _inner;
         private readonly IThreadReader? _innerThreads;
@@ -43,6 +43,7 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
         private readonly IThreadInfoReader? _innerThreadInfo;
         private readonly IProcessInfoProvider? _innerProcessInfo;
         private readonly IMemoryRegionReader? _innerRegions;
+        private readonly IModuleSegmentReader? _innerModuleSegments;
         private readonly MemoryMappedFile _mmf;
         private readonly MemoryMappedViewAccessor _accessor;
         // Base address of the mapped view, stored as IntPtr so the field itself is not unsafe.
@@ -97,6 +98,7 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
             _innerThreadInfo = inner as IThreadInfoReader;
             _innerProcessInfo = inner as IProcessInfoProvider;
             _innerRegions = inner as IMemoryRegionReader;
+            _innerModuleSegments = inner as IModuleSegmentReader;
 
             MemoryMappedFile? mmf = null;
             MemoryMappedViewAccessor? accessor = null;
@@ -427,6 +429,11 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
         public IEnumerable<MemoryRegion> EnumerateMemoryRegions()
             => _innerRegions?.EnumerateMemoryRegions()
                ?? throw CreateUnsupportedInterfaceException(nameof(IMemoryRegionReader));
+
+        // IModuleSegmentReader passthrough
+        public IEnumerable<ModuleSegment> EnumerateModuleSegments(ulong moduleBaseAddress)
+            => _innerModuleSegments?.EnumerateModuleSegments(moduleBaseAddress)
+               ?? throw CreateUnsupportedInterfaceException(nameof(IModuleSegmentReader));
 
         private static NotSupportedException CreateUnsupportedInterfaceException(string interfaceName)
             => new($"The inner data reader does not implement {interfaceName}.");


### PR DESCRIPTION
New IModuleSegmentReader interface (in DataReaders.Implementation namespace) exposes ELF PT_LOAD program-header segments per loaded module. Implemented on CoredumpReader (reads from ElfFile.ProgramHeaders, applies load bias) and forwarded by LockFreeMmfDataReader to its inner reader.