### PR TITLE
Replace self-attach CollectibleTypeTest with dump-based target

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/TestTargets.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/TestTargets.cs
@@ -40,6 +40,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         private static readonly Lazy<TestTarget> _finalizationQueue = new(() => new TestTarget("FinalizationQueue"));
         private static readonly Lazy<TestTarget> _byReference = new(() => new TestTarget("ByReference"));
         private static readonly Lazy<TestTarget> _stressLog = new(() => new TestTarget("StressLog"));
+        private static readonly Lazy<TestTarget> _collectibleTypes = new(() => new TestTarget("CollectibleTypes"));
 
         public static TestTarget GCRoot => _gcroot.Value;
         public static TestTarget GCRoot2 => _gcroot2.Value;
@@ -54,6 +55,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         public static TestTarget Arrays => _arrays.Value;
         public static TestTarget ByReference => _byReference.Value;
         public static TestTarget StressLog => _stressLog.Value;
+        public static TestTarget CollectibleTypes => _collectibleTypes.Value;
     }
 
     public class TestTarget

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/TypeTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/TypeTests.cs
@@ -6,9 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Runtime.Loader;
 using Microsoft.Diagnostics.Runtime.Implementation;
 using Xunit;
 
@@ -586,25 +584,20 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         [WindowsFact]
         public void CollectibleTypeTest()
         {
-            CollectibleAssemblyLoadContext context = new();
-
-            RuntimeHelpers.RunClassConstructor(context.LoadFromAssemblyPath(Assembly.GetExecutingAssembly().Location)
-                .GetType(typeof(CollectibleUnmanagedStruct).FullName).TypeHandle);
-
-            RuntimeHelpers.RunClassConstructor(Assembly.GetExecutingAssembly()
-                .GetType(typeof(UncollectibleUnmanagedStruct).FullName).TypeHandle);
-
-            using DataTarget dataTarget = DataTarget.CreateSnapshotAndAttach(Environment.ProcessId);
-
-            ClrHeap heap = dataTarget.ClrVersions.Single(v => v.ModuleInfo.FileName.EndsWith("coreclr.dll", true, null)).CreateRuntime().Heap;
+            // The CollectibleTypes target loads its own assembly into a collectible
+            // ALC, runs CollectibleUnmanagedStruct's cctor inside it, then throws
+            // (the unhandled exception triggers the dump). Self-attach is not
+            // supported by ClrMD, so the test target captures the heap state for us.
+            using DataTarget dataTarget = TestTargets.CollectibleTypes.LoadFullDump();
+            using ClrRuntime runtime = dataTarget.ClrVersions.Single().CreateRuntime();
+            ClrHeap heap = runtime.Heap;
 
             ClrType[] types = heap.EnumerateObjects().Select(obj => obj.Type).ToArray();
 
             // Filter by IsCollectible: newer runtimes may also create a boxed static for
-            // the default-ALC's copy of this struct (triggered by various reflection paths
-            // in the xunit runner).  The scenario we're validating is specifically the
-            // one in the collectible ALC, so match that explicitly.
-            ClrType collectibleType = types.Single(type => type?.Name == typeof(CollectibleUnmanagedStruct).FullName && type.IsCollectible);
+            // the default-ALC's copy of this struct, so match the collectible-ALC instance
+            // explicitly.
+            ClrType collectibleType = types.Single(type => type?.Name == "CollectibleUnmanagedStruct" && type.IsCollectible);
 
             Assert.False(collectibleType.ContainsPointers);
             Assert.True(collectibleType.IsCollectible);
@@ -612,13 +605,11 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             ulong obj = dataTarget.DataReader.ReadPointer(collectibleType.LoaderAllocatorHandle);
             Assert.Equal("System.Reflection.LoaderAllocator", heap.GetObjectType(obj).Name);
 
-            ClrType uncollectibleType = types.Single(type => type?.Name == typeof(UncollectibleUnmanagedStruct).FullName);
+            ClrType uncollectibleType = types.Single(type => type?.Name == "UncollectibleUnmanagedStruct");
 
             Assert.False(uncollectibleType.ContainsPointers);
             Assert.False(uncollectibleType.IsCollectible);
             Assert.Equal(default, uncollectibleType.LoaderAllocatorHandle);
-
-            context.Unload();
         }
 
         [Theory, MemberData(nameof(TypesVariants))]
@@ -649,23 +640,6 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             ClrInterface[] clrInterfaces = clrType.EnumerateInterfaces().ToArray();
 
             Assert.NotEmpty(clrInterfaces);
-        }
-
-        private struct CollectibleUnmanagedStruct
-        {
-            public static CollectibleUnmanagedStruct Instance = default;
-        }
-
-        private struct UncollectibleUnmanagedStruct
-        {
-            public static UncollectibleUnmanagedStruct Instance = default;
-        }
-
-        private sealed class CollectibleAssemblyLoadContext : AssemblyLoadContext
-        {
-            public CollectibleAssemblyLoadContext() : base(true)
-            {
-            }
         }
     }
 

--- a/src/TestTargets/CollectibleTypes/CollectibleTypes.cs
+++ b/src/TestTargets/CollectibleTypes/CollectibleTypes.cs
@@ -1,0 +1,54 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.Loader;
+
+#pragma warning disable 0414
+
+// Value-type whose box (the backing storage for its static field) we want to
+// observe in a collectible AssemblyLoadContext.
+public struct CollectibleUnmanagedStruct
+{
+    public static CollectibleUnmanagedStruct Instance = default;
+}
+
+// Same shape, but loaded in the default (uncollectible) ALC for comparison.
+public struct UncollectibleUnmanagedStruct
+{
+    public static UncollectibleUnmanagedStruct Instance = default;
+}
+
+internal sealed class CollectibleAssemblyLoadContext : AssemblyLoadContext
+{
+    public CollectibleAssemblyLoadContext() : base(isCollectible: true) { }
+}
+
+internal static class CollectibleTypesTarget
+{
+    // Static fields so the GC can't reclaim the ALC, its assembly, or the
+    // boxed statics before the dump is captured.
+    private static CollectibleAssemblyLoadContext s_alc;
+    private static Assembly s_alcAssembly;
+
+    public static void Main()
+    {
+        s_alc = new CollectibleAssemblyLoadContext();
+        s_alcAssembly = s_alc.LoadFromAssemblyPath(typeof(CollectibleTypesTarget).Assembly.Location);
+
+        Type collectibleInAlc = s_alcAssembly.GetType(typeof(CollectibleUnmanagedStruct).FullName)
+            ?? throw new InvalidOperationException("CollectibleUnmanagedStruct not found in collectible ALC.");
+        RuntimeHelpers.RunClassConstructor(collectibleInAlc.TypeHandle);
+
+        // Also run the default-ALC cctor so the uncollectible counterpart is on the heap.
+        RuntimeHelpers.RunClassConstructor(typeof(UncollectibleUnmanagedStruct).TypeHandle);
+
+        GC.KeepAlive(s_alc);
+        GC.KeepAlive(s_alcAssembly);
+
+        // Unhandled exception triggers the test-harness dump generator.
+        throw new Exception("CollectibleTypes dump trigger");
+    }
+}

--- a/src/TestTargets/CollectibleTypes/CollectibleTypes.csproj
+++ b/src/TestTargets/CollectibleTypes/CollectibleTypes.csproj
@@ -1,0 +1,11 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Shared\SharedLibrary.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Self-attach via CreateSnapshotAndAttach(Environment.ProcessId) is not supported by ClrMD - the runtime in the live process can have boxed statics for collectible value-type statics reclaimed by the GC between cctor execution and snapshot, producing a flaky 'sequence contains no matching element' failure on x86 Debug.

Move the scenario to a dedicated test target (CollectibleTypes) that loads its own assembly into a collectible ALC, runs the relevant cctors, and throws an unhandled exception so the test harness can capture a deterministic crash dump.