### PR TITLE
Fix ClrType.IsFinalizable over-reporting

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/IsFinalizableTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/IsFinalizableTests.cs
@@ -1,0 +1,75 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Microsoft.Diagnostics.Runtime.Tests
+{
+    public class IsFinalizableTests
+    {
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void IsFinalizable_DoesNotOverReport(bool singleFile)
+        {
+            using DataTarget dt = TestTargets.FinalizationQueue.LoadFullDump(singleFile);
+            using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
+            ClrHeap heap = runtime.Heap;
+
+            // Types known to NOT have a finalizer.  Pre-fix, IsFinalizable was implemented by
+            // walking Methods looking for any virtual method named "Finalize" — which always
+            // matches the inherited slot from System.Object.Finalize, causing every type to
+            // report true.  These assertions guard against regression.
+            Assert.False(heap.StringType.IsFinalizable, "System.String should not be finalizable.");
+            Assert.False(heap.ObjectType.IsFinalizable, "System.Object should not be finalizable.");
+
+            ClrType? int32 = runtime.BaseClassLibrary.GetTypeByName("System.Int32");
+            Assert.NotNull(int32);
+            Assert.False(int32!.IsFinalizable, "System.Int32 should not be finalizable.");
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void IsFinalizable_TrueForUserFinalizers(bool singleFile)
+        {
+            using DataTarget dt = TestTargets.FinalizationQueue.LoadFullDump(singleFile);
+            using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
+            ClrHeap heap = runtime.Heap;
+
+            // The FinalizationQueue test target defines SampleA/B/C and DieHard, all with ~Finalize.
+            HashSet<string> finalizableNames = new(heap.EnumerateObjects()
+                                                      .Where(o => o.Type is not null && o.Type.IsFinalizable)
+                                                      .Select(o => o.Type!.Name!));
+
+            Assert.Contains("SampleA", finalizableNames);
+            Assert.Contains("SampleB", finalizableNames);
+            Assert.Contains("SampleC", finalizableNames);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void IsFinalizable_AgreesWithFinalizerQueue(bool singleFile)
+        {
+            using DataTarget dt = TestTargets.FinalizationQueue.LoadFullDump(singleFile);
+            using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
+            ClrHeap heap = runtime.Heap;
+
+            // Every distinct type that actually has objects on the FQ must report IsFinalizable.
+            // (The reverse is not true: a type can have a finalizer with no live FQ instances.)
+            foreach (ClrObject obj in heap.EnumerateFinalizableObjects())
+            {
+                if (obj.Type is null)
+                    continue;
+
+                Assert.True(obj.Type.IsFinalizable,
+                    $"Type {obj.Type.Name} has objects on the finalizer queue but IsFinalizable is false.");
+            }
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/AbstractDac/IAbstractTypeHelpers.cs
+++ b/src/Microsoft.Diagnostics.Runtime/AbstractDac/IAbstractTypeHelpers.cs
@@ -46,6 +46,7 @@ namespace Microsoft.Diagnostics.Runtime.AbstractDac
         public bool IsShared { get; set; }
         public int MethodCount { get; set; }
         public bool ContainsPointers { get; set; }
+        public bool HasFinalizer { get; set; }
     }
 
     public struct ObjectArrayInformation

--- a/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacTypeHelpers.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacTypeHelpers.cs
@@ -58,8 +58,29 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
                 MethodTable = methodTable,
                 ParentMethodTable = data.ParentMethodTable.ToAddress(_target),
                 ModuleAddress = data.Module.ToAddress(_target),
+                HasFinalizer = ReadHasFinalizer(methodTable),
             };
             return true;
+        }
+
+        // MethodTable layout (verified on modern .NET and Desktop Framework, all
+        // architectures — x86, x64, ARM, ARM64):
+        //   - m_dwFlags is a DWORD at offset 0
+        //   - enum_flag_HasFinalizer = 0x00100000 lives in the high half of m_dwFlags
+        //   - High flags are read directly with no string/array special-casing
+        //     (only the low WORD is overloaded for component size)
+        // SOS's MethodTableData does not surface this flag, so we read it from target memory.
+        private const uint enum_flag_HasFinalizer = 0x00100000;
+
+        private bool ReadHasFinalizer(ulong methodTable)
+        {
+            if (methodTable == 0)
+                return false;
+
+            if (!_dataReader.Read(methodTable, out uint flags))
+                return false;
+
+            return (flags & enum_flag_HasFinalizer) != 0;
         }
 
         public string? GetTypeName(ulong module, ulong methodTable, int token)

--- a/src/Microsoft.Diagnostics.Runtime/Implementation/ClrDacType.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Implementation/ClrDacType.cs
@@ -232,7 +232,7 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
             return (value & FinalizationSuppressedFlag) == FinalizationSuppressedFlag;
         }
 
-        public override bool IsFinalizable => Methods.Any(method => (method.Attributes & MethodAttributes.Virtual) == MethodAttributes.Virtual && method.Name == "Finalize");
+        public override bool IsFinalizable => TypeInfo.HasFinalizer;
 
         public override bool IsArray => ComponentSize != 0 && !IsString && !IsFree;
         public override bool IsCollectible => LoaderAllocatorHandle != 0;

--- a/src/Microsoft.Diagnostics.Runtime/Implementation/ClrStringType.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Implementation/ClrStringType.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
 
         public override ClrElementType ElementType => ClrElementType.String;
 
-        public override bool IsFinalizable => true;
+        public override bool IsFinalizable => false;
 
         public override TypeAttributes TypeAttributes => TypeAttributes.Public;
 


### PR DESCRIPTION
The previous implementation walked Methods looking for any virtual method named "Finalize". Every type inherits the slot for System.Object.Finalize, so this returned true for System.String, System.Object, primitive arrays, and ~64% of all reflected types in real dumps — types that have no user finalizer and are never registered with the finalizer queue.

Read MethodTable.m_dwFlags & enum_flag_HasFinalizer (0x00100000) directly from target memory instead. The flag's location and value were verified to match across both modern .NET and Desktop Framework for x86, x64, ARM, and ARM64: m_dwFlags is a DWORD at offset 0 of MethodTable, and high flags (where HasFinalizer lives) are read directly without the string/array component-size special-casing that applies to low flags.

SOS's MethodTableData does not surface this bit, so we read raw memory via IDataReader.

- Add HasFinalizer to AbstractDac.TypeInfo
- Populate it in DacTypeHelpers.GetTypeInfo
- ClrDacType.IsFinalizable now returns TypeInfo.HasFinalizer
- ClrStringType.IsFinalizable hard-coded true -> false (System.String has no finalizer)
- Add IsFinalizableTests covering: System.String/Object/Int32 are not finalizable, user finalizers (SampleA/B/C) are, and every type with objects on the finalizer queue reports IsFinalizable = true.