### PR TITLE
Decode thin locks with runtime-specific layout

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/DacHeapTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/DacHeapTests.cs
@@ -1,0 +1,50 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Microsoft.Diagnostics.Runtime.DacImplementation;
+using Xunit;
+
+namespace Microsoft.Diagnostics.Runtime.Tests
+{
+    public class DacHeapTests
+    {
+        [Theory]
+        [InlineData(ClrFlavor.Desktop, 8, 0)]
+        [InlineData(ClrFlavor.Core, 0, 2)]
+        [InlineData(ClrFlavor.Core, 7, 0)]
+        [InlineData(ClrFlavor.Core, 8, 2)]
+        [InlineData(ClrFlavor.Core, 9, 1)]
+        public void GetThinLockLayoutSelectsRuntimeLayout(ClrFlavor flavor, int majorVersion, int expected)
+        {
+            Assert.Equal(expected, (int)DacHeap.GetThinLockLayout(flavor, new Version(majorVersion, 0)));
+        }
+
+        [Theory]
+        [InlineData(false, 0x00001401u, 1u, 5u)]
+        [InlineData(true, 0x00050001u, 1u, 5u)]
+        [InlineData(false, 0x000017FFu, 1023u, 5u)]
+        [InlineData(true, 0x0005FFFFu, 65535u, 5u)]
+        public void GetThinlockDataDecodesRuntimeLayout(bool useLargeThreadIdLayout, uint header, uint expectedThreadId, uint expectedRecursion)
+        {
+            (uint threadId, uint recursion) = DacHeap.GetThinlockData(header, useLargeThreadIdLayout);
+
+            Assert.Equal(expectedThreadId, threadId);
+            Assert.Equal(expectedRecursion, recursion);
+        }
+
+        [Theory]
+        [InlineData(false, 0x00001401u, true)]
+        [InlineData(true, 0x00050001u, true)]
+        [InlineData(false, 0x00001400u, false)]
+        [InlineData(true, 0x00050000u, false)]
+        [InlineData(false, 0x08000001u, false)]
+        [InlineData(true, 0x08000001u, false)]
+        [InlineData(false, 0x10000001u, false)]
+        [InlineData(true, 0x10000001u, false)]
+        public void HasThinlockUsesRuntimeLayout(bool useLargeThreadIdLayout, uint header, bool expected)
+        {
+            Assert.Equal(expected, DacHeap.HasThinlock(header, useLargeThreadIdLayout));
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacHeap.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacHeap.cs
@@ -22,15 +22,26 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
         private readonly IMemoryReader _memoryReader;
         private readonly TargetProperties _target;
         private readonly GCState _gcState;
+        private readonly ThinLockLayout _thinLockLayout;
         private readonly HashSet<ulong> _validMethodTables = new();
 
-        private const uint SyncBlockRecLevelMask = 0x0000FC00;
-        private const int SyncBlockRecLevelShift = 10;
-        private const uint SyncBlockThreadIdMask = 0x000003FF;
+        private const uint LegacySyncBlockRecLevelMask = 0x0000FC00;
+        private const int LegacySyncBlockRecLevelShift = 10;
+        private const uint LegacySyncBlockThreadIdMask = 0x000003FF;
+        private const uint LargeSyncBlockRecLevelMask = 0x003F0000;
+        private const int LargeSyncBlockRecLevelShift = 16;
+        private const uint LargeSyncBlockThreadIdMask = 0x0000FFFF;
         private const uint SyncBlockSpinLock = 0x10000000;
         private const uint SyncBlockHashOrSyncBlockIndex = 0x08000000;
 
-        public DacHeap(SOSDac sos, SOSDac8? sos8, SosDac12? sos12, ISOSDac16? sos16, IMemoryReader reader, TargetProperties target, in GCInfo gcInfo, in CommonMethodTables commonMethodTables)
+        internal enum ThinLockLayout
+        {
+            Legacy,
+            Large,
+            LargeWithLegacyFallback,
+        }
+
+        public DacHeap(SOSDac sos, SOSDac8? sos8, SosDac12? sos12, ISOSDac16? sos16, IMemoryReader reader, TargetProperties target, ThinLockLayout thinLockLayout, in GCInfo gcInfo, in CommonMethodTables commonMethodTables)
         {
             _sos = sos;
             _sos8 = sos8;
@@ -38,6 +49,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
             _sos16 = sos16;
             _memoryReader = reader;
             _target = target;
+            _thinLockLayout = thinLockLayout;
 
             _gcState = new()
             {
@@ -407,29 +419,64 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
 
         public (ulong Thread, int Recursion) GetThinLock(uint header)
         {
-            if (!HasThinlock(header))
-                return default;
-
-            (uint threadId, uint recursion) = GetThinlockData(header);
-            ulong threadAddress;
-            lock (_sos.SyncRoot)
-                threadAddress = _sos.GetThreadFromThinlockId(threadId).ToAddress(_target);
-
-            if (threadAddress == 0)
+            if (!TryGetThinLock(header, _thinLockLayout, out ulong threadAddress, out uint recursion))
                 return default;
 
             return (threadAddress, recursion.ToSigned());
+
+            bool TryGetThinLock(uint header, ThinLockLayout layout, out ulong threadAddress, out uint recursion)
+            {
+                bool useLargeThreadIdLayout = layout != ThinLockLayout.Legacy;
+                if (!HasThinlock(header, useLargeThreadIdLayout))
+                {
+                    threadAddress = 0;
+                    recursion = 0;
+                    return false;
+                }
+
+                (uint threadId, recursion) = GetThinlockData(header, useLargeThreadIdLayout);
+                lock (_sos.SyncRoot)
+                    threadAddress = _sos.GetThreadFromThinlockId(threadId).ToAddress(_target);
+                if (threadAddress != 0)
+                    return true;
+
+                if (layout != ThinLockLayout.LargeWithLegacyFallback || !HasThinlock(header, useLargeThreadIdLayout: false))
+                    return false;
+
+                (threadId, recursion) = GetThinlockData(header, useLargeThreadIdLayout: false);
+                lock (_sos.SyncRoot)
+                    threadAddress = _sos.GetThreadFromThinlockId(threadId).ToAddress(_target);
+                return threadAddress != 0;
+            }
         }
 
-        private static bool HasThinlock(uint header)
+        internal static ThinLockLayout GetThinLockLayout(ClrFlavor flavor, Version version)
         {
-            return (header & (SyncBlockHashOrSyncBlockIndex | SyncBlockSpinLock)) == 0 && (header & SyncBlockThreadIdMask) != 0;
+            if (flavor != ClrFlavor.Core)
+                return ThinLockLayout.Legacy;
+
+            return version.Major switch
+            {
+                0 => ThinLockLayout.LargeWithLegacyFallback,
+                8 => ThinLockLayout.LargeWithLegacyFallback,
+                > 8 => ThinLockLayout.Large,
+                _ => ThinLockLayout.Legacy,
+            };
         }
 
-        private static (uint ThreadId, uint Recursion) GetThinlockData(uint header)
+        internal static bool HasThinlock(uint header, bool useLargeThreadIdLayout)
         {
-            uint threadId = header & SyncBlockThreadIdMask;
-            uint recursion = (header & SyncBlockRecLevelMask) >> SyncBlockRecLevelShift;
+            uint threadIdMask = useLargeThreadIdLayout ? LargeSyncBlockThreadIdMask : LegacySyncBlockThreadIdMask;
+            return (header & (SyncBlockHashOrSyncBlockIndex | SyncBlockSpinLock)) == 0 && (header & threadIdMask) != 0;
+        }
+
+        internal static (uint ThreadId, uint Recursion) GetThinlockData(uint header, bool useLargeThreadIdLayout)
+        {
+            uint threadIdMask = useLargeThreadIdLayout ? LargeSyncBlockThreadIdMask : LegacySyncBlockThreadIdMask;
+            uint recursionMask = useLargeThreadIdLayout ? LargeSyncBlockRecLevelMask : LegacySyncBlockRecLevelMask;
+            int recursionShift = useLargeThreadIdLayout ? LargeSyncBlockRecLevelShift : LegacySyncBlockRecLevelShift;
+            uint threadId = header & threadIdMask;
+            uint recursion = (header & recursionMask) >> recursionShift;
 
             return (threadId, recursion);
         }

--- a/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacServiceProvider.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacServiceProvider.cs
@@ -123,7 +123,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
                     }
 
                     if (initialized)
-                        return _heapHelper = new DacHeap(_sos, _sos8, _sos12, _sos16, _dataReader, _dac.TargetProperties, data, mts);
+                        return _heapHelper = new DacHeap(_sos, _sos8, _sos12, _sos16, _dataReader, _dac.TargetProperties, DacHeap.GetThinLockLayout(_clrInfo.Flavor, _clrInfo.Version), data, mts);
 
                     return null;
                 }


### PR DESCRIPTION
Use the legacy object-header thin-lock layout for desktop and pre-.NET 8 CoreCLR, and the widened .NET 8+ layout with legacy fallback for .NET 8 or unknown-version CoreCLR targets. Add unit coverage for layout selection, old and new masks, and hash/spin exclusions.