### PR TITLE
Fix mis-classification of IOCompletionPoller._nativeEvents field type

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/ClrObjectTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/ClrObjectTests.cs
@@ -171,6 +171,23 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         }
 
         [Theory, MemberData(nameof(Variants))]
+        public void StringFieldCtor_UsesResolvedTypeWhenDacMarksStruct(DumpVariant variant, bool singleFile)
+        {
+            using Scope s = new(variant, singleFile);
+            ClrInstanceField original = s.PrimitiveCarrier.Type.GetFieldByName(nameof(s.Prototype.HelloWorldString));
+
+            Microsoft.Diagnostics.Runtime.AbstractDac.FieldInfo fieldInfo = original.FieldInfo;
+            fieldInfo.ElementType = ClrElementType.Struct;
+
+            ClrInstanceField field = new(original.ContainingType, original.Type, original._helpers, fieldInfo);
+
+            Assert.Equal(ClrElementType.String, field.ElementType);
+            Assert.False(field.IsValueType);
+            Assert.True(field.IsObjectReference);
+            Assert.Equal(s.Prototype.HelloWorldString, s.PrimitiveCarrier.ReadStringField(field));
+        }
+
+        [Theory, MemberData(nameof(Variants))]
         public void ReadValueTypeFieldByInstance_WhenDateTime_ReturnsExpected(DumpVariant variant, bool singleFile)
         {
             using Scope s = new(variant, singleFile);

--- a/src/Microsoft.Diagnostics.Runtime/ClrField.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrField.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Diagnostics.Runtime
             if (_type is not null)
                 _typeInitialized = 1;
 
-            if (data.ElementType == ClrElementType.Class && _type != null)
+            if (_type is not null && data.ElementType is ClrElementType.Class or ClrElementType.Struct)
                 data.ElementType = _type.ElementType;
 
             FieldInfo = data;


### PR DESCRIPTION
Trust the value of _type.ElementType for structs as well.

Fixes #1458.