### PR TITLE
Harden lock-free MMF dump reader

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/Attributes/DataReaderKind.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/Attributes/DataReaderKind.cs
@@ -21,7 +21,8 @@ namespace Microsoft.Diagnostics.Runtime.Tests
 
         /// <summary>
         /// The opt-in <see cref="DataTargetOptions.UseLockFreeMemoryMapReader"/>
-        /// reader: single-threaded, lock-free, memory-mapped over the dump file.
+        /// reader: thread-safe for concurrent memory reads/direct spans, lock-free, and
+        /// memory-mapped over the dump file. Dispose must not race active use.
         /// </summary>
         LockFreeMmf,
     }

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/MemoryReaderTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/MemoryReaderTests.cs
@@ -5,6 +5,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Diagnostics.Runtime.Implementation;
+using System.IO;
+using System.Runtime.InteropServices;
 using Xunit;
 
 namespace Microsoft.Diagnostics.Runtime.Tests
@@ -112,6 +114,359 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             // Zero-length succeeds even on a bogus address by contract.
             Assert.True(direct.TryGetDirectSpan(0xBAADF00DBAADF00D, 0, out span));
             Assert.Equal(0, span.Length);
+        }
+
+        [WindowsFact]
+        public void LockFreeMmfDataReader_IsThreadSafe()
+        {
+            using DataTarget dt = TestTargets.NestedException.LoadFullDump(
+                options: DataReaderKind.LockFreeMmf.ToOptions());
+
+            Assert.True(dt.DataReader.IsThreadSafe);
+        }
+
+        [WindowsFact]
+        public void LockFreeMmfDataReader_ConcurrentReads_MatchSerialReads()
+        {
+            using DataTarget dt = TestTargets.NestedException.LoadFullDump(
+                options: DataReaderKind.LockFreeMmf.ToOptions());
+
+            Assert.True(dt.DataReader.IsThreadSafe);
+
+            using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
+
+            // Build a baseline (address, length, expected bytes) tuple set serially. Each
+            // parallel worker will replay reads against the same addresses and assert it
+            // gets the same bytes back.
+            List<(ulong Address, byte[] Expected)> baseline = new();
+            foreach (ClrObject obj in runtime.Heap.EnumerateObjects())
+            {
+                if (obj.Address == 0)
+                    continue;
+
+                ulong size = obj.Size;
+                if (size == 0 || size > 4096)
+                    continue;
+
+                int len = (int)size;
+                byte[] buf = new byte[len];
+                if (dt.DataReader.Read(obj.Address, buf) != len)
+                    continue;
+
+                baseline.Add((obj.Address, buf));
+                if (baseline.Count >= 2000)
+                    break;
+            }
+
+            Assert.True(baseline.Count > 100, $"fixture too small for a stress test (got {baseline.Count})");
+
+            // Each thread iterates the baseline in a different order to maximize stripe
+            // contention and force segment-cache misses.
+            int threadCount = Math.Max(4, Environment.ProcessorCount);
+            int iterations = 4;
+            System.Collections.Concurrent.ConcurrentQueue<Exception> failures = new();
+
+            System.Threading.Tasks.Parallel.For(0, threadCount, threadIndex =>
+            {
+                try
+                {
+                    Random rng = new(threadIndex * 17 + 1);
+                    byte[] scratch = new byte[4096];
+
+                    for (int iter = 0; iter < iterations; iter++)
+                    {
+                        for (int i = 0; i < baseline.Count; i++)
+                        {
+                            // Permute the order per-thread. Use unchecked arithmetic since
+                            // we only want bit-mixing, not a meaningful integer result.
+                            int idx;
+                            unchecked
+                            {
+                                idx = ((i * (rng.Next() | 1)) + threadIndex * 31) & 0x7fffffff;
+                            }
+                            idx %= baseline.Count;
+
+                            (ulong addr, byte[] expected) = baseline[idx];
+                            Span<byte> slice = scratch.AsSpan(0, expected.Length);
+                            int read = dt.DataReader.Read(addr, slice);
+                            Assert.Equal(expected.Length, read);
+                            Assert.True(slice.SequenceEqual(expected),
+                                $"thread {threadIndex} got divergent bytes for address {addr:x}");
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    failures.Enqueue(ex);
+                }
+            });
+
+            if (!failures.IsEmpty)
+                throw new Xunit.Sdk.XunitException("concurrent read mismatch: " + failures.ToArray()[0]);
+        }
+
+        [WindowsFact]
+        public void LockFreeMmfDataReader_ConcurrentDirectSpan_MatchesRead()
+        {
+            using DataTarget dt = TestTargets.NestedException.LoadFullDump(
+                options: DataReaderKind.LockFreeMmf.ToOptions());
+
+            ISegmentedDirectMemoryAccess direct = Assert.IsAssignableFrom<ISegmentedDirectMemoryAccess>(dt.DataReader);
+            using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
+
+            List<(ulong Address, byte[] Expected)> baseline = new();
+            foreach (ClrObject obj in runtime.Heap.EnumerateObjects())
+            {
+                if (obj.Address == 0)
+                    continue;
+
+                ulong size = obj.Size;
+                if (size == 0 || size > 4096)
+                    continue;
+
+                int len = (int)size;
+                if (!direct.TryGetDirectSpan(obj.Address, len, out ReadOnlySpan<byte> span))
+                    continue;
+
+                baseline.Add((obj.Address, span.ToArray()));
+                if (baseline.Count >= 1000)
+                    break;
+            }
+
+            Assert.True(baseline.Count > 50, $"fixture too small (got {baseline.Count})");
+
+            int threadCount = Math.Max(4, Environment.ProcessorCount);
+            System.Collections.Concurrent.ConcurrentQueue<Exception> failures = new();
+
+            System.Threading.Tasks.Parallel.For(0, threadCount, threadIndex =>
+            {
+                try
+                {
+                    foreach ((ulong addr, byte[] expected) in baseline)
+                    {
+                        Assert.True(direct.TryGetDirectSpan(addr, expected.Length, out ReadOnlySpan<byte> span));
+                        Assert.True(span.SequenceEqual(expected),
+                            $"thread {threadIndex} got divergent direct-span bytes for address {addr:x}");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    failures.Enqueue(ex);
+                }
+            });
+
+            if (!failures.IsEmpty)
+                throw new Xunit.Sdk.XunitException("concurrent direct-span mismatch: " + failures.ToArray()[0]);
+        }
+
+        [Fact]
+        public void LockFreeMmfDataReader_FiltersInvalidSegmentsWithoutBreakingAdjacentReads()
+        {
+            byte[] fileBytes = [1, 2, 3, 4, 5, 6, 7, 8];
+            string path = WriteTempFile(fileBytes);
+            try
+            {
+                using FakeDumpReader inner = new(new[]
+                {
+                    new DumpMemorySegment(0x1000, 0, 4),
+                    new DumpMemorySegment(0x1004, ulong.MaxValue - 1, 4),
+                    new DumpMemorySegment(0x1004, 4, 4),
+                });
+                using LockFreeMmfDataReader reader = new(path, inner);
+
+                byte[] buffer = new byte[8];
+                Assert.Equal(8, reader.Read(0x1000, buffer));
+                Assert.Equal(fileBytes, buffer);
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
+
+        [Fact]
+        public void LockFreeMmfDataReader_FindsEarlierOverlappingSegment()
+        {
+            byte[] fileBytes = new byte[0x4000];
+            fileBytes[0x1000] = 0xa1;
+            fileBytes[0x1001] = 0xb2;
+            fileBytes[0x1002] = 0xc3;
+            fileBytes[0x1003] = 0xd4;
+            string path = WriteTempFile(fileBytes);
+            try
+            {
+                using FakeDumpReader inner = new(new[]
+                {
+                    new DumpMemorySegment(0x1000, 0, 0x2000),
+                    new DumpMemorySegment(0x1800, 0x3000, 0x100),
+                    new DumpMemorySegment(0x3000, 0x3100, 0x10),
+                });
+                using LockFreeMmfDataReader reader = new(path, inner);
+
+                byte[] buffer = new byte[4];
+                Assert.Equal(4, reader.Read(0x2000, buffer));
+                Assert.Equal(new byte[] { 0xa1, 0xb2, 0xc3, 0xd4 }, buffer);
+
+                ISegmentedDirectMemoryAccess direct = reader;
+                Assert.True(direct.TryGetDirectSpan(0x2000, 4, out ReadOnlySpan<byte> span));
+                Assert.True(span.SequenceEqual(buffer));
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
+
+        [Fact]
+        public void LockFreeMmfDataReader_RejectsOutOfViewDirectSpan()
+        {
+            string path = WriteTempFile([1, 2, 3, 4]);
+            try
+            {
+                using FakeDumpReader inner = new(new[]
+                {
+                    new DumpMemorySegment(0x1000, ulong.MaxValue - 1, 4),
+                });
+                using LockFreeMmfDataReader reader = new(path, inner);
+
+                ISegmentedDirectMemoryAccess direct = reader;
+                Assert.False(direct.TryGetDirectSpan(0x1000, 1, out ReadOnlySpan<byte> span));
+                Assert.Equal(0, span.Length);
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
+
+        [Fact]
+        public void LockFreeMmfDataReader_ReadAfterDisposeThrowsObjectDisposedException()
+        {
+            string path = WriteTempFile([1, 2, 3, 4]);
+            try
+            {
+                using FakeDumpReader inner = new(new[] { new DumpMemorySegment(0x1000, 0, 4) });
+                LockFreeMmfDataReader reader = new(path, inner);
+                reader.Dispose();
+
+                byte[] buffer = new byte[1];
+                Assert.Throws<ObjectDisposedException>(() => reader.Read(0x1000, buffer));
+                ISegmentedDirectMemoryAccess direct = reader;
+                Assert.Throws<ObjectDisposedException>(() => direct.TryGetDirectSpan(0x1000, 1, out _));
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
+
+        [Fact]
+        public async System.Threading.Tasks.Task LockFreeMmfDataReader_ConcurrentDisposeDisposesInnerReaderOnce()
+        {
+            string path = WriteTempFile([1, 2, 3, 4]);
+            try
+            {
+                FakeDumpReader inner = new(new[] { new DumpMemorySegment(0x1000, 0, 4) });
+                LockFreeMmfDataReader reader = new(path, inner);
+                int threadCount = Math.Max(8, Environment.ProcessorCount * 2);
+                using System.Threading.ManualResetEventSlim gate = new(initialState: false);
+                System.Collections.Concurrent.ConcurrentQueue<Exception> failures = new();
+                System.Threading.Tasks.Task[] tasks = Enumerable.Range(0, threadCount)
+                    .Select(_ => System.Threading.Tasks.Task.Run(() =>
+                    {
+                        try
+                        {
+                            gate.Wait();
+                            reader.Dispose();
+                        }
+                        catch (Exception ex)
+                        {
+                            failures.Enqueue(ex);
+                        }
+                    }))
+                    .ToArray();
+
+                gate.Set();
+                await System.Threading.Tasks.Task.WhenAll(tasks);
+
+                if (!failures.IsEmpty)
+                    throw new Xunit.Sdk.XunitException("concurrent dispose failed: " + failures.ToArray()[0]);
+
+                Assert.Equal(1, inner.DisposeCount);
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
+
+        [Fact]
+        public void LockFreeMmfDataReader_ConstructorFailureDisposesInnerReader()
+        {
+            string path = WriteTempFile([1, 2, 3, 4]);
+            try
+            {
+                FakeDumpReader inner = new(Array.Empty<DumpMemorySegment>(), throwOnEnumerate: true);
+
+                Assert.Throws<InvalidOperationException>(() => new LockFreeMmfDataReader(path, inner));
+                Assert.True(inner.Disposed);
+
+                using FileStream stream = File.Open(path, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+                Assert.Equal(4, stream.Length);
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
+
+        private static string WriteTempFile(byte[] bytes)
+        {
+            string path = Path.GetTempFileName();
+            File.WriteAllBytes(path, bytes);
+            return path;
+        }
+
+        private sealed class FakeDumpReader : IDataReader, IDumpFileMemorySource, IDisposable
+        {
+            private readonly IReadOnlyList<DumpMemorySegment> _segments;
+            private readonly bool _throwOnEnumerate;
+
+            public FakeDumpReader(IReadOnlyList<DumpMemorySegment> segments, bool throwOnEnumerate = false)
+            {
+                _segments = segments;
+                _throwOnEnumerate = throwOnEnumerate;
+            }
+
+            public int DisposeCount;
+            public bool Disposed => DisposeCount != 0;
+            public int PointerSize => 8;
+            public string DisplayName => nameof(FakeDumpReader);
+            public bool IsThreadSafe => true;
+            public OSPlatform TargetPlatform => OSPlatform.Windows;
+            public Architecture Architecture => Architecture.X64;
+            public int ProcessId => 0;
+
+            public IReadOnlyList<DumpMemorySegment> EnumerateMemorySegments()
+                => _throwOnEnumerate ? throw new InvalidOperationException("synthetic segment enumeration failure") : _segments;
+
+            public int Read(ulong address, Span<byte> buffer) => 0;
+            public bool Read<T>(ulong address, out T value) where T : unmanaged
+            {
+                value = default;
+                return false;
+            }
+            public T Read<T>(ulong address) where T : unmanaged => default;
+            public bool ReadPointer(ulong address, out ulong value)
+            {
+                value = 0;
+                return false;
+            }
+            public ulong ReadPointer(ulong address) => 0;
+            public IEnumerable<ModuleInfo> EnumerateModules() => Array.Empty<ModuleInfo>();
+            public bool GetThreadContext(uint threadID, uint contextFlags, Span<byte> context) => false;
+            public void FlushCachedData() { }
+            public void Dispose() => System.Threading.Interlocked.Increment(ref DisposeCount);
         }
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/DataReaders/LockFreeMmfDataReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DataReaders/LockFreeMmfDataReader.cs
@@ -12,9 +12,9 @@ using Microsoft.Diagnostics.Runtime.DataReaders.Implementation;
 namespace Microsoft.Diagnostics.Runtime.Implementation
 {
     /// <summary>
-    /// A lock-free, single-threaded <see cref="IDataReader"/> that satisfies memory reads
-    /// directly from a memory-mapped view of the dump file. Eliminates per-read locks and
-    /// stream seeks compared to the default cached/uncached minidump readers.
+    /// A lock-free <see cref="IDataReader"/> that satisfies memory reads directly from a
+    /// memory-mapped view of the dump file. Eliminates per-read locks and stream seeks
+    /// compared to the default cached/uncached minidump readers.
     ///
     /// <para>
     /// Construction strategy: the inner <see cref="IDataReader"/> (a normal
@@ -25,14 +25,25 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
     /// </para>
     ///
     /// <para>
-    /// Hot path: a sorted segment array + a single-slot last-used-segment cache provide
-    /// O(1) access for the dominant sequential-read pattern (heap walks, GC root traversal),
-    /// falling back to binary search for non-local addresses.
+    /// Hot path: a sorted segment array + a per-thread (striped) last-used-segment cache
+    /// provide O(1) access for the dominant sequential-read pattern (heap walks, GC root
+    /// traversal), falling back to binary search for non-local addresses. The stripe is
+    /// indexed by <see cref="Environment.CurrentManagedThreadId"/>, padded to a cache line
+    /// to avoid false sharing. Multiple threads can read concurrently with zero locking.
     /// </para>
     ///
     /// <para>
     /// All non-memory operations (modules, thread contexts, OS thread enumeration) delegate
-    /// to the inner reader, which retains its own access to the dump.
+    /// to the inner reader. If the inner reader does not report
+    /// <see cref="IDataReader.IsThreadSafe"/> as <c>true</c>, those delegated calls are
+    /// serialized through an instance-level lock. Memory reads never take this lock.
+    /// </para>
+    ///
+    /// <para>
+    /// Thread safety: concurrent calls to <see cref="Read(ulong, Span{byte})"/>,
+    /// <see cref="TryGetDirectSpan(ulong, int, out ReadOnlySpan{byte})"/>, and the typed
+    /// <c>Read</c>/<c>ReadPointer</c> overloads are safe. <see cref="Dispose"/> must not
+    /// race with active reads — the standard .NET disposal contract applies.
     /// </para>
     /// </summary>
     internal sealed class LockFreeMmfDataReader : IDataReader, IThreadReader, IDumpInfoProvider, ISegmentedDirectMemoryAccess, IDisposable, IThreadInfoReader, IProcessInfoProvider, IMemoryRegionReader, IModuleSegmentReader
@@ -44,6 +55,9 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
         private readonly IProcessInfoProvider? _innerProcessInfo;
         private readonly IMemoryRegionReader? _innerRegions;
         private readonly IModuleSegmentReader? _innerModuleSegments;
+        // Non-null only when the inner reader is not itself thread-safe. Memory reads never
+        // touch this lock; only delegated cold-path calls (modules, threads, contexts) do.
+        private readonly object? _innerLock;
         private readonly MemoryMappedFile _mmf;
         private readonly MemoryMappedViewAccessor _accessor;
         // Base address of the mapped view, stored as IntPtr so the field itself is not unsafe.
@@ -54,8 +68,23 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
         private readonly IntPtr _basePtr;
         private readonly long _viewLength;
         private readonly Segment[] _segments;
-        private int _lastSegmentIndex;
-        private bool _disposed;
+        // Per-thread last-used-segment cache, striped by managed thread id. Each slot is
+        // padded to 64 bytes to prevent false sharing between adjacent stripes. A torn read
+        // is impossible (int is atomic on .NET) and a stale value just causes a cache miss
+        // that falls back to binary search via FindSegment.
+        private readonly PaddedInt[] _lastSegmentByStripe;
+        private readonly int _stripeMask;
+        private readonly bool _hasOverlappingSegments;
+        private int _disposed;
+
+        // Cache-line sized container for an int. The 64-byte size is a generous floor that
+        // covers x64 (64), Apple silicon (128 — we accept some sharing there), and most ARM.
+        [StructLayout(LayoutKind.Explicit, Size = 64)]
+        private struct PaddedInt
+        {
+            [FieldOffset(0)]
+            public int Value;
+        }
 
         private readonly struct Segment
         {
@@ -99,13 +128,16 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
             _innerProcessInfo = inner as IProcessInfoProvider;
             _innerRegions = inner as IMemoryRegionReader;
             _innerModuleSegments = inner as IModuleSegmentReader;
+            // Only synchronize cold-path delegation when the inner cannot do it itself.
+            _innerLock = inner.IsThreadSafe ? null : new object();
 
             MemoryMappedFile? mmf = null;
             MemoryMappedViewAccessor? accessor = null;
             FileStream? fs = null;
+            bool pointerAcquired = false;
             try
             {
-                // Open the file ourselves with FileShare.Read|Write|Delete so we don't conflict with
+                // Open the file ourselves with FileShare.Read|Delete so we don't conflict with
                 // the inner reader (which already has the file open with FileShare.Read).
                 // MemoryMappedFile.CreateFromFile(string, ...) opens with FileShare.None internally,
                 // which would throw "file in use" against the inner reader's existing handle.
@@ -113,31 +145,73 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
                 mmf = MemoryMappedFile.CreateFromFile(fs, mapName: null, capacity: 0, MemoryMappedFileAccess.Read,
                     HandleInheritability.None, leaveOpen: false);
                 accessor = mmf.CreateViewAccessor(0, 0, MemoryMappedFileAccess.Read);
-                _viewLength = (long)accessor.SafeMemoryMappedViewHandle.ByteLength;
+                long viewLength = (long)accessor.SafeMemoryMappedViewHandle.ByteLength;
 
+                IntPtr basePtr;
                 unsafe
                 {
                     byte* ptr = null;
                     accessor.SafeMemoryMappedViewHandle.AcquirePointer(ref ptr);
-                    _basePtr = (IntPtr)(ptr + accessor.PointerOffset);
+                    pointerAcquired = true;
+                    basePtr = (IntPtr)(ptr + accessor.PointerOffset);
                 }
 
+                Segment[] segments = BuildSegments(segmentSource.EnumerateMemorySegments(), (ulong)viewLength, out bool hasOverlappingSegments);
+                // Size the stripe array to ProcessorCount * 2 (rounded up to a power of two,
+                // minimum 4). This covers oversubscription cheaply — total footprint is
+                // 64 * stripes bytes (~1–2 KB on typical machines).
+                int stripes = RoundUpToPowerOfTwo(Math.Max(4, Environment.ProcessorCount * 2));
+
+                _viewLength = viewLength;
+                _basePtr = basePtr;
                 _mmf = mmf;
                 _accessor = accessor;
+                _segments = segments;
+                _lastSegmentByStripe = new PaddedInt[stripes];
+                _hasOverlappingSegments = hasOverlappingSegments;
+                _stripeMask = stripes - 1;
             }
-            catch (Exception ex) when (IsAddressSpaceExhaustion(ex))
+            catch (Exception ex)
             {
+                if (pointerAcquired)
+                    accessor?.SafeMemoryMappedViewHandle.ReleasePointer();
                 accessor?.Dispose();
                 mmf?.Dispose();
                 fs?.Dispose();
-                throw new OutOfMemoryException(BuildOomMessage(dumpPath), ex);
-            }
+                if (inner is IDisposable disposableInner)
+                    disposableInner.Dispose();
 
-            _segments = BuildSegments(segmentSource.EnumerateMemorySegments());
+                if (IsAddressSpaceExhaustion(ex))
+                    throw new OutOfMemoryException(BuildOomMessage(dumpPath), ex);
+
+                throw;
+            }
         }
+
+        private static int RoundUpToPowerOfTwo(int value)
+        {
+            // value is always >= 4 here; this is the standard bithack rounded up.
+            value--;
+            value |= value >> 1;
+            value |= value >> 2;
+            value |= value >> 4;
+            value |= value >> 8;
+            value |= value >> 16;
+            return value + 1;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private int CurrentStripe() => Environment.CurrentManagedThreadId & _stripeMask;
 
         private static bool IsAddressSpaceExhaustion(Exception ex)
             => ex is OutOfMemoryException or IOException;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void ThrowIfDisposed()
+        {
+            if (_disposed != 0)
+                throw new ObjectDisposedException(nameof(LockFreeMmfDataReader));
+        }
 
         private static string BuildOomMessage(string dumpPath)
         {
@@ -164,26 +238,39 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
                 $"to the streaming reader.";
         }
 
-        private Segment[] BuildSegments(IReadOnlyList<DumpMemorySegment> source)
+        private static Segment[] BuildSegments(IReadOnlyList<DumpMemorySegment> source, ulong viewLength, out bool hasOverlappingSegments)
         {
             int count = source.Count;
             Segment[] result = new Segment[count];
+            int validCount = 0;
             for (int i = 0; i < count; i++)
             {
                 DumpMemorySegment s = source[i];
-                if (s.FileOffset > (ulong)_viewLength || s.FileOffset + s.Size > (ulong)_viewLength)
-                {
-                    // Truncate / skip out-of-range entries rather than fail outright; the
-                    // inner reader can fall back if needed for cold paths (we never invoke it
-                    // for memory reads, so an empty slot just produces a 0-byte read).
-                    result[i] = new Segment(s.VirtualAddress, 0, s.FileOffset);
+                if (s.FileOffset > viewLength || s.Size > viewLength - s.FileOffset)
                     continue;
-                }
-                result[i] = new Segment(s.VirtualAddress, s.Size, s.FileOffset);
+
+                result[validCount++] = new Segment(s.VirtualAddress, s.Size, s.FileOffset);
             }
 
+            if (validCount != result.Length)
+                Array.Resize(ref result, validCount);
+
             // The contract of IDumpFileMemorySource requires sorted-by-VA, but be defensive.
-            Array.Sort(result, static (a, b) => a.VirtualAddress.CompareTo(b.VirtualAddress));
+            Array.Sort(result, static (a, b) => a.VirtualAddress != b.VirtualAddress ? a.VirtualAddress.CompareTo(b.VirtualAddress) : b.Size.CompareTo(a.Size));
+
+            hasOverlappingSegments = false;
+            ulong maxEnd = 0;
+            for (int i = 0; i < result.Length; i++)
+            {
+                Segment segment = result[i];
+                if (i != 0 && segment.VirtualAddress < maxEnd)
+                    hasOverlappingSegments = true;
+
+                ulong end = segment.Size > ulong.MaxValue - segment.VirtualAddress ? ulong.MaxValue : segment.VirtualAddress + segment.Size;
+                if (end > maxEnd)
+                    maxEnd = end;
+            }
+
             return result;
         }
 
@@ -191,16 +278,26 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
         // IMemoryReader — hot path (lock-free pointer reads)
         // ============================================================
 
-        public int PointerSize => _inner.PointerSize;
+        public int PointerSize
+        {
+            get
+            {
+                ThrowIfDisposed();
+                return _inner.PointerSize;
+            }
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public int Read(ulong address, Span<byte> buffer)
         {
+            ThrowIfDisposed();
+
             if (buffer.Length == 0)
                 return 0;
 
+            int stripe = CurrentStripe();
             int idx;
-            int lastIdx = _lastSegmentIndex;
+            int lastIdx = _lastSegmentByStripe[stripe].Value;
             if ((uint)lastIdx < (uint)_segments.Length && _segments[lastIdx].Contains(address))
             {
                 idx = lastIdx;
@@ -210,7 +307,7 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
                 idx = FindSegment(address);
                 if (idx < 0)
                     return 0;
-                _lastSegmentIndex = idx;
+                _lastSegmentByStripe[stripe].Value = idx;
             }
 
             int bytesRead = ReadFromSegment(ref _segments[idx], address, buffer);
@@ -218,11 +315,11 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
             // Span adjacent segments transparently — matches the existing minidump readers.
             while (bytesRead < buffer.Length)
             {
-                int nextIdx = idx + 1;
-                if ((uint)nextIdx >= (uint)_segments.Length)
+                ulong nextAddress = address + (ulong)bytesRead;
+                int nextIdx = _hasOverlappingSegments ? FindSegment(nextAddress) : idx + 1;
+                if (nextIdx == idx || (uint)nextIdx >= (uint)_segments.Length)
                     break;
 
-                ulong nextAddress = address + (ulong)bytesRead;
                 ref Segment nextSeg = ref _segments[nextIdx];
                 if (!nextSeg.Contains(nextAddress))
                     break;
@@ -233,7 +330,7 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
 
                 bytesRead += additional;
                 idx = nextIdx;
-                _lastSegmentIndex = idx;
+                _lastSegmentByStripe[stripe].Value = idx;
             }
 
             return bytesRead;
@@ -287,7 +384,18 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
         private int ReadFromSegment(ref Segment seg, ulong address, Span<byte> buffer)
         {
             ulong offsetInSeg = address - seg.VirtualAddress;
-            ulong availableU = seg.Size - offsetInSeg;
+            if (offsetInSeg > seg.Size)
+                return 0;
+
+            ulong availableInSegment = seg.Size - offsetInSeg;
+            if (availableInSegment == 0 || seg.FileOffset > (ulong)_viewLength)
+                return 0;
+
+            ulong availableInView = (ulong)_viewLength - seg.FileOffset;
+            if (offsetInSeg > availableInView)
+                return 0;
+
+            ulong availableU = Math.Min(availableInSegment, availableInView - offsetInSeg);
             if (availableU == 0)
                 return 0;
 
@@ -307,6 +415,8 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool TryGetDirectSpan(ulong address, int length, out ReadOnlySpan<byte> span)
         {
+            ThrowIfDisposed();
+
             if (length == 0)
             {
                 span = default;
@@ -319,8 +429,9 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
                 return false;
             }
 
+            int stripe = CurrentStripe();
             int idx;
-            int lastIdx = _lastSegmentIndex;
+            int lastIdx = _lastSegmentByStripe[stripe].Value;
             if ((uint)lastIdx < (uint)_segments.Length && _segments[lastIdx].Contains(address))
             {
                 idx = lastIdx;
@@ -333,33 +444,44 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
                     span = default;
                     return false;
                 }
-                _lastSegmentIndex = idx;
+                _lastSegmentByStripe[stripe].Value = idx;
             }
 
             ref Segment seg = ref _segments[idx];
             ulong offsetInSeg = address - seg.VirtualAddress;
-            ulong availableU = seg.Size - offsetInSeg;
+            if (offsetInSeg > seg.Size || seg.FileOffset > (ulong)_viewLength)
+            {
+                span = default;
+                return false;
+            }
+
+            ulong availableInSegment = seg.Size - offsetInSeg;
+            ulong availableInView = (ulong)_viewLength - seg.FileOffset;
+            if (offsetInSeg > availableInView)
+            {
+                span = default;
+                return false;
+            }
+
+            ulong availableU = Math.Min(availableInSegment, availableInView - offsetInSeg);
             if (availableU < (ulong)length)
             {
-                // Range crosses a segment boundary (or extends past the segment end);
+                // Range crosses a segment boundary (or extends past the mapped view);
                 // caller falls back to Read which transparently spans adjacent segments.
                 span = default;
                 return false;
             }
 
             ulong fileOffset = seg.FileOffset + offsetInSeg;
-            if (fileOffset > (ulong)_viewLength || fileOffset + (ulong)length > (ulong)_viewLength)
-            {
-                span = default;
-                return false;
-            }
-
             span = ViewSpan((long)fileOffset, length);
             return true;
         }
 
         private int FindSegment(ulong address)
         {
+            if (_hasOverlappingSegments)
+                return FindOverlappingSegment(address);
+
             int lo = 0;
             int hi = _segments.Length - 1;
 
@@ -379,70 +501,226 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
             return -1;
         }
 
+        private int FindOverlappingSegment(ulong address)
+        {
+            for (int i = 0; i < _segments.Length; i++)
+            {
+                ref Segment seg = ref _segments[i];
+                if (address < seg.VirtualAddress)
+                    break;
+
+                if (seg.Contains(address))
+                    return i;
+            }
+
+            return -1;
+        }
+
         // ============================================================
         // IDataReader — cold path (delegated to inner)
         // ============================================================
 
-        public string DisplayName => _inner.DisplayName;
-        public bool IsThreadSafe => false;
-        public OSPlatform TargetPlatform => _inner.TargetPlatform;
-        public Architecture Architecture => _inner.Architecture;
-        public int ProcessId => _inner.ProcessId;
+        public string DisplayName
+        {
+            get
+            {
+                ThrowIfDisposed();
+                return _inner.DisplayName;
+            }
+        }
+        public bool IsThreadSafe => true;
+        public OSPlatform TargetPlatform
+        {
+            get
+            {
+                ThrowIfDisposed();
+                return _inner.TargetPlatform;
+            }
+        }
+        public Architecture Architecture
+        {
+            get
+            {
+                ThrowIfDisposed();
+                return _inner.Architecture;
+            }
+        }
+        public int ProcessId
+        {
+            get
+            {
+                ThrowIfDisposed();
+                return _inner.ProcessId;
+            }
+        }
 
-        public IEnumerable<ModuleInfo> EnumerateModules() => _inner.EnumerateModules();
+        public IEnumerable<ModuleInfo> EnumerateModules()
+        {
+            ThrowIfDisposed();
+
+            if (_innerLock is null)
+                return _inner.EnumerateModules();
+
+            // Materialize under the lock; lazy enumeration would otherwise leak across threads.
+            lock (_innerLock)
+                return new List<ModuleInfo>(_inner.EnumerateModules());
+        }
 
         public bool GetThreadContext(uint threadID, uint contextFlags, Span<byte> context)
-            => _inner.GetThreadContext(threadID, contextFlags, context);
+        {
+            ThrowIfDisposed();
 
-        public void FlushCachedData() => _inner.FlushCachedData();
+            if (_innerLock is null)
+                return _inner.GetThreadContext(threadID, contextFlags, context);
+
+            lock (_innerLock)
+                return _inner.GetThreadContext(threadID, contextFlags, context);
+        }
+
+        public void FlushCachedData()
+        {
+            ThrowIfDisposed();
+
+            // Reset every stripe so stale cache entries don't survive across a flush.
+            for (int i = 0; i < _lastSegmentByStripe.Length; i++)
+                _lastSegmentByStripe[i].Value = 0;
+
+            if (_innerLock is null)
+                _inner.FlushCachedData();
+            else
+                lock (_innerLock)
+                    _inner.FlushCachedData();
+        }
 
         // IThreadReader (passthrough so DAC OS thread enumeration keeps working)
         public IEnumerable<uint> EnumerateOSThreadIds()
-            => _innerThreads?.EnumerateOSThreadIds() ?? Array.Empty<uint>();
+        {
+            ThrowIfDisposed();
+
+            if (_innerThreads is null)
+                return Array.Empty<uint>();
+
+            if (_innerLock is null)
+                return _innerThreads.EnumerateOSThreadIds();
+
+            lock (_innerLock)
+                return new List<uint>(_innerThreads.EnumerateOSThreadIds());
+        }
 
         public ulong GetThreadTeb(uint osThreadId)
-            => _innerThreads?.GetThreadTeb(osThreadId) ?? 0;
+        {
+            ThrowIfDisposed();
 
-        // IDumpInfoProvider passthrough
-        public bool IsMiniOrTriage => _innerInfo?.IsMiniOrTriage ?? false;
-        public bool IsCreatedByDotNetRuntime => _innerInfo?.IsCreatedByDotNetRuntime ?? false;
+            if (_innerThreads is null)
+                return 0;
+
+            if (_innerLock is null)
+                return _innerThreads.GetThreadTeb(osThreadId);
+
+            lock (_innerLock)
+                return _innerThreads.GetThreadTeb(osThreadId);
+        }
+
+        // IDumpInfoProvider passthrough. These properties are computed once by the inner
+        // and read-only thereafter, so no locking is required.
+        public bool IsMiniOrTriage
+        {
+            get
+            {
+                ThrowIfDisposed();
+                return _innerInfo?.IsMiniOrTriage ?? false;
+            }
+        }
+        public bool IsCreatedByDotNetRuntime
+        {
+            get
+            {
+                ThrowIfDisposed();
+                return _innerInfo?.IsCreatedByDotNetRuntime ?? false;
+            }
+        }
 
         // IThreadInfoReader passthrough
         public bool TryGetThreadInfo(uint osThreadId, out ThreadInfo info)
         {
+            ThrowIfDisposed();
+
             if (_innerThreadInfo is null)
                 throw CreateUnsupportedInterfaceException(nameof(IThreadInfoReader));
 
-            return _innerThreadInfo.TryGetThreadInfo(osThreadId, out info);
+            if (_innerLock is null)
+                return _innerThreadInfo.TryGetThreadInfo(osThreadId, out info);
+
+            lock (_innerLock)
+                return _innerThreadInfo.TryGetThreadInfo(osThreadId, out info);
         }
 
         public IEnumerable<ThreadInfo> EnumerateThreadInfo()
-            => _innerThreadInfo?.EnumerateThreadInfo()
-               ?? throw CreateUnsupportedInterfaceException(nameof(IThreadInfoReader));
+        {
+            ThrowIfDisposed();
+
+            if (_innerThreadInfo is null)
+                throw CreateUnsupportedInterfaceException(nameof(IThreadInfoReader));
+
+            if (_innerLock is null)
+                return _innerThreadInfo.EnumerateThreadInfo();
+
+            lock (_innerLock)
+                return new List<ThreadInfo>(_innerThreadInfo.EnumerateThreadInfo());
+        }
 
         // IProcessInfoProvider passthrough
         public ProcessInfo GetProcessInfo()
-            => _innerProcessInfo?.GetProcessInfo()
-               ?? throw CreateUnsupportedInterfaceException(nameof(IProcessInfoProvider));
+        {
+            ThrowIfDisposed();
+
+            if (_innerProcessInfo is null)
+                throw CreateUnsupportedInterfaceException(nameof(IProcessInfoProvider));
+
+            if (_innerLock is null)
+                return _innerProcessInfo.GetProcessInfo();
+
+            lock (_innerLock)
+                return _innerProcessInfo.GetProcessInfo();
+        }
 
         // IMemoryRegionReader passthrough
         public IEnumerable<MemoryRegion> EnumerateMemoryRegions()
-            => _innerRegions?.EnumerateMemoryRegions()
-               ?? throw CreateUnsupportedInterfaceException(nameof(IMemoryRegionReader));
+        {
+            ThrowIfDisposed();
+
+            if (_innerRegions is null)
+                throw CreateUnsupportedInterfaceException(nameof(IMemoryRegionReader));
+
+            if (_innerLock is null)
+                return _innerRegions.EnumerateMemoryRegions();
+
+            lock (_innerLock)
+                return new List<MemoryRegion>(_innerRegions.EnumerateMemoryRegions());
+        }
 
         // IModuleSegmentReader passthrough
         public IEnumerable<ModuleSegment> EnumerateModuleSegments(ulong moduleBaseAddress)
-            => _innerModuleSegments?.EnumerateModuleSegments(moduleBaseAddress)
-               ?? throw CreateUnsupportedInterfaceException(nameof(IModuleSegmentReader));
+        {
+            ThrowIfDisposed();
+
+            if (_innerModuleSegments is null)
+                throw CreateUnsupportedInterfaceException(nameof(IModuleSegmentReader));
+
+            if (_innerLock is null)
+                return _innerModuleSegments.EnumerateModuleSegments(moduleBaseAddress);
+
+            lock (_innerLock)
+                return new List<ModuleSegment>(_innerModuleSegments.EnumerateModuleSegments(moduleBaseAddress));
+        }
 
         private static NotSupportedException CreateUnsupportedInterfaceException(string interfaceName)
             => new($"The inner data reader does not implement {interfaceName}.");
 
         public void Dispose()
         {
-            if (_disposed)
+            if (System.Threading.Interlocked.Exchange(ref _disposed, 1) != 0)
                 return;
-            _disposed = true;
 
             if (_inner is IDisposable d)
                 d.Dispose();

--- a/src/Microsoft.Diagnostics.Runtime/DataTargetOptions.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DataTargetOptions.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
@@ -102,8 +102,9 @@ public class DataTargetOptions
 
     /// <summary>
     /// When true, <see cref="DataTarget.LoadDump(string, DataTargetOptions?)"/> will wrap the underlying
-    /// dump reader with a single-threaded, lock-free, memory-mapped data reader. This trades thread safety
-    /// for significantly faster sequential read patterns (heap walks, GC root traversal).
+    /// dump reader with a thread-safe, lock-free, memory-mapped data reader. This removes per-read locks
+    /// and stream seeks from concurrent memory reads and direct-span access, which significantly improves
+    /// sequential read patterns (heap walks, GC root traversal).
     ///
     /// <para>
     /// Only takes effect when loading a dump from a file path (Minidump, ELF coredump, or Mach-O coredump).
@@ -111,9 +112,10 @@ public class DataTargetOptions
     /// </para>
     ///
     /// <para>
-    /// Default is <c>false</c>. Setting this to <c>true</c> means the resulting
-    /// <see cref="IDataReader"/> is NOT thread safe; callers must serialize all access to the
-    /// <see cref="DataTarget"/>, <see cref="ClrRuntime"/>, and <see cref="ClrHeap"/>.
+    /// Default is <c>false</c>. When enabled, concurrent memory reads and
+    /// <see cref="ISegmentedDirectMemoryAccess.TryGetDirectSpan"/>
+    /// calls are safe. <see cref="DataTarget.Dispose"/> must not race active use; dispose the data target
+    /// only after all readers are quiesced.
     /// </para>
     ///
     /// <para>


### PR DESCRIPTION
## Summary

Hardens the existing opt-in lock-free memory-mapped dump reader for concurrent read/direct-span use.

This PR keeps the existing reader architecture, but closes correctness and lifetime gaps found during review:

- validates dump-controlled segment file ranges with overflow-safe subtraction checks
- filters invalid file ranges before publishing the segment table
- handles overlapping virtual-address segments without losing valid memory
- fails closed after disposal before touching mapped memory or delegated reader state
- makes `Dispose` idempotent for concurrent callers with an atomic disposed transition
- releases acquired MMF resources and disposes the inner reader if construction fails after pointer acquisition
- updates the public/test contract for concurrent reads/direct spans and dispose quiescence

Part of microsoft/clrmd#420.

## Validation

- Built as part of the split branch verification: `dotnet build src/Microsoft.Diagnostics.Runtime/Microsoft.Diagnostics.Runtime.csproj --framework net10.0` -- passed with 0 warnings and 0 errors.
- This split branch was recombined with the other reduced branches and compared against `lockfree-mmf-threadsafe`; all non-stress paths matched the original combined branch.
