### PR TITLE
Fixes for StressLog handling

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/StressLogIntegrationTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/StressLogIntegrationTests.cs
@@ -149,6 +149,48 @@ namespace Microsoft.Diagnostics.Runtime.Tests
                         knownCounts.GetValueOrDefault(StressLogKnownFormat.GcEnd, 0) > 0,
                         BuildDiagnosticMessage("GcEnd not observed", runtime, stressLog, messages, knownCounts, diagnostics));
                 }
+
+                // Header config fields are exposed for in-process logs.
+                Assert.NotNull(stressLog.FacilitiesToLog);
+                Assert.NotNull(stressLog.LevelToLog);
+                Assert.NotNull(stressLog.MaxSizePerThread);
+                Assert.NotNull(stressLog.MaxSizeTotal);
+                Assert.NotNull(stressLog.ChunkCount);
+                Assert.True(
+                    stressLog.TickFrequency > 0,
+                    BuildDiagnosticMessage("TickFrequency was zero", runtime, stressLog, messages, knownCounts, diagnostics));
+
+                // EnumerateMemoryRanges must cover the live chunk memory.
+                List<MemoryRange> ranges = new();
+                foreach (MemoryRange range in stressLog.EnumerateMemoryRanges())
+                {
+                    ranges.Add(range);
+                    if (ranges.Count >= 100_000)
+                        break;
+                }
+                Assert.True(
+                    ranges.Count > 0,
+                    BuildDiagnosticMessage("EnumerateMemoryRanges returned no ranges", runtime, stressLog, messages, knownCounts, diagnostics));
+
+                // The address-based open returns an independent, caller-owned log.
+                ulong stressLogAddr = runtime.GetStressLogAddress();
+                Assert.NotEqual(0ul, stressLogAddr);
+                bool openedByAddr = StressLog.TryOpen(runtime.DataTarget.DataReader, stressLogAddr, out StressLog? byAddr, out string? addrFailure);
+                Assert.True(
+                    openedByAddr,
+                    BuildDiagnosticMessage($"address-based StressLog.TryOpen failed: {addrFailure}", runtime, stressLog, messages, knownCounts, diagnostics));
+                using (byAddr)
+                {
+                    int byAddrCount = 0;
+                    foreach (StressLogMessage _ in byAddr!.EnumerateMessages())
+                    {
+                        byAddrCount++;
+                        break;
+                    }
+                    Assert.True(
+                        byAddrCount > 0,
+                        BuildDiagnosticMessage("address-based log yielded no messages", runtime, stressLog, messages, knownCounts, diagnostics));
+                }
             }
         }
 

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/StressLogTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/StressLogTests.cs
@@ -652,6 +652,77 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         }
 
         [Fact]
+        public void EnumerateMemoryRanges_SkipsCorruptThreadAndContinues()
+        {
+            SyntheticStressLogBuilder builder = new SyntheticStressLogBuilder();
+            ulong stressLogAddr = builder.Build(out ulong threadAddr, out _);
+
+            StressLogLayout layout = StressLogLayout.CoreX64;
+            ulong badChunkAddr = 0x800000;   // not present in memory -> read failure on its next pointer
+            ulong thread2Addr = 0x900000;
+            ulong chunk2Addr = 0xA00000;
+
+            // Thread 1: its chunk list leads to an unreadable chunk, then links to thread 2.
+            BinaryPrimitives.WriteUInt64LittleEndian(builder.Memory[threadAddr].AsSpan(layout.ThreadChunkListHeadOffset), badChunkAddr);
+            BinaryPrimitives.WriteUInt64LittleEndian(builder.Memory[threadAddr].AsSpan(layout.ThreadNextOffset), thread2Addr);
+
+            // Thread 2: a healthy single-chunk ring at the end of the thread list.
+            byte[] chunk2 = new byte[layout.ChunkTotalSize];
+            BinaryPrimitives.WriteUInt64LittleEndian(chunk2.AsSpan(layout.ChunkNextOffset), chunk2Addr);
+            builder.Memory[chunk2Addr] = chunk2;
+            byte[] thread2 = new byte[layout.ThreadHeaderSize];
+            BinaryPrimitives.WriteUInt64LittleEndian(thread2.AsSpan(layout.ThreadChunkListHeadOffset), chunk2Addr);
+            builder.Memory[thread2Addr] = thread2;
+
+            SyntheticDataReader reader = new(builder.Memory);
+            Assert.True(StressLog.TryOpen(reader, stressLogAddr, out StressLog? log, out _));
+            Assert.NotNull(log);
+            using (log)
+            {
+                List<StressLogDiagnostic> diagnostics = new();
+                log!.Diagnostic += d => diagnostics.Add(d);
+
+                List<MemoryRange> ranges = new();
+                foreach (MemoryRange range in log.EnumerateMemoryRanges())
+                    ranges.Add(range);
+
+                // Thread 1's read failure is reported but does not abort the walk:
+                // thread 2's chunk is still enumerated.
+                Assert.Contains(diagnostics, d => d.Kind == StressLogDiagnosticKind.ReadMemoryFailed);
+                Assert.Contains(ranges, r => r.Start == chunk2Addr);
+            }
+        }
+
+        [Fact]
+        public void MemoryMapped_HeaderConfigFieldsAreNull()
+        {
+            StressLogLayout layout = StressLogLayout.CoreX64;
+            byte[] header = new byte[layout.MmHeaderReadSize];
+            BinaryPrimitives.WriteUInt32LittleEndian(header.AsSpan(layout.MmMagicOffset), StressLogConstants.MemoryMappedMagic);
+            BinaryPrimitives.WriteUInt32LittleEndian(header.AsSpan(layout.MmVersionOffset), StressLogConstants.MemoryMappedVersionV1);
+            BinaryPrimitives.WriteUInt64LittleEndian(header.AsSpan(layout.MmTickFrequencyOffset), 10_000_000UL);
+            // logs = 0 (empty log); module entries left zeroed.
+
+            ulong stressLogAddr = 0x100000;
+            Dictionary<ulong, byte[]> memory = new() { [stressLogAddr] = header };
+            SyntheticDataReader reader = new(memory);
+
+            Assert.True(StressLog.TryOpen(reader, stressLogAddr, out StressLog? log, out string? reason), reason);
+            Assert.NotNull(log);
+            using (log)
+            {
+                // Memory-mapped logs do not record these in-process header fields.
+                Assert.Null(log!.FacilitiesToLog);
+                Assert.Null(log.LevelToLog);
+                Assert.Null(log.MaxSizePerThread);
+                Assert.Null(log.MaxSizeTotal);
+                Assert.Null(log.ChunkCount);
+                // TickFrequency is non-nullable and present for memory-mapped logs.
+                Assert.Equal(10_000_000UL, log.TickFrequency);
+            }
+        }
+
+        [Fact]
         public void EndToEnd_ConcurrentEnumerationsDoNotInterfere()
         {
             // Two threads enumerating the same StressLog instance must each

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/StressLogTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/StressLogTests.cs
@@ -559,8 +559,9 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             SyntheticStressLogBuilder builder = new SyntheticStressLogBuilder();
             ulong stressLogAddr = builder.Build(out ulong threadAddr, out _);
 
-            // Corrupt the thread list into a self-cycle (next -> itself). Without
-            // cycle detection this would re-yield the thread's chunk MaxThreads times.
+            // Corrupt the thread list into a self-cycle (next -> itself). Without the
+            // visitedThreads guard the loop never makes progress (Count never grows)
+            // and spins forever, so cap the enumeration to fail cleanly, not hang.
             StressLogLayout layout = StressLogLayout.CoreX64;
             BinaryPrimitives.WriteUInt64LittleEndian(builder.Memory[threadAddr].AsSpan(layout.ThreadNextOffset), threadAddr);
 
@@ -571,7 +572,11 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             {
                 List<MemoryRange> ranges = new();
                 foreach (MemoryRange range in log!.EnumerateMemoryRanges())
+                {
                     ranges.Add(range);
+                    if (ranges.Count > 16)
+                        break;
+                }
 
                 Assert.Single(ranges);
             }
@@ -592,6 +597,44 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             BinaryPrimitives.WriteUInt64LittleEndian(chunk2.AsSpan(layout.ChunkNextOffset), chunk2Addr);
             builder.Memory[chunk2Addr] = chunk2;
             BinaryPrimitives.WriteUInt64LittleEndian(builder.Memory[chunkAddr].AsSpan(layout.ChunkNextOffset), chunk2Addr);
+
+            SyntheticDataReader reader = new(builder.Memory);
+            Assert.True(StressLog.TryOpen(reader, stressLogAddr, out StressLog? log, out _));
+            Assert.NotNull(log);
+            using (log)
+            {
+                List<MemoryRange> ranges = new();
+                foreach (MemoryRange range in log!.EnumerateMemoryRanges())
+                    ranges.Add(range);
+
+                Assert.Equal(2, ranges.Count);
+                Assert.Equal(chunkAddr, ranges[0].Start);
+                Assert.Equal(chunk2Addr, ranges[1].Start);
+            }
+        }
+
+        [Fact]
+        public void EnumerateMemoryRanges_MultipleThreads()
+        {
+            SyntheticStressLogBuilder builder = new SyntheticStressLogBuilder();
+            ulong stressLogAddr = builder.Build(out ulong threadAddr, out ulong chunkAddr);
+
+            // Append a second thread (with its own single-chunk ring) to the thread
+            // list, exercising the per-thread loop and the cross-thread visited set.
+            StressLogLayout layout = StressLogLayout.CoreX64;
+            ulong thread2Addr = threadAddr + 0x1000000;
+            ulong chunk2Addr = chunkAddr + 0x1000000;
+
+            byte[] chunk2 = new byte[layout.ChunkTotalSize];
+            BinaryPrimitives.WriteUInt64LittleEndian(chunk2.AsSpan(layout.ChunkNextOffset), chunk2Addr); // self-ring
+            builder.Memory[chunk2Addr] = chunk2;
+
+            byte[] thread2 = new byte[layout.ThreadHeaderSize];
+            BinaryPrimitives.WriteUInt64LittleEndian(thread2.AsSpan(layout.ThreadChunkListHeadOffset), chunk2Addr);
+            // thread2.next stays 0 (end of the thread list).
+            builder.Memory[thread2Addr] = thread2;
+
+            BinaryPrimitives.WriteUInt64LittleEndian(builder.Memory[threadAddr].AsSpan(layout.ThreadNextOffset), thread2Addr);
 
             SyntheticDataReader reader = new(builder.Memory);
             Assert.True(StressLog.TryOpen(reader, stressLogAddr, out StressLog? log, out _));

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/StressLogTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/StressLogTests.cs
@@ -4,6 +4,7 @@
 #nullable enable
 
 using System;
+using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Text;
 using Microsoft.Diagnostics.Runtime.StressLogs;
@@ -495,6 +496,61 @@ namespace Microsoft.Diagnostics.Runtime.Tests
 
             Assert.Equal(1, count);
             log.Dispose();
+        }
+
+        [Fact]
+        public void EndToEnd_HeaderConfigFieldsExposed()
+        {
+            SyntheticStressLogBuilder builder = new SyntheticStressLogBuilder();
+            ulong stressLogAddr = builder.Build(out _, out _);
+
+            // Populate the in-process header config fields the builder leaves zeroed.
+            StressLogLayout layout = StressLogLayout.CoreX64;
+            byte[] header = builder.Memory[SyntheticStressLogBuilder.StressLogAddr];
+            BinaryPrimitives.WriteUInt32LittleEndian(header.AsSpan(layout.InProcFacilitiesToLogOffset), 0xFFFFFFFFu);
+            BinaryPrimitives.WriteUInt32LittleEndian(header.AsSpan(layout.InProcLevelToLogOffset), 6u);
+            BinaryPrimitives.WriteUInt32LittleEndian(header.AsSpan(layout.InProcMaxSizePerThreadOffset), 0x10000u);
+            BinaryPrimitives.WriteUInt32LittleEndian(header.AsSpan(layout.InProcMaxSizeTotalOffset), 0x1000000u);
+            BinaryPrimitives.WriteInt32LittleEndian(header.AsSpan(layout.InProcTotalChunkOffset), 3);
+
+            SyntheticDataReader reader = new(builder.Memory);
+            Assert.True(StressLog.TryOpen(reader, stressLogAddr, out StressLog? log, out _));
+            Assert.NotNull(log);
+            using (log)
+            {
+                Assert.Equal(0xFFFFFFFFu, log!.FacilitiesToLog);
+                Assert.Equal(6u, log.LevelToLog);
+                Assert.Equal(0x10000u, log.MaxSizePerThread);
+                Assert.Equal(0x1000000u, log.MaxSizeTotal);
+                Assert.Equal(3, log.ChunkCount);
+                Assert.Equal(SyntheticStressLogBuilder.TickFrequency, log.TickFrequency);
+            }
+        }
+
+        [Fact]
+        public void EndToEnd_EnumerateMemoryRangesCoversChunk()
+        {
+            SyntheticStressLogBuilder builder = new SyntheticStressLogBuilder();
+            ulong stressLogAddr = builder.Build(out _, out ulong chunkAddr);
+            SyntheticDataReader reader = new(builder.Memory);
+
+            Assert.True(StressLog.TryOpen(reader, stressLogAddr, out StressLog? log, out _));
+            Assert.NotNull(log);
+            using (log)
+            {
+                List<MemoryRange> ranges = new();
+                foreach (MemoryRange range in log!.EnumerateMemoryRanges())
+                    ranges.Add(range);
+
+                Assert.Single(ranges);
+                Assert.Equal(chunkAddr, ranges[0].Start);
+                Assert.Equal(chunkAddr + (ulong)StressLogLayout.CoreX64.ChunkTotalSize, ranges[0].End);
+
+                // The single message lives inside the chunk's buffer, so its address
+                // must fall within the enumerated range.
+                ulong messageAddr = chunkAddr + (ulong)StressLogLayout.CoreX64.ChunkBufOffset;
+                Assert.True(ranges[0].Contains(messageAddr));
+            }
         }
 
         [Fact]

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/StressLogTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/StressLogTests.cs
@@ -554,6 +554,61 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         }
 
         [Fact]
+        public void EnumerateMemoryRanges_ThreadCycleIsBounded()
+        {
+            SyntheticStressLogBuilder builder = new SyntheticStressLogBuilder();
+            ulong stressLogAddr = builder.Build(out ulong threadAddr, out _);
+
+            // Corrupt the thread list into a self-cycle (next -> itself). Without
+            // cycle detection this would re-yield the thread's chunk MaxThreads times.
+            StressLogLayout layout = StressLogLayout.CoreX64;
+            BinaryPrimitives.WriteUInt64LittleEndian(builder.Memory[threadAddr].AsSpan(layout.ThreadNextOffset), threadAddr);
+
+            SyntheticDataReader reader = new(builder.Memory);
+            Assert.True(StressLog.TryOpen(reader, stressLogAddr, out StressLog? log, out _));
+            Assert.NotNull(log);
+            using (log)
+            {
+                List<MemoryRange> ranges = new();
+                foreach (MemoryRange range in log!.EnumerateMemoryRanges())
+                    ranges.Add(range);
+
+                Assert.Single(ranges);
+            }
+        }
+
+        [Fact]
+        public void EnumerateMemoryRanges_ChunkCycleIsBounded()
+        {
+            SyntheticStressLogBuilder builder = new SyntheticStressLogBuilder();
+            ulong stressLogAddr = builder.Build(out _, out ulong chunkAddr);
+
+            // Add a second chunk whose next points to itself (a cycle that never
+            // returns to the list head), and link the head chunk to it. Without
+            // cycle detection the walk would spin on the second chunk.
+            StressLogLayout layout = StressLogLayout.CoreX64;
+            ulong chunk2Addr = chunkAddr + 0x100000;
+            byte[] chunk2 = new byte[layout.ChunkTotalSize];
+            BinaryPrimitives.WriteUInt64LittleEndian(chunk2.AsSpan(layout.ChunkNextOffset), chunk2Addr);
+            builder.Memory[chunk2Addr] = chunk2;
+            BinaryPrimitives.WriteUInt64LittleEndian(builder.Memory[chunkAddr].AsSpan(layout.ChunkNextOffset), chunk2Addr);
+
+            SyntheticDataReader reader = new(builder.Memory);
+            Assert.True(StressLog.TryOpen(reader, stressLogAddr, out StressLog? log, out _));
+            Assert.NotNull(log);
+            using (log)
+            {
+                List<MemoryRange> ranges = new();
+                foreach (MemoryRange range in log!.EnumerateMemoryRanges())
+                    ranges.Add(range);
+
+                Assert.Equal(2, ranges.Count);
+                Assert.Equal(chunkAddr, ranges[0].Start);
+                Assert.Equal(chunk2Addr, ranges[1].Start);
+            }
+        }
+
+        [Fact]
         public void EndToEnd_ConcurrentEnumerationsDoNotInterfere()
         {
             // Two threads enumerating the same StressLog instance must each

--- a/src/Microsoft.Diagnostics.Runtime/ClrRuntime.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrRuntime.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;

--- a/src/Microsoft.Diagnostics.Runtime/ClrRuntime.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrRuntime.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;

--- a/src/Microsoft.Diagnostics.Runtime/StressLog/StressLog.cs
+++ b/src/Microsoft.Diagnostics.Runtime/StressLog/StressLog.cs
@@ -403,35 +403,58 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs
         {
             ThrowIfDisposed();
 
-            // Track visited threads and chunks so a corrupt log whose links form
-            // a cycle (rather than terminating at the list head) stays bounded:
-            // each node is yielded at most once and revisiting one ends the walk.
+            // Conservative per-entry charge for the visited-chunk set, so a crafted
+            // log with many disjoint chunk chains is bounded by the allocation budget
+            // (the per-thread MaxChunksPerThread bound resets per thread and does NOT
+            // bound the global set).
+            const int visitedChunkBytes = 32;
+
+            // Track visited threads and chunks so a corrupt log whose links form a
+            // cycle (rather than terminating at the list head) stays bounded: each
+            // node is yielded at most once and revisiting one ends the walk.
             HashSet<ulong> visitedThreads = new();
             HashSet<ulong> visitedChunks = new();
-
-            ulong threadAddr = _firstThreadAddr;
-            while (threadAddr != 0 && visitedThreads.Count < _options.MaxThreads && visitedThreads.Add(threadAddr))
+            int reservedBytes = 0;
+            try
             {
-                if (!TryReadTargetPointer(threadAddr + (ulong)_layout.ThreadChunkListHeadOffset, out ulong chunkListHead) || chunkListHead == 0)
-                    yield break;
-
-                ulong chunkAddr = chunkListHead;
-                int chunkCount = 0;
-                while (chunkCount < _options.MaxChunksPerThread && visitedChunks.Add(chunkAddr))
+                ulong threadAddr = _firstThreadAddr;
+                while (threadAddr != 0 && visitedThreads.Count < _options.MaxThreads && visitedThreads.Add(threadAddr))
                 {
-                    yield return new MemoryRange(chunkAddr, chunkAddr + (ulong)_layout.ChunkTotalSize);
-
-                    if (!TryReadTargetPointer(chunkAddr + (ulong)_layout.ChunkNextOffset, out ulong nextChunk) || nextChunk == 0)
+                    if (!TryReadTargetPointer(threadAddr + (ulong)_layout.ThreadChunkListHeadOffset, out ulong chunkListHead) || chunkListHead == 0)
                         yield break;
-                    if (nextChunk == chunkListHead)
-                        break;
-                    chunkAddr = nextChunk;
-                    chunkCount++;
-                }
 
-                if (!TryReadTargetPointer(threadAddr + (ulong)_layout.ThreadNextOffset, out ulong nextThread))
-                    yield break;
-                threadAddr = nextThread;
+                    ulong chunkAddr = chunkListHead;
+                    int chunkCount = 0;
+                    while (chunkCount < _options.MaxChunksPerThread)
+                    {
+                        // Skip a chunk whose range would wrap past the end of the
+                        // address space (mirrors ChunkReader's ChunkFits guard).
+                        if (!_layout.ChunkFits(chunkAddr))
+                            break;
+                        if (!visitedChunks.Add(chunkAddr))
+                            break;
+                        if (!_budget.TryReserve(visitedChunkBytes))
+                            yield break;
+                        reservedBytes += visitedChunkBytes;
+
+                        yield return new MemoryRange(chunkAddr, chunkAddr + (ulong)_layout.ChunkTotalSize);
+
+                        if (!TryReadTargetPointer(chunkAddr + (ulong)_layout.ChunkNextOffset, out ulong nextChunk) || nextChunk == 0)
+                            yield break;
+                        if (nextChunk == chunkListHead)
+                            break;
+                        chunkAddr = nextChunk;
+                        chunkCount++;
+                    }
+
+                    if (!TryReadTargetPointer(threadAddr + (ulong)_layout.ThreadNextOffset, out ulong nextThread))
+                        yield break;
+                    threadAddr = nextThread;
+                }
+            }
+            finally
+            {
+                _budget.Release(reservedBytes);
             }
         }
 

--- a/src/Microsoft.Diagnostics.Runtime/StressLog/StressLog.cs
+++ b/src/Microsoft.Diagnostics.Runtime/StressLog/StressLog.cs
@@ -393,11 +393,12 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs
         /// logged message.
         /// </summary>
         /// <remarks>
-        /// Each range covers a whole <c>StressLogChunk</c> structure, matching
-        /// the runtime's chunk allocation granularity. Enumeration stops at the
-        /// first unreadable thread or chunk, yielding whatever ranges were
-        /// discovered before the failure. Each thread and chunk is visited at
-        /// most once, so a corrupt log whose links form a cycle stays bounded.
+        /// Each range covers a whole <c>StressLogChunk</c> structure, matching the
+        /// runtime's chunk allocation granularity. A thread or chunk that cannot be
+        /// read, or that looks corrupt, is skipped and reported through
+        /// <see cref="Diagnostic"/>; enumeration continues with the remaining
+        /// threads where possible. Each thread and chunk is visited at most once, so
+        /// a corrupt log whose links form a cycle stays bounded.
         /// </remarks>
         public IEnumerable<MemoryRange> EnumerateMemoryRanges()
         {
@@ -418,37 +419,74 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs
             try
             {
                 ulong threadAddr = _firstThreadAddr;
-                while (threadAddr != 0 && visitedThreads.Count < _options.MaxThreads && visitedThreads.Add(threadAddr))
+                while (threadAddr != 0)
                 {
-                    if (!TryReadTargetPointer(threadAddr + (ulong)_layout.ThreadChunkListHeadOffset, out ulong chunkListHead) || chunkListHead == 0)
-                        yield break;
-
-                    ulong chunkAddr = chunkListHead;
-                    int chunkCount = 0;
-                    while (chunkCount < _options.MaxChunksPerThread)
+                    if (visitedThreads.Count >= _options.MaxThreads)
                     {
-                        // Skip a chunk whose range would wrap past the end of the
-                        // address space (mirrors ChunkReader's ChunkFits guard).
-                        if (!_layout.ChunkFits(chunkAddr))
-                            break;
-                        if (!visitedChunks.Add(chunkAddr))
-                            break;
-                        if (!_budget.TryReserve(visitedChunkBytes))
-                            yield break;
-                        reservedBytes += visitedChunkBytes;
-
-                        yield return new MemoryRange(chunkAddr, chunkAddr + (ulong)_layout.ChunkTotalSize);
-
-                        if (!TryReadTargetPointer(chunkAddr + (ulong)_layout.ChunkNextOffset, out ulong nextChunk) || nextChunk == 0)
-                            yield break;
-                        if (nextChunk == chunkListHead)
-                            break;
-                        chunkAddr = nextChunk;
-                        chunkCount++;
+                        RaiseDiagnostic(StressLogDiagnosticKind.LimitExceeded, threadAddr);
+                        yield break;
+                    }
+                    if (!visitedThreads.Add(threadAddr))
+                    {
+                        // Thread-list cycle: we cannot make progress, so stop.
+                        RaiseDiagnostic(StressLogDiagnosticKind.CorruptThread, threadAddr);
+                        yield break;
                     }
 
+                    // Walk this thread's chunk ring. A failure here is isolated to
+                    // the thread: report it and fall through to the next thread.
+                    // chunkListHead == 0 is a legitimately empty/dead thread.
+                    if (TryReadTargetPointer(threadAddr + (ulong)_layout.ThreadChunkListHeadOffset, out ulong chunkListHead))
+                    {
+                        ulong chunkAddr = chunkListHead;
+                        int chunkCount = 0;
+                        while (chunkAddr != 0 && chunkCount < _options.MaxChunksPerThread)
+                        {
+                            // Skip a chunk whose range would wrap past the end of the
+                            // address space (mirrors ChunkReader's ChunkFits guard).
+                            if (!_layout.ChunkFits(chunkAddr))
+                            {
+                                RaiseDiagnostic(StressLogDiagnosticKind.CorruptChunk, chunkAddr);
+                                break;
+                            }
+                            if (!visitedChunks.Add(chunkAddr))
+                            {
+                                // Non-head cycle or cross-thread chunk reuse.
+                                RaiseDiagnostic(StressLogDiagnosticKind.CorruptChunk, chunkAddr);
+                                break;
+                            }
+                            if (!_budget.TryReserve(visitedChunkBytes))
+                            {
+                                // Global memory ceiling: stop the whole enumeration.
+                                RaiseDiagnostic(StressLogDiagnosticKind.LimitExceeded, chunkAddr);
+                                yield break;
+                            }
+                            reservedBytes += visitedChunkBytes;
+
+                            yield return new MemoryRange(chunkAddr, chunkAddr + (ulong)_layout.ChunkTotalSize);
+
+                            if (!TryReadTargetPointer(chunkAddr + (ulong)_layout.ChunkNextOffset, out ulong nextChunk))
+                            {
+                                RaiseDiagnostic(StressLogDiagnosticKind.ReadMemoryFailed, chunkAddr);
+                                break;
+                            }
+                            if (nextChunk == chunkListHead)
+                                break;
+                            chunkAddr = nextChunk;
+                            chunkCount++;
+                        }
+                    }
+                    else
+                    {
+                        RaiseDiagnostic(StressLogDiagnosticKind.ReadMemoryFailed, threadAddr);
+                    }
+
+                    // Advance to the next thread; without the link we cannot continue.
                     if (!TryReadTargetPointer(threadAddr + (ulong)_layout.ThreadNextOffset, out ulong nextThread))
+                    {
+                        RaiseDiagnostic(StressLogDiagnosticKind.ReadMemoryFailed, threadAddr);
                         yield break;
+                    }
                     threadAddr = nextThread;
                 }
             }
@@ -471,6 +509,9 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs
             value = _layout.ReadTargetPointer(buffer, 0);
             return true;
         }
+
+        private void RaiseDiagnostic(StressLogDiagnosticKind kind, ulong address)
+            => Diagnostic?.Invoke(new StressLogDiagnostic(kind, address));
 
         /// <summary>
         /// Enumerate messages from all threads in newest-first chronological
@@ -571,20 +612,20 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs
             {
                 if (iterators.Count >= _options.MaxThreads)
                 {
-                    Diagnostic?.Invoke(new StressLogDiagnostic(StressLogDiagnosticKind.LimitExceeded, addr));
+                    RaiseDiagnostic(StressLogDiagnosticKind.LimitExceeded, addr);
                     break;
                 }
 
                 if (!visited.Add(addr))
                 {
-                    Diagnostic?.Invoke(new StressLogDiagnostic(StressLogDiagnosticKind.CorruptThread, addr));
+                    RaiseDiagnostic(StressLogDiagnosticKind.CorruptThread, addr);
                     break;
                 }
 
                 int got = _reader.Read(addr, threadHeader);
                 if (got < _layout.ThreadHeaderSize)
                 {
-                    Diagnostic?.Invoke(new StressLogDiagnostic(StressLogDiagnosticKind.ReadMemoryFailed, addr));
+                    RaiseDiagnostic(StressLogDiagnosticKind.ReadMemoryFailed, addr);
                     break;
                 }
 

--- a/src/Microsoft.Diagnostics.Runtime/StressLog/StressLog.cs
+++ b/src/Microsoft.Diagnostics.Runtime/StressLog/StressLog.cs
@@ -463,15 +463,17 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs
                             }
                             reservedBytes += visitedChunkBytes;
 
-                            yield return new MemoryRange(chunkAddr, chunkAddr + (ulong)_layout.ChunkTotalSize);
-
                             if (!TryReadTargetPointer(chunkAddr + (ulong)_layout.ChunkNextOffset, out ulong nextChunk))
                             {
                                 RaiseDiagnostic(StressLogDiagnosticKind.ReadMemoryFailed, chunkAddr);
                                 break;
                             }
+
+                            yield return new MemoryRange(chunkAddr, chunkAddr + (ulong)_layout.ChunkTotalSize);
+
                             if (nextChunk == chunkListHead)
                                 break;
+
                             chunkAddr = nextChunk;
                             chunkCount++;
                         }

--- a/src/Microsoft.Diagnostics.Runtime/StressLog/StressLog.cs
+++ b/src/Microsoft.Diagnostics.Runtime/StressLog/StressLog.cs
@@ -396,20 +396,28 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs
         /// Each range covers a whole <c>StressLogChunk</c> structure, matching
         /// the runtime's chunk allocation granularity. Enumeration stops at the
         /// first unreadable thread or chunk, yielding whatever ranges were
-        /// discovered before the failure.
+        /// discovered before the failure. Each thread and chunk is visited at
+        /// most once, so a corrupt log whose links form a cycle stays bounded.
         /// </remarks>
         public IEnumerable<MemoryRange> EnumerateMemoryRanges()
         {
             ThrowIfDisposed();
 
+            // Track visited threads and chunks so a corrupt log whose links form
+            // a cycle (rather than terminating at the list head) stays bounded:
+            // each node is yielded at most once and revisiting one ends the walk.
+            HashSet<ulong> visitedThreads = new();
+            HashSet<ulong> visitedChunks = new();
+
             ulong threadAddr = _firstThreadAddr;
-            for (int threadCount = 0; threadAddr != 0 && threadCount < _options.MaxThreads; threadCount++)
+            while (threadAddr != 0 && visitedThreads.Count < _options.MaxThreads && visitedThreads.Add(threadAddr))
             {
                 if (!TryReadTargetPointer(threadAddr + (ulong)_layout.ThreadChunkListHeadOffset, out ulong chunkListHead) || chunkListHead == 0)
                     yield break;
 
                 ulong chunkAddr = chunkListHead;
-                for (int chunkCount = 0; chunkCount < _options.MaxChunksPerThread; chunkCount++)
+                int chunkCount = 0;
+                while (chunkCount < _options.MaxChunksPerThread && visitedChunks.Add(chunkAddr))
                 {
                     yield return new MemoryRange(chunkAddr, chunkAddr + (ulong)_layout.ChunkTotalSize);
 
@@ -418,6 +426,7 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs
                     if (nextChunk == chunkListHead)
                         break;
                     chunkAddr = nextChunk;
+                    chunkCount++;
                 }
 
                 if (!TryReadTargetPointer(threadAddr + (ulong)_layout.ThreadNextOffset, out ulong nextThread))

--- a/src/Microsoft.Diagnostics.Runtime/StressLog/StressLog.cs
+++ b/src/Microsoft.Diagnostics.Runtime/StressLog/StressLog.cs
@@ -49,6 +49,11 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs
         private readonly DateTime? _startTimeUtc;
         private readonly bool _isV4;
         private readonly StressLogVariant _variant;
+        private readonly uint? _facilitiesToLog;
+        private readonly uint? _levelToLog;
+        private readonly uint? _maxSizePerThread;
+        private readonly uint? _maxSizeTotal;
+        private readonly int? _chunkCount;
 
         private bool _disposed;
 
@@ -62,7 +67,12 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs
                           ulong startTimeStamp,
                           DateTime? startTimeUtc,
                           bool isV4,
-                          StressLogVariant variant)
+                          StressLogVariant variant,
+                          uint? facilitiesToLog,
+                          uint? levelToLog,
+                          uint? maxSizePerThread,
+                          uint? maxSizeTotal,
+                          int? chunkCount)
         {
             _reader = reader;
             _layout = layout;
@@ -75,6 +85,11 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs
             _startTimeUtc = startTimeUtc;
             _isV4 = isV4;
             _variant = variant;
+            _facilitiesToLog = facilitiesToLog;
+            _levelToLog = levelToLog;
+            _maxSizePerThread = maxSizePerThread;
+            _maxSizeTotal = maxSizeTotal;
+            _chunkCount = chunkCount;
             _formatCache = new FormatStringCache(reader, budget, options.MaxFormatStringLength, options.MaxFormatStringCacheEntries);
         }
 
@@ -99,6 +114,45 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs
         /// to match the target's native pointer width.
         /// </summary>
         public int PointerSize => _layout.PointerSize;
+
+        /// <summary>
+        /// QueryPerformanceFrequency tick rate the log timestamps were captured with,
+        /// used to convert raw timestamps to elapsed seconds.
+        /// </summary>
+        public ulong TickFrequency => _tickFrequency;
+
+        /// <summary>
+        /// Bitmask of logging facilities the runtime was configured to record
+        /// (the runtime's <c>facilitiesToLog</c>). In-process logs only;
+        /// <see langword="null"/> for memory-mapped logs.
+        /// </summary>
+        public uint? FacilitiesToLog => _facilitiesToLog;
+
+        /// <summary>
+        /// Maximum logging verbosity level the runtime was configured to record
+        /// (the runtime's <c>levelToLog</c>). In-process logs only;
+        /// <see langword="null"/> for memory-mapped logs.
+        /// </summary>
+        public uint? LevelToLog => _levelToLog;
+
+        /// <summary>
+        /// Configured maximum log size per thread, in bytes. In-process logs
+        /// only; <see langword="null"/> for memory-mapped logs.
+        /// </summary>
+        public uint? MaxSizePerThread => _maxSizePerThread;
+
+        /// <summary>
+        /// Configured maximum total log size, in bytes. In-process logs only;
+        /// <see langword="null"/> for memory-mapped logs.
+        /// </summary>
+        public uint? MaxSizeTotal => _maxSizeTotal;
+
+        /// <summary>
+        /// Current number of allocated stress log chunks across all threads
+        /// (the runtime's <c>totalChunk</c>). In-process logs only;
+        /// <see langword="null"/> for memory-mapped logs.
+        /// </summary>
+        public int? ChunkCount => _chunkCount;
 
         /// <summary>
         /// Try to open the stress log for the given <paramref name="runtime"/>.
@@ -130,12 +184,15 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs
         }
 
         /// <summary>
-        /// Try to open the stress log at <paramref name="address"/> in the
-        /// target. Returns <see langword="false"/> on any structural
-        /// validation failure; <paramref name="failureReason"/> is a
-        /// human-readable explanation in that case.
+        /// Open the stress log located at <paramref name="address"/> in the target
+        /// described by <paramref name="reader"/>. Use this to read a stress log
+        /// that is not the runtime's own — for example a different utilcode-linked
+        /// module's log such as <c>mscordbi!StressLog::theLog</c>. Returns
+        /// <see langword="false"/> on any structural validation failure, with
+        /// <paramref name="failureReason"/> describing the problem. The returned
+        /// <see cref="StressLog"/> is owned by the caller and must be disposed.
         /// </summary>
-        internal static bool TryOpen(IDataReader reader, ulong address, out StressLog? stressLog, out string? failureReason)
+        public static bool TryOpen(IDataReader reader, ulong address, out StressLog? stressLog, out string? failureReason)
         {
             stressLog = null;
             failureReason = null;
@@ -246,6 +303,11 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs
             ulong startTs = BinaryPrimitives.ReadUInt64LittleEndian(header.Slice(layout.InProcStartTimeStampOffset));
             ulong startFiletime = BinaryPrimitives.ReadUInt64LittleEndian(header.Slice(layout.InProcStartTimeOffset));
             ulong moduleOffset = layout.ReadTargetPointer(header, layout.InProcModuleOffsetOffset);
+            uint facilitiesToLog = BinaryPrimitives.ReadUInt32LittleEndian(header.Slice(layout.InProcFacilitiesToLogOffset));
+            uint levelToLog = BinaryPrimitives.ReadUInt32LittleEndian(header.Slice(layout.InProcLevelToLogOffset));
+            uint maxSizePerThread = BinaryPrimitives.ReadUInt32LittleEndian(header.Slice(layout.InProcMaxSizePerThreadOffset));
+            uint maxSizeTotal = BinaryPrimitives.ReadUInt32LittleEndian(header.Slice(layout.InProcMaxSizeTotalOffset));
+            int chunkCount = BinaryPrimitives.ReadInt32LittleEndian(header.Slice(layout.InProcTotalChunkOffset));
 
             DateTime? startTimeUtc = null;
             try
@@ -289,7 +351,8 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs
             // module table in CoreCLR; Framework V1 predates it and uses V3.
             bool isV4 = variant == StressLogVariant.Core;
 
-            return new StressLog(reader, layout, options, budget, modules, logs, tickFreq, startTs, startTimeUtc, isV4: isV4, variant: variant);
+            return new StressLog(reader, layout, options, budget, modules, logs, tickFreq, startTs, startTimeUtc, isV4: isV4, variant: variant,
+                facilitiesToLog: facilitiesToLog, levelToLog: levelToLog, maxSizePerThread: maxSizePerThread, maxSizeTotal: maxSizeTotal, chunkCount: chunkCount);
         }
 
         private static StressLog? OpenMemoryMapped(IDataReader reader,
@@ -318,7 +381,63 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs
 
             StressLogModuleTable modules = StressLogModuleTable.BuildMemoryMapped(layout, entries, maxOffset);
 
-            return new StressLog(reader, layout, options, budget, modules, logs, tickFreq, startTs, startTimeUtc: null, isV4: true, variant: StressLogVariant.Core);
+            return new StressLog(reader, layout, options, budget, modules, logs, tickFreq, startTs, startTimeUtc: null, isV4: true, variant: StressLogVariant.Core,
+                facilitiesToLog: null, levelToLog: null, maxSizePerThread: null, maxSizeTotal: null, chunkCount: null);
+        }
+
+        /// <summary>
+        /// Enumerate the target memory ranges occupied by the stress log's
+        /// per-thread chunk buffers. Callers can use this to exclude stress
+        /// log memory from a broader scan — for example, to distinguish a real
+        /// reference to an object from a reference that merely appears inside a
+        /// logged message.
+        /// </summary>
+        /// <remarks>
+        /// Each range covers a whole <c>StressLogChunk</c> structure, matching
+        /// the runtime's chunk allocation granularity. Enumeration stops at the
+        /// first unreadable thread or chunk, yielding whatever ranges were
+        /// discovered before the failure.
+        /// </remarks>
+        public IEnumerable<MemoryRange> EnumerateMemoryRanges()
+        {
+            ThrowIfDisposed();
+
+            ulong threadAddr = _firstThreadAddr;
+            for (int threadCount = 0; threadAddr != 0 && threadCount < _options.MaxThreads; threadCount++)
+            {
+                if (!TryReadTargetPointer(threadAddr + (ulong)_layout.ThreadChunkListHeadOffset, out ulong chunkListHead) || chunkListHead == 0)
+                    yield break;
+
+                ulong chunkAddr = chunkListHead;
+                for (int chunkCount = 0; chunkCount < _options.MaxChunksPerThread; chunkCount++)
+                {
+                    yield return new MemoryRange(chunkAddr, chunkAddr + (ulong)_layout.ChunkTotalSize);
+
+                    if (!TryReadTargetPointer(chunkAddr + (ulong)_layout.ChunkNextOffset, out ulong nextChunk) || nextChunk == 0)
+                        yield break;
+                    if (nextChunk == chunkListHead)
+                        break;
+                    chunkAddr = nextChunk;
+                }
+
+                if (!TryReadTargetPointer(threadAddr + (ulong)_layout.ThreadNextOffset, out ulong nextThread))
+                    yield break;
+                threadAddr = nextThread;
+            }
+        }
+
+        private bool TryReadTargetPointer(ulong address, out ulong value)
+        {
+            Span<byte> buffer = stackalloc byte[8];
+            buffer = buffer.Slice(0, _layout.PointerSize);
+            if (_reader.Read(address, buffer) < _layout.PointerSize)
+            {
+                value = 0;
+                return false;
+            }
+
+            value = _layout.ReadTargetPointer(buffer, 0);
+            return true;
         }
 
         /// <summary>


### PR DESCRIPTION
This pull request enhances the stress log integration and testing infrastructure by exposing additional configuration fields for in-process logs, improving memory range enumeration robustness, and expanding test coverage to validate these behaviors. The changes affect both the `StressLog` implementation and its associated tests, ensuring more accurate diagnostics and safer handling of edge cases.

**Enhancements to StressLog configuration and API:**

- Exposed new properties on the `StressLog` class for in-process logs: `FacilitiesToLog`, `LevelToLog`, `MaxSizePerThread`, `MaxSizeTotal`, and `ChunkCount`, all nullable and unavailable for memory-mapped logs. These are now parsed from the log header and surfaced as public properties. [[1]](diffhunk://#diff-4eb448cff27aca71a5ad6ca9b12a7a049fdb0468af20d3c3862b661725a0255aR52-R56) [[2]](diffhunk://#diff-4eb448cff27aca71a5ad6ca9b12a7a049fdb0468af20d3c3862b661725a0255aL65-R75) [[3]](diffhunk://#diff-4eb448cff27aca71a5ad6ca9b12a7a049fdb0468af20d3c3862b661725a0255aR88-R92) [[4]](diffhunk://#diff-4eb448cff27aca71a5ad6ca9b12a7a049fdb0468af20d3c3862b661725a0255aR118-R156) [[5]](diffhunk://#diff-4eb448cff27aca71a5ad6ca9b12a7a049fdb0468af20d3c3862b661725a0255aR306-R310) [[6]](diffhunk://#diff-4eb448cff27aca71a5ad6ca9b12a7a049fdb0468af20d3c3862b661725a0255aL292-R355)
- Made `StressLog.TryOpen(IDataReader, ulong, ...)` public to allow callers to open logs at arbitrary addresses, not just the runtime's default.

**Expanded and improved test coverage:**

- Added comprehensive tests in `StressLogTests` to verify:
  - The new header config fields are correctly exposed for in-process logs and are null for memory-mapped logs.
  - The `EnumerateMemoryRanges` method covers all live chunk memory, handles thread and chunk cycles gracefully, supports multiple threads, and continues enumeration even when encountering corrupt threads.
- Updated `StressLogIntegrationTests` to assert the presence and correctness of the new header config fields and to validate memory range enumeration for live chunk memory.

**Supporting changes:**

- Added `System.Buffers.Binary` import to support low-level header parsing in tests.