### PR TITLE
CoredumpReader: populate ImagePath from AT_EXECFN auxv entry

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/DumpAuxiliaryDataReaderTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/DumpAuxiliaryDataReaderTests.cs
@@ -138,6 +138,19 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             // Image path should resolve to the EXE/host that created the dump.
             Assert.False(string.IsNullOrWhiteSpace(info.ImagePath), "ImagePath was empty");
 
+            // Image path basename should actually be the test target binary
+            // (e.g. "Types" on Linux, "Types.exe" on Windows). The whole
+            // point of ImagePath is "the main executable" — historically
+            // the Linux CoredumpReader path returned a managed-DLL filename
+            // because it walked LoadedImages in load-address order and
+            // grabbed the first non-interpreter entry. Anchor that
+            // regression here so it can't silently recur (see #ELF_AT_EXECFN).
+            string expectedBase = info.TargetPlatform == OSPlatform.Windows
+                ? "Types.exe"
+                : "Types";
+            string actualBase = System.IO.Path.GetFileName(info.ImagePath!);
+            Assert.Equal(expectedBase, actualBase, ignoreCase: false);
+
             // ProcessorCount is only carried by Windows minidumps.
             if (info.TargetPlatform == OSPlatform.Windows)
                 Assert.True(info.ProcessorCount >= 1, $"ProcessorCount={info.ProcessorCount}");

--- a/src/Microsoft.Diagnostics.Runtime/DataReaders/Core/CoreDumpReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DataReaders/Core/CoreDumpReader.cs
@@ -227,19 +227,29 @@ namespace Microsoft.Diagnostics.Runtime
                 }
             }
 
-            // ImagePath: prefer the first non-interpreter loaded image whose path
-            // matches AT_EXECFN's basename when available; otherwise fall back to
-            // the first non-interpreter image.
-            ulong interpreter = _core.GetAuxvValue(ElfAuxvType.Base);
-            string? imagePath = null;
-            foreach (ElfLoadedImage image in _core.LoadedImages.Values)
+            // ImagePath: prefer AT_EXECFN (kernel-recorded absolute path of
+            // the originally exec()'d binary) — this is the only auxv entry
+            // that uniquely identifies the main executable. Fall back to
+            // the first non-interpreter LoadedImage when AT_EXECFN is
+            // absent or unreadable. The legacy "first LoadedImage" path
+            // returns whatever ImmutableDictionary enumerated first, which
+            // is essentially arbitrary across runs and tends to surface a
+            // managed .dll on .NET cores rather than the actual exe
+            // (the kernel loads the .NET host last, so the host is rarely
+            // first in load-address order).
+            string? imagePath = TryGetImagePathFromAuxv();
+            if (imagePath is null)
             {
-                if (image.BaseAddress == interpreter)
-                    continue;
-                if (image.FileName.StartsWith("/dev", StringComparison.Ordinal))
-                    continue;
-                imagePath = image.FileName.Replace(" (deleted)", "");
-                break;
+                ulong interpreter = _core.GetAuxvValue(ElfAuxvType.Base);
+                foreach (ElfLoadedImage image in _core.LoadedImages.Values)
+                {
+                    if (image.BaseAddress == interpreter)
+                        continue;
+                    if (image.FileName.StartsWith("/dev", StringComparison.Ordinal))
+                        continue;
+                    imagePath = image.FileName.Replace(" (deleted)", "");
+                    break;
+                }
             }
 
             return new ProcessInfo
@@ -257,6 +267,57 @@ namespace Microsoft.Diagnostics.Runtime
                 ProcessorCount = 0,
                 DumpTimestampUtc = null,
             };
+        }
+
+        /// <summary>
+        /// Reads the absolute path of the originally exec()'d binary from
+        /// the ELF core's auxiliary vector. The auxv entry AT_EXECFN holds
+        /// a pointer (into the target process's address space) to a
+        /// NUL-terminated string with the kernel-recorded path. Returns
+        /// null when the auxv entry is missing, the pointer can't be
+        /// dereferenced from the dump's mapped memory, or the string is
+        /// empty.
+        /// </summary>
+        private string? TryGetImagePathFromAuxv()
+        {
+            ulong execfnPtr = _core.GetAuxvValue(ElfAuxvType.Execfn);
+            if (execfnPtr == 0)
+                return null;
+
+            // PATH_MAX on Linux is 4096; cap the read so a corrupt auxv
+            // pointer into a large readable region can't make us hang
+            // looking for a NUL byte. AT_EXECFN by convention ends within
+            // PATH_MAX.
+            const int maxLen = 4096;
+            Span<byte> buffer = stackalloc byte[256];
+            var sb = new System.Text.StringBuilder();
+            ulong cursor = execfnPtr;
+            while (sb.Length < maxLen)
+            {
+                int read = _core.ReadMemory(cursor, buffer);
+                if (read <= 0)
+                    return null;
+
+                for (int i = 0; i < read; i++)
+                {
+                    byte b = buffer[i];
+                    if (b == 0)
+                    {
+                        string s = sb.ToString();
+                        return s.Length == 0 ? null : s.Replace(" (deleted)", "");
+                    }
+                    // Auxv strings are ASCII paths. Reject any high-bit
+                    // byte — that's almost certainly a stale pointer into
+                    // non-text memory rather than the actual path.
+                    if (b >= 0x80)
+                        return null;
+                    sb.Append((char)b);
+                }
+
+                cursor += (ulong)read;
+            }
+
+            return null;
         }
 
         // -- IMemoryRegionReader --

--- a/src/Microsoft.Diagnostics.Runtime/Linux/Structs/ElfAuxvType.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Linux/Structs/ElfAuxvType.cs
@@ -7,5 +7,10 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
     {
         Null = 0,           // end of vector
         Base = 7,           // base address of interpreter
+        Execfn = 31,        // pointer to NUL-terminated absolute path of the
+                            // executable that was originally exec()'d. Lives
+                            // in the target process's address space — must
+                            // be dereferenced via ReadMemory to recover the
+                            // string itself.
     }
 }


### PR DESCRIPTION
Fixes IProcessInfoProvider.GetProcessInfo().ImagePath on Linux ELF cores returning a managed assembly DLL path instead of the actual executable binary the process was originally exec()'d as.

## Background

`ProcessInfo.ImagePath` is documented as "Full path to the main executable image, if available". On Windows minidumps this works correctly via MinidumpReader. On Linux ELF cores, CoredumpReader had a comment promising AT_EXECFN-based resolution but the implementation simply walked LoadedImages.Values (an ImmutableDictionary) and returned the first non-interpreter, non-/dev entry. In practice that picks whichever image happens to come first in dictionary enumeration order — on modern .NET cores this is almost always a managed assembly DLL, NOT the actual exe.

Observed on three real-world Linux ELF cores:
- core1 → "System.Runtime.Loader.dll"
- core2 → "System.Security.Cryptography.X509Certificates.dll"
- core3 → "System.Numerics.Vectors.dll"

None of those are the real executable. Downstream consumers (dump-analysis tooling that surfaces "what was this process?" to users / LLMs) had no reliable way to identify the binary.

## Fix

The Linux kernel records the absolute path of the originally exec()'d binary in auxv entry AT_EXECFN (value 31). The entry is a pointer into the target process's address space pointing at a NUL-terminated ASCII string. This is the canonical source for "what binary was this".

This change:
1. Adds `Execfn = 31` to the internal `ElfAuxvType` enum.
2. Adds private `TryGetImagePathFromAuxv()` helper to CoredumpReader that reads the AT_EXECFN pointer, then dereferences it via `_core.ReadMemory()` to recover the NUL-terminated path.
3. Modifies `GetProcessInfo()` to prefer the AT_EXECFN value, falling back to the legacy "first non-interpreter LoadedImage" behavior only when AT_EXECFN is absent (older cores) or unreadable (corrupt / not mapped into the core's address space).
4. Strips the trailing " (deleted)" marker — same treatment the fallback path already applies to image filenames.

## Safety

- 4096-byte cap on the string read (PATH_MAX on Linux). A corrupt AT_EXECFN pointer into a large readable region can't make us hang scanning for a NUL.
- Rejects high-bit (>= 0x80) bytes. A pointer to non-text memory (e.g. a stale auxv pointer into a slab arena) will fail the ASCII-only check and we fall back, rather than returning garbage.
- `ReadMemory` returning 0 bytes (pointer not in any PT_LOAD range) triggers fallback.
- Empty string triggers fallback.

## Test

Strengthens the existing
`ProcessInfoProvider_FullDump_ReportsPlausibleData` test to assert `Path.GetFileName(info.ImagePath) == "Types"` (Linux) / `"Types.exe"` (Windows). Previously the test only asserted `!IsNullOrWhiteSpace(ImagePath)`, which both the buggy and the fixed code path satisfy. The new assertion would have caught the regression where a managed DLL slipped into ImagePath.