### PR TITLE
Fix managed cache publication races

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/ClrModule.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrModule.cs
@@ -29,6 +29,7 @@ namespace Microsoft.Diagnostics.Runtime
         private PdbInfo? _pdb;
         private (ulong MethodTable, int Token)[]? _typeDefMap;
         private (ulong MethodTable, int Token)[]? _typeRefMap;
+        private readonly object _typeMapLock = new();
         private ClrHeap? _heap;
 
         private readonly ulong _moduleAddress;
@@ -203,9 +204,41 @@ namespace Microsoft.Diagnostics.Runtime
         /// Enumerates the constructed methodtables in this module which correspond to typedef tokens defined by this module.
         /// </summary>
         /// <returns>An enumeration of (ulong methodTable, uint typeDef).</returns>
-        public IEnumerable<(ulong MethodTable, int Token)> EnumerateTypeDefToMethodTableMap() => _typeDefMap ??= (_helpers?.EnumerateTypeDefMap(Address) ?? Enumerable.Empty<(ulong, int)>()).ToArray();
+        public IEnumerable<(ulong MethodTable, int Token)> EnumerateTypeDefToMethodTableMap()
+        {
+            var map = Volatile.Read(ref _typeDefMap);
+            if (map is not null)
+                return map;
 
-        public IEnumerable<(ulong MethodTable, int Token)> EnumerateTypeRefToMethodTableMap() => _typeRefMap ??= (_helpers?.EnumerateTypeRefMap(Address) ?? Enumerable.Empty<(ulong, int)>()).ToArray();
+            lock (_typeMapLock)
+            {
+                map = _typeDefMap;
+                if (map is null)
+                {
+                    map = (_helpers?.EnumerateTypeDefMap(Address) ?? Enumerable.Empty<(ulong, int)>()).ToArray();
+                    Volatile.Write(ref _typeDefMap, map);
+                }
+                return map;
+            }
+        }
+
+        public IEnumerable<(ulong MethodTable, int Token)> EnumerateTypeRefToMethodTableMap()
+        {
+            var map = Volatile.Read(ref _typeRefMap);
+            if (map is not null)
+                return map;
+
+            lock (_typeMapLock)
+            {
+                map = _typeRefMap;
+                if (map is null)
+                {
+                    map = (_helpers?.EnumerateTypeRefMap(Address) ?? Enumerable.Empty<(ulong, int)>()).ToArray();
+                    Volatile.Write(ref _typeRefMap, map);
+                }
+                return map;
+            }
+        }
 
         /// <summary>
         /// Enumerates the <see cref="ClrType"/>s reachable through this module's

--- a/src/Microsoft.Diagnostics.Runtime/ClrObject.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrObject.cs
@@ -133,7 +133,13 @@ namespace Microsoft.Diagnostics.Runtime
         /// <summary>
         /// Gets the type of the object.
         /// </summary>
-        public ClrType? Type => _type is null || _type.Heap.ErrorType == _type ? null : _type;
+        // Use ReferenceEquals here: ErrorType is a per-heap singleton (initialized once via
+        // Interlocked.CompareExchange in ClrTypeFactory.ErrorType). Using `==` dispatches to
+        // ClrType.Equals which falls through to IsPrimitive -> GetElementType -> base-type
+        // Name lookups when MethodTable==0 (true for ErrorType). Under high-frequency stress
+        // those Name lookups go through the DAC and have produced intermittent AVs; identity
+        // comparison is sufficient and avoids the heavy path entirely.
+        public ClrType? Type => _type is null || ReferenceEquals(_type.Heap.ErrorType, _type) ? null : _type;
 
         IClrType? IClrValue.Type => Type;
 

--- a/src/Microsoft.Diagnostics.Runtime/ClrType.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrType.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -519,8 +519,11 @@ namespace Microsoft.Diagnostics.Runtime
             if (IsPrimitive && other.IsPrimitive && ElementType != ClrElementType.Unknown)
                 return ElementType == other.ElementType;
 
-            // Ok we aren't a primitive type, or a pointer, and our MethodTables are 0.  Last resort is to
-            // check if we resolved from the same token out of the same module.
+            if ((MethodTable == 0) != (other.MethodTable == 0))
+                return false;
+
+            // Ok we aren't a primitive type or a pointer, and both MethodTables are 0.
+            // Last resort is to check if we resolved from the same token out of the same module.
             if (Module != null && MetadataToken != 0)
                 return Module == other.Module && MetadataToken == other.MetadataToken;
 

--- a/src/Microsoft.Diagnostics.Runtime/Implementation/ClrDacType.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Implementation/ClrDacType.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
+using System.Threading;
 using Microsoft.Diagnostics.Runtime.AbstractDac;
 using Microsoft.Diagnostics.Runtime.DacInterface;
 using TypeInfo = Microsoft.Diagnostics.Runtime.AbstractDac.TypeInfo;
@@ -22,7 +23,19 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
         private ulong _assemblyLoadContextHandle = ulong.MaxValue - 1;
 
         private ClrElementType _elementType;
-        private GCDesc _gcDesc;
+
+        // Thread-safe GC desc cache: the GCDesc struct has three fields, so a plain
+        // `_gcDesc = new GCDesc(...)` assignment is not atomic and another thread can
+        // observe a half-initialized struct (e.g. _data set but _pointerSize still 0).
+        // We publish the immutable GCDesc through a reference-typed holder so that the
+        // reference store is atomic and other threads only ever see the fully-constructed
+        // value. Null means "not cached yet" (the result of a failed dump read is NOT
+        // cached so it will be retried on the next call, matching the previous behavior).
+        private sealed class GCDescHolder
+        {
+            public GCDesc Value;
+        }
+        private GCDescHolder? _gcDescHolder;
         private ClrType? _componentType;
         private int _baseArrayOffset;
 
@@ -106,8 +119,12 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
 
         private GCDesc GetOrCreateGCDesc()
         {
-            if (!ContainsPointers || !_gcDesc.IsEmpty)
-                return _gcDesc;
+            if (!ContainsPointers)
+                return default;
+
+            GCDescHolder? holder = Volatile.Read(ref _gcDescHolder);
+            if (holder is not null)
+                return holder.Value;
 
             IDataReader reader = Module.DataReader;
             if (reader is null)
@@ -116,10 +133,7 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
             int pointerSize = reader.PointerSize;
             DebugOnly.Assert(MethodTable != 0, "Attempted to fill GC desc with a constructed (not real) type.");
             if (!reader.Read(MethodTable - (ulong)pointerSize, out int entries))
-            {
-                _gcDesc = default;
                 return default;
-            }
 
             // Get entries in map
             if (entries < 0)
@@ -128,13 +142,14 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
             int slots = 1 + entries * 2;
             byte[] buffer = new byte[slots * pointerSize];
             if (reader.Read(MethodTable - (ulong)(slots * pointerSize), buffer) != buffer.Length)
-            {
-                _gcDesc = default;
                 return default;
-            }
 
-            // Construct the gc desc
-            return _gcDesc = new GCDesc(buffer, pointerSize);
+            // Publish the fully-constructed GCDesc through a reference store. Multiple
+            // threads can race here; whichever one wins the CompareExchange wins the
+            // race, but all subsequent reads return that holder's value.
+            GCDescHolder fresh = new() { Value = new GCDesc(buffer, pointerSize) };
+            GCDescHolder published = Interlocked.CompareExchange(ref _gcDescHolder, fresh, null) ?? fresh;
+            return published.Value;
         }
 
         private ClrElementType GetElementType()
@@ -142,10 +157,10 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
             if (_elementType != ClrElementType.Unknown)
                 return _elementType;
 
-            if (this == Heap.ObjectType)
+            if (ReferenceEquals(this, Heap.ObjectType))
                 return _elementType = ClrElementType.Object;
 
-            if (this == Heap.StringType)
+            if (ReferenceEquals(this, Heap.StringType))
                 return _elementType = ClrElementType.String;
 
             if (ComponentSize > 0)
@@ -155,7 +170,7 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
             if (baseType is null)
                 return _elementType = ClrElementType.Object;
 
-            if (baseType == Heap.ObjectType)
+            if (ReferenceEquals(baseType, Heap.ObjectType))
                 return _elementType = ClrElementType.Class;
 
             if (baseType.Name != "System.ValueType")
@@ -220,7 +235,10 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
             return new ClrEnum(this);
         }
 
-        public override bool IsFree => this == Heap.FreeType;
+        // ReferenceEquals: FreeType is a per-heap singleton (Interlocked.CompareExchange in
+        // ClrTypeFactory.GetOrCreateBasicType). Avoids dispatching to ClrType.Equals, which
+        // can do expensive (and racy under stress) Name/IsPrimitive lookups.
+        public override bool IsFree => ReferenceEquals(this, Heap.FreeType);
 
         private const uint FinalizationSuppressedFlag = 0x40000000;
 

--- a/src/Microsoft.Diagnostics.Runtime/Implementation/ClrTypeFactory.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Implementation/ClrTypeFactory.cs
@@ -117,15 +117,17 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
             ClrType? existing = TryGetType(mt);
             if (existing != null)
             {
-                if (obj != 0 && !existing.IsString && existing.ComponentSize != 0 && existing.ComponentType is null && existing is ClrDacType type)
-                    type.SetComponentType(TryGetComponentType(obj));
-
+                ApplyDeferredComponentType(existing, obj);
                 return existing;
             }
 
             if (!_typeHelpers.GetTypeInfo(mt, out TypeInfo mtd))
                 return null;
 
+            // Build the type outside of any lock: construction recursively calls
+            // GetOrCreateType for the parent MT and other helpers (TryGetComponentType,
+            // GetModule) which would deadlock or starve other threads if held under
+            // _types.
             ClrType? baseType = GetOrCreateType(mtd.ParentMethodTable, 0);
             ClrModule module = GetModule(mtd.ModuleAddress);
             ClrType? componentType = null;
@@ -136,11 +138,35 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
             ClrType result = new ClrDacType(_typeHelpers, _heap, baseType, componentType, module, mtd);
             if (_options.CacheTypes)
             {
+                ClrType? winner = null;
+
+                // Atomic publish-or-discard. If another thread raced ahead and
+                // already cached a type for this MT, return the winner so all
+                // callers observe a single canonical ClrType instance per MT.
+                // Returning a duplicate would break reference equality assumptions
+                // elsewhere (e.g. ClrType.IsFree compares `this == Heap.FreeType`)
+                // and can race a still-uninitialized ClrDacType into a code path
+                // that dereferences its fields under another thread's lock.
                 lock (_types)
-                    _types[mt] = result;
+                {
+                    if (!_types.TryGetValue(mt, out winner))
+                    {
+                        _types[mt] = result;
+                        winner = result;
+                    }
+                }
+
+                ApplyDeferredComponentType(winner, obj);
+                return winner;
             }
 
             return result;
+        }
+
+        private void ApplyDeferredComponentType(ClrType existing, ulong obj)
+        {
+            if (obj != 0 && !existing.IsString && existing.ComponentSize != 0 && existing.ComponentType is null && existing is ClrDacType type)
+                type.SetComponentType(TryGetComponentType(obj));
         }
 
         public ClrType? TryGetType(ulong mt)
@@ -430,7 +456,11 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
                 basicTypes[(int)ClrElementType.Object] = _heap.ObjectType;
                 basicTypes[(int)ClrElementType.String] = _heap.StringType;
 
-                Interlocked.CompareExchange(ref _basicTypes, basicTypes, null);
+                // If we lost the publication race, switch to the winner's array
+                // so subsequent slot writes are visible to all readers (otherwise
+                // the loser would write into an orphaned array and leak duplicate
+                // ClrPrimitiveType instances).
+                basicTypes = Interlocked.CompareExchange(ref _basicTypes, basicTypes, null) ?? basicTypes;
             }
 
             int index = (int)basicType - 1;
@@ -441,7 +471,11 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
             if (result is not null)
                 return result;
 
-            return basicTypes[index] = new ClrPrimitiveType(_typeHelpers, bcl, _heap, basicType);
+            // Atomically install a new primitive type into the slot so all threads
+            // observe a single canonical instance for each ClrElementType.
+            ClrType fresh = new ClrPrimitiveType(_typeHelpers, bcl, _heap, basicType);
+            result = Interlocked.CompareExchange(ref basicTypes[index], fresh, null) ?? fresh;
+            return result;
         }
 
         private ClrModule GetModule(ulong moduleAddress)
@@ -452,10 +486,22 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
                 Interlocked.CompareExchange(ref _modules, modules, null);
             }
 
-            if (!_modules.TryGetValue(moduleAddress, out ClrModule? module))
-                module = _errorModule ??= new(_heap.Runtime.AppDomains[0], 0, _heap.Runtime.GetServiceOrThrow<IAbstractModuleHelpers>(), null, _heap.Runtime.DataTarget.DataReader);
+            if (_modules.TryGetValue(moduleAddress, out ClrModule? module))
+                return module;
 
-            return module;
+            // Race-safe lazy init for the error-module fallback. The previous `??=`
+            // pattern allowed two threads to construct distinct ClrModule instances
+            // and the loser's instance could still be observed (with potentially
+            // unpublished fields) by a third thread that read _errorModule between
+            // the two writes.
+            ClrModule? errorModule = _errorModule;
+            if (errorModule is null)
+            {
+                ClrModule fresh = new(_heap.Runtime.AppDomains[0], 0, _heap.Runtime.GetServiceOrThrow<IAbstractModuleHelpers>(), null, _heap.Runtime.DataTarget.DataReader);
+                errorModule = Interlocked.CompareExchange(ref _errorModule, fresh, null) ?? fresh;
+            }
+
+            return errorModule;
         }
     }
 }


### PR DESCRIPTION
## Summary

Fixes ClrMD-owned managed cache publication races that do not require DAC serialization.

This PR keeps the change focused on managed object/cache safety:

- avoids torn struct publication for `ClrDacType.GCDesc`
- deduplicates racing `ClrTypeFactory` type creation
- publishes singleton/error-module/basic-type state atomically
- uses reference equality for singleton type comparisons so equality checks do not accidentally dispatch into DAC-backed type/name work
- fixes related racy lazy cache patterns in managed ClrMD state

Part of microsoft/clrmd#420.

## Validation

- Built as part of the split branch verification: `dotnet build src/Microsoft.Diagnostics.Runtime/Microsoft.Diagnostics.Runtime.csproj --framework net10.0` -- passed with 0 warnings and 0 errors.
- This split branch was recombined with the other reduced branches and compared against `lockfree-mmf-threadsafe`; all non-stress paths matched the original combined branch.
