### PR TITLE
Serialize DAC access and materialize unsafe enumerations

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/ThreadReaderTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/ThreadReaderTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             IAbstractRuntime runtimeService = runtime.GetService<IAbstractRuntime>();
             Assert.NotNull(runtimeService);
 
-            ClrThreadInfo[] threads = runtimeService.EnumerateThreads().ToArray();
+            ClrThreadInfo[] threads = runtimeService.EnumerateThreads(int.MaxValue).ToArray();
 
             foreach (ClrThread thread in runtime.Threads)
             {

--- a/src/Microsoft.Diagnostics.Runtime/AbstractDac/IAbstractRuntime.cs
+++ b/src/Microsoft.Diagnostics.Runtime/AbstractDac/IAbstractRuntime.cs
@@ -19,9 +19,9 @@ namespace Microsoft.Diagnostics.Runtime.AbstractDac
     /// </summary>
     public interface IAbstractRuntime
     {
-        IEnumerable<ClrThreadInfo> EnumerateThreads();
-        IEnumerable<AppDomainInfo> EnumerateAppDomains();
-        IEnumerable<ulong> GetModuleList(ulong appDomain);
+        IEnumerable<ClrThreadInfo> EnumerateThreads(int maxCount);
+        IEnumerable<AppDomainInfo> EnumerateAppDomains(int maxCount);
+        IEnumerable<ulong> GetModuleList(ulong appDomain, int maxCount);
         IEnumerable<ClrHandleInfo> EnumerateHandles();
         IEnumerable<JitManagerInfo> EnumerateClrJitManagers();
         string? GetJitHelperFunctionName(ulong address);

--- a/src/Microsoft.Diagnostics.Runtime/AbstractDac/IAbstractThreadHelpers.cs
+++ b/src/Microsoft.Diagnostics.Runtime/AbstractDac/IAbstractThreadHelpers.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
@@ -26,15 +26,16 @@ namespace Microsoft.Diagnostics.Runtime.AbstractDac
 
         /// <summary>
         /// Enumerates the stack trace of this method.  Note that in the event of bugs or corrupted
-        /// state, this can occasionally produce bad data and run "forever", so be sure to break out of
-        /// the loop when a threshold is reached when calling it.
+        /// state, this can occasionally produce bad data and run "forever", so <paramref name="maxFrames" />
+        /// is enforced inside the DAC stack walk.
         /// </summary>
         /// <param name="osThreadId">The thread to enumerate.</param>
         /// <param name="includeContext">Whether to calculate and include the thread's CONTEXT record or not.
         /// Registers are always in the Windows CONTEXT format, as that's what the OS uses.</param>
+        /// <param name="maxFrames">The maximum number of stack frames to walk.</param>
         /// <param name="traceErrors">Whether or not to Trace any errors encountered.</param>
         /// <returns>An enumeration of stack frames.</returns>
-        IEnumerable<StackFrameInfo> EnumerateStackTrace(uint osThreadId, bool includeContext, bool traceErrors);
+        IEnumerable<StackFrameInfo> EnumerateStackTrace(uint osThreadId, bool includeContext, int maxFrames, bool traceErrors);
     }
 
     /// <summary>

--- a/src/Microsoft.Diagnostics.Runtime/ClrHeap.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrHeap.cs
@@ -40,6 +40,7 @@ namespace Microsoft.Diagnostics.Runtime
         private volatile SyncBlockContainer? _syncBlocks;
         private volatile ClrSegment? _currSegment;
         private volatile ArrayPool<ObjectCorruption>? _objectCorruptionPool;
+        private readonly object _heapCacheLock = new();
         private ulong _lastComFlags;
 
         internal ClrHeap(ClrRuntime runtime, IMemoryReader memoryReader, IAbstractHeap helpers, IAbstractTypeHelpers typeHelpers)
@@ -796,13 +797,23 @@ namespace Microsoft.Diagnostics.Runtime
         private SyncBlockContainer GetSyncBlocks()
         {
             SyncBlockContainer? container = _syncBlocks;
-            if (container is null)
-            {
-                container = new SyncBlockContainer(Helpers.EnumerateSyncBlocks());
-                Interlocked.CompareExchange(ref _syncBlocks, container, null);
-            }
+            if (container is not null)
+                return container;
 
-            return container;
+            // Serialize cache population so two concurrent DAC EnumerateSyncBlocks
+            // calls don't each build a SyncBlockContainer (with one's partial
+            // results getting permanently published).
+            lock (_heapCacheLock)
+            {
+                container = _syncBlocks;
+                if (container is null)
+                {
+                    container = new SyncBlockContainer(Helpers.EnumerateSyncBlocks());
+                    _syncBlocks = container;
+                }
+
+                return container;
+            }
         }
 
         internal ClrThinLock? GetThinlock(ulong address)
@@ -1165,16 +1176,26 @@ namespace Microsoft.Diagnostics.Runtime
             if (result is not null)
                 return result;
 
-            result = new();
-            foreach (MemoryRange allocContext in Helpers.EnumerateThreadAllocationContexts())
-                result[allocContext.Start] = allocContext.End;
+            // Serialize cache population so the DAC's per-runtime
+            // EnumerateThreadAllocationContexts call doesn't race with itself
+            // and produce two divergent dictionaries (the winner's published).
+            lock (_heapCacheLock)
+            {
+                result = _allocationContexts;
+                if (result is not null)
+                    return result;
 
-            foreach (ClrSubHeap subHeap in SubHeaps)
-                if (subHeap.AllocationContext.Start < subHeap.AllocationContext.End)
-                    result[subHeap.AllocationContext.Start] = subHeap.AllocationContext.End;
+                result = new();
+                foreach (MemoryRange allocContext in Helpers.EnumerateThreadAllocationContexts())
+                    result[allocContext.Start] = allocContext.End;
 
-            Interlocked.CompareExchange(ref _allocationContexts, result, null);
-            return result;
+                foreach (ClrSubHeap subHeap in SubHeaps)
+                    if (subHeap.AllocationContext.Start < subHeap.AllocationContext.End)
+                        result[subHeap.AllocationContext.Start] = subHeap.AllocationContext.End;
+
+                _allocationContexts = result;
+                return result;
+            }
         }
 
         private (ulong Source, ulong Target)[] GetDependentHandles()
@@ -1183,10 +1204,19 @@ namespace Microsoft.Diagnostics.Runtime
             if (handles is not null)
                 return handles;
 
-            handles = Helpers.EnumerateDependentHandles().OrderBy(r => r.Source).ToArray();
+            // Serialize cache population: concurrent DAC handle enumerations can return
+            // partial results, and the previous CompareExchange pattern would publish
+            // the first-to-finish (possibly truncated) array as the cached value.
+            lock (_heapCacheLock)
+            {
+                handles = _dependentHandles;
+                if (handles is not null)
+                    return handles;
 
-            Interlocked.CompareExchange(ref _dependentHandles, handles, null);
-            return handles;
+                handles = Helpers.EnumerateDependentHandles().OrderBy(r => r.Source).ToArray();
+                _dependentHandles = handles;
+                return handles;
+            }
         }
 
         private IEnumerable<ClrRoot> EnumerateFinalizers(IEnumerable<MemoryRange> memoryRanges)

--- a/src/Microsoft.Diagnostics.Runtime/ClrRuntime.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrRuntime.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -26,6 +26,7 @@ namespace Microsoft.Diagnostics.Runtime
         private volatile ClrHeap? _heap;
         private ImmutableArray<ClrThread> _threads;
         private volatile DomainAndModules? _domainAndModules;
+        private ImmutableArray<ClrHandle> _handles;
 
         private IAbstractRuntime? _runtime;
         private IAbstractComHelpers? _comHelpers;
@@ -36,6 +37,7 @@ namespace Microsoft.Diagnostics.Runtime
         private string? _stressLogFailureReason;
         private bool _stressLogProbed;
         private readonly object _stressLogGate = new();
+        private readonly object _runtimeCacheLock = new();
 
         internal ClrRuntime(ClrInfo clrInfo, IServiceProvider services)
         {
@@ -61,6 +63,7 @@ namespace Microsoft.Diagnostics.Runtime
             _controller.Flush();
             _domainAndModules = null;
             _threads = default;
+            _handles = default;
             _heap = null;
 
             lock (_stressLogGate)
@@ -208,22 +211,29 @@ namespace Microsoft.Diagnostics.Runtime
                 if (!_threads.IsDefault)
                     return _threads;
 
-                IAbstractThreadHelpers? threadHelpers = GetService<IAbstractThreadHelpers>();
-                ImmutableArray<ClrThread>.Builder builder = ImmutableArray.CreateBuilder<ClrThread>();
-
-                int max = DataTarget.Options.Limits.MaxThreads;
-                foreach (ClrThreadInfo data in GetDacRuntime().EnumerateThreads())
+                // Serialize cache population: concurrent DAC EnumerateThreads calls can
+                // truncate each other and the CAS winner's partial result would become
+                // the permanent cached value.
+                lock (_runtimeCacheLock)
                 {
-                    builder.Add(new ClrThread(DataTarget.DataReader, this, threadHelpers, data));
+                    if (!_threads.IsDefault)
+                        return _threads;
 
-                    if (max-- == 0)
-                        break;
+                    IAbstractThreadHelpers? threadHelpers = GetService<IAbstractThreadHelpers>();
+                    ImmutableArray<ClrThread>.Builder builder = ImmutableArray.CreateBuilder<ClrThread>();
+
+                    int max = DataTarget.Options.Limits.MaxThreads;
+                    foreach (ClrThreadInfo data in GetDacRuntime().EnumerateThreads())
+                    {
+                        if (builder.Count >= max)
+                            break;
+
+                        builder.Add(new ClrThread(DataTarget.DataReader, this, threadHelpers, data));
+                    }
+
+                    _threads = builder.MoveOrCopyToImmutable();
+                    return _threads;
                 }
-
-                ImmutableArray<ClrThread> threads = builder.MoveOrCopyToImmutable();
-                ImmutableInterlocked.InterlockedCompareExchange(ref _threads, threads, _threads);
-
-                return _threads;
             }
         }
 
@@ -275,7 +285,28 @@ namespace Microsoft.Diagnostics.Runtime
         /// depending on the state of the process when we attempt to walk the handle table.
         /// </summary>
         /// <returns>An enumeration of GC handles in the process.</returns>
-        public IEnumerable<ClrHandle> EnumerateHandles() => GetDacRuntime().EnumerateHandles().Select(r => new ClrHandle(this, r));
+        public IEnumerable<ClrHandle> EnumerateHandles()
+        {
+            if (!_handles.IsDefault)
+                return _handles;
+
+            // Serialize cache population: SOSDac.EnumerateHandles is a stateful DAC
+            // enumerator and concurrent calls on the same SOSDac can return truncated
+            // (or wildly wrong) results, manifesting as off-by-one or order-of-magnitude
+            // root-count mismatches during parallel EnumerateRoots() calls.
+            lock (_runtimeCacheLock)
+            {
+                if (!_handles.IsDefault)
+                    return _handles;
+
+                ImmutableArray<ClrHandle>.Builder builder = ImmutableArray.CreateBuilder<ClrHandle>();
+                foreach (ClrHandleInfo info in GetDacRuntime().EnumerateHandles())
+                    builder.Add(new ClrHandle(this, info));
+
+                _handles = builder.MoveOrCopyToImmutable();
+                return _handles;
+            }
+        }
 
         /// <summary>
         /// Gets the GC heap of the process.
@@ -285,21 +316,31 @@ namespace Microsoft.Diagnostics.Runtime
             get
             {
                 ClrHeap? heap = _heap;
-                while (heap is null) // Flush can cause a race.
+                if (heap is not null)
+                    return heap;
+
+                // Serialize cache population so we never construct two ClrHeap
+                // instances for the same runtime (each carries its own internal
+                // caches; readers obtaining different heaps would observe
+                // divergent state).
+                lock (_runtimeCacheLock)
                 {
-                    IAbstractHeap? heapHelpers = GetService<IAbstractHeap>();
-                    IAbstractTypeHelpers? typeHelpers = GetService<IAbstractTypeHelpers>();
-
-                    // These are defined as non-nullable but just in case, double check we have a non-null instance.
-                    if (heapHelpers is null || typeHelpers is null)
-                        throw new InvalidDataException("Unable to create a ClrHeap for this runtime. This may indicate that the CLR wasn't fully initialized at the time the dump was taken, or the dump is corrupt or truncated.");
-
-                    heap = new(this, DataTarget.DataReader, heapHelpers, typeHelpers);
-                    Interlocked.CompareExchange(ref _heap, heap, null);
                     heap = _heap;
-                }
+                    if (heap is null)
+                    {
+                        IAbstractHeap? heapHelpers = GetService<IAbstractHeap>();
+                        IAbstractTypeHelpers? typeHelpers = GetService<IAbstractTypeHelpers>();
 
-                return heap;
+                        // These are defined as non-nullable but just in case, double check we have a non-null instance.
+                        if (heapHelpers is null || typeHelpers is null)
+                            throw new InvalidDataException("Unable to create a ClrHeap for this runtime. This may indicate that the CLR wasn't fully initialized at the time the dump was taken, or the dump is corrupt or truncated.");
+
+                        heap = new(this, DataTarget.DataReader, heapHelpers, typeHelpers);
+                        _heap = heap;
+                    }
+
+                    return heap;
+                }
             }
         }
 
@@ -486,13 +527,24 @@ namespace Microsoft.Diagnostics.Runtime
         private DomainAndModules GetAppDomainData()
         {
             DomainAndModules? data = _domainAndModules;
-            if (data is null)
-            {
-                data = InitAppDomainData();
-                _domainAndModules = data;
-            }
+            if (data is not null)
+                return data;
 
-            return data;
+            // Serialize cache population: InitAppDomainData performs heavy DAC
+            // enumeration of AppDomains and Modules. Concurrent callers would
+            // race on the underlying DAC (truncating results) AND the previous
+            // unguarded `_domainAndModules = data` write left the "winner" as
+            // whichever thread happened to assign last.
+            lock (_runtimeCacheLock)
+            {
+                data = _domainAndModules;
+                if (data is null)
+                {
+                    data = InitAppDomainData();
+                    _domainAndModules = data;
+                }
+                return data;
+            }
         }
 
         private DomainAndModules InitAppDomainData()

--- a/src/Microsoft.Diagnostics.Runtime/ClrRuntime.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrRuntime.cs
@@ -66,14 +66,20 @@ namespace Microsoft.Diagnostics.Runtime
                  throw new NotSupportedException($"This version of CLR debugging does not support flushing the runtime.");
 
             _controller.Flush();
-            _domainAndModules = null;
-            // Clear the published flag (volatile) before resetting the array so a racing
-            // reader either sees the old published array or falls into the lock to rebuild.
-            _threadsPublished = false;
-            _threads = default;
-            _handlesPublished = false;
-            _handles = default;
-            _heap = null;
+
+            // Reset the managed caches under the same lock their builders publish under, so a
+            // builder that is mid-population cannot republish pre-flush data after the reset.
+            lock (_runtimeCacheLock)
+            {
+                _domainAndModules = null;
+                // Clear the published flag (volatile) before resetting the array so a racing
+                // reader either sees the old published array or falls into the lock to rebuild.
+                _threadsPublished = false;
+                _threads = default;
+                _handlesPublished = false;
+                _handles = default;
+                _heap = null;
+            }
 
             lock (_stressLogGate)
             {
@@ -232,7 +238,7 @@ namespace Microsoft.Diagnostics.Runtime
                     ImmutableArray<ClrThread>.Builder builder = ImmutableArray.CreateBuilder<ClrThread>();
 
                     int max = DataTarget.Options.Limits.MaxThreads;
-                    foreach (ClrThreadInfo data in GetDacRuntime().EnumerateThreads())
+                    foreach (ClrThreadInfo data in GetDacRuntime().EnumerateThreads(max))
                     {
                         if (builder.Count >= max)
                             break;
@@ -569,7 +575,7 @@ namespace Microsoft.Diagnostics.Runtime
 
             int domainCount = 0;
             ImmutableArray<ClrAppDomain>.Builder builder = ImmutableArray.CreateBuilder<ClrAppDomain>();
-            foreach (AppDomainInfo domainInfo in GetDacRuntime().EnumerateAppDomains())
+            foreach (AppDomainInfo domainInfo in GetDacRuntime().EnumerateAppDomains(limits.MaxAppDomains))
             {
                 if (domainCount++ >= limits.MaxAppDomains)
                     break;
@@ -597,7 +603,7 @@ namespace Microsoft.Diagnostics.Runtime
                 IAbstractModuleHelpers moduleHelpers = GetServiceOrThrow<IAbstractModuleHelpers>();
                 IAbstractClrNativeHeaps? nativeHeaps = GetService<IAbstractClrNativeHeaps>();
                 ImmutableArray<ClrModule>.Builder moduleBuilder = ImmutableArray.CreateBuilder<ClrModule>();
-                foreach (ulong moduleAddress in GetDacRuntime().GetModuleList(domain.Address))
+                foreach (ulong moduleAddress in GetDacRuntime().GetModuleList(domain.Address, limits.MaxModules - modules.Count))
                 {
                     if (modules.Count >= limits.MaxModules)
                         break;

--- a/src/Microsoft.Diagnostics.Runtime/ClrRuntime.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrRuntime.cs
@@ -25,8 +25,13 @@ namespace Microsoft.Diagnostics.Runtime
         private readonly IServiceProvider _services;
         private volatile ClrHeap? _heap;
         private ImmutableArray<ClrThread> _threads;
+        // ImmutableArray<T> is a struct and cannot be marked volatile, so the lock-free
+        // double-checked reads of _threads/_handles below use these volatile flags as the
+        // acquire/release barrier that publishes the array contents safely.
+        private volatile bool _threadsPublished;
         private volatile DomainAndModules? _domainAndModules;
         private ImmutableArray<ClrHandle> _handles;
+        private volatile bool _handlesPublished;
 
         private IAbstractRuntime? _runtime;
         private IAbstractComHelpers? _comHelpers;
@@ -62,7 +67,11 @@ namespace Microsoft.Diagnostics.Runtime
 
             _controller.Flush();
             _domainAndModules = null;
+            // Clear the published flag (volatile) before resetting the array so a racing
+            // reader either sees the old published array or falls into the lock to rebuild.
+            _threadsPublished = false;
             _threads = default;
+            _handlesPublished = false;
             _handles = default;
             _heap = null;
 
@@ -208,7 +217,7 @@ namespace Microsoft.Diagnostics.Runtime
         {
             get
             {
-                if (!_threads.IsDefault)
+                if (_threadsPublished)
                     return _threads;
 
                 // Serialize cache population: concurrent DAC EnumerateThreads calls can
@@ -216,7 +225,7 @@ namespace Microsoft.Diagnostics.Runtime
                 // the permanent cached value.
                 lock (_runtimeCacheLock)
                 {
-                    if (!_threads.IsDefault)
+                    if (_threadsPublished)
                         return _threads;
 
                     IAbstractThreadHelpers? threadHelpers = GetService<IAbstractThreadHelpers>();
@@ -232,6 +241,7 @@ namespace Microsoft.Diagnostics.Runtime
                     }
 
                     _threads = builder.MoveOrCopyToImmutable();
+                    _threadsPublished = true;
                     return _threads;
                 }
             }
@@ -287,7 +297,7 @@ namespace Microsoft.Diagnostics.Runtime
         /// <returns>An enumeration of GC handles in the process.</returns>
         public IEnumerable<ClrHandle> EnumerateHandles()
         {
-            if (!_handles.IsDefault)
+            if (_handlesPublished)
                 return _handles;
 
             // Serialize cache population: SOSDac.EnumerateHandles is a stateful DAC
@@ -296,7 +306,7 @@ namespace Microsoft.Diagnostics.Runtime
             // root-count mismatches during parallel EnumerateRoots() calls.
             lock (_runtimeCacheLock)
             {
-                if (!_handles.IsDefault)
+                if (_handlesPublished)
                     return _handles;
 
                 ImmutableArray<ClrHandle>.Builder builder = ImmutableArray.CreateBuilder<ClrHandle>();
@@ -304,6 +314,7 @@ namespace Microsoft.Diagnostics.Runtime
                     builder.Add(new ClrHandle(this, info));
 
                 _handles = builder.MoveOrCopyToImmutable();
+                _handlesPublished = true;
                 return _handles;
             }
         }

--- a/src/Microsoft.Diagnostics.Runtime/ClrThread.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrThread.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -21,6 +21,8 @@ namespace Microsoft.Diagnostics.Runtime
         private ClrException? _lastThrownException;
         private volatile Cache<ClrStackFrame>? _frameCache;
         private volatile Cache<ClrStackRoot>? _rootCache;
+        private readonly object _rootCacheLock = new();
+        private readonly object _frameCacheLock = new();
 
         internal ClrThread(IDataReader dataReader, ClrRuntime runtime, IAbstractThreadHelpers? helpers, in ClrThreadInfo threadInfo)
         {
@@ -127,26 +129,32 @@ namespace Microsoft.Diagnostics.Runtime
             if (cache is not null)
                 return Array.AsReadOnly(cache.Elements);
 
-            ClrHeap heap = Runtime.Heap;
-            ClrStackFrame[] frames = GetFramesForRoots();
-            IEnumerable<ClrStackRoot> roots = threadHelpers.EnumerateStackRoots(OSThreadId, traceErrors: IsAlive).Select(r => CreateClrStackRoot(heap, frames, r)).Where(r => r is not null)!;
             if (!Runtime.DataTarget.CacheOptions.CacheStackRoots)
-                return roots;
-
-            return CacheAndReturnRoots(roots);
-        }
-
-        private IEnumerable<ClrStackRoot> CacheAndReturnRoots(IEnumerable<ClrStackRoot> roots)
-        {
-            List<ClrStackRoot> cache = new();
-            foreach (ClrStackRoot root in roots)
             {
-                cache.Add(root);
-                yield return root;
+                ClrHeap heap = Runtime.Heap;
+                ClrStackFrame[] frames = GetFramesForRoots();
+                return threadHelpers.EnumerateStackRoots(OSThreadId, traceErrors: IsAlive).Select(r => CreateClrStackRoot(heap, frames, r)).Where(r => r is not null)!;
             }
 
-            // it's ok if we race and replace another cache as this will stabilize eventually
-            _rootCache ??= new(cache.ToArray(), false);
+            // Serialize cache population: the DAC is not thread-safe, so concurrent
+            // calls to EnumerateStackRoots for the same OSThreadId can return truncated
+            // results. Without serialization, a racing thread could publish a partial
+            // result to _rootCache and "stabilize" the wrong value forever.
+            lock (_rootCacheLock)
+            {
+                cache = _rootCache;
+                if (cache is not null)
+                    return Array.AsReadOnly(cache.Elements);
+
+                ClrHeap heap = Runtime.Heap;
+                ClrStackFrame[] frames = GetFramesForRoots();
+                ClrStackRoot[] roots = threadHelpers.EnumerateStackRoots(OSThreadId, traceErrors: IsAlive)
+                    .Select(r => CreateClrStackRoot(heap, frames, r))
+                    .Where(r => r is not null)
+                    .ToArray()!;
+                _rootCache = new(roots, false);
+                return Array.AsReadOnly(roots);
+            }
         }
 
         private ClrStackFrame[] GetFramesForRoots()
@@ -159,15 +167,24 @@ namespace Microsoft.Diagnostics.Runtime
             if (cache is not null)
                 return cache.Elements;
 
-            // We need to make sure we don't loop forever when enumerating the stack trace.
-            // We will only cache the stack if we completed enumeratione (i.e. got less
-            // than maxFrames frames)
-            int maxFrames = Runtime.DataTarget.Options.Limits.MaxStackFrames;
-            ClrStackFrame[] stack = threadHelpers.EnumerateStackTrace(OSThreadId, includeContext: false, traceErrors: IsAlive).Select(r => CreateClrStackFrame(r)).Take(maxFrames).ToArray();
-            if (Runtime.DataTarget.CacheOptions.CacheStackTraces && stack.Length < maxFrames)
-                _frameCache = new(stack, includedContext: false);
+            // Serialize cache population so concurrent DAC stack-walks don't truncate
+            // each other and publish a partial frame array.
+            lock (_frameCacheLock)
+            {
+                cache = _frameCache;
+                if (cache is not null)
+                    return cache.Elements;
 
-            return stack;
+                // We need to make sure we don't loop forever when enumerating the stack trace.
+                // We will only cache the stack if we completed enumeration (i.e. got less
+                // than maxFrames frames)
+                int maxFrames = Runtime.DataTarget.Options.Limits.MaxStackFrames;
+                ClrStackFrame[] stack = maxFrames <= 0 ? Array.Empty<ClrStackFrame>() : threadHelpers.EnumerateStackTrace(OSThreadId, includeContext: false, maxFrames: maxFrames, traceErrors: IsAlive).Select(r => CreateClrStackFrame(r)).Take(maxFrames).ToArray();
+                if (Runtime.DataTarget.CacheOptions.CacheStackTraces && stack.Length < maxFrames)
+                    _frameCache = new(stack, includedContext: false);
+
+                return stack;
+            }
         }
 
         private ClrStackRoot? CreateClrStackRoot(ClrHeap heap, ClrStackFrame[] stack, StackRootInfo stackRef)
@@ -244,29 +261,33 @@ namespace Microsoft.Diagnostics.Runtime
             if (threadHelpers is null)
                 return Array.Empty<ClrStackFrame>();
 
+            if (maxFrames <= 0)
+                return Array.Empty<ClrStackFrame>();
+
             Cache<ClrStackFrame>? cache = _frameCache;
             if (cache is not null && (!includeContext || cache.IncludedContext))
-                return Array.AsReadOnly(cache.Elements);
+                return cache.Elements.Length <= maxFrames ? Array.AsReadOnly(cache.Elements) : cache.Elements.Take(maxFrames);
 
-            IEnumerable<ClrStackFrame> frames = threadHelpers.EnumerateStackTrace(OSThreadId, includeContext, traceErrors: IsAlive).Select(r => CreateClrStackFrame(r));
             if (!Runtime.DataTarget.CacheOptions.CacheStackTraces)
-                return frames;
+                return threadHelpers.EnumerateStackTrace(OSThreadId, includeContext, maxFrames, traceErrors: IsAlive).Select(r => CreateClrStackFrame(r)).Take(maxFrames);
 
-            return CacheAndReturnFrames(includeContext, frames);
-        }
-
-        private IEnumerable<ClrStackFrame> CacheAndReturnFrames(bool includeContext, IEnumerable<ClrStackFrame> frames)
-        {
-            // Only cache frames if enumeration completed and the user didn't break out of the loop
-            List<ClrStackFrame> cachedFrames = new();
-            foreach (ClrStackFrame frame in frames)
+            // Serialize cache population so concurrent DAC stack-walks don't truncate
+            // each other and publish a partial frame array.
+            lock (_frameCacheLock)
             {
-                cachedFrames.Add(frame);
-                yield return frame;
-            }
+                cache = _frameCache;
+                if (cache is not null && (!includeContext || cache.IncludedContext))
+                    return cache.Elements.Length <= maxFrames ? Array.AsReadOnly(cache.Elements) : cache.Elements.Take(maxFrames);
 
-            // it's ok if we race and replace another cache as this will stabilize eventually
-            _frameCache ??= new(cachedFrames.ToArray(), includeContext);
+                ClrStackFrame[] frames = threadHelpers.EnumerateStackTrace(OSThreadId, includeContext, maxFrames, traceErrors: IsAlive)
+                    .Select(r => CreateClrStackFrame(r))
+                    .Take(maxFrames)
+                    .ToArray();
+                if (frames.Length < maxFrames)
+                    _frameCache = new(frames, includeContext);
+
+                return Array.AsReadOnly(frames);
+            }
         }
 
         private ClrStackFrame CreateClrStackFrame(in StackFrameInfo frame)

--- a/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacComHelpers.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacComHelpers.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -23,27 +23,41 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
 
         public IEnumerable<ClrRcwCleanupData> EnumerateRcwCleanupData()
         {
-            return _sos.EnumerateRCWCleanup(ClrDataAddress.Null).Select(r => new ClrRcwCleanupData(r.Rcw.ToAddress(_target), r.Context.ToAddress(_target), r.Thread.ToAddress(_target), r.IsFreeThreaded));
+            List<ClrRcwCleanupData>? results = null;
+            lock (_sos.SyncRoot)
+            {
+                foreach ((ClrDataAddress Rcw, ClrDataAddress Context, ClrDataAddress Thread, bool IsFreeThreaded) r in _sos.EnumerateRCWCleanup(ClrDataAddress.Null))
+                {
+                    results ??= new List<ClrRcwCleanupData>();
+                    results.Add(new ClrRcwCleanupData(r.Rcw.ToAddress(_target), r.Context.ToAddress(_target), r.Thread.ToAddress(_target), r.IsFreeThreaded));
+                }
+            }
+
+            return (IEnumerable<ClrRcwCleanupData>?)results ?? Array.Empty<ClrRcwCleanupData>();
         }
 
         public bool GetCcwInfo(ulong obj, out CcwInfo info)
         {
             info = default;
-            if (_sos.GetObjectData(ClrDataAddress.FromTargetAddress(obj, _target), out ObjectData objData) &&
-                !objData.CCW.IsNull &&
-                _sos.GetCCWData(objData.CCW, out CcwData ccwData))
+            lock (_sos.SyncRoot)
             {
-                COMInterfacePointerData[]? pointers = _sos.GetCCWInterfaces(objData.CCW, ccwData.InterfaceCount);
-                info = new()
+                if (_sos.GetObjectData(ClrDataAddress.FromTargetAddress(obj, _target), out ObjectData objData) &&
+                    !objData.CCW.IsNull &&
+                    _sos.GetCCWData(objData.CCW, out CcwData ccwData))
                 {
-                    Address = objData.CCW.ToAddress(_target),
-                    IUnknown = ccwData.OuterIUnknown.ToAddress(_target),
-                    Object = ccwData.ManagedObject.ToAddress(_target),
-                    Handle = ccwData.Handle.ToAddress(_target),
-                    RefCount = ccwData.RefCount,
-                    JupiterRefCount = ccwData.JupiterRefCount,
-                    Interfaces = pointers?.Select(r => new ComInterfaceEntry() { InterfacePointer = r.InterfacePointer.ToAddress(_target), MethodTable = r.MethodTable.ToAddress(_target) }).ToArray() ?? Array.Empty<ComInterfaceEntry>()
-                };
+                    COMInterfacePointerData[]? pointers = _sos.GetCCWInterfaces(objData.CCW, ccwData.InterfaceCount);
+                    info = new()
+                    {
+                        Address = objData.CCW.ToAddress(_target),
+                        IUnknown = ccwData.OuterIUnknown.ToAddress(_target),
+                        Object = ccwData.ManagedObject.ToAddress(_target),
+                        Handle = ccwData.Handle.ToAddress(_target),
+                        RefCount = ccwData.RefCount,
+                        JupiterRefCount = ccwData.JupiterRefCount,
+                        Interfaces = pointers?.Select(r => new ComInterfaceEntry() { InterfacePointer = r.InterfacePointer.ToAddress(_target), MethodTable = r.MethodTable.ToAddress(_target) }).ToArray() ?? Array.Empty<ComInterfaceEntry>()
+                    };
+                    return true;
+                }
             }
 
             return false;
@@ -52,22 +66,26 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
         public bool GetRcwInfo(ulong obj, out RcwInfo info)
         {
             info = default;
-            if (_sos.GetObjectData(ClrDataAddress.FromTargetAddress(obj, _target), out ObjectData objData) &&
-                !objData.RCW.IsNull &&
-                _sos.GetRCWData(objData.RCW, out RcwData rcwData))
+            lock (_sos.SyncRoot)
             {
-                COMInterfacePointerData[]? pointers = _sos.GetRCWInterfaces(objData.RCW, rcwData.InterfaceCount);
-                info = new()
+                if (_sos.GetObjectData(ClrDataAddress.FromTargetAddress(obj, _target), out ObjectData objData) &&
+                    !objData.RCW.IsNull &&
+                    _sos.GetRCWData(objData.RCW, out RcwData rcwData))
                 {
-                    Address = objData.RCW.ToAddress(_target),
-                    IUnknown = rcwData.IUnknownPointer.ToAddress(_target),
-                    Object = rcwData.ManagedObject.ToAddress(_target),
-                    RefCount = rcwData.RefCount,
-                    CreatorThread = rcwData.CreatorThread.ToAddress(_target),
-                    IsDisconnected = rcwData.IsDisconnected != 0,
-                    VTablePointer = rcwData.VTablePointer.ToAddress(_target),
-                    Interfaces = pointers?.Select(r => new ComInterfaceEntry() { InterfacePointer = r.InterfacePointer.ToAddress(_target), MethodTable = r.MethodTable.ToAddress(_target) }).ToArray() ?? Array.Empty<ComInterfaceEntry>()
-                };
+                    COMInterfacePointerData[]? pointers = _sos.GetRCWInterfaces(objData.RCW, rcwData.InterfaceCount);
+                    info = new()
+                    {
+                        Address = objData.RCW.ToAddress(_target),
+                        IUnknown = rcwData.IUnknownPointer.ToAddress(_target),
+                        Object = rcwData.ManagedObject.ToAddress(_target),
+                        RefCount = rcwData.RefCount,
+                        CreatorThread = rcwData.CreatorThread.ToAddress(_target),
+                        IsDisconnected = rcwData.IsDisconnected != 0,
+                        VTablePointer = rcwData.VTablePointer.ToAddress(_target),
+                        Interfaces = pointers?.Select(r => new ComInterfaceEntry() { InterfacePointer = r.InterfacePointer.ToAddress(_target), MethodTable = r.MethodTable.ToAddress(_target) }).ToArray() ?? Array.Empty<ComInterfaceEntry>()
+                    };
+                    return true;
+                }
             }
 
             return false;

--- a/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacHeap.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacHeap.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
         private readonly IMemoryReader _memoryReader;
         private readonly TargetProperties _target;
         private readonly GCState _gcState;
-        private HashSet<ulong>? _validMethodTables;
+        private readonly HashSet<ulong> _validMethodTables = new();
 
         private const uint SyncBlockRecLevelMask = 0x0000FC00;
         private const int SyncBlockRecLevelShift = 10;
@@ -56,103 +56,139 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
 
         public IEnumerable<MemoryRange> EnumerateThreadAllocationContexts()
         {
-            if (_sos12 is not null && _sos12.GetGlobalAllocationContext(out ulong allocPointer, out ulong allocLimit))
+            List<MemoryRange>? results = null;
+            lock (_sos.SyncRoot)
             {
-                if (allocPointer < allocLimit)
-                    yield return new(allocPointer, allocLimit);
+                if (_sos12 is not null && _sos12.GetGlobalAllocationContext(out ulong allocPointer, out ulong allocLimit))
+                {
+                    if (allocPointer < allocLimit)
+                    {
+                        results ??= new List<MemoryRange>();
+                        results.Add(new(allocPointer, allocLimit));
+                    }
+                }
+
+                if (!_sos.GetThreadStoreData(out ThreadStoreData threadStore))
+                    return (IEnumerable<MemoryRange>?)results ?? Array.Empty<MemoryRange>();
+
+                ulong address = threadStore.FirstThread.ToAddress(_target);
+                for (int i = 0; i < threadStore.ThreadCount && address != 0; i++)
+                {
+                    if (!_sos.GetThreadData(ClrDataAddress.FromTargetAddress(address, _target), out ThreadData thread))
+                        break;
+
+                    if (thread.AllocationContextPointer.ToAddress(_target) < thread.AllocationContextLimit.ToAddress(_target))
+                    {
+                        results ??= new List<MemoryRange>();
+                        results.Add(new(thread.AllocationContextPointer.ToAddress(_target), thread.AllocationContextLimit.ToAddress(_target)));
+                    }
+
+                    address = thread.NextThread.ToAddress(_target);
+                }
             }
 
-            if (!_sos.GetThreadStoreData(out ThreadStoreData threadStore))
-                yield break;
-
-            ulong address = threadStore.FirstThread.ToAddress(_target);
-            for (int i = 0; i < threadStore.ThreadCount && address != 0; i++)
-            {
-                if (!_sos.GetThreadData(ClrDataAddress.FromTargetAddress(address, _target), out ThreadData thread))
-                    break;
-
-                if (thread.AllocationContextPointer.ToAddress(_target) < thread.AllocationContextLimit.ToAddress(_target))
-                    yield return new(thread.AllocationContextPointer.ToAddress(_target), thread.AllocationContextLimit.ToAddress(_target));
-
-                address = thread.NextThread.ToAddress(_target);
-            }
+            return (IEnumerable<MemoryRange>?)results ?? Array.Empty<MemoryRange>();
         }
 
         public IEnumerable<(ulong Source, ulong Target)> EnumerateDependentHandles()
         {
-            using SOSHandleEnum? handleEnum = _sos.EnumerateHandles(ClrHandleKind.Dependent);
-            if (handleEnum is null)
-                yield break;
-
-            foreach (HandleData handle in handleEnum.ReadHandles())
+            // SOSHandleEnum is a stateful DAC enumerator; serialize its lifetime
+            // against other DAC calls (Flush, other enumerators).
+            List<(ulong Source, ulong Target)>? results = null;
+            lock (_sos.SyncRoot)
             {
-                if (handle.Type == (int)ClrHandleKind.Dependent)
+                using SOSHandleEnum? handleEnum = _sos.EnumerateHandles(ClrHandleKind.Dependent);
+                if (handleEnum is null)
+                    return Array.Empty<(ulong, ulong)>();
+
+                foreach (HandleData handle in handleEnum.ReadHandles())
                 {
-                    ulong obj = _memoryReader.ReadPointer(handle.Handle.ToAddress(_target));
-                    if (obj != 0)
-                        yield return (obj, handle.Secondary.ToAddress(_target));
+                    if (handle.Type == (int)ClrHandleKind.Dependent)
+                    {
+                        ulong obj = _memoryReader.ReadPointer(handle.Handle.ToAddress(_target));
+                        if (obj != 0)
+                        {
+                            results ??= new List<(ulong, ulong)>();
+                            results.Add((obj, handle.Secondary.ToAddress(_target)));
+                        }
+                    }
                 }
             }
+
+            return (IEnumerable<(ulong, ulong)>?)results ?? Array.Empty<(ulong, ulong)>();
         }
 
         public IEnumerable<SyncBlockInfo> EnumerateSyncBlocks()
         {
-            HResult hr = _sos.GetSyncBlockData(1, out SyncBlockData data);
-            if (!hr || data.TotalSyncBlockCount == 0)
-                yield break;
-
-            int max = data.TotalSyncBlockCount >= int.MaxValue ? int.MaxValue : (int)data.TotalSyncBlockCount;
-
-            int curr = 1;
-            do
+            List<SyncBlockInfo>? results = null;
+            lock (_sos.SyncRoot)
             {
-                if (data.Free == 0)
+                HResult hr = _sos.GetSyncBlockData(1, out SyncBlockData data);
+                if (!hr || data.TotalSyncBlockCount == 0)
+                    return Array.Empty<SyncBlockInfo>();
+
+                int max = data.TotalSyncBlockCount >= int.MaxValue ? int.MaxValue : (int)data.TotalSyncBlockCount;
+
+                int curr = 1;
+                do
                 {
-                    yield return new()
+                    if (data.Free == 0)
                     {
-                        Index = curr,
-                        Address = data.Address.ToAddress(_target),
-                        Object = data.Object.ToAddress(_target),
-                        AppDomain = data.AppDomain.ToAddress(_target),
-                        AdditionalThreadCount = data.AdditionalThreadCount.ToSigned(),
-                        COMFlags = (SyncBlockComFlags)data.COMFlags,
-                        HoldingThread = data.HoldingThread.ToAddress(_target),
-                        MonitorHeldCount = data.MonitorHeld.ToSigned(),
-                        Recursion = data.Recursion.ToSigned()
-                    };
-                }
+                        results ??= new List<SyncBlockInfo>();
+                        results.Add(new()
+                        {
+                            Index = curr,
+                            Address = data.Address.ToAddress(_target),
+                            Object = data.Object.ToAddress(_target),
+                            AppDomain = data.AppDomain.ToAddress(_target),
+                            AdditionalThreadCount = data.AdditionalThreadCount.ToSigned(),
+                            COMFlags = (SyncBlockComFlags)data.COMFlags,
+                            HoldingThread = data.HoldingThread.ToAddress(_target),
+                            MonitorHeldCount = data.MonitorHeld.ToSigned(),
+                            Recursion = data.Recursion.ToSigned()
+                        });
+                    }
 
-                curr++;
-                if (curr > max)
-                    break;
+                    curr++;
+                    if (curr > max)
+                        break;
 
-                hr = _sos.GetSyncBlockData(curr, out data);
-            } while (hr);
+                    hr = _sos.GetSyncBlockData(curr, out data);
+                } while (hr);
+            }
+
+            return (IEnumerable<SyncBlockInfo>?)results ?? Array.Empty<SyncBlockInfo>();
         }
 
         public IEnumerable<SubHeapInfo> EnumerateSubHeaps()
         {
-            if (_gcState.Kind == AbstractDac.GCKind.Server)
+            List<SubHeapInfo>? results = null;
+            lock (_sos.SyncRoot)
             {
-                ClrDataAddress[] heapAddresses = _sos.GetHeapList(_gcState.HeapCount);
-                for (int i = 0; i < heapAddresses.Length; i++)
+                if (_gcState.Kind == AbstractDac.GCKind.Server)
                 {
-                    if (_sos.GetServerHeapDetails(heapAddresses[i], out HeapDetails heapData))
+                    ClrDataAddress[] heapAddresses = _sos.GetHeapList(_gcState.HeapCount);
+                    for (int i = 0; i < heapAddresses.Length; i++)
                     {
-                        ulong heapAddr = heapAddresses[i].ToAddress(_target);
-                        SubHeapInfo subHeapInfo = CreateSubHeapInfo(heapAddr, i, heapData);
-                        yield return subHeapInfo;
+                        if (_sos.GetServerHeapDetails(heapAddresses[i], out HeapDetails heapData))
+                        {
+                            ulong heapAddr = heapAddresses[i].ToAddress(_target);
+                            results ??= new List<SubHeapInfo>();
+                            results.Add(CreateSubHeapInfo(heapAddr, i, heapData));
+                        }
+                    }
+                }
+                else
+                {
+                    if (_sos.GetWksHeapDetails(out HeapDetails heapData))
+                    {
+                        results ??= new List<SubHeapInfo>();
+                        results.Add(CreateSubHeapInfo(0, 0, heapData));
                     }
                 }
             }
-            else
-            {
-                if (_sos.GetWksHeapDetails(out HeapDetails heapData))
-                {
-                    SubHeapInfo subHeapInfo = CreateSubHeapInfo(0, 0, heapData);
-                    yield return subHeapInfo;
-                }
-            }
+
+            return (IEnumerable<SubHeapInfo>?)results ?? Array.Empty<SubHeapInfo>();
         }
 
         private SubHeapInfo CreateSubHeapInfo(ulong address, int i, HeapDetails heapData)
@@ -366,7 +402,9 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
                 return default;
 
             (uint threadId, uint recursion) = GetThinlockData(header);
-            ulong threadAddress = _sos.GetThreadFromThinlockId(threadId).ToAddress(_target);
+            ulong threadAddress;
+            lock (_sos.SyncRoot)
+                threadAddress = _sos.GetThreadFromThinlockId(threadId).ToAddress(_target);
 
             if (threadAddress == 0)
                 return default;
@@ -392,12 +430,14 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
             // clear the mark bit
             mt &= ~1ul;
 
-            HashSet<ulong> validMts = _validMethodTables ??= new();
+            HashSet<ulong> validMts = _validMethodTables;
             lock (validMts)
                 if (validMts.Contains(mt))
                     return true;
 
-            bool verified = _sos.GetMethodTableData(ClrDataAddress.FromTargetAddress(mt, _target), out _);
+            bool verified;
+            lock (_sos.SyncRoot)
+                verified = _sos.GetMethodTableData(ClrDataAddress.FromTargetAddress(mt, _target), out _);
             if (verified)
             {
                 lock (validMts)
@@ -410,10 +450,13 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
         public MemoryRange GetInternalRootArray(ulong subHeapAddress)
         {
             DacHeapAnalyzeData analyzeData;
-            if (subHeapAddress != 0)
-                _sos.GetHeapAnalyzeData(ClrDataAddress.FromTargetAddress(subHeapAddress, _target), out analyzeData);
-            else
-                _sos.GetHeapAnalyzeData(out analyzeData);
+            lock (_sos.SyncRoot)
+            {
+                if (subHeapAddress != 0)
+                    _sos.GetHeapAnalyzeData(ClrDataAddress.FromTargetAddress(subHeapAddress, _target), out analyzeData);
+                else
+                    _sos.GetHeapAnalyzeData(out analyzeData);
+            }
 
             if (analyzeData.InternalRootArray.IsNull || analyzeData.InternalRootArrayIndex == 0)
                 return default;
@@ -426,20 +469,23 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
         public bool GetOOMInfo(ulong subHeapAddress, out OomInfo oomInfo)
         {
             DacOOMData oomData;
-            if (subHeapAddress != 0)
+            lock (_sos.SyncRoot)
             {
-                if (!_sos.GetOOMData(ClrDataAddress.FromTargetAddress(subHeapAddress, _target), out oomData) || oomData.Reason == OutOfMemoryReason.None && oomData.GetMemoryFailure == GetMemoryFailureReason.None)
+                if (subHeapAddress != 0)
                 {
-                    oomInfo = default;
-                    return false;
+                    if (!_sos.GetOOMData(ClrDataAddress.FromTargetAddress(subHeapAddress, _target), out oomData) || oomData.Reason == OutOfMemoryReason.None && oomData.GetMemoryFailure == GetMemoryFailureReason.None)
+                    {
+                        oomInfo = default;
+                        return false;
+                    }
                 }
-            }
-            else
-            {
-                if (!_sos.GetOOMData(out oomData) || oomData.Reason == OutOfMemoryReason.None && oomData.GetMemoryFailure == GetMemoryFailureReason.None)
+                else
                 {
-                    oomInfo = default;
-                    return false;
+                    if (!_sos.GetOOMData(out oomData) || oomData.Reason == OutOfMemoryReason.None && oomData.GetMemoryFailure == GetMemoryFailureReason.None)
+                    {
+                        oomInfo = default;
+                        return false;
+                    }
                 }
             }
 
@@ -460,7 +506,8 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
         {
             if (_sos16 != null)
             {
-                return _sos16.GetDynamicAdaptationMode();
+                lock (_sos.SyncRoot)
+                    return _sos16.GetDynamicAdaptationMode();
             }
             else
             {

--- a/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacHeap.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacHeap.cs
@@ -93,8 +93,10 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
         public IEnumerable<(ulong Source, ulong Target)> EnumerateDependentHandles()
         {
             // SOSHandleEnum is a stateful DAC enumerator; serialize its lifetime
-            // against other DAC calls (Flush, other enumerators).
-            List<(ulong Source, ulong Target)>? results = null;
+            // against other DAC calls (Flush, other enumerators). Collect only the raw
+            // dependent HandleData under the lock; resolving the source object
+            // (IMemoryReader.ReadPointer) is not a DAC call, so do it outside the lock.
+            List<HandleData>? raw = null;
             lock (_sos.SyncRoot)
             {
                 using SOSHandleEnum? handleEnum = _sos.EnumerateHandles(ClrHandleKind.Dependent);
@@ -105,17 +107,24 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
                 {
                     if (handle.Type == (int)ClrHandleKind.Dependent)
                     {
-                        ulong obj = _memoryReader.ReadPointer(handle.Handle.ToAddress(_target));
-                        if (obj != 0)
-                        {
-                            results ??= new List<(ulong, ulong)>();
-                            results.Add((obj, handle.Secondary.ToAddress(_target)));
-                        }
+                        raw ??= new List<HandleData>();
+                        raw.Add(handle);
                     }
                 }
             }
 
-            return (IEnumerable<(ulong, ulong)>?)results ?? Array.Empty<(ulong, ulong)>();
+            if (raw is null)
+                return Array.Empty<(ulong, ulong)>();
+
+            List<(ulong Source, ulong Target)> results = new(raw.Count);
+            foreach (HandleData handle in raw)
+            {
+                ulong obj = _memoryReader.ReadPointer(handle.Handle.ToAddress(_target));
+                if (obj != 0)
+                    results.Add((obj, handle.Secondary.ToAddress(_target)));
+            }
+
+            return results;
         }
 
         public IEnumerable<SyncBlockInfo> EnumerateSyncBlocks()

--- a/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacLegacyThreadPool.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacLegacyThreadPool.cs
@@ -23,7 +23,11 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
 
         public bool GetLegacyThreadPoolData(out LegacyThreadPoolInfo result)
         {
-            HResult hr = _sos.GetThreadPoolData(out ThreadPoolData data);
+            HResult hr;
+            ThreadPoolData data;
+            lock (_sos.SyncRoot)
+                hr = _sos.GetThreadPoolData(out data);
+
             result = new()
             {
                 AsyncTimerCallbackCompletionFPtr = data.AsyncTimerCallbackCompletionFPtr.ToAddress(_target),
@@ -52,7 +56,11 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
 
         public bool GetLegacyWorkRequestData(ulong workRequest, out LegacyWorkRequestInfo workRequestInfo)
         {
-            bool res = _sos.GetWorkRequestData(ClrDataAddress.FromTargetAddress(workRequest, _target), out WorkRequestData workRequestData);
+            bool res;
+            WorkRequestData workRequestData;
+            lock (_sos.SyncRoot)
+                res = _sos.GetWorkRequestData(ClrDataAddress.FromTargetAddress(workRequest, _target), out workRequestData);
+
             workRequestInfo = new()
             {
                 Function = workRequestData.Function.ToAddress(_target),

--- a/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacMetadataReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacMetadataReader.cs
@@ -14,11 +14,13 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
     internal class DacMetadataReader : IAbstractMetadataReader, IDisposable
     {
         private readonly MetadataImport _import;
+        private readonly object _syncRoot;
         private bool _disposed;
 
-        public DacMetadataReader(MetadataImport import)
+        public DacMetadataReader(MetadataImport import, object syncRoot)
         {
             _import = import;
+            _syncRoot = syncRoot;
         }
 
         public void Dispose()
@@ -30,115 +32,172 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
             _import.Dispose();
         }
 
-        public bool GetMethodAttributes(int methodDef, out MethodAttributes attributes) => _import.GetMethodAttributes(methodDef, out attributes);
+        public bool GetMethodAttributes(int methodDef, out MethodAttributes attributes)
+        {
+            lock (_syncRoot)
+                return _import.GetMethodAttributes(methodDef, out attributes);
+        }
 
         public bool GetFieldDefInfo(int token, out FieldDefInfo info)
         {
-            if (!_import.GetFieldProps(token, out string? name, out FieldAttributes attributes, out nint fieldSig, out int sigLen, out int type, out nint pValue))
+            lock (_syncRoot)
             {
-                info = default;
-                return false;
-            }
+                if (!_import.GetFieldProps(token, out string? name, out FieldAttributes attributes, out nint fieldSig, out int sigLen, out int type, out nint pValue))
+                {
+                    info = default;
+                    return false;
+                }
 
-            info = new()
-            {
-                Token = token,
-                Name = name,
-                Attributes = attributes,
-                Signature = fieldSig,
-                SignatureSize = sigLen,
-                Type = type,
-                ValuePointer = pValue
-            };
-
-            return true;
-        }
-
-        public bool GetTypeDefInfo(int typeDef, out TypeDefInfo info)
-        {
-            HResult hr = _import.GetTypeDefProperties(typeDef, out string? name, out TypeAttributes attributes, out int parent);
-            if (hr.IsOK)
-            {
                 info = new()
                 {
-                    Token = typeDef,
+                    Token = token,
                     Name = name,
                     Attributes = attributes,
-                    Parent = parent,
+                    Signature = fieldSig,
+                    SignatureSize = sigLen,
+                    Type = type,
+                    ValuePointer = pValue
                 };
 
                 return true;
             }
-
-            info = default;
-            return false;
         }
 
-        public string? GetTypeRefName(int typeRef) => _import.GetTypeRefName(typeRef);
+        public bool GetTypeDefInfo(int typeDef, out TypeDefInfo info)
+        {
+            lock (_syncRoot)
+            {
+                HResult hr = _import.GetTypeDefProperties(typeDef, out string? name, out TypeAttributes attributes, out int parent);
+                if (hr.IsOK)
+                {
+                    info = new()
+                    {
+                        Token = typeDef,
+                        Name = name,
+                        Attributes = attributes,
+                        Parent = parent,
+                    };
 
-        public bool GetNestedClassToken(int typeDef, out int parent) => _import.GetNestedClassProperties(typeDef, out parent);
+                    return true;
+                }
+
+                info = default;
+                return false;
+            }
+        }
+
+        public string? GetTypeRefName(int typeRef)
+        {
+            lock (_syncRoot)
+                return _import.GetTypeRefName(typeRef);
+        }
+
+        public bool GetNestedClassToken(int typeDef, out int parent)
+        {
+            lock (_syncRoot)
+                return _import.GetNestedClassProperties(typeDef, out parent);
+        }
 
         public IEnumerable<FieldDefInfo> EnumerateFields(int typeDef)
         {
-            foreach (int token in _import.EnumerateFields(typeDef))
+            List<FieldDefInfo>? results = null;
+            lock (_syncRoot)
             {
-                if (GetFieldDefInfo(token, out FieldDefInfo info))
-                    yield return info;
+                foreach (int token in _import.EnumerateFields(typeDef))
+                {
+                    if (!_import.GetFieldProps(token, out string? name, out FieldAttributes attributes, out nint fieldSig, out int sigLen, out int type, out nint pValue))
+                        continue;
+
+                    results ??= new List<FieldDefInfo>();
+                    results.Add(new FieldDefInfo
+                    {
+                        Token = token,
+                        Name = name,
+                        Attributes = attributes,
+                        Signature = fieldSig,
+                        SignatureSize = sigLen,
+                        Type = type,
+                        ValuePointer = pValue
+                    });
+                }
             }
+
+            return (IEnumerable<FieldDefInfo>?)results ?? Array.Empty<FieldDefInfo>();
         }
 
         public IEnumerable<GenericParameterInfo> EnumerateGenericParameters(int typeDef)
         {
-            foreach (int token in _import.EnumerateGenericParams(typeDef))
+            List<GenericParameterInfo>? results = null;
+            lock (_syncRoot)
             {
-                if (_import.GetGenericParamProps(token, out int index, out GenericParameterAttributes attributes, out string? name))
+                foreach (int token in _import.EnumerateGenericParams(typeDef))
                 {
-                    yield return new()
+                    if (_import.GetGenericParamProps(token, out int index, out GenericParameterAttributes attributes, out string? name))
                     {
-                        Token = token,
-                        Index = index,
-                        Attributes = attributes,
-                        Name = name
-                    };
+                        results ??= new List<GenericParameterInfo>();
+                        results.Add(new GenericParameterInfo
+                        {
+                            Token = token,
+                            Index = index,
+                            Attributes = attributes,
+                            Name = name
+                        });
+                    }
                 }
             }
+
+            return (IEnumerable<GenericParameterInfo>?)results ?? Array.Empty<GenericParameterInfo>();
         }
 
         public IEnumerable<InterfaceInfo> EnumerateInterfaces(int typeDef)
         {
-            foreach (int token in _import.EnumerateInterfaceImpls(typeDef))
+            List<InterfaceInfo>? results = null;
+            lock (_syncRoot)
             {
-                if (_import.GetInterfaceImplProps(token, out _, out int mdIFace))
+                foreach (int token in _import.EnumerateInterfaceImpls(typeDef))
                 {
-                    yield return new()
+                    if (_import.GetInterfaceImplProps(token, out _, out int mdIFace))
                     {
-                        Token = token,
-                        InterfaceToken = mdIFace
-                    };
+                        results ??= new List<InterfaceInfo>();
+                        results.Add(new InterfaceInfo
+                        {
+                            Token = token,
+                            InterfaceToken = mdIFace
+                        });
+                    }
                 }
             }
+
+            return (IEnumerable<InterfaceInfo>?)results ?? Array.Empty<InterfaceInfo>();
         }
 
 
         public unsafe int GetCustomAttributeData(int token, string name, Span<byte> buffer)
         {
-            if (_import.GetCustomAttributeByName(token, name, out nint pData, out uint cbData))
+            lock (_syncRoot)
             {
-                if (pData != 0 && cbData > 0)
+                if (_import.GetCustomAttributeByName(token, name, out nint pData, out uint cbData))
                 {
-                    int size = cbData > int.MaxValue ? 0 : (int)cbData;
-                    int result = Math.Min(size, buffer.Length);
+                    if (pData != 0 && cbData > 0)
+                    {
+                        int size = cbData > int.MaxValue ? 0 : (int)cbData;
+                        int result = Math.Min(size, buffer.Length);
 
-                    ReadOnlySpan<byte> data = new((void*)pData, result);
-                    data.CopyTo(buffer);
+                        ReadOnlySpan<byte> data = new((void*)pData, result);
+                        data.CopyTo(buffer);
 
-                    return result;
+                        return result;
+                    }
                 }
-            }
 
-            return 0;
+                return 0;
+            }
         }
 
-        public uint GetRva(int metadataToken) => _import.GetRva(metadataToken);
+        public uint GetRva(int metadataToken)
+        {
+            lock (_syncRoot)
+                return _import.GetRva(metadataToken);
+        }
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacMethodLocator.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacMethodLocator.cs
@@ -22,74 +22,83 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
 
         public ulong GetMethodHandleContainingType(ulong methodDesc)
         {
-            if (!_sos.GetMethodDescData(ClrDataAddress.FromTargetAddress(methodDesc, _target), ClrDataAddress.Null, out MethodDescData mdData))
-                return 0;
+            lock (_sos.SyncRoot)
+            {
+                if (!_sos.GetMethodDescData(ClrDataAddress.FromTargetAddress(methodDesc, _target), ClrDataAddress.Null, out MethodDescData mdData))
+                    return 0;
 
-            return mdData.MethodTable.ToAddress(_target);
+                return mdData.MethodTable.ToAddress(_target);
+            }
         }
 
         public ulong GetMethodHandleByInstructionPointer(ulong ip)
         {
-            ulong md = _sos.GetMethodDescPtrFromIP(ClrDataAddress.FromTargetAddress(ip, _target)).ToAddress(_target);
-            if (md == 0)
+            lock (_sos.SyncRoot)
             {
-                if (_sos.GetCodeHeaderData(ClrDataAddress.FromTargetAddress(ip, _target), out CodeHeaderData codeHeaderData))
-                    md = codeHeaderData.MethodDesc.ToAddress(_target);
-            }
+                ulong md = _sos.GetMethodDescPtrFromIP(ClrDataAddress.FromTargetAddress(ip, _target)).ToAddress(_target);
+                if (md == 0)
+                {
+                    if (_sos.GetCodeHeaderData(ClrDataAddress.FromTargetAddress(ip, _target), out CodeHeaderData codeHeaderData))
+                        md = codeHeaderData.MethodDesc.ToAddress(_target);
+                }
 
-            return md;
+                return md;
+            }
         }
 
         public bool GetMethodInfo(ulong methodDesc, out MethodInfo methodInfo)
         {
-            if (!_sos.GetMethodDescData(ClrDataAddress.FromTargetAddress(methodDesc, _target), ClrDataAddress.Null, out MethodDescData mdd))
+            lock (_sos.SyncRoot)
             {
-                methodInfo = default;
-                return false;
-            }
+                if (!_sos.GetMethodDescData(ClrDataAddress.FromTargetAddress(methodDesc, _target), ClrDataAddress.Null, out MethodDescData mdd))
+                {
+                    methodInfo = default;
+                    return false;
+                }
 
-            if (mdd.HasNativeCode != 0 && _sos.GetCodeHeaderData(mdd.NativeCodeAddr, out CodeHeaderData chd))
-            {
-                ulong nativeCodeAddr = mdd.NativeCodeAddr.ToAddress(_target);
-                methodInfo = new()
+                if (mdd.HasNativeCode != 0 && _sos.GetCodeHeaderData(mdd.NativeCodeAddr, out CodeHeaderData chd))
                 {
-                    CompilationType = (MethodCompilationType)chd.JITType,
-                    HotCold = new(nativeCodeAddr, chd.HotRegionSize, chd.ColdRegionStart.ToAddress(_target), chd.ColdRegionSize),
-                    MethodDesc = chd.MethodDesc.ToAddress(_target),
-                    Token = (int)mdd.MDToken
-                };
-            }
-            else
-            {
-                // Fall back to slot-based lookup (issue #935). Reference-type generic
-                // instantiations share code via canonical method descs and may not have
-                // NativeCodeAddr set, but the method table slot points to the shared code.
-                ClrDataAddress slot = _sos.GetMethodTableSlot(mdd.MethodTable, mdd.SlotNumber);
-                if (!slot.IsNull && _sos.GetCodeHeaderData(slot, out CodeHeaderData slotChd))
-                {
-                    ulong slotAddr = slot.ToAddress(_target);
+                    ulong nativeCodeAddr = mdd.NativeCodeAddr.ToAddress(_target);
                     methodInfo = new()
                     {
-                        CompilationType = (MethodCompilationType)slotChd.JITType,
-                        HotCold = new(slotAddr, slotChd.HotRegionSize, slotChd.ColdRegionStart.ToAddress(_target), slotChd.ColdRegionSize),
-                        MethodDesc = methodDesc,
+                        CompilationType = (MethodCompilationType)chd.JITType,
+                        HotCold = new(nativeCodeAddr, chd.HotRegionSize, chd.ColdRegionStart.ToAddress(_target), chd.ColdRegionSize),
+                        MethodDesc = chd.MethodDesc.ToAddress(_target),
                         Token = (int)mdd.MDToken
                     };
                 }
                 else
                 {
-                    // Method has no native code by either path (not yet JIT compiled)
-                    methodInfo = new()
+                    // Fall back to slot-based lookup (issue #935). Reference-type generic
+                    // instantiations share code via canonical method descs and may not have
+                    // NativeCodeAddr set, but the method table slot points to the shared code.
+                    ClrDataAddress slot = _sos.GetMethodTableSlot(mdd.MethodTable, mdd.SlotNumber);
+                    if (!slot.IsNull && _sos.GetCodeHeaderData(slot, out CodeHeaderData slotChd))
                     {
-                        CompilationType = MethodCompilationType.None,
-                        HotCold = default,
-                        MethodDesc = methodDesc,
-                        Token = (int)mdd.MDToken
-                    };
+                        ulong slotAddr = slot.ToAddress(_target);
+                        methodInfo = new()
+                        {
+                            CompilationType = (MethodCompilationType)slotChd.JITType,
+                            HotCold = new(slotAddr, slotChd.HotRegionSize, slotChd.ColdRegionStart.ToAddress(_target), slotChd.ColdRegionSize),
+                            MethodDesc = methodDesc,
+                            Token = (int)mdd.MDToken
+                        };
+                    }
+                    else
+                    {
+                        // Method has no native code by either path (not yet JIT compiled)
+                        methodInfo = new()
+                        {
+                            CompilationType = MethodCompilationType.None,
+                            HotCold = default,
+                            MethodDesc = methodDesc,
+                            Token = (int)mdd.MDToken
+                        };
+                    }
                 }
-            }
 
-            return true;
+                return true;
+            }
         }
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacModuleHelpers.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacModuleHelpers.cs
@@ -26,32 +26,48 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
 
         public ClrModuleInfo GetModuleInfo(ulong moduleAddress)
         {
-            _sos.GetModuleData(ClrDataAddress.FromTargetAddress(moduleAddress, _target), out ModuleData data);
-
-            ulong assemblyAddr = data.Assembly.ToAddress(_target);
-            ClrModuleInfo result = new()
+            ClrModuleInfo result;
+            lock (_sos.SyncRoot)
             {
-                Address = moduleAddress,
-                Assembly = assemblyAddr,
-                AssemblyName = assemblyAddr != 0 ? _sos.GetAssemblyName(ClrDataAddress.FromTargetAddress(assemblyAddr, _target)) : null,
-                Id = data.ModuleID,
-                Index = data.ModuleIndex,
-                IsPEFile = data.IsPEFile != 0,
-                ImageBase = data.ILBase.ToAddress(_target),
-                MetadataAddress = data.MetadataStart.ToAddress(_target),
-                MetadataSize = data.MetadataSize,
-                IsDynamic = data.IsReflection != 0,
-                ThunkHeap = data.ThunkHeap.ToAddress(_target),
-                LoaderAllocator = data.LoaderAllocator.ToAddress(_target),
-            };
+                _sos.GetModuleData(ClrDataAddress.FromTargetAddress(moduleAddress, _target), out ModuleData data);
+
+                ulong assemblyAddr = data.Assembly.ToAddress(_target);
+                result = new()
+                {
+                    Address = moduleAddress,
+                    Assembly = assemblyAddr,
+                    AssemblyName = assemblyAddr != 0 ? _sos.GetAssemblyName(ClrDataAddress.FromTargetAddress(assemblyAddr, _target)) : null,
+                    Id = data.ModuleID,
+                    Index = data.ModuleIndex,
+                    IsPEFile = data.IsPEFile != 0,
+                    ImageBase = data.ILBase.ToAddress(_target),
+                    MetadataAddress = data.MetadataStart.ToAddress(_target),
+                    MetadataSize = data.MetadataSize,
+                    IsDynamic = data.IsReflection != 0,
+                    ThunkHeap = data.ThunkHeap.ToAddress(_target),
+                    LoaderAllocator = data.LoaderAllocator.ToAddress(_target),
+                };
+            }
 
             ClrDataModule? dataModule = GetClrDataModule(moduleAddress);
-            if (dataModule is not null && dataModule.GetModuleData(out ExtendedModuleData extended))
+            if (dataModule is not null)
             {
-                result.Layout = extended.IsFlatLayout != 0 ? ModuleLayout.Flat : ModuleLayout.Mapped;
-                result.IsDynamic |= extended.IsDynamic != 0;
-                result.Size = extended.LoadedPESize;
-                result.FileName = dataModule.GetFileName();
+                bool ok;
+                ExtendedModuleData extended;
+                string? fileName;
+                lock (_sos.SyncRoot)
+                {
+                    ok = dataModule.GetModuleData(out extended);
+                    fileName = ok ? dataModule.GetFileName() : null;
+                }
+
+                if (ok)
+                {
+                    result.Layout = extended.IsFlatLayout != 0 ? ModuleLayout.Flat : ModuleLayout.Mapped;
+                    result.IsDynamic |= extended.IsDynamic != 0;
+                    result.Size = extended.LoadedPESize;
+                    result.FileName = fileName;
+                }
             }
 
             return result;
@@ -65,7 +81,8 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
         {
             int tokenType = kind == SOSDac.ModuleMapTraverseKind.TypeDefToMethodTable ? mdtTypeDef : mdtTypeRef;
             List<(ulong MethodTable, int Token)> result = new();
-            _sos.TraverseModuleMap(kind, ClrDataAddress.FromTargetAddress(module, _target), (token, mt, _) => { result.Add((mt, token | tokenType)); });
+            lock (_sos.SyncRoot)
+                _sos.TraverseModuleMap(kind, ClrDataAddress.FromTargetAddress(module, _target), (token, mt, _) => { result.Add((mt, token | tokenType)); });
 
             return result;
         }
@@ -81,14 +98,17 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
 
             if (module is not null)
             {
-                nint qiResult = module.QueryInterface(MetadataImport.IID_IMetaDataImport);
-                if (qiResult != 0)
+                lock (_sos.SyncRoot)
                 {
-                    import = new(module.Library, qiResult);
+                    nint qiResult = module.QueryInterface(MetadataImport.IID_IMetaDataImport);
+                    if (qiResult != 0)
+                    {
+                        import = new(module.Library, qiResult);
+                    }
                 }
             }
 
-            DacMetadataReader? result = import != null ? new(import) : null;
+            DacMetadataReader? result = import != null ? new(import, _sos.SyncRoot) : null;
             lock (_imports)
             {
                 try
@@ -115,7 +135,9 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
                 if (_modules.TryGetValue(moduleAddress, out ClrDataModule? dataModule))
                     return dataModule;
 
-            ClrDataModule? result = _sos.GetClrDataModule(ClrDataAddress.FromTargetAddress(moduleAddress, _target));
+            ClrDataModule? result;
+            lock (_sos.SyncRoot)
+                result = _sos.GetClrDataModule(ClrDataAddress.FromTargetAddress(moduleAddress, _target));
 
             lock (_modules)
             {

--- a/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacNativeHeaps.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacNativeHeaps.cs
@@ -31,211 +31,279 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
 
         public IEnumerable<ClrNativeHeapInfo> EnumerateGCFreeRegions()
         {
-            using (SosMemoryEnum? memoryEnum = _sos13?.GetGCFreeRegions())
+            List<ClrNativeHeapInfo>? results = null;
+            lock (_sos.SyncRoot)
             {
-                if (memoryEnum is not null)
+                using SosMemoryEnum? memoryEnum = _sos13?.GetGCFreeRegions();
+                if (memoryEnum is null)
+                    return Array.Empty<ClrNativeHeapInfo>();
+
+                foreach (SosMemoryRegion mem in memoryEnum)
                 {
-                    foreach (SosMemoryRegion mem in memoryEnum)
+                    NativeHeapKind kind = mem.ExtraData.ToAddress(_target) switch
                     {
-                        NativeHeapKind kind = mem.ExtraData.ToAddress(_target) switch
-                        {
-                            1 => NativeHeapKind.GCFreeGlobalHugeRegion,
-                            2 => NativeHeapKind.GCFreeGlobalRegion,
-                            3 => NativeHeapKind.GCFreeRegion,
-                            4 => NativeHeapKind.GCFreeSohSegment,
-                            5 => NativeHeapKind.GCFreeUohSegment,
-                            _ => NativeHeapKind.GCFreeRegion
-                        };
+                        1 => NativeHeapKind.GCFreeGlobalHugeRegion,
+                        2 => NativeHeapKind.GCFreeGlobalRegion,
+                        3 => NativeHeapKind.GCFreeRegion,
+                        4 => NativeHeapKind.GCFreeSohSegment,
+                        5 => NativeHeapKind.GCFreeUohSegment,
+                        _ => NativeHeapKind.GCFreeRegion
+                    };
 
-                        ulong raw = mem.Start.ToAddress(_target);
-                        ulong start = raw & ~0xfful;
-                        ulong diff = raw - start;
-                        ulong len = mem.Length.ToAddress(_target) + diff;
+                    ulong raw = mem.Start.ToAddress(_target);
+                    ulong start = raw & ~0xfful;
+                    ulong diff = raw - start;
+                    ulong len = mem.Length.ToAddress(_target) + diff;
 
-                        yield return new ClrNativeHeapInfo(MemoryRange.CreateFromLength(start, len), kind, ClrNativeHeapState.Inactive, mem.Heap);
-                    }
+                    results ??= new();
+                    results.Add(new ClrNativeHeapInfo(MemoryRange.CreateFromLength(start, len), kind, ClrNativeHeapState.Inactive, mem.Heap));
                 }
             }
+
+            return (IEnumerable<ClrNativeHeapInfo>?)results ?? Array.Empty<ClrNativeHeapInfo>();
         }
 
         public IEnumerable<ClrNativeHeapInfo> EnumerateHandleTableRegions()
         {
-            using (SosMemoryEnum? memoryEnum = _sos13?.GetHandleTableRegions())
+            List<ClrNativeHeapInfo>? results = null;
+            lock (_sos.SyncRoot)
             {
-                if (memoryEnum is not null)
+                using SosMemoryEnum? memoryEnum = _sos13?.GetHandleTableRegions();
+                if (memoryEnum is null)
+                    return Array.Empty<ClrNativeHeapInfo>();
+
+                foreach (SosMemoryRegion mem in memoryEnum)
                 {
-                    foreach (SosMemoryRegion mem in memoryEnum)
-                        yield return new ClrNativeHeapInfo(MemoryRange.CreateFromLength(mem.Start.ToAddress(_target), mem.Length.ToAddress(_target)), NativeHeapKind.HandleTable, ClrNativeHeapState.Active, mem.Heap);
+                    results ??= new();
+                    results.Add(new ClrNativeHeapInfo(MemoryRange.CreateFromLength(mem.Start.ToAddress(_target), mem.Length.ToAddress(_target)), NativeHeapKind.HandleTable, ClrNativeHeapState.Active, mem.Heap));
                 }
             }
+
+            return (IEnumerable<ClrNativeHeapInfo>?)results ?? Array.Empty<ClrNativeHeapInfo>();
         }
 
         public IEnumerable<ClrNativeHeapInfo> EnumerateGCBookkeepingRegions()
         {
-            using (SosMemoryEnum? memoryEnum = _sos13?.GetGCBookkeepingMemoryRegions())
+            List<ClrNativeHeapInfo>? results = null;
+            lock (_sos.SyncRoot)
             {
-                if (memoryEnum is not null)
+                using SosMemoryEnum? memoryEnum = _sos13?.GetGCBookkeepingMemoryRegions();
+                if (memoryEnum is null)
+                    return Array.Empty<ClrNativeHeapInfo>();
+
+                foreach (SosMemoryRegion mem in memoryEnum)
                 {
-                    foreach (SosMemoryRegion mem in memoryEnum)
-                        yield return new ClrNativeHeapInfo(MemoryRange.CreateFromLength(mem.Start.ToAddress(_target), mem.Length.ToAddress(_target)), NativeHeapKind.GCBookkeeping, ClrNativeHeapState.RegionOfRegions);
+                    results ??= new();
+                    results.Add(new ClrNativeHeapInfo(MemoryRange.CreateFromLength(mem.Start.ToAddress(_target), mem.Length.ToAddress(_target)), NativeHeapKind.GCBookkeeping, ClrNativeHeapState.RegionOfRegions));
                 }
             }
+
+            return (IEnumerable<ClrNativeHeapInfo>?)results ?? Array.Empty<ClrNativeHeapInfo>();
         }
 
         public IEnumerable<ClrSyncBlockCleanupData> EnumerateSyncBlockCleanupData()
         {
-            HashSet<ulong> seen = [0];
-            ulong syncBlock = 0;
-            HResult hr = default;
-            // For back-compat with older versions of CLRMD, SOS returns E_INVALIDARG if you pass in 0 for the sync block.
-            // So we will continue on E_INVALIDARG if it is this special case of passing 0 to start enumerating.
-            while ((hr = _sos.GetSyncBlockCleanupData(ClrDataAddress.FromTargetAddress(syncBlock, _target), out SyncBlockCleanupData data)) || (hr == HResult.E_INVALIDARG && syncBlock == 0))
+            List<ClrSyncBlockCleanupData>? results = null;
+            lock (_sos.SyncRoot)
             {
-                yield return new(data.SyncBlockPointer.ToAddress(_target), data.BlockRCW.ToAddress(_target), data.BlockCCW.ToAddress(_target), data.BlockClassFactory.ToAddress(_target));
+                HashSet<ulong> seen = [0];
+                ulong syncBlock = 0;
+                HResult hr = default;
+                // For back-compat with older versions of CLRMD, SOS returns E_INVALIDARG if you pass in 0 for the sync block.
+                // So we will continue on E_INVALIDARG if it is this special case of passing 0 to start enumerating.
+                while ((hr = _sos.GetSyncBlockCleanupData(ClrDataAddress.FromTargetAddress(syncBlock, _target), out SyncBlockCleanupData data)) || (hr == HResult.E_INVALIDARG && syncBlock == 0))
+                {
+                    results ??= new();
+                    results.Add(new(data.SyncBlockPointer.ToAddress(_target), data.BlockRCW.ToAddress(_target), data.BlockCCW.ToAddress(_target), data.BlockClassFactory.ToAddress(_target)));
 
-                if (!seen.Add(data.NextSyncBlock.ToAddress(_target)))
-                    break;
+                    if (!seen.Add(data.NextSyncBlock.ToAddress(_target)))
+                        break;
 
-                syncBlock = data.NextSyncBlock.ToAddress(_target);
+                    syncBlock = data.NextSyncBlock.ToAddress(_target);
+                }
             }
+
+            return (IEnumerable<ClrSyncBlockCleanupData>?)results ?? Array.Empty<ClrSyncBlockCleanupData>();
         }
 
         private NativeHeapKind[] GetNativeHeaps()
         {
-            if (_heapNativeTypes is not null)
-                return _heapNativeTypes;
+            NativeHeapKind[]? heapNativeTypes = _heapNativeTypes;
+            if (heapNativeTypes is not null)
+                return heapNativeTypes;
 
             if (_sos13 is null)
-                return _heapNativeTypes = Array.Empty<NativeHeapKind>();
+                heapNativeTypes = Array.Empty<NativeHeapKind>();
+            else
+                heapNativeTypes = _sos13.GetLoaderAllocatorHeapNames().Select(r => r switch {
+                    "LowFrequencyHeap" => NativeHeapKind.LowFrequencyHeap,
+                    "HighFrequencyHeap" => NativeHeapKind.HighFrequencyHeap,
+                    "StubHeap" => NativeHeapKind.StubHeap,
+                    "ExecutableHeap" => NativeHeapKind.ExecutableHeap,
+                    "FixupPrecodeHeap" => NativeHeapKind.FixupPrecodeHeap,
+                    "NewStubPrecodeHeap" => NativeHeapKind.NewStubPrecodeHeap,
+                    "IndcellHeap" => NativeHeapKind.IndirectionCellHeap,
+                    "LookupHeap" => NativeHeapKind.LookupHeap,
+                    "ResolveHeap" => NativeHeapKind.ResolveHeap,
+                    "DispatchHeap" => NativeHeapKind.DispatchHeap,
+                    "CacheEntryHeap" => NativeHeapKind.CacheEntryHeap,
+                    "VtableHeap" => NativeHeapKind.VtableHeap,
+                    _ => NativeHeapKind.Unknown
+                }).ToArray();
 
-            return _heapNativeTypes = _sos13.GetLoaderAllocatorHeapNames().Select(r => r switch {
-                "LowFrequencyHeap" => NativeHeapKind.LowFrequencyHeap,
-                "HighFrequencyHeap" => NativeHeapKind.HighFrequencyHeap,
-                "StubHeap" => NativeHeapKind.StubHeap,
-                "ExecutableHeap" => NativeHeapKind.ExecutableHeap,
-                "FixupPrecodeHeap" => NativeHeapKind.FixupPrecodeHeap,
-                "NewStubPrecodeHeap" => NativeHeapKind.NewStubPrecodeHeap,
-                "IndcellHeap" => NativeHeapKind.IndirectionCellHeap,
-                "LookupHeap" => NativeHeapKind.LookupHeap,
-                "ResolveHeap" => NativeHeapKind.ResolveHeap,
-                "DispatchHeap" => NativeHeapKind.DispatchHeap,
-                "CacheEntryHeap" => NativeHeapKind.CacheEntryHeap,
-                "VtableHeap" => NativeHeapKind.VtableHeap,
-                _ => NativeHeapKind.Unknown
-            }).ToArray();
+            _heapNativeTypes = heapNativeTypes;
+            return heapNativeTypes;
         }
 
         public IEnumerable<ClrNativeHeapInfo> EnumerateJitManagerHeaps(ulong jitManager)
         {
-            List<ClrNativeHeapInfo>? codeLoaderHeaps = null;
-
-            foreach (JitCodeHeapInfo mem in _sos.GetCodeHeapList(ClrDataAddress.FromTargetAddress(jitManager, _target)))
+            List<ClrNativeHeapInfo>? results = null;
+            lock (_sos.SyncRoot)
             {
-                if (mem.Kind == CodeHeapKind.Loader)
+                foreach (JitCodeHeapInfo mem in _sos.GetCodeHeapList(ClrDataAddress.FromTargetAddress(jitManager, _target)))
                 {
-                    codeLoaderHeaps?.Clear();
-
-                    foreach (ClrNativeHeapInfo heap in LegacyEnumerateLoaderAllocatorHeaps(mem.Address.ToAddress(_target), LoaderHeapKind.LoaderHeapKindExplicitControl, NativeHeapKind.LoaderCodeHeap))
-                        yield return heap;
-                }
-                else if (mem.Kind == CodeHeapKind.Host)
-                {
-                    yield return new ClrNativeHeapInfo(new(mem.Address.ToAddress(_target), mem.CurrentAddress.ToAddress(_target)), NativeHeapKind.HostCodeHeap, ClrNativeHeapState.Active);
-                }
-                else
-                {
-                    ulong addr = mem.Address.ToAddress(_target);
-                    yield return new ClrNativeHeapInfo(new(addr, addr), NativeHeapKind.Unknown, ClrNativeHeapState.None);
+                    if (mem.Kind == CodeHeapKind.Loader)
+                    {
+                        foreach (ClrNativeHeapInfo heap in LegacyEnumerateLoaderAllocatorHeaps(mem.Address.ToAddress(_target), LoaderHeapKind.LoaderHeapKindExplicitControl, NativeHeapKind.LoaderCodeHeap))
+                        {
+                            results ??= new();
+                            results.Add(heap);
+                        }
+                    }
+                    else if (mem.Kind == CodeHeapKind.Host)
+                    {
+                        results ??= new();
+                        results.Add(new ClrNativeHeapInfo(new(mem.Address.ToAddress(_target), mem.CurrentAddress.ToAddress(_target)), NativeHeapKind.HostCodeHeap, ClrNativeHeapState.Active));
+                    }
+                    else
+                    {
+                        ulong addr = mem.Address.ToAddress(_target);
+                        results ??= new();
+                        results.Add(new ClrNativeHeapInfo(new(addr, addr), NativeHeapKind.Unknown, ClrNativeHeapState.None));
+                    }
                 }
             }
+
+            return (IEnumerable<ClrNativeHeapInfo>?)results ?? Array.Empty<ClrNativeHeapInfo>();
         }
 
         public IEnumerable<ClrNativeHeapInfo> EnumerateDomainHeaps(ulong domain)
         {
             if (domain == 0)
-                yield break;
+                return Array.Empty<ClrNativeHeapInfo>();
 
-            ulong loaderAllocator;
-            if (_sos13 is not null
-                && (loaderAllocator = _sos13.GetDomainLoaderAllocator(ClrDataAddress.FromTargetAddress(domain, _target)).ToAddress(_target)) != 0
-                && GetNativeHeaps().Length > 0)
+            List<ClrNativeHeapInfo>? results = null;
+            lock (_sos.SyncRoot)
             {
-                foreach (ClrNativeHeapInfo heap in EnumerateLoaderAllocatorNativeHeaps(loaderAllocator))
-                    yield return heap;
+                ulong loaderAllocator;
+                if (_sos13 is not null
+                    && (loaderAllocator = _sos13.GetDomainLoaderAllocator(ClrDataAddress.FromTargetAddress(domain, _target)).ToAddress(_target)) != 0
+                    && GetNativeHeaps().Length > 0)
+                {
+                    foreach (ClrNativeHeapInfo heap in EnumerateLoaderAllocatorNativeHeapsLocked(loaderAllocator))
+                    {
+                        results ??= new();
+                        results.Add(heap);
+                    }
+                }
+                else if (_sos.GetAppDomainData(ClrDataAddress.FromTargetAddress(domain, _target), out AppDomainData data))
+                {
+                    foreach (ClrNativeHeapInfo heapInfo in LegacyEnumerateLoaderAllocatorHeaps(data.StubHeap.ToAddress(_target), LoaderHeapKind.LoaderHeapKindNormal, NativeHeapKind.StubHeap))
+                    {
+                        results ??= new();
+                        results.Add(heapInfo);
+                    }
+
+                    foreach (ClrNativeHeapInfo heapInfo in LegacyEnumerateLoaderAllocatorHeaps(data.HighFrequencyHeap.ToAddress(_target), LoaderHeapKind.LoaderHeapKindNormal, NativeHeapKind.HighFrequencyHeap))
+                    {
+                        results ??= new();
+                        results.Add(heapInfo);
+                    }
+
+                    foreach (ClrNativeHeapInfo heapInfo in LegacyEnumerateLoaderAllocatorHeaps(data.LowFrequencyHeap.ToAddress(_target), LoaderHeapKind.LoaderHeapKindNormal, NativeHeapKind.LowFrequencyHeap))
+                    {
+                        results ??= new();
+                        results.Add(heapInfo);
+                    }
+
+                    foreach (ClrNativeHeapInfo heapInfo in LegacyEnumerateStubHeaps(domain))
+                    {
+                        results ??= new();
+                        results.Add(heapInfo);
+                    }
+                }
             }
-            else if (_sos.GetAppDomainData(ClrDataAddress.FromTargetAddress(domain, _target), out AppDomainData data))
-            {
-                foreach (ClrNativeHeapInfo heapInfo in LegacyEnumerateLoaderAllocatorHeaps(data.StubHeap.ToAddress(_target), LoaderHeapKind.LoaderHeapKindNormal, NativeHeapKind.StubHeap))
-                    yield return heapInfo;
 
-                foreach (ClrNativeHeapInfo heapInfo in LegacyEnumerateLoaderAllocatorHeaps(data.HighFrequencyHeap.ToAddress(_target), LoaderHeapKind.LoaderHeapKindNormal, NativeHeapKind.HighFrequencyHeap))
-                    yield return heapInfo;
-
-                foreach (ClrNativeHeapInfo heapInfo in LegacyEnumerateLoaderAllocatorHeaps(data.LowFrequencyHeap.ToAddress(_target), LoaderHeapKind.LoaderHeapKindNormal, NativeHeapKind.LowFrequencyHeap))
-                    yield return heapInfo;
-
-                foreach (ClrNativeHeapInfo heapInfo in LegacyEnumerateStubHeaps(domain))
-                    yield return heapInfo;
-            }
+            return (IEnumerable<ClrNativeHeapInfo>?)results ?? Array.Empty<ClrNativeHeapInfo>();
         }
 
         public IEnumerable<ClrNativeHeapInfo> EnumerateLoaderAllocatorNativeHeaps(ulong loaderAllocator)
+        {
+            lock (_sos.SyncRoot)
+                return EnumerateLoaderAllocatorNativeHeapsLocked(loaderAllocator);
+        }
+
+        private IEnumerable<ClrNativeHeapInfo> EnumerateLoaderAllocatorNativeHeapsLocked(ulong loaderAllocator)
         {
             NativeHeapKind[] heapNativeTypes;
             if (loaderAllocator == 0
                 || _sos13 is null
                 || (heapNativeTypes = GetNativeHeaps()).Length == 0)
             {
-                yield break;
+                return Array.Empty<ClrNativeHeapInfo>();
             }
 
-            List<ClrNativeHeapInfo>? result = null;
-
+            List<ClrNativeHeapInfo>? results = null;
+            List<ClrNativeHeapInfo>? current = null;
             (ClrDataAddress Address, LoaderHeapKind Kind)[] heaps = _sos13.GetLoaderAllocatorHeaps(ClrDataAddress.FromTargetAddress(loaderAllocator, _target));
             for (int i = 0; i < heaps.Length; i++)
             {
-                HResult hr = _sos13.TraverseLoaderHeap(heaps[i].Address, heaps[i].Kind, (address, size, current) => {
-                    result ??= new(16);
-                    result.Add(new(MemoryRange.CreateFromLength(address, SanitizeSize(size)), heapNativeTypes[i], current != 0 ? ClrNativeHeapState.Active : ClrNativeHeapState.Inactive));
+                current?.Clear();
+                HResult hr = _sos13.TraverseLoaderHeap(heaps[i].Address, heaps[i].Kind, (address, size, currentSegment) => {
+                    current ??= new(16);
+                    current.Add(new(MemoryRange.CreateFromLength(address, SanitizeSize(size)), heapNativeTypes[i], currentSegment != 0 ? ClrNativeHeapState.Active : ClrNativeHeapState.Inactive));
                 });
 
-                if (hr && result is not null)
+                if (hr && current is not null)
                 {
-                    foreach (ClrNativeHeapInfo info in result)
-                        yield return info;
+                    results ??= new();
+                    results.AddRange(current);
                 }
-
-                result?.Clear();
             }
+
+            return (IEnumerable<ClrNativeHeapInfo>?)results ?? Array.Empty<ClrNativeHeapInfo>();
         }
 
         private IEnumerable<ClrNativeHeapInfo> LegacyEnumerateStubHeaps(ulong domain)
         {
-            List<ClrNativeHeapInfo> result = new(16);
+            List<ClrNativeHeapInfo>? results = null;
+            List<ClrNativeHeapInfo> current = new(16);
 
-            TraverseOneStubKind(domain, result, SOSDac.VCSHeapType.IndcellHeap, NativeHeapKind.IndirectionCellHeap);
-            foreach (ClrNativeHeapInfo heap in result)
-                yield return heap;
+            TraverseOneStubKind(domain, current, SOSDac.VCSHeapType.IndcellHeap, NativeHeapKind.IndirectionCellHeap);
+            if (current.Count > 0)
+                (results ??= new()).AddRange(current);
 
-            TraverseOneStubKind(domain, result, SOSDac.VCSHeapType.LookupHeap, NativeHeapKind.LookupHeap);
-            foreach (ClrNativeHeapInfo heap in result)
-                yield return heap;
+            TraverseOneStubKind(domain, current, SOSDac.VCSHeapType.LookupHeap, NativeHeapKind.LookupHeap);
+            if (current.Count > 0)
+                (results ??= new()).AddRange(current);
 
-            TraverseOneStubKind(domain, result, SOSDac.VCSHeapType.ResolveHeap, NativeHeapKind.ResolveHeap);
-            foreach (ClrNativeHeapInfo heap in result)
-                yield return heap;
+            TraverseOneStubKind(domain, current, SOSDac.VCSHeapType.ResolveHeap, NativeHeapKind.ResolveHeap);
+            if (current.Count > 0)
+                (results ??= new()).AddRange(current);
 
-            TraverseOneStubKind(domain, result, SOSDac.VCSHeapType.DispatchHeap, NativeHeapKind.DispatchHeap);
-            foreach (ClrNativeHeapInfo heap in result)
-                yield return heap;
+            TraverseOneStubKind(domain, current, SOSDac.VCSHeapType.DispatchHeap, NativeHeapKind.DispatchHeap);
+            if (current.Count > 0)
+                (results ??= new()).AddRange(current);
 
-            TraverseOneStubKind(domain, result, SOSDac.VCSHeapType.CacheEntryHeap, NativeHeapKind.CacheEntryHeap);
-            foreach (ClrNativeHeapInfo heap in result)
-                yield return heap;
+            TraverseOneStubKind(domain, current, SOSDac.VCSHeapType.CacheEntryHeap, NativeHeapKind.CacheEntryHeap);
+            if (current.Count > 0)
+                (results ??= new()).AddRange(current);
 
-            TraverseOneStubKind(domain, result, SOSDac.VCSHeapType.VtableHeap, NativeHeapKind.VtableHeap);
-            foreach (ClrNativeHeapInfo heap in result)
-                yield return heap;
+            TraverseOneStubKind(domain, current, SOSDac.VCSHeapType.VtableHeap, NativeHeapKind.VtableHeap);
+            if (current.Count > 0)
+                (results ??= new()).AddRange(current);
+
+            return (IEnumerable<ClrNativeHeapInfo>?)results ?? Array.Empty<ClrNativeHeapInfo>();
         }
 
         private void TraverseOneStubKind(ulong domain, List<ClrNativeHeapInfo> result, SOSDac.VCSHeapType vcsType, NativeHeapKind heapKind)
@@ -329,7 +397,10 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
 
         public IEnumerable<ClrNativeHeapInfo> EnumerateThunkHeaps(ulong thunkHeapAddress)
         {
-            if (thunkHeapAddress != 0)
+            if (thunkHeapAddress == 0)
+                return Array.Empty<ClrNativeHeapInfo>();
+
+            lock (_sos.SyncRoot)
             {
                 List<ClrNativeHeapInfo>? heaps = null;
                 HResult hr = TraverseLoaderHeap(thunkHeapAddress, LoaderHeapKind.LoaderHeapKindNormal, (address, size, current) => {
@@ -341,7 +412,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
                     return heaps;
             }
 
-            return Enumerable.Empty<ClrNativeHeapInfo>();
+            return Array.Empty<ClrNativeHeapInfo>();
         }
 
         internal static ulong SanitizeSize(nint size)

--- a/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacRuntime.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacRuntime.cs
@@ -30,13 +30,18 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
             _target = target;
 
             int version = 0;
-            if (!_dac.Request(DacRequests.VERSION, ReadOnlySpan<byte>.Empty, new Span<byte>(&version, sizeof(int))))
-                throw new InvalidDataException("This instance of CLR either has not been initialized or does not contain any data. This may indicate the dump was taken before the CLR was fully initialized, or the dump is corrupt or truncated. Failed to request DacVersion.");
+            // This DAC request runs during lazy service construction (under _serviceLock);
+            // serialize it on the DAC lock like every other DAC entry point.
+            lock (_sos.SyncRoot)
+            {
+                if (!_dac.Request(DacRequests.VERSION, ReadOnlySpan<byte>.Empty, new Span<byte>(&version, sizeof(int))))
+                    throw new InvalidDataException("This instance of CLR either has not been initialized or does not contain any data. This may indicate the dump was taken before the CLR was fully initialized, or the dump is corrupt or truncated. Failed to request DacVersion.");
 
-            if (version is not (9 or 10))
-                throw new NotSupportedException($"The CLR debugging layer reported a version of {version} which this build of ClrMD does not support.");
+                if (version is not (9 or 10))
+                    throw new NotSupportedException($"The CLR debugging layer reported a version of {version} which this build of ClrMD does not support.");
 
-            _sos.DacVersion = version;
+                _sos.DacVersion = version;
+            }
         }
 
         internal ulong GetStressLogAddress()
@@ -48,11 +53,12 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
                 return _sos.TryGetStressLogAddress(out ClrDataAddress addr) ? addr.ToAddress(_target) : 0;
         }
 
-        public IEnumerable<ClrThreadInfo> EnumerateThreads()
+        public IEnumerable<ClrThreadInfo> EnumerateThreads(int maxCount)
         {
             // Materialize entirely under the DAC lock. The IDataReader.ReadPointer
             // / GetThreadTeb calls don't go through the DAC, but the surrounding
-            // _sos.* calls must be serialized.
+            // _sos.* calls must be serialized. maxCount bounds the work so a corrupt
+            // dump reporting a huge ThreadCount can't drive unbounded materialization.
             List<ClrThreadInfo>? results = null;
             lock (_sos.SyncRoot)
             {
@@ -65,6 +71,9 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
 
                 for (int i = 0; i < threadStore.ThreadCount && seen.Add(threadAddress); i++)
                 {
+                    if ((results?.Count ?? 0) >= maxCount)
+                        break;
+
                     if (!_sos.GetThreadData(currentThread, out ThreadData threadData))
                         break;
 
@@ -117,7 +126,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
             return (IEnumerable<ClrThreadInfo>?)results ?? Array.Empty<ClrThreadInfo>();
         }
 
-        public IEnumerable<AppDomainInfo> EnumerateAppDomains()
+        public IEnumerable<AppDomainInfo> EnumerateAppDomains(int maxCount)
         {
             List<AppDomainInfo>? results = null;
             lock (_sos.SyncRoot)
@@ -125,13 +134,13 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
                 if (!_sos.GetAppDomainStoreData(out AppDomainStoreData domainStore))
                     throw new InvalidDataException("This instance of CLR either has not been initialized or does not contain any data. This may indicate the dump was taken before the CLR was fully initialized, or the dump is corrupt or truncated. Failed to request AppDomainStoreData.");
 
-                if (!domainStore.SharedDomain.IsNull)
+                if (!domainStore.SharedDomain.IsNull && (results?.Count ?? 0) < maxCount)
                 {
                     results ??= new List<AppDomainInfo>();
                     results.Add(CreateAppDomainInfo(domainStore.SharedDomain.ToAddress(_target), AppDomainKind.Shared, "Shared Domain"));
                 }
 
-                if (!domainStore.SystemDomain.IsNull)
+                if (!domainStore.SystemDomain.IsNull && (results?.Count ?? 0) < maxCount)
                 {
                     results ??= new List<AppDomainInfo>();
                     results.Add(CreateAppDomainInfo(domainStore.SystemDomain.ToAddress(_target), AppDomainKind.System, "System Domain"));
@@ -139,6 +148,9 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
 
                 foreach (ClrDataAddress domain in _sos.GetAppDomainList())
                 {
+                    if ((results?.Count ?? 0) >= maxCount)
+                        break;
+
                     ulong domainAddr = domain.ToAddress(_target);
                     string name = _sos.GetAppDomainName(domain) ?? "";
                     results ??= new List<AppDomainInfo>();
@@ -174,15 +186,23 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
             return result;
         }
 
-        public IEnumerable<ulong> GetModuleList(ulong domain)
+        public IEnumerable<ulong> GetModuleList(ulong domain, int maxCount)
         {
             List<ulong> result = new();
             lock (_sos.SyncRoot)
             {
                 foreach (ClrDataAddress assembly in _sos.GetAssemblyList(ClrDataAddress.FromTargetAddress(domain, _target)))
                 {
+                    if (result.Count >= maxCount)
+                        break;
+
                     foreach (ClrDataAddress module in _sos.GetModuleList(assembly))
+                    {
+                        if (result.Count >= maxCount)
+                            break;
+
                         result.Add(module.ToAddress(_target));
+                    }
                 }
             }
 
@@ -192,10 +212,12 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
         public IEnumerable<ClrHandleInfo> EnumerateHandles()
         {
             // SOSHandleEnum is a stateful DAC enumerator. Concurrent enumerations
-            // share internal DAC state and can truncate each other. Materialize the
-            // entire enumeration under the DAC lock so the enumerator's lifetime
-            // (creation, iteration, dispose) is fully serialized.
-            List<ClrHandleInfo>? results = null;
+            // share internal DAC state and can truncate each other. Drain the enumerator
+            // entirely under the DAC lock (creation, iteration, dispose), but collect only
+            // the raw HandleData under the lock. Resolving the object pointer
+            // (IDataReader.ReadPointer) does not go through the DAC, so do it outside the
+            // lock to keep the global DAC lock hold time short.
+            List<HandleData>? raw = null;
             lock (_sos.SyncRoot)
             {
                 using SOSHandleEnum? handleEnum = _sos.EnumerateHandles();
@@ -204,21 +226,31 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
 
                 foreach (HandleData handle in handleEnum.ReadHandles())
                 {
-                    ulong handleAddr = handle.Handle.ToAddress(_target);
-                    results ??= new List<ClrHandleInfo>();
-                    results.Add(new ClrHandleInfo()
-                    {
-                        Address = handleAddr,
-                        Object = _dataReader.ReadPointer(handleAddr),
-                        Kind = (ClrHandleKind)handle.Type,
-                        AppDomain = handle.AppDomain.ToAddress(_target),
-                        DependentTarget = handle.Secondary.ToAddress(_target),
-                        RefCount = handle.IsPegged != 0 ? handle.JupiterRefCount : handle.RefCount,
-                    });
+                    raw ??= new List<HandleData>();
+                    raw.Add(handle);
                 }
             }
 
-            return (IEnumerable<ClrHandleInfo>?)results ?? Array.Empty<ClrHandleInfo>();
+            if (raw is null)
+                return Array.Empty<ClrHandleInfo>();
+
+            ClrHandleInfo[] results = new ClrHandleInfo[raw.Count];
+            for (int i = 0; i < raw.Count; i++)
+            {
+                HandleData handle = raw[i];
+                ulong handleAddr = handle.Handle.ToAddress(_target);
+                results[i] = new ClrHandleInfo()
+                {
+                    Address = handleAddr,
+                    Object = _dataReader.ReadPointer(handleAddr),
+                    Kind = (ClrHandleKind)handle.Type,
+                    AppDomain = handle.AppDomain.ToAddress(_target),
+                    DependentTarget = handle.Secondary.ToAddress(_target),
+                    RefCount = handle.IsPegged != 0 ? handle.JupiterRefCount : handle.RefCount,
+                };
+            }
+
+            return results;
         }
 
         public IEnumerable<JitManagerInfo> EnumerateClrJitManagers()

--- a/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacRuntime.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacRuntime.cs
@@ -44,89 +44,115 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
             // Translate the wire-format ClrDataAddress to a target-process
             // pointer; ToAddress un-sign-extends the high 32 bits on 32-bit
             // targets so the address can be used directly with IDataReader.
-            return _sos.TryGetStressLogAddress(out ClrDataAddress addr) ? addr.ToAddress(_target) : 0;
+            lock (_sos.SyncRoot)
+                return _sos.TryGetStressLogAddress(out ClrDataAddress addr) ? addr.ToAddress(_target) : 0;
         }
 
         public IEnumerable<ClrThreadInfo> EnumerateThreads()
         {
-            if (!_sos.GetThreadStoreData(out ThreadStoreData threadStore))
-                yield break;
-
-            HashSet<ulong> seen = new() { 0 };
-            ClrDataAddress currentThread = threadStore.FirstThread;
-            ulong threadAddress = currentThread.ToAddress(_target);
-
-            for (int i = 0; i < threadStore.ThreadCount && seen.Add(threadAddress); i++)
+            // Materialize entirely under the DAC lock. The IDataReader.ReadPointer
+            // / GetThreadTeb calls don't go through the DAC, but the surrounding
+            // _sos.* calls must be serialized.
+            List<ClrThreadInfo>? results = null;
+            lock (_sos.SyncRoot)
             {
-                if (!_sos.GetThreadData(currentThread, out ThreadData threadData))
-                    break;
+                if (!_sos.GetThreadStoreData(out ThreadStoreData threadStore))
+                    return Array.Empty<ClrThreadInfo>();
 
-                ulong ex = 0;
-                if (!threadData.LastThrownObjectHandle.IsNull)
-                    ex = _dataReader.ReadPointer(threadData.LastThrownObjectHandle.ToAddress(_target));
+                HashSet<ulong> seen = new() { 0 };
+                ClrDataAddress currentThread = threadStore.FirstThread;
+                ulong threadAddress = currentThread.ToAddress(_target);
 
-                ulong stackBase = 0;
-                ulong stackLimit = 0;
-                ulong teb = 0;
-
-                // Prefer IThreadReader.GetThreadTeb which looks up the TEB from the OS thread ID
-                // via the data reader. Fall back to threadData.Teb for DesktopCLR or when the
-                // data reader doesn't implement IThreadReader.
-                if (_dataReader is IThreadReader threadReader)
-                    teb = threadReader.GetThreadTeb(threadData.OSThreadId);
-
-                if (teb == 0)
-                    teb = threadData.Teb.ToAddress(_target);
-
-                if (teb != 0)
+                for (int i = 0; i < threadStore.ThreadCount && seen.Add(threadAddress); i++)
                 {
-                    stackBase = _dataReader.ReadPointer(teb + (uint)_target.PointerSize);
-                    stackLimit = _dataReader.ReadPointer(teb + (uint)_target.PointerSize * 2);
+                    if (!_sos.GetThreadData(currentThread, out ThreadData threadData))
+                        break;
+
+                    ulong ex = 0;
+                    if (!threadData.LastThrownObjectHandle.IsNull)
+                        ex = _dataReader.ReadPointer(threadData.LastThrownObjectHandle.ToAddress(_target));
+
+                    ulong stackBase = 0;
+                    ulong stackLimit = 0;
+                    ulong teb = 0;
+
+                    // Prefer IThreadReader.GetThreadTeb which looks up the TEB from the OS thread ID
+                    // via the data reader. Fall back to threadData.Teb for DesktopCLR or when the
+                    // data reader doesn't implement IThreadReader.
+                    if (_dataReader is IThreadReader threadReader)
+                        teb = threadReader.GetThreadTeb(threadData.OSThreadId);
+
+                    if (teb == 0)
+                        teb = threadData.Teb.ToAddress(_target);
+
+                    if (teb != 0)
+                    {
+                        stackBase = _dataReader.ReadPointer(teb + (uint)_target.PointerSize);
+                        stackLimit = _dataReader.ReadPointer(teb + (uint)_target.PointerSize * 2);
+                    }
+
+                    results ??= new List<ClrThreadInfo>();
+                    results.Add(new()
+                    {
+                        Address = threadAddress,
+                        AppDomain = threadData.Domain.ToAddress(_target),
+                        ExceptionInFlight = ex,
+                        GCMode = threadData.PreemptiveGCDisabled == 0 ? GCMode.Preemptive : GCMode.Cooperative,
+                        IsFinalizer = threadStore.FinalizerThread.ToAddress(_target) == threadAddress,
+                        IsGC = threadStore.GCThread.ToAddress(_target) == threadAddress,
+                        LockCount = threadData.LockCount,
+                        ManagedThreadId = threadData.ManagedThreadId < int.MaxValue ? (int)threadData.ManagedThreadId : int.MaxValue,
+                        OSThreadId = threadData.OSThreadId,
+                        StackBase = stackBase,
+                        StackLimit = stackLimit,
+                        State = (ClrThreadState)threadData.State,
+                        Teb = teb,
+                    });
+
+                    currentThread = threadData.NextThread;
+                    threadAddress = currentThread.ToAddress(_target);
                 }
-
-                yield return new()
-                {
-                    Address = threadAddress,
-                    AppDomain = threadData.Domain.ToAddress(_target),
-                    ExceptionInFlight = ex,
-                    GCMode = threadData.PreemptiveGCDisabled == 0 ? GCMode.Preemptive : GCMode.Cooperative,
-                    IsFinalizer = threadStore.FinalizerThread.ToAddress(_target) == threadAddress,
-                    IsGC = threadStore.GCThread.ToAddress(_target) == threadAddress,
-                    LockCount = threadData.LockCount,
-                    ManagedThreadId = threadData.ManagedThreadId < int.MaxValue ? (int)threadData.ManagedThreadId : int.MaxValue,
-                    OSThreadId = threadData.OSThreadId,
-                    StackBase = stackBase,
-                    StackLimit = stackLimit,
-                    State = (ClrThreadState)threadData.State,
-                    Teb = teb,
-                };
-
-                currentThread = threadData.NextThread;
-                threadAddress = currentThread.ToAddress(_target);
             }
+
+            return (IEnumerable<ClrThreadInfo>?)results ?? Array.Empty<ClrThreadInfo>();
         }
 
         public IEnumerable<AppDomainInfo> EnumerateAppDomains()
         {
-            if (!_sos.GetAppDomainStoreData(out AppDomainStoreData domainStore))
-                throw new InvalidDataException("This instance of CLR either has not been initialized or does not contain any data. This may indicate the dump was taken before the CLR was fully initialized, or the dump is corrupt or truncated. Failed to request AppDomainStoreData.");
-
-            if (!domainStore.SharedDomain.IsNull)
-                yield return CreateAppDomainInfo(domainStore.SharedDomain.ToAddress(_target), AppDomainKind.Shared, "Shared Domain");
-
-            if (!domainStore.SystemDomain.IsNull)
-                yield return CreateAppDomainInfo(domainStore.SystemDomain.ToAddress(_target), AppDomainKind.System, "System Domain");
-
-            foreach (ClrDataAddress domain in _sos.GetAppDomainList())
+            List<AppDomainInfo>? results = null;
+            lock (_sos.SyncRoot)
             {
-                ulong domainAddr = domain.ToAddress(_target);
-                string name = _sos.GetAppDomainName(domain) ?? "";
-                yield return CreateAppDomainInfo(domainAddr, AppDomainKind.Normal, name);
+                if (!_sos.GetAppDomainStoreData(out AppDomainStoreData domainStore))
+                    throw new InvalidDataException("This instance of CLR either has not been initialized or does not contain any data. This may indicate the dump was taken before the CLR was fully initialized, or the dump is corrupt or truncated. Failed to request AppDomainStoreData.");
+
+                if (!domainStore.SharedDomain.IsNull)
+                {
+                    results ??= new List<AppDomainInfo>();
+                    results.Add(CreateAppDomainInfo(domainStore.SharedDomain.ToAddress(_target), AppDomainKind.Shared, "Shared Domain"));
+                }
+
+                if (!domainStore.SystemDomain.IsNull)
+                {
+                    results ??= new List<AppDomainInfo>();
+                    results.Add(CreateAppDomainInfo(domainStore.SystemDomain.ToAddress(_target), AppDomainKind.System, "System Domain"));
+                }
+
+                foreach (ClrDataAddress domain in _sos.GetAppDomainList())
+                {
+                    ulong domainAddr = domain.ToAddress(_target);
+                    string name = _sos.GetAppDomainName(domain) ?? "";
+                    results ??= new List<AppDomainInfo>();
+                    results.Add(CreateAppDomainInfo(domainAddr, AppDomainKind.Normal, name));
+                }
             }
+
+            return (IEnumerable<AppDomainInfo>?)results ?? Array.Empty<AppDomainInfo>();
         }
 
         private AppDomainInfo CreateAppDomainInfo(ulong address, AppDomainKind kind, string name)
         {
+            // Always called from within lock(_sos.SyncRoot); Monitor is reentrant
+            // so taking it again here would be safe but unnecessary.
             AppDomainInfo result = new()
             {
                 Address = address,
@@ -150,43 +176,75 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
 
         public IEnumerable<ulong> GetModuleList(ulong domain)
         {
-            return _sos.GetAssemblyList(ClrDataAddress.FromTargetAddress(domain, _target))
-                .SelectMany(assembly => _sos.GetModuleList(assembly))
-                .Select(module => module.ToAddress(_target));
+            List<ulong> result = new();
+            lock (_sos.SyncRoot)
+            {
+                foreach (ClrDataAddress assembly in _sos.GetAssemblyList(ClrDataAddress.FromTargetAddress(domain, _target)))
+                {
+                    foreach (ClrDataAddress module in _sos.GetModuleList(assembly))
+                        result.Add(module.ToAddress(_target));
+                }
+            }
+
+            return result;
         }
 
         public IEnumerable<ClrHandleInfo> EnumerateHandles()
         {
-            using SOSHandleEnum? handleEnum = _sos.EnumerateHandles();
-            if (handleEnum is null)
-                yield break;
-
-            foreach (HandleData handle in handleEnum.ReadHandles())
+            // SOSHandleEnum is a stateful DAC enumerator. Concurrent enumerations
+            // share internal DAC state and can truncate each other. Materialize the
+            // entire enumeration under the DAC lock so the enumerator's lifetime
+            // (creation, iteration, dispose) is fully serialized.
+            List<ClrHandleInfo>? results = null;
+            lock (_sos.SyncRoot)
             {
-                ulong handleAddr = handle.Handle.ToAddress(_target);
-                yield return new ClrHandleInfo()
+                using SOSHandleEnum? handleEnum = _sos.EnumerateHandles();
+                if (handleEnum is null)
+                    return Array.Empty<ClrHandleInfo>();
+
+                foreach (HandleData handle in handleEnum.ReadHandles())
                 {
-                    Address = handleAddr,
-                    Object = _dataReader.ReadPointer(handleAddr),
-                    Kind = (ClrHandleKind)handle.Type,
-                    AppDomain = handle.AppDomain.ToAddress(_target),
-                    DependentTarget = handle.Secondary.ToAddress(_target),
-                    RefCount = handle.IsPegged != 0 ? handle.JupiterRefCount : handle.RefCount,
-                };
+                    ulong handleAddr = handle.Handle.ToAddress(_target);
+                    results ??= new List<ClrHandleInfo>();
+                    results.Add(new ClrHandleInfo()
+                    {
+                        Address = handleAddr,
+                        Object = _dataReader.ReadPointer(handleAddr),
+                        Kind = (ClrHandleKind)handle.Type,
+                        AppDomain = handle.AppDomain.ToAddress(_target),
+                        DependentTarget = handle.Secondary.ToAddress(_target),
+                        RefCount = handle.IsPegged != 0 ? handle.JupiterRefCount : handle.RefCount,
+                    });
+                }
             }
+
+            return (IEnumerable<ClrHandleInfo>?)results ?? Array.Empty<ClrHandleInfo>();
         }
 
         public IEnumerable<JitManagerInfo> EnumerateClrJitManagers()
         {
-            foreach (JitManagerData jitMgr in _sos.GetJitManagers())
-                yield return new()
+            List<JitManagerInfo>? results = null;
+            lock (_sos.SyncRoot)
+            {
+                foreach (JitManagerData jitMgr in _sos.GetJitManagers())
                 {
-                    Address = jitMgr.Address.ToAddress(_target),
-                    Kind = jitMgr.Kind,
-                    HeapList = jitMgr.HeapList.ToAddress(_target),
-                };
+                    results ??= new List<JitManagerInfo>();
+                    results.Add(new()
+                    {
+                        Address = jitMgr.Address.ToAddress(_target),
+                        Kind = jitMgr.Kind,
+                        HeapList = jitMgr.HeapList.ToAddress(_target),
+                    });
+                }
+            }
+
+            return (IEnumerable<JitManagerInfo>?)results ?? Array.Empty<JitManagerInfo>();
         }
 
-        public string? GetJitHelperFunctionName(ulong address) => _sos.GetJitHelperFunctionName(ClrDataAddress.FromTargetAddress(address, _target));
+        public string? GetJitHelperFunctionName(ulong address)
+        {
+            lock (_sos.SyncRoot)
+                return _sos.GetJitHelperFunctionName(ClrDataAddress.FromTargetAddress(address, _target));
+        }
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacServiceProvider.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacServiceProvider.cs
@@ -23,15 +23,19 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
         private readonly SosDac14? _sos14;
         private readonly ISOSDac16? _sos16;
 
-        private IAbstractClrNativeHeaps? _nativeHeaps;
-        private IAbstractComHelpers? _com;
-        private IAbstractHeap? _heapHelper;
-        private IAbstractLegacyThreadPool? _threadPool;
-        private IAbstractMethodLocator? _methodLocator;
-        private DacModuleHelpers? _moduleHelper;
-        private IAbstractRuntime? _runtime;
-        private IAbstractThreadHelpers? _threadHelper;
-        private IAbstractTypeHelpers? _typeHelper;
+        // These service singletons are read on a lock-free fast path in GetService and
+        // published under _serviceLock, so they must be volatile to give the fast-path
+        // read an acquire barrier (otherwise a partially-constructed instance could be
+        // observed on a weak memory model).
+        private volatile IAbstractClrNativeHeaps? _nativeHeaps;
+        private volatile IAbstractComHelpers? _com;
+        private volatile IAbstractHeap? _heapHelper;
+        private volatile IAbstractLegacyThreadPool? _threadPool;
+        private volatile IAbstractMethodLocator? _methodLocator;
+        private volatile DacModuleHelpers? _moduleHelper;
+        private volatile IAbstractRuntime? _runtime;
+        private volatile IAbstractThreadHelpers? _threadHelper;
+        private volatile IAbstractTypeHelpers? _typeHelper;
 
         private bool _disposed;
         private readonly object _serviceLock = new();
@@ -60,18 +64,27 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
             if (_disposed)
                 throw new ObjectDisposedException(GetType().FullName);
 
-            _disposed = true;
-            _sos13?.LockedFlush();
-            _process.Dispose();
-            _sos.Dispose();
-            _sos6?.Dispose();
-            _sos8?.Dispose();
-            _sos12?.Dispose();
-            _sos13?.Dispose();
-            _sos14?.Dispose();
-            _sos16?.Dispose();
-            _dac.Dispose();
-            _moduleHelper?.Dispose();
+            // Serialize teardown against in-flight DAC reads: every DAC entry point takes
+            // _sos.SyncRoot (== _dac.SyncRoot), so disposing the native/COM wrappers under
+            // that same lock guarantees no reader is mid-call when we free them.
+            lock (_sos.SyncRoot)
+            {
+                if (_disposed)
+                    return;
+
+                _disposed = true;
+                _sos13?.LockedFlush();
+                _process.Dispose();
+                _sos.Dispose();
+                _sos6?.Dispose();
+                _sos8?.Dispose();
+                _sos12?.Dispose();
+                _sos13?.Dispose();
+                _sos14?.Dispose();
+                _sos16?.Dispose();
+                _dac.Dispose();
+                _moduleHelper?.Dispose();
+            }
         }
 
         public object? GetService(Type serviceType)

--- a/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacServiceProvider.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacServiceProvider.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -34,6 +34,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
         private IAbstractTypeHelpers? _typeHelper;
 
         private bool _disposed;
+        private readonly object _serviceLock = new();
 
         public DacServiceProvider(ClrInfo clrInfo, DacLibrary library)
         {
@@ -75,8 +76,18 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
 
         public object? GetService(Type serviceType)
         {
+            // Fast path: return already-initialized services without locking.
+            // Lock only when we need to construct a new service singleton so two
+            // racing callers can't each produce their own DacRuntime / DacHeap /
+            // DacTypeHelpers (each with its own caches, which would silently diverge).
             if (serviceType == typeof(IAbstractRuntime))
-                return _runtime ??= new DacRuntime(_clrInfo, _process, _sos, _sos13, _dac.TargetProperties);
+            {
+                IAbstractRuntime? r = _runtime;
+                if (r is not null)
+                    return r;
+                lock (_serviceLock)
+                    return _runtime ??= new DacRuntime(_clrInfo, _process, _sos, _sos13, _dac.TargetProperties);
+            }
 
             if (serviceType == typeof(IAbstractHeap))
             {
@@ -84,35 +95,92 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
                 if (heap is not null)
                     return heap;
 
-                if (_sos.GetGCHeapData(out GCInfo data) && _sos.GetCommonMethodTables(out CommonMethodTables mts) && !mts.ObjectMethodTable.IsNull)
-                    return _heapHelper = new DacHeap(_sos, _sos8, _sos12, _sos16, _dataReader, _dac.TargetProperties, data, mts);
+                lock (_serviceLock)
+                {
+                    heap = _heapHelper;
+                    if (heap is not null)
+                        return heap;
 
-                return null;
+                    GCInfo data = default;
+                    CommonMethodTables mts = default;
+                    bool initialized;
+                    lock (_dac.SyncRoot)
+                    {
+                        initialized = _sos.GetGCHeapData(out data) && _sos.GetCommonMethodTables(out mts) && !mts.ObjectMethodTable.IsNull;
+                    }
+
+                    if (initialized)
+                        return _heapHelper = new DacHeap(_sos, _sos8, _sos12, _sos16, _dataReader, _dac.TargetProperties, data, mts);
+
+                    return null;
+                }
             }
 
             if (serviceType == typeof(IAbstractTypeHelpers))
             {
-                _moduleHelper ??= new(_sos, _dac.TargetProperties);
-                return _typeHelper ??= new DacTypeHelpers(_process, _sos, _sos6, _sos8, _sos14, _dataReader, _moduleHelper, _dac.TargetProperties);
+                IAbstractTypeHelpers? t = _typeHelper;
+                if (t is not null)
+                    return t;
+                lock (_serviceLock)
+                {
+                    _moduleHelper ??= new(_sos, _dac.TargetProperties);
+                    return _typeHelper ??= new DacTypeHelpers(_process, _sos, _sos6, _sos8, _sos14, _dataReader, _moduleHelper, _dac.TargetProperties);
+                }
             }
 
             if (serviceType == typeof(IAbstractClrNativeHeaps))
-                return _nativeHeaps ??= new DacNativeHeaps(_clrInfo, _sos, _sos13, _dataReader, _dac.TargetProperties);
+            {
+                IAbstractClrNativeHeaps? n = _nativeHeaps;
+                if (n is not null)
+                    return n;
+                lock (_serviceLock)
+                    return _nativeHeaps ??= new DacNativeHeaps(_clrInfo, _sos, _sos13, _dataReader, _dac.TargetProperties);
+            }
 
             if (serviceType == typeof(IAbstractModuleHelpers))
-                return _moduleHelper ??= new DacModuleHelpers(_sos, _dac.TargetProperties);
+            {
+                DacModuleHelpers? m = _moduleHelper;
+                if (m is not null)
+                    return m;
+                lock (_serviceLock)
+                    return _moduleHelper ??= new DacModuleHelpers(_sos, _dac.TargetProperties);
+            }
 
             if (serviceType == typeof(IAbstractComHelpers))
-                return _com ??= new DacComHelpers(_sos, _dac.TargetProperties);
+            {
+                IAbstractComHelpers? c = _com;
+                if (c is not null)
+                    return c;
+                lock (_serviceLock)
+                    return _com ??= new DacComHelpers(_sos, _dac.TargetProperties);
+            }
 
             if (serviceType == typeof(IAbstractLegacyThreadPool))
-                return _threadPool ??= new DacLegacyThreadPool(_sos, _dac.TargetProperties);
+            {
+                IAbstractLegacyThreadPool? p = _threadPool;
+                if (p is not null)
+                    return p;
+                lock (_serviceLock)
+                    return _threadPool ??= new DacLegacyThreadPool(_sos, _dac.TargetProperties);
+            }
 
             if (serviceType == typeof(IAbstractMethodLocator))
-                return _methodLocator ??= new DacMethodLocator(_sos, _dataReader, _dac.TargetProperties);
+            {
+                IAbstractMethodLocator? l = _methodLocator;
+                if (l is not null)
+                    return l;
+                lock (_serviceLock)
+                    return _methodLocator ??= new DacMethodLocator(_sos, _dataReader, _dac.TargetProperties);
+            }
 
             if (serviceType == typeof(IAbstractThreadHelpers))
-                return _threadHelper ??= new DacThreadHelpers(_process, _sos, _dataReader, _dac.TargetProperties);
+            {
+                IAbstractThreadHelpers? th = _threadHelper;
+                if (th is not null)
+                    return th;
+                lock (_serviceLock)
+                    return _threadHelper ??= new DacThreadHelpers(_process, _sos, _dataReader, _dac.TargetProperties);
+            }
 
             if (serviceType == typeof(IAbstractDacController))
                 return this;
@@ -132,43 +200,50 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
             if (!CanFlush)
                 throw new InvalidOperationException($"This version of CLR does not support the Flush operation.");
 
-            _moduleHelper?.Flush();
-            if (_sos13 is not null)
+            // The DAC is not thread-safe: Flush tears down internal DAC structures
+            // (handle tables, stack-walk state, type caches). Concurrent DAC reads
+            // observe truncated/empty enumerations during the flush window. Serialize
+            // on the same lock the readers take.
+            lock (_dac.SyncRoot)
             {
-                _sos13.LockedFlush();
-            }
-            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                // IXClrDataProcess::Flush is unfortunately not wrapped with DAC_ENTER.  This means that
-                // when it starts deleting memory, it's completely unsynchronized with parallel reads
-                // and writes, leading to heap corruption and other issues.  This means that in order to
-                // properly clear dac data structures, we need to trick the dac into entering the critical
-                // section for us so we can call Flush safely then.
-
-                // To accomplish this, we set a hook in our implementation of IDacDataTarget::ReadVirtual
-                // which will call IXClrDataProcess::Flush if the dac tries to read the address set by
-                // MagicCallbackConstant.  Additionally we make sure this doesn't interfere with other
-                // reads by 1) Ensuring that the address is in kernel space, 2) only calling when we've
-                // entered a special context.
-
-                _dac.DacDataTarget.EnterMagicCallbackContext();
-                try
+                _moduleHelper?.Flush();
+                if (_sos13 is not null)
                 {
-                    _sos.GetWorkRequestData(ClrDataAddress.FromTargetAddress(DacDataTarget.MagicCallbackConstant, _dac.TargetProperties), out _);
+                    _sos13.LockedFlush();
                 }
-                finally
+                else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 {
-                    _dac.DacDataTarget.ExitMagicCallbackContext();
-                }
-            }
-            else
-            {
-                // On Linux/MacOS, skip the above workaround because calling Flush() in the DAC data target's
-                // ReadVirtual function can cause a SEGSIGV because of an access of freed memory causing the
-                // tool/app running CLRMD to crash. On Windows, it would be caught by the SEH try/catch handler
-                // in DAC enter/leave code.
+                    // IXClrDataProcess::Flush is unfortunately not wrapped with DAC_ENTER.  This means that
+                    // when it starts deleting memory, it's completely unsynchronized with parallel reads
+                    // and writes, leading to heap corruption and other issues.  This means that in order to
+                    // properly clear dac data structures, we need to trick the dac into entering the critical
+                    // section for us so we can call Flush safely then.
 
-                _process.Flush();
+                    // To accomplish this, we set a hook in our implementation of IDacDataTarget::ReadVirtual
+                    // which will call IXClrDataProcess::Flush if the dac tries to read the address set by
+                    // MagicCallbackConstant.  Additionally we make sure this doesn't interfere with other
+                    // reads by 1) Ensuring that the address is in kernel space, 2) only calling when we've
+                    // entered a special context.
+
+                    _dac.DacDataTarget.EnterMagicCallbackContext();
+                    try
+                    {
+                        _sos.GetWorkRequestData(ClrDataAddress.FromTargetAddress(DacDataTarget.MagicCallbackConstant, _dac.TargetProperties), out _);
+                    }
+                    finally
+                    {
+                        _dac.DacDataTarget.ExitMagicCallbackContext();
+                    }
+                }
+                else
+                {
+                    // On Linux/MacOS, skip the above workaround because calling Flush() in the DAC data target's
+                    // ReadVirtual function can cause a SEGSIGV because of an access of freed memory causing the
+                    // tool/app running CLRMD to crash. On Windows, it would be caught by the SEH try/catch handler
+                    // in DAC enter/leave code.
+
+                    _process.Flush();
+                }
             }
         }
     }

--- a/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacServiceProvider.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacServiceProvider.cs
@@ -104,7 +104,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
                     GCInfo data = default;
                     CommonMethodTables mts = default;
                     bool initialized;
-                    lock (_dac.SyncRoot)
+                    lock (_sos.SyncRoot)
                     {
                         initialized = _sos.GetGCHeapData(out data) && _sos.GetCommonMethodTables(out mts) && !mts.ObjectMethodTable.IsNull;
                     }
@@ -203,8 +203,8 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
             // The DAC is not thread-safe: Flush tears down internal DAC structures
             // (handle tables, stack-walk state, type caches). Concurrent DAC reads
             // observe truncated/empty enumerations during the flush window. Serialize
-            // on the same lock the readers take.
-            lock (_dac.SyncRoot)
+            // on the same lock the readers take (SOSDac.SyncRoot is DacLibrary.SyncRoot).
+            lock (_sos.SyncRoot)
             {
                 _moduleHelper?.Flush();
                 if (_sos13 is not null)

--- a/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacThreadHelpers.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacThreadHelpers.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -31,158 +31,188 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
         // IClrThreadHelpers
         public IEnumerable<StackRootInfo> EnumerateStackRoots(uint osThreadId, bool traceErrors)
         {
-            using SOSStackRefEnum? stackRefEnum = _sos.EnumerateStackRefs(osThreadId);
-            if (stackRefEnum is null)
-                yield break;
-
-            const int GCInteriorFlag = 1;
-            const int GCPinnedFlag = 2;
-            const int SOS_StackSourceIP = 0;
-            const int SOS_StackSourceFrame = 1;
-            foreach (StackRefData stackRef in stackRefEnum.ReadStackRefs())
+            // The DAC is not thread-safe. Two simultaneous stack-ref enumerations (even on
+            // different OS threads) share internal DAC state and can truncate each other,
+            // yielding nondeterministic root counts. Serialize the enumerator's lifetime
+            // and materialize the result before releasing the lock.
+            List<StackRootInfo>? results = null;
+            lock (_sos.SyncRoot)
             {
-                if (stackRef.Object.IsNull)
+                using SOSStackRefEnum? stackRefEnum = _sos.EnumerateStackRefs(osThreadId);
+                if (stackRefEnum is null)
+                    return Array.Empty<StackRootInfo>();
+
+                const int GCInteriorFlag = 1;
+                const int GCPinnedFlag = 2;
+                const int SOS_StackSourceIP = 0;
+                const int SOS_StackSourceFrame = 1;
+                foreach (StackRefData stackRef in stackRefEnum.ReadStackRefs())
                 {
-                    if (traceErrors)
-                        Debug.WriteLine($"EnumerateStackRoots found an unexpected entry with Object == 0, addr:{stackRef.Address.ToAddress(_target):x} srcType:{stackRef.SourceType:x}");
-                    continue;
+                    if (stackRef.Object.IsNull)
+                    {
+                        if (traceErrors)
+                            Debug.WriteLine($"EnumerateStackRoots found an unexpected entry with Object == 0, addr:{stackRef.Address.ToAddress(_target):x} srcType:{stackRef.SourceType:x}");
+                        continue;
+                    }
+
+                    bool interior = (stackRef.Flags & GCInteriorFlag) == GCInteriorFlag;
+                    bool isPinned = (stackRef.Flags & GCPinnedFlag) == GCPinnedFlag;
+                    int regOffset = 0;
+                    string? regName = null;
+                    if (stackRef.HasRegisterInformation != 0)
+                    {
+                        regOffset = stackRef.Offset;
+                        regName = _sos.GetRegisterName(stackRef.Register);
+                    }
+
+                    ulong ip = 0;
+                    ulong frame = 0;
+                    if (stackRef.SourceType == SOS_StackSourceIP)
+                        ip = stackRef.Source.ToAddress(_target);
+                    else if (stackRef.SourceType == SOS_StackSourceFrame)
+                        frame = stackRef.Source.ToAddress(_target);
+
+                    results ??= new List<StackRootInfo>();
+                    results.Add(new StackRootInfo()
+                    {
+                        InstructionPointer = ip,
+                        StackPointer = stackRef.StackPointer.ToAddress(_target),
+                        InternalFrame = frame,
+
+                        IsInterior = interior,
+                        IsPinned = isPinned,
+
+                        Address = stackRef.Address.ToAddress(_target),
+                        Object = stackRef.Object.ToAddress(_target),
+
+                        IsEnregistered = stackRef.HasRegisterInformation != 0,
+                        RegisterName = regName,
+                        RegisterOffset = regOffset,
+                    });
                 }
-
-                bool interior = (stackRef.Flags & GCInteriorFlag) == GCInteriorFlag;
-                bool isPinned = (stackRef.Flags & GCPinnedFlag) == GCPinnedFlag;
-                int regOffset = 0;
-                string? regName = null;
-                if (stackRef.HasRegisterInformation != 0)
-                {
-                    regOffset = stackRef.Offset;
-                    regName = _sos.GetRegisterName(stackRef.Register);
-                }
-
-                ulong ip = 0;
-                ulong frame = 0;
-                if (stackRef.SourceType == SOS_StackSourceIP)
-                    ip = stackRef.Source.ToAddress(_target);
-                else if (stackRef.SourceType == SOS_StackSourceFrame)
-                    frame = stackRef.Source.ToAddress(_target);
-
-                yield return new StackRootInfo()
-                {
-                    InstructionPointer = ip,
-                    StackPointer = stackRef.StackPointer.ToAddress(_target),
-                    InternalFrame = frame,
-
-                    IsInterior = interior,
-                    IsPinned = isPinned,
-
-                    Address = stackRef.Address.ToAddress(_target),
-                    Object = stackRef.Object.ToAddress(_target),
-
-                    IsEnregistered = stackRef.HasRegisterInformation != 0,
-                    RegisterName = regName,
-                    RegisterOffset = regOffset,
-                };
             }
+
+            return (IEnumerable<StackRootInfo>?)results ?? Array.Empty<StackRootInfo>();
         }
 
-        public IEnumerable<StackFrameInfo> EnumerateStackTrace(uint osThreadId, bool includeContext, bool traceErrors)
+        public IEnumerable<StackFrameInfo> EnumerateStackTrace(uint osThreadId, bool includeContext, int maxFrames, bool traceErrors)
         {
-            using ClrStackWalk? stackwalk = _dac.CreateStackWalk(osThreadId, 0xf);
-            if (stackwalk is null)
-                yield break;
+            if (maxFrames <= 0)
+                return Array.Empty<StackFrameInfo>();
+            // Serialize the entire stack walk: the ClrStackWalk is a stateful DAC enumerator
+            // and concurrent walks on the same DAC can truncate each other.
+            List<StackFrameInfo>? results = null;
+            lock (_sos.SyncRoot)
+            {
+                using ClrStackWalk? stackwalk = _dac.CreateStackWalk(osThreadId, 0xf);
+                if (stackwalk is null)
+                    return Array.Empty<StackFrameInfo>();
 
-            int ipOffset;
-            int spOffset;
-            int contextSize;
-            uint contextFlags = 0;
-            if (_dataReader.Architecture == Architecture.Arm)
-            {
-                ipOffset = 64;
-                spOffset = 56;
-                contextSize = 416;
-            }
-            else if (_dataReader.Architecture == Architecture.Arm64)
-            {
-                ipOffset = 264;
-                spOffset = 256;
-                contextSize = 912;
-            }
-            else if (_dataReader.Architecture == (Architecture)9 /* Architecture.RiscV64 */)
-            {
-                ipOffset = 264;
-                spOffset = 24;
-                contextSize = 544;
-            }
-            else if (_dataReader.Architecture == (Architecture)6 /* Architecture.LoongArch64 */)
-            {
-                ipOffset = 264;
-                spOffset = 32;
-                contextSize = 1312;
-            }
-            else if (_dataReader.Architecture == Architecture.X86)
-            {
-                ipOffset = 184;
-                spOffset = 196;
-                contextSize = 716;
-                contextFlags = 0x1003f;
-            }
-            else // Architecture.X64
-            {
-                ipOffset = 248;
-                spOffset = 152;
-                contextSize = 1232;
-                contextFlags = 0x10003f;
-            }
-
-            HResult hr = HResult.S_OK;
-            byte[] context = ArrayPool<byte>.Shared.Rent(contextSize);
-            while (hr.IsOK)
-            {
-                hr = stackwalk.GetContext(contextFlags, contextSize, out _, context);
-                if (!hr)
+                int ipOffset;
+                int spOffset;
+                int contextSize;
+                uint contextFlags = 0;
+                if (_dataReader.Architecture == Architecture.Arm)
                 {
-                    if (traceErrors)
-                        Debug.WriteLine($"GetContext failed, flags:{contextFlags:x} size: {contextSize:x} hr={hr}");
-
-                    break;
+                    ipOffset = 64;
+                    spOffset = 56;
+                    contextSize = 416;
+                }
+                else if (_dataReader.Architecture == Architecture.Arm64)
+                {
+                    ipOffset = 264;
+                    spOffset = 256;
+                    contextSize = 912;
+                }
+                else if (_dataReader.Architecture == (Architecture)9 /* Architecture.RiscV64 */)
+                {
+                    ipOffset = 264;
+                    spOffset = 24;
+                    contextSize = 544;
+                }
+                else if (_dataReader.Architecture == (Architecture)6 /* Architecture.LoongArch64 */)
+                {
+                    ipOffset = 264;
+                    spOffset = 32;
+                    contextSize = 1312;
+                }
+                else if (_dataReader.Architecture == Architecture.X86)
+                {
+                    ipOffset = 184;
+                    spOffset = 196;
+                    contextSize = 716;
+                    contextFlags = 0x1003f;
+                }
+                else // Architecture.X64
+                {
+                    ipOffset = 248;
+                    spOffset = 152;
+                    contextSize = 1232;
+                    contextFlags = 0x10003f;
                 }
 
-                ulong ip = context.AsSpan().AsPointer(_dataReader.PointerSize, ipOffset);
-                ulong sp = context.AsSpan().AsPointer(_dataReader.PointerSize, spOffset);
-
-                ulong frameVtbl = stackwalk.GetFrameVtable().ToAddress(_target);
-                string? frameName = null;
-                ulong frameMethod = 0;
-                if (frameVtbl != 0)
+                HResult hr = HResult.S_OK;
+                byte[] context = ArrayPool<byte>.Shared.Rent(contextSize);
+                try
                 {
-                    sp = frameVtbl;
-                    frameVtbl = _dataReader.ReadPointer(sp);
-                    frameName = _sos.GetFrameName(ClrDataAddress.FromTargetAddress(frameVtbl, _target));
-                    frameMethod = _sos.GetMethodDescPtrFromFrame(ClrDataAddress.FromTargetAddress(sp, _target)).ToAddress(_target);
+                    while (hr.IsOK && (results?.Count ?? 0) < maxFrames)
+                    {
+                        hr = stackwalk.GetContext(contextFlags, contextSize, out _, context);
+                        if (!hr)
+                        {
+                            if (traceErrors)
+                                Debug.WriteLine($"GetContext failed, flags:{contextFlags:x} size: {contextSize:x} hr={hr}");
+
+                            break;
+                        }
+
+                        ulong ip = context.AsSpan().AsPointer(_dataReader.PointerSize, ipOffset);
+                        ulong sp = context.AsSpan().AsPointer(_dataReader.PointerSize, spOffset);
+
+                        ulong frameVtbl = stackwalk.GetFrameVtable().ToAddress(_target);
+                        string? frameName = null;
+                        ulong frameMethod = 0;
+                        if (frameVtbl != 0)
+                        {
+                            sp = frameVtbl;
+                            frameVtbl = _dataReader.ReadPointer(sp);
+                            frameName = _sos.GetFrameName(ClrDataAddress.FromTargetAddress(frameVtbl, _target));
+                            frameMethod = _sos.GetMethodDescPtrFromFrame(ClrDataAddress.FromTargetAddress(sp, _target)).ToAddress(_target);
+                        }
+
+                        byte[]? contextCopy = null;
+                        if (includeContext)
+                        {
+                            contextCopy = new byte[contextSize];
+                            context.AsSpan(0, contextSize).CopyTo(contextCopy);
+                        }
+
+                        results ??= new List<StackFrameInfo>();
+                        results.Add(new StackFrameInfo()
+                        {
+                            InstructionPointer = ip,
+                            StackPointer = sp,
+                            Context = contextCopy,
+                            InternalFrameVTable = frameVtbl,
+                            InternalFrameName = frameName,
+                            InnerMethodMethodHandle = frameMethod,
+                        });
+
+                        if (results.Count >= maxFrames)
+                            break;
+
+                        hr = stackwalk.Next();
+                        if (traceErrors && !hr)
+                            Debug.WriteLine($"STACKWALK FAILED - hr:{hr}");
+                    }
                 }
-
-                byte[]? contextCopy = null;
-                if (includeContext)
+                finally
                 {
-                    contextCopy = new byte[contextSize];
-                    context.AsSpan(0, contextSize).CopyTo(contextCopy);
+                    ArrayPool<byte>.Shared.Return(context);
                 }
-
-                yield return new StackFrameInfo()
-                {
-                    InstructionPointer = ip,
-                    StackPointer = sp,
-                    Context = contextCopy,
-                    InternalFrameVTable = frameVtbl,
-                    InternalFrameName = frameName,
-                    InnerMethodMethodHandle = frameMethod,
-                };
-
-                hr = stackwalk.Next();
-                if (traceErrors && !hr)
-                    Debug.WriteLine($"STACKWALK FAILED - hr:{hr}");
             }
 
-            ArrayPool<byte>.Shared.Return(context);
+            return (IEnumerable<StackFrameInfo>?)results ?? Array.Empty<StackFrameInfo>();
         }
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacTypeHelpers.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacTypeHelpers.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Reflection;
@@ -41,26 +42,29 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
 
         public bool GetTypeInfo(ulong methodTable, out TypeInfo info)
         {
-            if (!_sos.GetMethodTableData(ClrDataAddress.FromTargetAddress(methodTable, _target), out MethodTableData data))
+            lock (_sos.SyncRoot)
             {
-                info = default;
-                return false;
-            }
+                if (!_sos.GetMethodTableData(ClrDataAddress.FromTargetAddress(methodTable, _target), out MethodTableData data))
+                {
+                    info = default;
+                    return false;
+                }
 
-            info = new()
-            {
-                MetadataToken = unchecked((int)data.Token),
-                StaticSize = unchecked((int)data.BaseSize),
-                ComponentSize = unchecked((int)data.ComponentSize),
-                ContainsPointers = data.ContainsPointers != 0,
-                IsShared = data.Shared != 0,
-                MethodCount = data.NumMethods,
-                MethodTable = methodTable,
-                ParentMethodTable = data.ParentMethodTable.ToAddress(_target),
-                ModuleAddress = data.Module.ToAddress(_target),
-                HasFinalizer = ReadHasFinalizer(methodTable),
-            };
-            return true;
+                info = new()
+                {
+                    MetadataToken = unchecked((int)data.Token),
+                    StaticSize = unchecked((int)data.BaseSize),
+                    ComponentSize = unchecked((int)data.ComponentSize),
+                    ContainsPointers = data.ContainsPointers != 0,
+                    IsShared = data.Shared != 0,
+                    MethodCount = data.NumMethods,
+                    MethodTable = methodTable,
+                    ParentMethodTable = data.ParentMethodTable.ToAddress(_target),
+                    ModuleAddress = data.Module.ToAddress(_target),
+                    HasFinalizer = ReadHasFinalizer(methodTable),
+                };
+                return true;
+            }
         }
 
         // MethodTable layout (verified on modern .NET and Desktop Framework, all
@@ -85,7 +89,11 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
 
         public string? GetTypeName(ulong module, ulong methodTable, int token)
         {
-            string? name = _sos.GetMethodTableName(ClrDataAddress.FromTargetAddress(methodTable, _target));
+            string? name;
+            lock (_sos.SyncRoot)
+            {
+                name = _sos.GetMethodTableName(ClrDataAddress.FromTargetAddress(methodTable, _target));
+            }
             if (string.IsNullOrWhiteSpace(name) || name == UnloadedTypeName)
                 return GetTypeByToken(module, token);
 
@@ -143,159 +151,187 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
 
         public ulong GetLoaderAllocatorHandle(ulong mt)
         {
-            if (_sos6 != null && _sos6.GetMethodTableCollectibleData(ClrDataAddress.FromTargetAddress(mt, _target), out MethodTableCollectibleData data) && data.Collectible != 0)
-                return data.LoaderAllocatorObjectHandle.ToAddress(_target);
+            lock (_sos.SyncRoot)
+            {
+                if (_sos6 != null && _sos6.GetMethodTableCollectibleData(ClrDataAddress.FromTargetAddress(mt, _target), out MethodTableCollectibleData data) && data.Collectible != 0)
+                    return data.LoaderAllocatorObjectHandle.ToAddress(_target);
+            }
 
             return 0;
         }
 
         public ulong GetAssemblyLoadContextAddress(ulong mt)
         {
-            if (_sos8 != null && _sos8.GetAssemblyLoadContext(ClrDataAddress.FromTargetAddress(mt, _target), out ClrDataAddress assemblyLoadContext))
-                return assemblyLoadContext.ToAddress(_target);
+            lock (_sos.SyncRoot)
+            {
+                if (_sos8 != null && _sos8.GetAssemblyLoadContext(ClrDataAddress.FromTargetAddress(mt, _target), out ClrDataAddress assemblyLoadContext))
+                    return assemblyLoadContext.ToAddress(_target);
+            }
 
             return 0;
         }
 
         public bool GetObjectArrayInformation(ulong objRef, out ObjectArrayInformation data)
         {
-            if (!_sos.GetObjectData(ClrDataAddress.FromTargetAddress(objRef, _target), out ObjectData objData))
+            lock (_sos.SyncRoot)
             {
-                data = default;
-                return false;
-            }
+                if (!_sos.GetObjectData(ClrDataAddress.FromTargetAddress(objRef, _target), out ObjectData objData))
+                {
+                    data = default;
+                    return false;
+                }
 
-            ulong dataPointer = objData.ArrayDataPointer.ToAddress(_target) > objRef ? objData.ArrayDataPointer.ToAddress(_target) - objRef : 0;
-            data = new()
-            {
-                ComponentType = objData.ElementTypeHandle.ToAddress(_target),
-                ComponentElementType = (ClrElementType)objData.ElementType,
-                DataPointer = dataPointer > int.MaxValue ? int.MaxValue : (int)dataPointer
-            };
-            return true;
+                ulong dataPointer = objData.ArrayDataPointer.ToAddress(_target) > objRef ? objData.ArrayDataPointer.ToAddress(_target) - objRef : 0;
+                data = new()
+                {
+                    ComponentType = objData.ElementTypeHandle.ToAddress(_target),
+                    ComponentElementType = (ClrElementType)objData.ElementType,
+                    DataPointer = dataPointer > int.MaxValue ? int.MaxValue : (int)dataPointer
+                };
+                return true;
+            }
         }
 
         public IEnumerable<MethodInfo> EnumerateMethodsForType(ulong methodTable)
         {
-            if (!_sos.GetMethodTableData(ClrDataAddress.FromTargetAddress(methodTable, _target), out MethodTableData data))
-                yield break;
-
-            for (uint i = 0; i < data.NumMethods; i++)
+            // Materialize entirely under the DAC lock: every step touches _sos.
+            List<MethodInfo>? results = null;
+            lock (_sos.SyncRoot)
             {
-                ClrDataAddress slot = _sos.GetMethodTableSlot(ClrDataAddress.FromTargetAddress(methodTable, _target), i);
-                if (_sos.GetCodeHeaderData(slot, out CodeHeaderData chd))
+                if (!_sos.GetMethodTableData(ClrDataAddress.FromTargetAddress(methodTable, _target), out MethodTableData data))
+                    return Array.Empty<MethodInfo>();
+
+                for (uint i = 0; i < data.NumMethods; i++)
                 {
-                    if (_sos.GetMethodDescData(chd.MethodDesc, ClrDataAddress.Null, out MethodDescData mdd))
+                    ClrDataAddress slot = _sos.GetMethodTableSlot(ClrDataAddress.FromTargetAddress(methodTable, _target), i);
+                    if (_sos.GetCodeHeaderData(slot, out CodeHeaderData chd))
                     {
-                        ulong md = chd.MethodDesc.ToAddress(_target);
-                        uint compilation = chd.JITType;
+                        if (_sos.GetMethodDescData(chd.MethodDesc, ClrDataAddress.Null, out MethodDescData mdd))
+                        {
+                            ulong md = chd.MethodDesc.ToAddress(_target);
+                            uint compilation = chd.JITType;
 
-                        HotColdRegions regions;
-                        if (mdd.HasNativeCode != 0 && _sos.GetCodeHeaderData(mdd.NativeCodeAddr, out CodeHeaderData chdBasedOnNative))
-                        {
-                            regions = new(mdd.NativeCodeAddr.ToAddress(_target), chdBasedOnNative.HotRegionSize, chdBasedOnNative.ColdRegionStart.ToAddress(_target), chdBasedOnNative.ColdRegionSize);
-                            md = chdBasedOnNative.MethodDesc.ToAddress(_target);
-                            compilation = chdBasedOnNative.JITType;
-                        }
-                        else
-                        {
-                            regions = new(mdd.NativeCodeAddr.ToAddress(_target), chd.HotRegionSize, chd.ColdRegionStart.ToAddress(_target), chd.ColdRegionSize);
-                        }
+                            HotColdRegions regions;
+                            if (mdd.HasNativeCode != 0 && _sos.GetCodeHeaderData(mdd.NativeCodeAddr, out CodeHeaderData chdBasedOnNative))
+                            {
+                                regions = new(mdd.NativeCodeAddr.ToAddress(_target), chdBasedOnNative.HotRegionSize, chdBasedOnNative.ColdRegionStart.ToAddress(_target), chdBasedOnNative.ColdRegionSize);
+                                md = chdBasedOnNative.MethodDesc.ToAddress(_target);
+                                compilation = chdBasedOnNative.JITType;
+                            }
+                            else
+                            {
+                                regions = new(mdd.NativeCodeAddr.ToAddress(_target), chd.HotRegionSize, chd.ColdRegionStart.ToAddress(_target), chd.ColdRegionSize);
+                            }
 
-                        yield return new()
-                        {
-                            MethodDesc = md,
-                            Token = (int)mdd.MDToken,
-                            CompilationType = (MethodCompilationType)compilation,
-                            HotCold = regions,
-                        };
+                            results ??= new List<MethodInfo>();
+                            results.Add(new()
+                            {
+                                MethodDesc = md,
+                                Token = (int)mdd.MDToken,
+                                CompilationType = (MethodCompilationType)compilation,
+                                HotCold = regions,
+                            });
+                        }
                     }
                 }
             }
+
+            return (IEnumerable<MethodInfo>?)results ?? Array.Empty<MethodInfo>();
         }
 
         public IEnumerable<FieldInfo> EnumerateFields(TypeInfo type, int baseFieldCount)
         {
-            if (!_sos.GetFieldInfo(ClrDataAddress.FromTargetAddress(type.MethodTable, _target), out MethodTableFieldInfo fieldInfo) || fieldInfo.FirstFieldAddress.IsNull)
-                yield break;
-
-            ulong nextField = fieldInfo.FirstFieldAddress.ToAddress(_target);
-            for (int i = baseFieldCount; i < fieldInfo.NumInstanceFields + fieldInfo.NumStaticFields; i++)
+            // Materialize entirely under the DAC lock.
+            List<FieldInfo>? results = null;
+            lock (_sos.SyncRoot)
             {
-                if (!_sos.GetFieldData(ClrDataAddress.FromTargetAddress(nextField, _target), out FieldData dacFieldData))
-                    break;
+                if (!_sos.GetFieldInfo(ClrDataAddress.FromTargetAddress(type.MethodTable, _target), out MethodTableFieldInfo fieldInfo) || fieldInfo.FirstFieldAddress.IsNull)
+                    return Array.Empty<FieldInfo>();
 
-                if (dacFieldData.IsContextLocal == 0)
+                ulong nextField = fieldInfo.FirstFieldAddress.ToAddress(_target);
+                for (int i = baseFieldCount; i < fieldInfo.NumInstanceFields + fieldInfo.NumStaticFields; i++)
                 {
-                    FieldKind kind;
-                    if (dacFieldData.IsThreadLocal != 0)
-                        kind = FieldKind.ThreadStatic;
-                    else if (dacFieldData.IsStatic != 0)
-                        kind = FieldKind.Static;
-                    else if (dacFieldData.IsContextLocal != 0)
-                        kind = FieldKind.Unsupported;
-                    else
-                        kind = FieldKind.Instance;
+                    if (!_sos.GetFieldData(ClrDataAddress.FromTargetAddress(nextField, _target), out FieldData dacFieldData))
+                        break;
 
-                    yield return new()
+                    if (dacFieldData.IsContextLocal == 0)
                     {
-                        FieldDesc = nextField,
-                        MethodTable = dacFieldData.TypeMethodTable.ToAddress(_target),
-                        ElementType = (ClrElementType)dacFieldData.ElementType,
-                        Offset = dacFieldData.Offset <= int.MaxValue ? (int)dacFieldData.Offset : int.MaxValue,
-                        Token = dacFieldData.FieldToken <= int.MaxValue ? (int)dacFieldData.FieldToken : int.MaxValue,
-                        Kind = kind,
-                    };
-                }
+                        FieldKind kind;
+                        if (dacFieldData.IsThreadLocal != 0)
+                            kind = FieldKind.ThreadStatic;
+                        else if (dacFieldData.IsStatic != 0)
+                            kind = FieldKind.Static;
+                        else if (dacFieldData.IsContextLocal != 0)
+                            kind = FieldKind.Unsupported;
+                        else
+                            kind = FieldKind.Instance;
 
-                nextField = dacFieldData.NextField.ToAddress(_target);
+                        results ??= new List<FieldInfo>();
+                        results.Add(new()
+                        {
+                            FieldDesc = nextField,
+                            MethodTable = dacFieldData.TypeMethodTable.ToAddress(_target),
+                            ElementType = (ClrElementType)dacFieldData.ElementType,
+                            Offset = dacFieldData.Offset <= int.MaxValue ? (int)dacFieldData.Offset : int.MaxValue,
+                            Token = dacFieldData.FieldToken <= int.MaxValue ? (int)dacFieldData.FieldToken : int.MaxValue,
+                            Kind = kind,
+                        });
+                    }
+
+                    nextField = dacFieldData.NextField.ToAddress(_target);
+                }
             }
+
+            return (IEnumerable<FieldInfo>?)results ?? Array.Empty<FieldInfo>();
         }
 
         public ulong GetStaticFieldAddress(in AppDomainInfo appDomain, in ClrModuleInfo module, in TypeInfo type, in FieldInfo field)
         {
-            if (_sos14 is not null)
+            lock (_sos.SyncRoot)
             {
-                // The static base for a type is allocated up front, but the .cctor may not
-                // have run yet (e.g. for beforefieldinit types whose statics have not been
-                // touched). Returning a non-zero slot address in that case would let callers
-                // read garbage/zero and believe it was a real field value. Match the legacy
-                // DomainLocalModuleData path, which returns 0 when the class is not initialized.
-                if (_sos14.GetMethodTableInitializationFlags(ClrDataAddress.FromTargetAddress(type.MethodTable, _target)) != MethodTableInitializationFlags.MethodTableInitialized)
+                if (_sos14 is not null)
+                {
+                    // The static base for a type is allocated up front, but the .cctor may not
+                    // have run yet (e.g. for beforefieldinit types whose statics have not been
+                    // touched). Returning a non-zero slot address in that case would let callers
+                    // read garbage/zero and believe it was a real field value. Match the legacy
+                    // DomainLocalModuleData path, which returns 0 when the class is not initialized.
+                    if (_sos14.GetMethodTableInitializationFlags(ClrDataAddress.FromTargetAddress(type.MethodTable, _target)) != MethodTableInitializationFlags.MethodTableInitialized)
+                        return 0;
+
+                    (ClrDataAddress nonGcBase, ClrDataAddress gcBase) = _sos14.GetStaticBaseAddress(ClrDataAddress.FromTargetAddress(type.MethodTable, _target));
+                    if (field.ElementType.IsPrimitive())
+                        return !nonGcBase.IsNull ? nonGcBase.ToAddress(_target) + (uint)field.Offset : 0;
+
+                    return !gcBase.IsNull ? gcBase.ToAddress(_target) + (uint)field.Offset : 0;
+                }
+
+                if (appDomain.Address == 0)
                     return 0;
 
-                (ClrDataAddress nonGcBase, ClrDataAddress gcBase) = _sos14.GetStaticBaseAddress(ClrDataAddress.FromTargetAddress(type.MethodTable, _target));
-                if (field.ElementType.IsPrimitive())
-                    return !nonGcBase.IsNull ? nonGcBase.ToAddress(_target) + (uint)field.Offset : 0;
+                if (type.IsShared)
+                {
+                    if (!_sos.GetDomainLocalModuleDataFromAppDomain(ClrDataAddress.FromTargetAddress(appDomain.Address, _target), (int)module.Id, out DomainLocalModuleData dlmd))
+                        return 0;
 
-                return !gcBase.IsNull ? gcBase.ToAddress(_target) + (uint)field.Offset : 0;
-            }
-
-            if (appDomain.Address == 0)
-                return 0;
-
-            if (type.IsShared)
-            {
-                if (!_sos.GetDomainLocalModuleDataFromAppDomain(ClrDataAddress.FromTargetAddress(appDomain.Address, _target), (int)module.Id, out DomainLocalModuleData dlmd))
-                    return 0;
-
-                if (field.ElementType.IsPrimitive())
-                    return dlmd.NonGCStaticDataStart.ToAddress(_target) + (uint)field.Offset;
+                    if (field.ElementType.IsPrimitive())
+                        return dlmd.NonGCStaticDataStart.ToAddress(_target) + (uint)field.Offset;
+                    else
+                        return dlmd.GCStaticDataStart.ToAddress(_target) + (uint)field.Offset;
+                }
                 else
-                    return dlmd.GCStaticDataStart.ToAddress(_target) + (uint)field.Offset;
-            }
-            else
-            {
-                if (!_sos.GetDomainLocalModuleDataFromModule(ClrDataAddress.FromTargetAddress(module.Address, _target), out DomainLocalModuleData dlmd))
-                    return 0;
+                {
+                    if (!_sos.GetDomainLocalModuleDataFromModule(ClrDataAddress.FromTargetAddress(module.Address, _target), out DomainLocalModuleData dlmd))
+                        return 0;
 
-                if (!IsInitialized(dlmd, type.MetadataToken))
-                    return 0;
+                    if (!IsInitialized(dlmd, type.MetadataToken))
+                        return 0;
 
-                if (field.ElementType.IsPrimitive())
-                    return dlmd.NonGCStaticDataStart.ToAddress(_target) + (uint)field.Offset;
-                else
-                    return dlmd.GCStaticDataStart.ToAddress(_target) + (uint)field.Offset;
+                    if (field.ElementType.IsPrimitive())
+                        return dlmd.NonGCStaticDataStart.ToAddress(_target) + (uint)field.Offset;
+                    else
+                        return dlmd.GCStaticDataStart.ToAddress(_target) + (uint)field.Offset;
+                }
             }
         }
 
@@ -304,28 +340,31 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
             if (threadAddress == 0)
                 return 0;
 
-            if (_sos14 is not null)
+            lock (_sos.SyncRoot)
             {
-                // See GetStaticFieldAddress: the per-type static bases are allocated even
-                // when the .cctor hasn't run. Match the legacy ThreadLocalModuleData path,
-                // which only returns an address once the class is initialized.
-                if (_sos14.GetMethodTableInitializationFlags(ClrDataAddress.FromTargetAddress(type.MethodTable, _target)) != MethodTableInitializationFlags.MethodTableInitialized)
+                if (_sos14 is not null)
+                {
+                    // See GetStaticFieldAddress: the per-type static bases are allocated even
+                    // when the .cctor hasn't run. Match the legacy ThreadLocalModuleData path,
+                    // which only returns an address once the class is initialized.
+                    if (_sos14.GetMethodTableInitializationFlags(ClrDataAddress.FromTargetAddress(type.MethodTable, _target)) != MethodTableInitializationFlags.MethodTableInitialized)
+                        return 0;
+
+                    (ClrDataAddress nonGcBase, ClrDataAddress gcBase) = _sos14.GetThreadStaticBaseAddress(ClrDataAddress.FromTargetAddress(type.MethodTable, _target), ClrDataAddress.FromTargetAddress(threadAddress, _target));
+                    if (field.ElementType.IsPrimitive())
+                        return !nonGcBase.IsNull ? nonGcBase.ToAddress(_target) + (uint)field.Offset : 0;
+
+                    return !gcBase.IsNull ? gcBase.ToAddress(_target) + (uint)field.Offset : 0;
+                }
+
+                if (!_sos.GetThreadLocalModuleData(ClrDataAddress.FromTargetAddress(threadAddress, _target), (uint)module.Index, out ThreadLocalModuleData threadData))
                     return 0;
 
-                (ClrDataAddress nonGcBase, ClrDataAddress gcBase) = _sos14.GetThreadStaticBaseAddress(ClrDataAddress.FromTargetAddress(type.MethodTable, _target), ClrDataAddress.FromTargetAddress(threadAddress, _target));
                 if (field.ElementType.IsPrimitive())
-                    return !nonGcBase.IsNull ? nonGcBase.ToAddress(_target) + (uint)field.Offset : 0;
+                    return threadData.NonGCStaticDataStart.ToAddress(_target) + (uint)field.Offset;
 
-                return !gcBase.IsNull ? gcBase.ToAddress(_target) + (uint)field.Offset : 0;
+                return threadData.GCStaticDataStart.ToAddress(_target) + (uint)field.Offset;
             }
-
-            if (!_sos.GetThreadLocalModuleData(ClrDataAddress.FromTargetAddress(threadAddress, _target), (uint)module.Index, out ThreadLocalModuleData threadData))
-                return 0;
-
-            if (field.ElementType.IsPrimitive())
-                return threadData.NonGCStaticDataStart.ToAddress(_target) + (uint)field.Offset;
-
-            return threadData.GCStaticDataStart.ToAddress(_target) + (uint)field.Offset;
         }
 
         private bool IsInitialized(in DomainLocalModuleData data, int token)
@@ -339,34 +378,45 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
 
         // Method helpers
 
-        public string? GetMethodSignature(ulong methodDesc) => _sos.GetMethodDescName(ClrDataAddress.FromTargetAddress(methodDesc, _target));
+        public string? GetMethodSignature(ulong methodDesc)
+        {
+            lock (_sos.SyncRoot)
+                return _sos.GetMethodDescName(ClrDataAddress.FromTargetAddress(methodDesc, _target));
+        }
 
-        public ulong GetILForModule(ulong address, uint rva) => _sos.GetILForModule(ClrDataAddress.FromTargetAddress(address, _target), rva).ToAddress(_target);
+        public ulong GetILForModule(ulong address, uint rva)
+        {
+            lock (_sos.SyncRoot)
+                return _sos.GetILForModule(ClrDataAddress.FromTargetAddress(address, _target), rva).ToAddress(_target);
+        }
 
         public ImmutableArray<ILToNativeMap> GetILMap(ulong ip, in HotColdRegions hotCold)
         {
             ImmutableArray<ILToNativeMap>.Builder result = ImmutableArray.CreateBuilder<ILToNativeMap>();
 
-            foreach (ClrDataMethod method in _clrDataProcess.EnumerateMethodInstancesByAddress(ClrDataAddress.FromTargetAddress(ip, _target)))
+            lock (_sos.SyncRoot)
             {
-                ILToNativeMap[]? map = method.GetILToNativeMap();
-                if (map != null)
+                foreach (ClrDataMethod method in _clrDataProcess.EnumerateMethodInstancesByAddress(ClrDataAddress.FromTargetAddress(ip, _target)))
                 {
-                    for (int i = 0; i < map.Length; i++)
+                    ILToNativeMap[]? map = method.GetILToNativeMap();
+                    if (map != null)
                     {
-                        if (map[i].StartAddress > map[i].EndAddress)
+                        for (int i = 0; i < map.Length; i++)
                         {
-                            if (i + 1 == map.Length)
-                                map[i].EndAddress = FindEnd(hotCold, map[i].StartAddress);
-                            else
-                                map[i].EndAddress = map[i + 1].StartAddress - 1;
+                            if (map[i].StartAddress > map[i].EndAddress)
+                            {
+                                if (i + 1 == map.Length)
+                                    map[i].EndAddress = FindEnd(hotCold, map[i].StartAddress);
+                                else
+                                    map[i].EndAddress = map[i + 1].StartAddress - 1;
+                            }
                         }
+
+                        result.AddRange(map);
                     }
 
-                    result.AddRange(map);
+                    method.Dispose();
                 }
-
-                method.Dispose();
             }
 
             return result.MoveOrCopyToImmutable();

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/SosDac.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/SosDac.cs
@@ -22,8 +22,8 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
         internal static readonly Guid IID_ISOSDac = new("436f00f2-b42a-4b9f-870c-e73db66ae930");
 
         private readonly DacLibrary _library;
-        private volatile Dictionary<int, string>? _regNames;
-        private volatile Dictionary<ClrDataAddress, string>? _frameNames;
+        private readonly Dictionary<int, string> _regNames = new();
+        private readonly Dictionary<ClrDataAddress, string> _frameNames = new();
 
         // CLRDATA_REQUEST_REVISION version from the DAC
         public int DacVersion { get; set; }
@@ -40,6 +40,12 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
         {
             _library = lib;
         }
+
+        /// <summary>
+        /// Process-wide lock that serializes stateful DAC enumerations (stack walks, etc.).
+        /// See <see cref="DacLibrary.SyncRoot"/> for the rationale.
+        /// </summary>
+        internal object SyncRoot => _library.SyncRoot;
 
         public RejitData[] GetRejitData(ClrDataAddress md, ClrDataAddress ip = default)
         {
@@ -67,7 +73,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
 
         public string? GetRegisterName(int index)
         {
-            Dictionary<int, string> regNames = _regNames ??= new();
+            Dictionary<int, string> regNames = _regNames;
             lock (regNames)
                 if (regNames.TryGetValue(index, out string? cached))
                     return cached;
@@ -275,10 +281,10 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
 
         public string GetFrameName(ClrDataAddress vtable)
         {
-            Dictionary<ClrDataAddress, string> frameNames = _frameNames ??= new();
+            Dictionary<ClrDataAddress, string> frameNames = _frameNames;
             lock (frameNames)
             {
-                if (_frameNames.TryGetValue(vtable, out string? cached))
+                if (frameNames.TryGetValue(vtable, out string? cached))
                     return cached;
             }
 
@@ -286,7 +292,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             if (result is not null)
             {
                 lock (frameNames)
-                    _frameNames[vtable] = result;
+                    frameNames[vtable] = result;
 
                 return result;
             }

--- a/src/Microsoft.Diagnostics.Runtime/DacLibrary.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacLibrary.cs
@@ -15,6 +15,16 @@ namespace Microsoft.Diagnostics.Runtime
         private bool _disposed;
         private readonly ClrDataProcess _clrDataProcess;
 
+        /// <summary>
+        /// A single lock that serializes calls into stateful DAC entry points (stack walks,
+        /// handle enumeration, etc.). The DAC is not thread-safe: even calls on different
+        /// entities (e.g. two ClrThreads' stack walks) share internal DAC state and can
+        /// corrupt each other when run concurrently. Most steady-state work hits ClrMD's
+        /// own caches and never acquires this lock; only the cold-miss DAC enumeration
+        /// paths take it.
+        /// </summary>
+        public object SyncRoot { get; } = new();
+
         public DacDataTarget DacDataTarget { get; }
 
         public RefCountedFreeLibrary? OwningLibrary { get; }


### PR DESCRIPTION
## Summary

Introduces and applies a single DAC serialization model for stateful DAC entry points.

The DAC is not safe to call concurrently across independent helpers/enumerators. This PR adds and applies the `DacLibrary`/`SOSDac` `SyncRoot` convention so DAC calls that can race native state are serialized and results are materialized before returning to callers.

Included here:

- shared DAC/SOS `SyncRoot` plumbing and documentation
- service singleton construction and DAC flush serialization
- heap service initialization under the DAC lock
- runtime/heap/thread cache population protection so partial native enumerations cannot be permanently cached
- stack walking materialized under the DAC lock with `maxFrames` enforced inside the DAC walk
- remaining DAC helper surfaces serialized through `SyncRoot`
- native heap traversal materialized under the lock instead of returning lazy DAC-backed enumerables

Part of microsoft/clrmd#420.

## Validation

- Built as part of the split branch verification: `dotnet build src/Microsoft.Diagnostics.Runtime/Microsoft.Diagnostics.Runtime.csproj --framework net10.0` -- passed with 0 warnings and 0 errors.
- This split branch was recombined with the other reduced branches and compared against `lockfree-mmf-threadsafe`; all non-stress paths matched the original combined branch.
