### PR TITLE
Make dump reader caches safe for concurrent reads

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/DataReaders/Core/CoreDumpReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DataReaders/Core/CoreDumpReader.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Threading;
 using Microsoft.Diagnostics.Runtime.DataReaders.Implementation;
 using Microsoft.Diagnostics.Runtime.Implementation;
 using Microsoft.Diagnostics.Runtime.Utilities;
@@ -18,7 +19,9 @@ namespace Microsoft.Diagnostics.Runtime
         private readonly DataTargetLimits? _limits;
         private Dictionary<uint, IElfPRStatus>? _threads;
         private List<ModuleInfo>? _modules;
-        private bool? _isCreatedByDotNetRuntime;
+        // 0 = unknown, 1 = false, 2 = true. Single int gives an atomic, lock-free
+        // tri-state without the torn-read hazard of Nullable<bool> (which is two fields).
+        private int _isCreatedByDotNetRuntimeState;
 
         public string DisplayName { get; }
         public OSPlatform TargetPlatform => OSPlatform.Linux;
@@ -46,7 +49,7 @@ namespace Microsoft.Diagnostics.Runtime
             };
         }
 
-        public bool IsThreadSafe => false;
+        public bool IsThreadSafe => true;
 
         public bool IsMiniOrTriage => false;
 
@@ -54,8 +57,14 @@ namespace Microsoft.Diagnostics.Runtime
         {
             get
             {
-                _isCreatedByDotNetRuntime ??= SpecialDiagInfo.TryReadSpecialDiagInfo(this, out _);
-                return _isCreatedByDotNetRuntime.Value;
+                int s = Volatile.Read(ref _isCreatedByDotNetRuntimeState);
+                if (s != 0)
+                    return s == 2;
+
+                bool result = SpecialDiagInfo.TryReadSpecialDiagInfo(this, out _);
+                int newState = result ? 2 : 1;
+                int publishedState = Interlocked.CompareExchange(ref _isCreatedByDotNetRuntimeState, newState, 0);
+                return publishedState == 0 ? result : publishedState == 2;
             }
         }
 
@@ -77,20 +86,23 @@ namespace Microsoft.Diagnostics.Runtime
 
         public IEnumerable<ModuleInfo> EnumerateModules()
         {
-            if (_modules is null)
-            {
-                // Need to filter out non-modules like the interpreter (named something
-                // like "ld-2.23") and anything that starts with /dev/ because their
-                // memory range overlaps with actual modules.
-                ulong interpreter = _core.GetAuxvValue(ElfAuxvType.Base);
+            List<ModuleInfo>? modules = Volatile.Read(ref _modules);
+            if (modules is not null)
+                return modules;
 
-                _modules = new List<ModuleInfo>();
-                foreach (ElfLoadedImage image in _core.LoadedImages.Values)
-                    if (image.BaseAddress != interpreter && !image.FileName.StartsWith("/dev", StringComparison.Ordinal))
-                        _modules.Add(CreateModuleInfo(image));
-            }
+            // Need to filter out non-modules like the interpreter (named something
+            // like "ld-2.23") and anything that starts with /dev/ because their
+            // memory range overlaps with actual modules.
+            ulong interpreter = _core.GetAuxvValue(ElfAuxvType.Base);
 
-            return _modules;
+            List<ModuleInfo> fresh = new();
+            foreach (ElfLoadedImage image in _core.LoadedImages.Values)
+                if (image.BaseAddress != interpreter && !image.FileName.StartsWith("/dev", StringComparison.Ordinal))
+                    fresh.Add(CreateModuleInfo(image));
+
+            // First publisher wins; subsequent callers see the same list. Concurrent
+            // double-construction is wasted work but never produces a torn view.
+            return Interlocked.CompareExchange(ref _modules, fresh, null) ?? fresh;
         }
 
         private ModuleInfo CreateModuleInfo(ElfLoadedImage image)
@@ -112,8 +124,9 @@ namespace Microsoft.Diagnostics.Runtime
 
         public void FlushCachedData()
         {
-            _threads = null;
-            _modules = null;
+            Volatile.Write(ref _threads, null);
+            Volatile.Write(ref _modules, null);
+            Volatile.Write(ref _isCreatedByDotNetRuntimeState, 0);
         }
 
         public Architecture Architecture { get; }
@@ -146,18 +159,16 @@ namespace Microsoft.Diagnostics.Runtime
 
         private Dictionary<uint, IElfPRStatus> LoadThreads()
         {
-            Dictionary<uint, IElfPRStatus>? threads = _threads;
+            Dictionary<uint, IElfPRStatus>? threads = Volatile.Read(ref _threads);
+            if (threads is not null)
+                return threads;
 
-            if (threads is null)
-            {
-                threads = new Dictionary<uint, IElfPRStatus>();
-                foreach (IElfPRStatus status in _core.EnumeratePRStatus())
-                    threads.Add(status.ThreadId, status);
+            Dictionary<uint, IElfPRStatus> fresh = new();
+            foreach (IElfPRStatus status in _core.EnumeratePRStatus())
+                fresh.Add(status.ThreadId, status);
 
-                _threads = threads;
-            }
-
-            return threads;
+            // First publisher wins; the loser's Dictionary is dropped on the floor.
+            return Interlocked.CompareExchange(ref _threads, fresh, null) ?? fresh;
         }
 
         public IReadOnlyList<DumpMemorySegment> EnumerateMemorySegments()

--- a/src/Microsoft.Diagnostics.Runtime/Linux/ElfCoreFile.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Linux/ElfCoreFile.cs
@@ -8,6 +8,7 @@ using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Threading;
 
 namespace Microsoft.Diagnostics.Runtime.Utilities
 {
@@ -22,7 +23,11 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
         private readonly bool _leaveOpen;
         private readonly Reader _reader;
         private ImmutableDictionary<ulong, ElfLoadedImage>? _loadedImages;
+        // _auxvEntries is mutated only under _auxvLock; _auxvLoaded is the publication
+        // flag readers check first to avoid taking the lock on the steady-state path.
         private readonly Dictionary<ulong, ulong> _auxvEntries = new();
+        private readonly object _auxvLock = new();
+        private volatile bool _auxvLoaded;
         private ElfVirtualAddressSpace? _virtualAddressSpace;
 
         /// <summary>
@@ -69,7 +74,18 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
         /// <summary>
         /// A mapping of all loaded images in the process.  The key is the base address that the module is loaded at.
         /// </summary>
-        public ImmutableDictionary<ulong, ElfLoadedImage> LoadedImages => _loadedImages ??= LoadFileTable();
+        public ImmutableDictionary<ulong, ElfLoadedImage> LoadedImages
+        {
+            get
+            {
+                ImmutableDictionary<ulong, ElfLoadedImage>? cached = Volatile.Read(ref _loadedImages);
+                if (cached is not null)
+                    return cached;
+
+                ImmutableDictionary<ulong, ElfLoadedImage> fresh = LoadFileTable();
+                return Interlocked.CompareExchange(ref _loadedImages, fresh, null) ?? fresh;
+            }
+        }
 
         /// <summary>
         /// Creates an ElfCoreFile from a file on disk.
@@ -113,8 +129,13 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
         /// <returns>The number of bytes written into the buffer.</returns>
         public int ReadMemory(ulong address, Span<byte> buffer)
         {
-            _virtualAddressSpace ??= new ElfVirtualAddressSpace(ElfFile.ProgramHeaders, _reader.DataSource);
-            return _virtualAddressSpace.Read(address, buffer);
+            ElfVirtualAddressSpace? vas = Volatile.Read(ref _virtualAddressSpace);
+            if (vas is null)
+            {
+                ElfVirtualAddressSpace fresh = new(ElfFile.ProgramHeaders, _reader.DataSource);
+                vas = Interlocked.CompareExchange(ref _virtualAddressSpace, fresh, null) ?? fresh;
+            }
+            return vas.Read(address, buffer);
         }
 
         private IEnumerable<ElfNote> GetNotes(ElfNoteType type)
@@ -124,38 +145,54 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
 
         private void LoadAuxvTable()
         {
-            if (_auxvEntries.Count != 0)
+            if (_auxvLoaded)
                 return;
 
-            ElfNote auxvNote = GetNotes(ElfNoteType.Aux).SingleOrDefault() ?? throw new BadImageFormatException($"No auxv entries in coredump");
-            ulong position = 0;
-            int count = 0;
-            while (true)
+            // Hold the lock for the full read+populate so concurrent first callers do
+            // not corrupt _auxvEntries via interleaved Add calls.
+            lock (_auxvLock)
             {
-                if (count++ > _limits.MaxElfAuxvEntries)
-                    throw new InvalidDataException($"ELF coredump contains more than {_limits.MaxElfAuxvEntries} auxv entries, which exceeds the maximum allowed.");
+                if (_auxvLoaded)
+                    return;
 
-                ulong type;
-                ulong value;
-                if (ElfFile.Header.Is64Bit)
+                // Defensive: if a previous attempt threw mid-population (e.g., hit
+                // MaxElfAuxvEntries), start fresh so duplicate-key Adds don't fire.
+                _auxvEntries.Clear();
+
+                ElfNote auxvNote = GetNotes(ElfNoteType.Aux).SingleOrDefault() ?? throw new BadImageFormatException($"No auxv entries in coredump");
+                ulong position = 0;
+                int count = 0;
+                while (true)
                 {
-                    ElfAuxv64 elfauxv64 = auxvNote.ReadContents<ElfAuxv64>(ref position);
-                    type = elfauxv64.Type;
-                    value = elfauxv64.Value;
-                }
-                else
-                {
-                    ElfAuxv32 elfauxv32 = auxvNote.ReadContents<ElfAuxv32>(ref position);
-                    type = elfauxv32.Type;
-                    value = elfauxv32.Value;
+                    if (count++ > _limits.MaxElfAuxvEntries)
+                        throw new InvalidDataException($"ELF coredump contains more than {_limits.MaxElfAuxvEntries} auxv entries, which exceeds the maximum allowed.");
+
+                    ulong type;
+                    ulong value;
+                    if (ElfFile.Header.Is64Bit)
+                    {
+                        ElfAuxv64 elfauxv64 = auxvNote.ReadContents<ElfAuxv64>(ref position);
+                        type = elfauxv64.Type;
+                        value = elfauxv64.Value;
+                    }
+                    else
+                    {
+                        ElfAuxv32 elfauxv32 = auxvNote.ReadContents<ElfAuxv32>(ref position);
+                        type = elfauxv32.Type;
+                        value = elfauxv32.Value;
+                    }
+
+                    if (type == (ulong)ElfAuxvType.Null)
+                    {
+                        break;
+                    }
+
+                    _auxvEntries.Add(type, value);
                 }
 
-                if (type == (ulong)ElfAuxvType.Null)
-                {
-                    break;
-                }
-
-                _auxvEntries.Add(type, value);
+                // _auxvLoaded is volatile: the write here happens-after all _auxvEntries
+                // mutations and is observed by readers using the fast-path check above.
+                _auxvLoaded = true;
             }
         }
 

--- a/src/Microsoft.Diagnostics.Runtime/Linux/ElfFile.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Linux/ElfFile.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Immutable;
 using System.IO;
+using System.Threading;
 
 namespace Microsoft.Diagnostics.Runtime.Utilities
 {
@@ -93,19 +94,24 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
         {
             get
             {
-                if (_dynamicSection is null)
+                ElfDynamicSection? cached = Volatile.Read(ref _dynamicSection);
+                if (cached is not null)
+                    return cached;
+
+                ElfDynamicSection? fresh = null;
+                foreach (ElfProgramHeader? header in ProgramHeaders)
                 {
-                    foreach (ElfProgramHeader? header in ProgramHeaders)
+                    if (header.Type == ElfProgramHeaderType.Dynamic)
                     {
-                        if (header.Type == ElfProgramHeaderType.Dynamic)
-                        {
-                            _dynamicSection = new ElfDynamicSection(Reader, Header.Is64Bit, _position + (_virtual ? header.VirtualAddress : header.FileOffset), _virtual ? header.VirtualSize : header.FileSize, _limits);
-                            break;
-                        }
+                        fresh = new ElfDynamicSection(Reader, Header.Is64Bit, _position + (_virtual ? header.VirtualAddress : header.FileOffset), _virtual ? header.VirtualSize : header.FileSize, _limits);
+                        break;
                     }
                 }
 
-                return _dynamicSection;
+                if (fresh is null)
+                    return null;
+
+                return Interlocked.CompareExchange(ref _dynamicSection, fresh, null) ?? fresh;
             }
         }
 
@@ -223,7 +229,11 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
 
         private void CreateVirtualAddressReader()
         {
-            _virtualAddressReader ??= new Reader(new ElfVirtualAddressSpace(ProgramHeaders, Reader.DataSource));
+            if (Volatile.Read(ref _virtualAddressReader) is not null)
+                return;
+
+            Reader fresh = new(new ElfVirtualAddressSpace(ProgramHeaders, Reader.DataSource));
+            Interlocked.CompareExchange(ref _virtualAddressReader, fresh, null);
         }
 
         private void LoadNotes()

--- a/src/Microsoft.Diagnostics.Runtime/Windows/ArrayPoolBasedCacheEntry.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Windows/ArrayPoolBasedCacheEntry.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Diagnostics.Runtime.Windows
         {
             ThrowIfDisposed();
 
-            (ulong dataRemoved, uint _) = TryRemoveAllPagesFromCache(disposeLocks: false);
+            ulong dataRemoved = TryRemoveAllPagesFromCache();
 
             int oldCurrent;
             int newCurrent;
@@ -48,7 +48,11 @@ namespace Microsoft.Diagnostics.Runtime.Windows
 
         protected override (byte[] Data, ulong DataExtent) GetPageDataAtOffset(ulong pageAlignedOffset)
         {
-            // NOTE: The caller ensures this method is not called concurrently
+            // NOTE: With the lock-free CompareExchange publish path, this method MAY
+            // execute concurrently on the same offset from multiple threads. That is
+            // safe here: each call acquires its own MemoryMappedViewAccessor and rents
+            // its own buffer; only the CAS winner's buffer is retained, and the loser's
+            // buffer is returned via DiscardUnusedPage.
 
             if (HeapSegmentCacheEventSource.Instance.IsEnabled())
                 HeapSegmentCacheEventSource.Instance.PageInDataStart((long)(_segmentData.VirtualAddress + pageAlignedOffset), EntryPageSize);
@@ -142,60 +146,40 @@ namespace Microsoft.Diagnostics.Runtime.Windows
             return sizeRead;
         }
 
-        protected override void Dispose(bool disposing)
+        protected override void DiscardUnusedPage(CachePage<byte[]> page)
         {
-            for (int i = 0; i < 3; i++)
-            {
-                if (TryRemoveAllPagesFromCache(disposeLocks: true).ItemsSkipped == 0)
-                {
-                    break;
-                }
-            }
+            // Loser of a publish-CAS: return the rented buffer to the pool.
+            if (page.Data != null)
+                ArrayPool<byte>.Shared.Return(page.Data);
         }
 
-        private (ulong DataRemoved, uint ItemsSkipped) TryRemoveAllPagesFromCache(bool disposeLocks)
+        protected override void Dispose(bool disposing)
         {
-            // Assume we will be able to evict all non-null pages
+            TryRemoveAllPagesFromCache();
+        }
+
+        private ulong TryRemoveAllPagesFromCache()
+        {
             ulong dataRemoved = 0;
-            uint itemsSkipped = 0;
 
             for (int i = 0; i < _pages.Length; i++)
             {
-                CachePage<byte[]> page = _pages[i];
+                // Atomically claim the slot. In-flight readers that already captured
+                // the page reference (via Volatile.Read on the read path) may still be
+                // inside CopyDataFromPage / InvokeCallbackWithDataPtr mid-memcpy on
+                // page.Data. We intentionally do NOT return page.Data to
+                // ArrayPool<byte>.Shared here: if we did, another thread could rent the
+                // same buffer and overwrite it under that reader, producing corrupted
+                // reads (e.g. zeroed MethodTable pointers leading to spurious null
+                // ClrType lookups). Letting GC reclaim the array preserves the data
+                // for any in-flight reader's lifetime. Eviction is rare relative to
+                // the hot read path, so the lost pool reuse is acceptable.
+                CachePage<byte[]> page = Interlocked.Exchange(ref _pages[i], null);
                 if (page != null)
-                {
-                    ReaderWriterLockSlim dataChunkLock = _pageLocks[i];
-                    if (!dataChunkLock.TryEnterWriteLock(timeout: TimeSpan.Zero))
-                    {
-                        // Someone holds a read or write lock on this page, skip it
-                        itemsSkipped++;
-                        continue;
-                    }
-
-                    try
-                    {
-                        // double check that no other thread already scavenged this entry
-                        page = _pages[i];
-                        if (page != null)
-                        {
-                            ArrayPool<byte>.Shared.Return(page.Data);
-                            dataRemoved += page.DataExtent;
-                            _pages[i] = null;
-                        }
-                    }
-                    finally
-                    {
-                        dataChunkLock.ExitWriteLock();
-                        if (disposeLocks)
-                        {
-                            dataChunkLock.Dispose();
-                            _pageLocks[i] = null;
-                        }
-                    }
-                }
+                    dataRemoved += page.DataExtent;
             }
 
-            return (dataRemoved, itemsSkipped);
+            return dataRemoved;
         }
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/Windows/CacheEntryBase.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Windows/CacheEntryBase.cs
@@ -17,7 +17,6 @@ namespace Microsoft.Diagnostics.Runtime.Windows
     internal abstract class CacheEntryBase<T> : SegmentCacheEntry, IDisposable
     {
         protected CachePage<T>[] _pages;
-        protected ReaderWriterLockSlim[] _pageLocks;
         protected MinidumpSegment _segmentData;
         protected volatile int _entrySize;
         private int _lastAccessTimestamp;
@@ -34,14 +33,9 @@ namespace Microsoft.Diagnostics.Runtime.Windows
                 pageCount++;
 
             _pages = new CachePage<T>[pageCount];
-            _pageLocks = new ReaderWriterLockSlim[pageCount];
-            for (int i = 0; i < _pageLocks.Length; i++)
-            {
-                _pageLocks[i] = new ReaderWriterLockSlim();
-            }
 
-            _minSize = 4 * UIntPtr.Size + /*our four fields that are reference type fields (pages, pageLocks, segmentData, and updateOwningCacheForAddedChunk)*/
-                           2 * (_pages.Length * UIntPtr.Size) + /*The array of cache pages and matching size array of locks */
+            _minSize = 3 * UIntPtr.Size + /*our three reference-typed fields (pages, segmentData, and updateOwningCacheForAddedChunk)*/
+                           (_pages.Length * UIntPtr.Size) + /*The array of cache pages */
                            2 * sizeof(uint) + /*entrySize and minSize fields*/
                            sizeof(long) /*lastAccessTickCount field*/ +
                            derivedMinSize /*size added from our derived classes bookkeeping overhead*/;
@@ -137,7 +131,6 @@ namespace Microsoft.Diagnostics.Runtime.Windows
             Dispose(disposing: true);
 
             _pages = null;
-            _pageLocks = null;
         }
 
         protected abstract void Dispose(bool disposing);
@@ -172,101 +165,56 @@ namespace Microsoft.Diagnostics.Runtime.Windows
 
         protected abstract (T Data, ulong DataExtent) GetPageDataAtOffset(ulong pageAlignedOffset);
 
+        /// <summary>
+        /// Called when a page was constructed by <see cref="GetPageDataAtOffset"/> but lost
+        /// the CompareExchange race to publish it into <c>_pages</c>. Derived classes that
+        /// rent buffers (e.g. ArrayPoolBasedCacheEntry) override this to return the buffer.
+        /// </summary>
+        protected virtual void DiscardUnusedPage(CachePage<T> page)
+        {
+        }
+
         private ulong ReadPageDataFromOffset(int pageIndex, ulong inPageOffset, uint byteCount, IntPtr buffer, Func<UIntPtr, ulong, uint> dataReader)
         {
-            bool notifyCacheOfSizeUpdate = false;
-
-            ulong sizeRead = 0;
-            int addedSize = 0;
-
-            ReaderWriterLockSlim pageLock = _pageLocks[pageIndex];
-
-            pageLock.EnterReadLock();
-            bool holdsReadLock = true;
-            try
+            // Lock-free fast path: pages are immutable once published. A successful
+            // Volatile.Read of a non-null CachePage<T> guarantees we observe its fully
+            // initialized Data + DataExtent (set in the ctor before the CAS publish).
+            CachePage<T> page = Volatile.Read(ref _pages[pageIndex]);
+            if (page != null)
             {
-                // THREADING: If the data is not null we can just read it directly as we hold the read lock, if it is null we must acquire the write lock in
-                // preparation to fetch the data from physical memory
-                if (_pages[pageIndex] != null)
-                {
-                    UpdateLastAccessTimstamp();
-
-                    if (dataReader == null)
-                    {
-                        sizeRead = CopyDataFromPage(_pages[pageIndex], buffer, inPageOffset, byteCount);
-                    }
-                    else
-                    {
-                        sizeRead = InvokeCallbackWithDataPtr(_pages[pageIndex], dataReader);
-                    }
-                }
-                else
-                {
-                    pageLock.ExitReadLock();
-                    holdsReadLock = false;
-
-                    pageLock.EnterWriteLock();
-                    try
-                    {
-                        // THREADING: Double check it's still null (i.e. no other thread beat us to paging this data in between dropping our read lock and acquiring
-                        // the write lock)
-                        if (_pages[pageIndex] == null)
-                        {
-                            ulong dataRange;
-                            T data;
-                            (data, dataRange) = GetPageDataAtOffset((ulong)pageIndex * EntryPageSize);
-
-                            _pages[pageIndex] = new CachePage<T>(data, dataRange);
-
-                            Interlocked.Add(ref _entrySize, (int)dataRange);
-
-                            UpdateLastAccessTimstamp();
-
-                            if (dataReader == null)
-                            {
-                                sizeRead = CopyDataFromPage(_pages[pageIndex], buffer, inPageOffset, byteCount);
-                            }
-                            else
-                            {
-                                sizeRead = InvokeCallbackWithDataPtr(_pages[pageIndex], dataReader);
-                            }
-
-                            addedSize = (int)dataRange;
-                            notifyCacheOfSizeUpdate = true;
-                        }
-                        else
-                        {
-                            // Someone else beat us to retrieving the data, so we can just read
-                            UpdateLastAccessTimstamp();
-
-                            if (dataReader == null)
-                            {
-                                sizeRead = CopyDataFromPage(_pages[pageIndex], buffer, inPageOffset, byteCount);
-                            }
-                            else
-                            {
-                                sizeRead = InvokeCallbackWithDataPtr(_pages[pageIndex], dataReader);
-                            }
-                        }
-                    }
-                    finally
-                    {
-                        pageLock.ExitWriteLock();
-                    }
-                }
-            }
-            finally
-            {
-                if (holdsReadLock)
-                    pageLock.ExitReadLock();
+                UpdateLastAccessTimstamp();
+                return dataReader == null
+                    ? CopyDataFromPage(page, buffer, inPageOffset, byteCount)
+                    : InvokeCallbackWithDataPtr(page, dataReader);
             }
 
-            if (notifyCacheOfSizeUpdate)
+            // Miss path: synthesize a page and try to publish it. Two threads racing on
+            // the same pageIndex will both fetch the page contents (cheap relative to
+            // RWLS contention), then only the CAS winner's page is retained; the loser
+            // hands its page to DiscardUnusedPage so any rented buffer is released.
+            (T data, ulong dataRange) = GetPageDataAtOffset((ulong)pageIndex * EntryPageSize);
+            CachePage<T> newPage = new CachePage<T>(data, dataRange);
+
+            CachePage<T> existing = Interlocked.CompareExchange(ref _pages[pageIndex], newPage, null);
+            if (existing == null)
             {
-                _updateOwningCacheForAddedChunk((uint)addedSize);
+                // We won the publish race.
+                Interlocked.Add(ref _entrySize, (int)dataRange);
+                UpdateLastAccessTimstamp();
+                _updateOwningCacheForAddedChunk((uint)dataRange);
+                page = newPage;
+            }
+            else
+            {
+                // We lost: another thread already published a page. Drop ours.
+                DiscardUnusedPage(newPage);
+                UpdateLastAccessTimstamp();
+                page = existing;
             }
 
-            return sizeRead;
+            return dataReader == null
+                ? CopyDataFromPage(page, buffer, inPageOffset, byteCount)
+                : InvokeCallbackWithDataPtr(page, dataReader);
         }
 
         private bool ReadPageDataFromOffsetUntil(uint segmentOffset, byte[] terminatingSequence, List<byte> bytesRead)


### PR DESCRIPTION
## Summary

Makes the file-backed dump reader cache layer safe for concurrent readers without changing DAC behavior.

This PR fixes managed cache publication in the dump-reader/cache-entry layer:

- publishes CoreDumpReader and ELF-derived lazy state with atomic/locked first-publisher patterns
- makes Windows cached reader pages immutable once published
- returns only ArrayPool buffers that lost publication and were never visible to readers
- avoids returning published evicted buffers to ArrayPool while in-flight readers might still hold references

Part of microsoft/clrmd#420.

## Validation

- Built as part of the split branch verification: `dotnet build src/Microsoft.Diagnostics.Runtime/Microsoft.Diagnostics.Runtime.csproj --framework net10.0` -- passed with 0 warnings and 0 errors.
- This split branch was recombined with the other reduced branches and compared against `lockfree-mmf-threadsafe`; all non-stress paths matched the original combined branch.
