### PR TITLE
Fix pointer-field type resolution (#1458)

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/TypeTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/TypeTests.cs
@@ -92,6 +92,49 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             Assert.Contains(obj.Address, heap.EnumerateObjects().Select(a => a.Address));
         }
 
+        public static IEnumerable<object[]> TypesCoreVariants => TestVariants.CoreOnly(TestTargets.Types);
+
+        [Theory, MemberData(nameof(TypesCoreVariants))]
+        public void PointerFieldResolvesToPointerType(DumpVariant variant)
+        {
+            // Regression for #1458: a field whose signature is ELEMENT_TYPE_PTR was
+            // short-circuiting through GetOrCreateBasicType because ClrElementType.Pointer
+            // is included in IsPrimitive(). Due to slot-index arithmetic in the basic-type
+            // cache, this returned the cached String type for any pointer field. The
+            // visible symptom was field.IsObjectReference==false but
+            // field.Type.IsObjectReference==true (Type was misresolved to System.String).
+            using DataTarget dt = TestTargets.Types.LoadFullDump(variant);
+            using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
+
+            ClrModule module = runtime.GetModule(ModuleName);
+            ClrType holder = module.GetTypeByName("PointerFieldHolder");
+            Assert.NotNull(holder);
+
+            foreach (string fieldName in new[] { "IntPointer", "VoidPointer", "StructPointer" })
+            {
+                ClrInstanceField field = holder.GetFieldByName(fieldName);
+                Assert.NotNull(field);
+                Assert.False(field.IsObjectReference, $"Field '{fieldName}' should not be an object reference.");
+
+                Assert.NotNull(field.Type);
+                Assert.False(field.Type.IsObjectReference, $"Field '{fieldName}' resolved type '{field.Type.Name}' is incorrectly an object reference (#1458 regression).");
+
+                // Consistency: the central symptom of #1458 was that these two booleans disagreed.
+                Assert.Equal(field.IsObjectReference, field.Type.IsObjectReference);
+            }
+
+            // Spot-check the int* field, which is the cleanest case where we expect a
+            // proper pointer ClrConstructedType wrapping System.Int32.
+            ClrInstanceField intPointer = holder.GetFieldByName("IntPointer");
+            Assert.True(intPointer.Type.IsPointer);
+            Assert.False(intPointer.Type.IsArray);
+            Assert.Equal(ClrElementType.Pointer, intPointer.Type.ElementType);
+            Assert.NotNull(intPointer.Type.ComponentType);
+            Assert.Equal("System.Int32", intPointer.Type.ComponentType.Name);
+            Assert.Equal("System.Int32*", intPointer.Type.Name);
+        }
+
+
         [FrameworkFact]
         public void ArrayComponentTypeTest()
         {

--- a/src/Microsoft.Diagnostics.Runtime/Implementation/ClrTypeFactory.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Implementation/ClrTypeFactory.cs
@@ -192,7 +192,7 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
             if (!parser.GetElemType(out ClrElementType etype))
                 return null;
 
-            if (etype.IsPrimitive() || etype == ClrElementType.Void || etype == ClrElementType.Object || etype == ClrElementType.String)
+            if ((etype.IsPrimitive() && etype != ClrElementType.Pointer) || etype == ClrElementType.Void || etype == ClrElementType.Object || etype == ClrElementType.String)
                 return GetOrCreateBasicType(etype);
 
             if (etype == ClrElementType.Array)

--- a/src/TestTargets/Types/Types.cs
+++ b/src/TestTargets/Types/Types.cs
@@ -34,6 +34,24 @@ class ThreadStaticsOnly
     public static int ts_counter;
 }
 
+// Type with an unmanaged pointer instance field. Used to verify ClrMD resolves
+// pointer field signatures to a ClrConstructedType pointer (not to the basic
+// String type via the buggy IsPrimitive() short-circuit). See issue #1458.
+#pragma warning disable CS0649 // fields are never assigned — we only need the metadata in the dump
+struct PointerFieldHolderStruct
+{
+    public int X;
+    public long Y;
+}
+
+unsafe class PointerFieldHolder
+{
+    public int* IntPointer;
+    public void* VoidPointer;
+    public PointerFieldHolderStruct* StructPointer; // pointer to a value type (mirrors OVERLAPPED_ENTRY*)
+}
+#pragma warning restore CS0649
+
 class Types
 {
     [ThreadStatic]
@@ -95,6 +113,7 @@ class Types
     public static void Main()
     {
         new StructTestClass(); // Ensure type is constructed
+        new PointerFieldHolder(); // Ensure PointerFieldHolder is constructed (issue #1458)
         ExplicitImpl ei = new ExplicitImpl();
         ((IExplicitTest)ei).ExplicitMethod();
         ei.RegularMethod();


### PR DESCRIPTION
ClrElementType.Pointer is included in IsPrimitive(), so the early-return branch in ClrTypeFactory.GetOrCreateTypeFromSignature was short-circuiting pointer-typed fields through GetOrCreateBasicType before reaching the dedicated ELEMENT_TYPE_PTR branch that recurses into the pointed-to type and wraps it in a ClrConstructedType.

GetOrCreateBasicType uses '(int)basicType - 1' as a cache index but populates the String/Object slots without the -1 adjustment, so a lookup for ClrElementType.Pointer (0x0F) read slot 14, which is exactly where StringType is cached. As a result every pointer field resolved to System.String, with the visible symptom that field.IsObjectReference was false but field.Type.IsObjectReference was true. shvez reported this on the IOCompletionPoller._nativeEvents field (OVERLAPPED_ENTRY*).

Exclude Pointer from the early-return so it falls through to the existing Pointer/ByRef branch, which already builds a correct ClrConstructedType wrapping the inner type.

Add a PointerFieldHolder type with int*, void*, and ValueType* fields to the Types test target and a regression test covering both the field-vs-type IsObjectReference consistency property and the resolved Type metadata for the int* case.

Hopefully fixes #1458.  There's plenty of ugly warts in the type system here.