### PR TITLE
Fix ArgumentOutOfRangeException in GetExceptionStackTrace

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/ExceptionTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/ExceptionTests.cs
@@ -44,6 +44,8 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             Assert.NotNull(exception);
 
             ImmutableArray<ClrStackFrame> stackTrace = exception.StackTrace;
+            Assert.NotEmpty(stackTrace);
+
             foreach (ClrStackFrame stackFrame in stackTrace)
             {
                 Assert.Equal(stackFrame.Thread, thread);

--- a/src/Microsoft.Diagnostics.Runtime/ClrException.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrException.cs
@@ -280,17 +280,28 @@ namespace Microsoft.Diagnostics.Runtime
                 return ImmutableArray<ClrStackFrame>.Empty;
 
             int elementSize = pointerSize * 4;
-            ulong dataPtr = _stackTrace + (ulong)(pointerSize * 2);
-            if (!dataReader.ReadPointer(dataPtr, out ulong count))
+            int headerSize = pointerSize * 2;
+            if (len < headerSize)
                 return ImmutableArray<ClrStackFrame>.Empty;
 
-            ImmutableArray<ClrStackFrame>.Builder result = ImmutableArray.CreateBuilder<ClrStackFrame>((int)count);
+            ulong dataPtr = _stackTrace + (ulong)headerSize;
+            int count = dataReader.Read<int>(dataPtr);
+            if (count <= 0)
+                return ImmutableArray<ClrStackFrame>.Empty;
+
+            int maxCount = (len - headerSize) / elementSize;
+            if (maxCount <= 0)
+                return ImmutableArray<ClrStackFrame>.Empty;
+
+            count = Math.Min(count, maxCount);
+
+            ImmutableArray<ClrStackFrame>.Builder result = ImmutableArray.CreateBuilder<ClrStackFrame>(count);
             result.Count = result.Capacity;
 
             // Skip size and header
-            dataPtr += (ulong)(pointerSize * 2);
+            dataPtr += (ulong)headerSize;
 
-            for (int i = 0; i < (int)count; ++i)
+            for (int i = 0; i < count; ++i)
             {
                 ulong ip = dataReader.ReadPointer(dataPtr);
                 ulong sp = dataReader.ReadPointer(dataPtr + (ulong)pointerSize);


### PR DESCRIPTION
Count was read with a pointer size, which is incorrect.

Fixes #1459.