### PR TITLE
Fix Static/ThreadStatic walking

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/GCRootTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/GCRootTests.cs
@@ -169,15 +169,54 @@ namespace Microsoft.Diagnostics.Runtime.Tests
 
             Assert.Contains(heap.EnumerateRoots(), r => r.RootKind == ClrRootKind.ThreadStaticVar);
 
-            // The thread-static roots are also exposed directly; every root it returns is a ThreadStaticVar.
-            List<ClrRoot> threadStaticRoots = heap.EnumerateThreadStaticRoots().ToList();
-            Assert.NotEmpty(threadStaticRoots);
-            Assert.All(threadStaticRoots, r => Assert.Equal(ClrRootKind.ThreadStaticVar, r.RootKind));
+            // The thread-static roots are also exposed through EnumerateAdditionalRoots.
+            List<ClrRoot> additionalRoots = heap.EnumerateAdditionalRoots().ToList();
+            Assert.Contains(additionalRoots, r => r.RootKind == ClrRootKind.ThreadStaticVar);
 
             GCRoot gcroot = new(heap, new ulong[] { target });
             var paths = gcroot.EnumerateRootPaths().ToList();
             Assert.NotEmpty(paths);
             Assert.Contains(paths, p => p.Root.RootKind == ClrRootKind.ThreadStaticVar);
+            foreach (var (_, path) in paths)
+                VerifyPath(heap, obj => obj.Address == target, path);
+        }
+
+        /// <summary>
+        /// Regression test for issue #1474: an object reachable through a regular (non-thread)
+        /// static field must be found by GCRoot, and reachable from a StaticVar root.  On .NET 9/10
+        /// a type's GC statics live in a shared pinned Object[] kept alive by a single strong
+        /// handle; on Server GC + DATAS the DAC can fail to enumerate that handle, leaving
+        /// static-rooted objects with no enumerable root.  EnumerateAdditionalRoots surfaces the
+        /// containing bucket directly as a StaticVar root.
+        ///
+        /// NOTE: this test dump is Workstation GC, where the strong handle <em>is</em> enumerated,
+        /// so here the StaticVar root is additive (the object is also reachable via the strong
+        /// handle).  The test therefore guards the new static-root code path rather than the DATAS
+        /// handle-walker condition, which is impractical to force in a test target.  The DATAS
+        /// condition itself was verified against the issue's customer dumps.
+        /// </summary>
+        [WindowsOrNet11Theory, MemberData(nameof(ReaderOnly))]
+        public void StaticRootsAreEnumerated(DataReaderKind reader)
+        {
+            using DataTarget dataTarget = TestTargets.GCRoot.LoadFullDump(options: reader.ToOptions());
+            using ClrRuntime runtime = dataTarget.ClrVersions.Single().CreateRuntime();
+            ClrHeap heap = runtime.Heap;
+
+            ulong target = heap.GetObjectsOfType("StaticTarget").Single();
+            Assert.NotEqual(0ul, target);
+
+            Assert.Contains(heap.EnumerateRoots(), r => r.RootKind == ClrRootKind.StaticVar);
+
+            // The static roots are also exposed through EnumerateAdditionalRoots; every StaticVar
+            // root points at a valid (pinned Object[] bucket) object.
+            List<ClrRoot> staticRoots = heap.EnumerateAdditionalRoots().Where(r => r.RootKind == ClrRootKind.StaticVar).ToList();
+            Assert.NotEmpty(staticRoots);
+            Assert.All(staticRoots, r => Assert.True(r.Object.IsValid));
+
+            GCRoot gcroot = new(heap, new ulong[] { target });
+            var paths = gcroot.EnumerateRootPaths().ToList();
+            Assert.NotEmpty(paths);
+            Assert.Contains(paths, p => p.Root.RootKind == ClrRootKind.StaticVar);
             foreach (var (_, path) in paths)
                 VerifyPath(heap, obj => obj.Address == target, path);
         }

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/GCRootTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/GCRootTests.cs
@@ -151,6 +151,37 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             ContainsPathsToTarget(heap, 0, target);
         }
 
+        /// <summary>
+        /// Regression test for issue #1474: an object reachable ONLY through a [ThreadStatic]
+        /// field must still be found by GCRoot.  On .NET 9+ non-collectible thread statics are
+        /// rooted through the thread's ThreadLocalData (scanned directly by the GC) rather than a
+        /// GC handle, so without thread-static root enumeration EnumerateRootPaths found no paths.
+        /// </summary>
+        [WindowsOrNet11Theory, MemberData(nameof(ReaderOnly))]
+        public void ThreadStaticRootsAreEnumerated(DataReaderKind reader)
+        {
+            using DataTarget dataTarget = TestTargets.GCRoot.LoadFullDump(options: reader.ToOptions());
+            using ClrRuntime runtime = dataTarget.ClrVersions.Single().CreateRuntime();
+            ClrHeap heap = runtime.Heap;
+
+            ulong target = heap.GetObjectsOfType("ThreadStaticTarget").Single();
+            Assert.NotEqual(0ul, target);
+
+            Assert.Contains(heap.EnumerateRoots(), r => r.RootKind == ClrRootKind.ThreadStaticVar);
+
+            // The thread-static roots are also exposed directly; every root it returns is a ThreadStaticVar.
+            List<ClrRoot> threadStaticRoots = heap.EnumerateThreadStaticRoots().ToList();
+            Assert.NotEmpty(threadStaticRoots);
+            Assert.All(threadStaticRoots, r => Assert.Equal(ClrRootKind.ThreadStaticVar, r.RootKind));
+
+            GCRoot gcroot = new(heap, new ulong[] { target });
+            var paths = gcroot.EnumerateRootPaths().ToList();
+            Assert.NotEmpty(paths);
+            Assert.Contains(paths, p => p.Root.RootKind == ClrRootKind.ThreadStaticVar);
+            foreach (var (_, path) in paths)
+                VerifyPath(heap, obj => obj.Address == target, path);
+        }
+
         [WindowsOrNet11Theory, MemberData(nameof(ReaderOnly))]
         public void GCRootsPredicate(DataReaderKind reader)
         {

--- a/src/Microsoft.Diagnostics.Runtime/AbstractDac/IAbstractTypeHelpers.cs
+++ b/src/Microsoft.Diagnostics.Runtime/AbstractDac/IAbstractTypeHelpers.cs
@@ -33,6 +33,11 @@ namespace Microsoft.Diagnostics.Runtime.AbstractDac
         // Field helpers
         ulong GetStaticFieldAddress(in AppDomainInfo appDomain, in ClrModuleInfo module, in TypeInfo typeInfo, in FieldInfo field);
         ulong GetThreadStaticFieldAddress(ulong threadAddress, in ClrModuleInfo module, in TypeInfo typeInfo, in FieldInfo field);
+
+        // Enumerates the GC thread-static storage objects (one per type with GC thread-static
+        // storage allocated on the given thread) for all constructed types defined by the module.
+        // Returns an empty enumeration for non-Core runtimes and for CLR versions before .NET 9.
+        IEnumerable<ulong> EnumerateThreadStaticRoots(ulong moduleAddress, ulong threadAddress);
     }
 
     public struct TypeInfo

--- a/src/Microsoft.Diagnostics.Runtime/AbstractDac/IAbstractTypeHelpers.cs
+++ b/src/Microsoft.Diagnostics.Runtime/AbstractDac/IAbstractTypeHelpers.cs
@@ -45,21 +45,45 @@ namespace Microsoft.Diagnostics.Runtime.AbstractDac
     }
 
     /// <summary>
+    /// The kind of "additional" GC root reported by <see cref="IAbstractTypeHelpers.EnumerateAdditionalRoots"/>.
+    /// New members may be added over time; consumers should handle unknown values defensively.
+    /// </summary>
+    public enum AdditionalRootKind
+    {
+        /// <summary>
+        /// The root comes from a regular (non-thread) static variable.
+        /// </summary>
+        StaticVariable,
+
+        /// <summary>
+        /// The root comes from a thread static variable.
+        /// </summary>
+        ThreadStaticVariable,
+    }
+
+    /// <summary>
     /// A GC root base discovered by <see cref="IAbstractTypeHelpers.EnumerateAdditionalRoots"/>.
     /// </summary>
     public struct AdditionalRootInfo
     {
         /// <summary>
-        /// The GC base address of the static storage.  For a regular static this is an interior
-        /// pointer into the pinned Object[] that backs the module's GC statics; for a thread static
-        /// it is the per-thread GC thread-static storage object itself.
+        /// The address of the static storage.  When <see cref="IsInteriorPointer"/> is true this is
+        /// an interior pointer into the object that backs the storage (for example the pinned
+        /// <see cref="System.Object"/>[] holding a module's GC statics); when false it points at the
+        /// start of the storage object.
         /// </summary>
         public ulong Address { get; set; }
 
         /// <summary>
-        /// True if this is a thread-static base; false if it is a regular static base.
+        /// The kind of root this base represents.
         /// </summary>
-        public bool IsThreadStatic { get; set; }
+        public AdditionalRootKind Kind { get; set; }
+
+        /// <summary>
+        /// Whether <see cref="Address"/> is an interior pointer (points inside an object) rather than
+        /// the start of an object.
+        /// </summary>
+        public bool IsInteriorPointer { get; set; }
     }
 
     public struct TypeInfo

--- a/src/Microsoft.Diagnostics.Runtime/AbstractDac/IAbstractTypeHelpers.cs
+++ b/src/Microsoft.Diagnostics.Runtime/AbstractDac/IAbstractTypeHelpers.cs
@@ -34,10 +34,32 @@ namespace Microsoft.Diagnostics.Runtime.AbstractDac
         ulong GetStaticFieldAddress(in AppDomainInfo appDomain, in ClrModuleInfo module, in TypeInfo typeInfo, in FieldInfo field);
         ulong GetThreadStaticFieldAddress(ulong threadAddress, in ClrModuleInfo module, in TypeInfo typeInfo, in FieldInfo field);
 
-        // Enumerates the GC thread-static storage objects (one per type with GC thread-static
-        // storage allocated on the given thread) for all constructed types defined by the module.
-        // Returns an empty enumeration for non-Core runtimes and for CLR versions before .NET 9.
-        IEnumerable<ulong> EnumerateThreadStaticRoots(ulong moduleAddress, ulong threadAddress);
+        // Enumerates "additional" GC roots that the normal handle/finalizer/stack walk does not
+        // surface: on .NET 9 and 10 Core this is the GC bases of regular statics (interior to the
+        // module's shared pinned Object[] storage) and non-collectible thread statics (the per-
+        // thread GC storage object) for every constructed type defined by the module.  threadAddresses
+        // are the live threads to probe for thread statics.  Returns an empty enumeration on non-Core
+        // runtimes and on CLR versions outside [9, 10] (pre-9 had no such split; .NET 11+ enumerates
+        // the handle table and statics correctly, so no special handling is needed there).
+        IEnumerable<AdditionalRootInfo> EnumerateAdditionalRoots(ulong moduleAddress, ulong[] threadAddresses);
+    }
+
+    /// <summary>
+    /// A GC root base discovered by <see cref="IAbstractTypeHelpers.EnumerateAdditionalRoots"/>.
+    /// </summary>
+    public struct AdditionalRootInfo
+    {
+        /// <summary>
+        /// The GC base address of the static storage.  For a regular static this is an interior
+        /// pointer into the pinned Object[] that backs the module's GC statics; for a thread static
+        /// it is the per-thread GC thread-static storage object itself.
+        /// </summary>
+        public ulong Address { get; set; }
+
+        /// <summary>
+        /// True if this is a thread-static base; false if it is a regular static base.
+        /// </summary>
+        public bool IsThreadStatic { get; set; }
     }
 
     public struct TypeInfo

--- a/src/Microsoft.Diagnostics.Runtime/ClrHeap.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrHeap.cs
@@ -34,6 +34,7 @@ namespace Microsoft.Diagnostics.Runtime
 
         private readonly ClrTypeFactory _typeFactory;
         private readonly IMemoryReader _memoryReader;
+        private readonly IAbstractTypeHelpers _typeHelpers;
         private readonly ISegmentedDirectMemoryAccess? _directMemoryAccess;
         private volatile Dictionary<ulong, ulong>? _allocationContexts;
         private volatile (ulong Source, ulong Target)[]? _dependentHandles;
@@ -47,6 +48,7 @@ namespace Microsoft.Diagnostics.Runtime
         {
             Runtime = runtime;
             _memoryReader = memoryReader;
+            _typeHelpers = typeHelpers;
             _directMemoryAccess = memoryReader as ISegmentedDirectMemoryAccess;
             _firstChar = (uint)memoryReader.PointerSize + 4;
             _stringLength = (uint)memoryReader.PointerSize;
@@ -673,6 +675,7 @@ namespace Microsoft.Diagnostics.Runtime
         ///     ClrRuntime.EnumerateHandles().Where(handle => handle.IsStrong)
         ///     ClrRuntime.EnumerateThreads().SelectMany(thread => thread.EnumerateStackRoots())
         ///     ClrHeap.EnumerateFinalizerRoots()
+        ///     ClrHeap.EnumerateThreadStaticRoots()
         /// </summary>
         public IEnumerable<ClrRoot> EnumerateRoots()
         {
@@ -716,7 +719,42 @@ namespace Microsoft.Diagnostics.Runtime
             foreach (ClrThread thread in Runtime.Threads.Where(t => t.IsAlive))
                 foreach (ClrRoot root in thread.EnumerateStackRoots())
                     yield return root;
+
+            // Thread statics
+            foreach (ClrRoot root in EnumerateThreadStaticRoots())
+                yield return root;
         }
+
+        /// <summary>
+        /// Enumerates GC roots that come from thread static variables.  These roots are only
+        /// reported on .NET Core 9 and later: starting with that runtime, non-collectible thread
+        /// statics are rooted through each thread's thread-local storage (which the GC scans
+        /// directly as part of the owning thread's roots) instead of through a GC handle.  On
+        /// earlier runtimes thread statics were folded into the handle table, so on those targets
+        /// they are surfaced through <see cref="ClrRuntime.EnumerateHandles"/> and this method
+        /// returns an empty enumeration.  These roots are also included in <see cref="EnumerateRoots"/>.
+        /// </summary>
+        public IEnumerable<ClrRoot> EnumerateThreadStaticRoots()
+        {
+            // Modules outer / threads inner: the DAC caches each module's candidate MethodTable set
+            // (thread-independent), so the first thread for a module pays the type-def/metadata walk
+            // and the rest reuse it.  Materialize the alive-thread set once.
+            ClrThread[] aliveThreads = Runtime.Threads.Where(t => t.IsAlive).ToArray();
+            foreach (ClrModule module in Runtime.EnumerateModules())
+            {
+                foreach (ClrThread thread in aliveThreads)
+                {
+                    foreach (ulong gcBase in _typeHelpers.EnumerateThreadStaticRoots(module.Address, thread.Address))
+                    {
+                        ClrObject obj = GetObject(gcBase);
+                        if (obj.IsValid)
+                            yield return new ClrRoot(gcBase, obj, ClrRootKind.ThreadStaticVar, isInterior: false, isPinned: false);
+                    }
+                }
+            }
+        }
+
+        IEnumerable<IClrRoot> IClrHeap.EnumerateThreadStaticRoots() => EnumerateThreadStaticRoots().Cast<IClrRoot>();
 
         private (ulong Address, ClrObject obj) GetObjectAndAddress(ClrObject containing, string fieldName)
         {

--- a/src/Microsoft.Diagnostics.Runtime/ClrHeap.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrHeap.cs
@@ -752,13 +752,18 @@ namespace Microsoft.Diagnostics.Runtime
             // MethodTable set (thread-independent), so one module pass covers both static kinds.
             ulong[] threadAddresses = Runtime.Threads.Where(t => t.IsAlive).Select(t => t.Address).ToArray();
 
-            // Interior bases (regular statics) point into a shared pinned Object[] bucket, and many
-            // types map to a small set of buckets.  Resolving the containing object is comparatively
-            // expensive, so cache the last resolved object as an O(1) fast path; back it with the set
-            // of buckets already resolved so each is reported exactly once and GetContainingObject is
-            // never called twice for the same bucket.  The DAC interleaves bases across the (few)
-            // live buckets rather than grouping them, so the last-object cache alone is not enough to
-            // dedupe -- the bucket set is required for correctness, but stays tiny (a handful).
+            // Report each distinct root object at most once.  Within this method a heap object is
+            // either a static bucket or a thread-static storage object, never both, so a single set
+            // of already-reported object addresses suffices.  This dedup lives at the ClrHeap layer
+            // so the "distinct roots" contract holds regardless of whether the IAbstractTypeHelpers
+            // implementation dedupes its output.
+            HashSet<ulong> seen = new();
+
+            // Perf cache for interior bases (regular statics): many types' bases point into the same
+            // few pinned Object[] buckets, and resolving the containing object is comparatively
+            // expensive.  Cache the last resolved bucket (O(1) fast path) plus every resolved bucket
+            // range so GetContainingObject is never called twice for the same bucket.  This is purely
+            // an optimization -- correctness/dedup is handled by 'seen' above.
             ClrObject lastInterior = default;
             ulong lastStart = 0;
             ulong lastEnd = 0;
@@ -771,36 +776,39 @@ namespace Microsoft.Diagnostics.Runtime
                     ClrObject obj;
                     if (info.IsInteriorPointer)
                     {
-                        // Fast path: still inside the last resolved bucket -> already reported.
+                        // Resolve the interior base to its containing object, reusing the cache so
+                        // GetContainingObject runs at most once per bucket.
                         if (lastInterior.IsValid && lastStart <= info.Address && info.Address < lastEnd)
-                            continue;
-
-                        // Already resolved (and reported) a different bucket that contains this base?
-                        // Reuse it -- no GetContainingObject, no duplicate yield -- and prime the cache.
-                        bool known = false;
-                        foreach ((ulong start, ulong end, ClrObject bucket) in resolvedBuckets)
                         {
-                            if (start <= info.Address && info.Address < end)
+                            obj = lastInterior;
+                        }
+                        else
+                        {
+                            obj = default;
+                            foreach ((ulong start, ulong end, ClrObject bucket) in resolvedBuckets)
                             {
-                                lastInterior = bucket;
-                                lastStart = start;
-                                lastEnd = end;
-                                known = true;
-                                break;
+                                if (start <= info.Address && info.Address < end)
+                                {
+                                    obj = bucket;
+                                    lastInterior = bucket;
+                                    lastStart = start;
+                                    lastEnd = end;
+                                    break;
+                                }
+                            }
+
+                            if (!obj.IsValid)
+                            {
+                                obj = GetContainingObject(info.Address);
+                                if (!obj.IsValid)
+                                    continue;
+
+                                lastInterior = obj;
+                                lastStart = obj.Address;
+                                lastEnd = obj.Address + obj.Size;
+                                resolvedBuckets.Add((lastStart, lastEnd, obj));
                             }
                         }
-
-                        if (known)
-                            continue;
-
-                        obj = GetContainingObject(info.Address);
-                        if (!obj.IsValid)
-                            continue;
-
-                        lastInterior = obj;
-                        lastStart = obj.Address;
-                        lastEnd = obj.Address + obj.Size;
-                        resolvedBuckets.Add((lastStart, lastEnd, obj));
                     }
                     else
                     {
@@ -809,6 +817,9 @@ namespace Microsoft.Diagnostics.Runtime
                         if (!obj.IsValid)
                             continue;
                     }
+
+                    if (!seen.Add(obj.Address))
+                        continue;
 
                     ClrRootKind rootKind;
                     bool isPinned;

--- a/src/Microsoft.Diagnostics.Runtime/ClrHeap.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrHeap.cs
@@ -675,7 +675,7 @@ namespace Microsoft.Diagnostics.Runtime
         ///     ClrRuntime.EnumerateHandles().Where(handle => handle.IsStrong)
         ///     ClrRuntime.EnumerateThreads().SelectMany(thread => thread.EnumerateStackRoots())
         ///     ClrHeap.EnumerateFinalizerRoots()
-        ///     ClrHeap.EnumerateThreadStaticRoots()
+        ///     ClrHeap.EnumerateAdditionalRoots()
         /// </summary>
         public IEnumerable<ClrRoot> EnumerateRoots()
         {
@@ -720,41 +720,104 @@ namespace Microsoft.Diagnostics.Runtime
                 foreach (ClrRoot root in thread.EnumerateStackRoots())
                     yield return root;
 
-            // Thread statics
-            foreach (ClrRoot root in EnumerateThreadStaticRoots())
+            // Additional roots not surfaced above (regular + thread statics on .NET 9/10)
+            foreach (ClrRoot root in EnumerateAdditionalRoots())
                 yield return root;
         }
 
         /// <summary>
-        /// Enumerates GC roots that come from thread static variables.  These roots are only
-        /// reported on .NET Core 9 and later: starting with that runtime, non-collectible thread
-        /// statics are rooted through each thread's thread-local storage (which the GC scans
-        /// directly as part of the owning thread's roots) instead of through a GC handle.  On
-        /// earlier runtimes thread statics were folded into the handle table, so on those targets
-        /// they are surfaced through <see cref="ClrRuntime.EnumerateHandles"/> and this method
-        /// returns an empty enumeration.  These roots are also included in <see cref="EnumerateRoots"/>.
+        /// Enumerates "additional" GC roots that are not surfaced by the handle table, finalizer
+        /// queue, or thread stacks.  On .NET 9 and 10 Core this returns the roots that come from
+        /// regular and thread static variables:
+        /// <list type="bullet">
+        /// <item>A type's GC statics live in slots inside a shared pinned <see cref="System.Object"/>[]
+        /// (the runtime's PinnedHeapHandleTable bucket) kept alive by a single strong handle.  That
+        /// handle is normally enumerated through the handle table, but on Server GC with DATAS the
+        /// DAC's handle walker can fail to enumerate it, leaving objects reachable only through a
+        /// static with no enumerable root.  Each such bucket is surfaced here as a
+        /// <see cref="ClrRootKind.StaticVar"/> root.</item>
+        /// <item>Non-collectible thread statics are rooted through each thread's thread-local storage
+        /// (scanned directly by the GC) rather than a GC handle, and are surfaced here as
+        /// <see cref="ClrRootKind.ThreadStaticVar"/> roots.</item>
+        /// </list>
+        /// On non-Core runtimes, on CLR versions before .NET 9 (where these were folded into the
+        /// handle table), and on .NET 11+ (where the DAC enumerates the handle table and statics
+        /// correctly), this returns an empty enumeration.  Reporting a bucket here is purely additive:
+        /// on targets where the strong handle <em>is</em> enumerated, the same object is simply
+        /// reported by both paths.  These roots are also included in <see cref="EnumerateRoots"/>.
         /// </summary>
-        public IEnumerable<ClrRoot> EnumerateThreadStaticRoots()
+        public IEnumerable<ClrRoot> EnumerateAdditionalRoots()
         {
-            // Modules outer / threads inner: the DAC caches each module's candidate MethodTable set
-            // (thread-independent), so the first thread for a module pays the type-def/metadata walk
-            // and the rest reuse it.  Materialize the alive-thread set once.
-            ClrThread[] aliveThreads = Runtime.Threads.Where(t => t.IsAlive).ToArray();
+            // Materialize the alive-thread set once; the DAC caches each module's candidate
+            // MethodTable set (thread-independent), so one module pass covers both static kinds.
+            ulong[] threadAddresses = Runtime.Threads.Where(t => t.IsAlive).Select(t => t.Address).ToArray();
+
+            // A regular static's GC base is interior to a shared pinned Object[] bucket, and many
+            // types map to the same bucket.  Resolve each base to its containing object and report
+            // each distinct bucket exactly once.  The bucket set is tiny, so a small list of
+            // already-resolved (range, object) entries keeps this near O(types).
+            List<(ulong Start, ulong End)> resolvedBuckets = new();
+
             foreach (ClrModule module in Runtime.EnumerateModules())
             {
-                foreach (ClrThread thread in aliveThreads)
+                foreach (AdditionalRootInfo info in _typeHelpers.EnumerateAdditionalRoots(module.Address, threadAddresses))
                 {
-                    foreach (ulong gcBase in _typeHelpers.EnumerateThreadStaticRoots(module.Address, thread.Address))
+                    if (info.IsThreadStatic)
                     {
-                        ClrObject obj = GetObject(gcBase);
+                        // The thread-static base is the GC storage object itself.
+                        ClrObject obj = GetObject(info.Address);
                         if (obj.IsValid)
-                            yield return new ClrRoot(gcBase, obj, ClrRootKind.ThreadStaticVar, isInterior: false, isPinned: false);
+                            yield return new ClrRoot(info.Address, obj, ClrRootKind.ThreadStaticVar, isInterior: false, isPinned: false);
+
+                        continue;
                     }
+
+                    // The regular-static base is interior to a pinned Object[] bucket; resolve it to
+                    // its container and report each bucket only once.
+                    bool known = false;
+                    foreach ((ulong start, ulong end) in resolvedBuckets)
+                    {
+                        if (start <= info.Address && info.Address < end)
+                        {
+                            known = true;
+                            break;
+                        }
+                    }
+
+                    if (known)
+                        continue;
+
+                    ClrObject bucket = GetContainingObject(info.Address);
+                    if (!bucket.IsValid)
+                        continue;
+
+                    resolvedBuckets.Add((bucket.Address, bucket.Address + bucket.Size));
+                    yield return new ClrRoot(info.Address, bucket, ClrRootKind.StaticVar, isInterior: false, isPinned: true);
                 }
             }
         }
 
-        IEnumerable<IClrRoot> IClrHeap.EnumerateThreadStaticRoots() => EnumerateThreadStaticRoots().Cast<IClrRoot>();
+        IEnumerable<IClrRoot> IClrHeap.EnumerateAdditionalRoots() => EnumerateAdditionalRoots().Cast<IClrRoot>();
+
+        // Resolves an interior address to the heap object that contains it, or default if none.
+        // Used to map a type's (interior) GC static base back to its containing pinned Object[].
+        private ClrObject GetContainingObject(ulong interiorAddress)
+        {
+            ClrSegment? segment = GetSegmentByAddress(interiorAddress);
+            if (segment is null)
+                return default;
+
+            foreach (ClrObject obj in segment.EnumerateObjects())
+            {
+                if (obj.Address > interiorAddress)
+                    break;
+
+                if (interiorAddress < obj.Address + obj.Size)
+                    return obj;
+            }
+
+            return default;
+        }
 
         private (ulong Address, ClrObject obj) GetObjectAndAddress(ClrObject containing, string fieldName)
         {

--- a/src/Microsoft.Diagnostics.Runtime/ClrHeap.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrHeap.cs
@@ -752,47 +752,83 @@ namespace Microsoft.Diagnostics.Runtime
             // MethodTable set (thread-independent), so one module pass covers both static kinds.
             ulong[] threadAddresses = Runtime.Threads.Where(t => t.IsAlive).Select(t => t.Address).ToArray();
 
-            // A regular static's GC base is interior to a shared pinned Object[] bucket, and many
-            // types map to the same bucket.  Resolve each base to its containing object and report
-            // each distinct bucket exactly once.  The bucket set is tiny, so a small list of
-            // already-resolved (range, object) entries keeps this near O(types).
-            List<(ulong Start, ulong End)> resolvedBuckets = new();
+            // Interior bases (regular statics) point into a shared pinned Object[] bucket, and many
+            // types map to a small set of buckets.  Resolving the containing object is comparatively
+            // expensive, so cache the last resolved object as an O(1) fast path; back it with the set
+            // of buckets already resolved so each is reported exactly once and GetContainingObject is
+            // never called twice for the same bucket.  The DAC interleaves bases across the (few)
+            // live buckets rather than grouping them, so the last-object cache alone is not enough to
+            // dedupe -- the bucket set is required for correctness, but stays tiny (a handful).
+            ClrObject lastInterior = default;
+            ulong lastStart = 0;
+            ulong lastEnd = 0;
+            List<(ulong Start, ulong End, ClrObject Obj)> resolvedBuckets = new();
 
             foreach (ClrModule module in Runtime.EnumerateModules())
             {
                 foreach (AdditionalRootInfo info in _typeHelpers.EnumerateAdditionalRoots(module.Address, threadAddresses))
                 {
-                    if (info.IsThreadStatic)
+                    ClrObject obj;
+                    if (info.IsInteriorPointer)
                     {
-                        // The thread-static base is the GC storage object itself.
-                        ClrObject obj = GetObject(info.Address);
-                        if (obj.IsValid)
-                            yield return new ClrRoot(info.Address, obj, ClrRootKind.ThreadStaticVar, isInterior: false, isPinned: false);
+                        // Fast path: still inside the last resolved bucket -> already reported.
+                        if (lastInterior.IsValid && lastStart <= info.Address && info.Address < lastEnd)
+                            continue;
 
-                        continue;
-                    }
-
-                    // The regular-static base is interior to a pinned Object[] bucket; resolve it to
-                    // its container and report each bucket only once.
-                    bool known = false;
-                    foreach ((ulong start, ulong end) in resolvedBuckets)
-                    {
-                        if (start <= info.Address && info.Address < end)
+                        // Already resolved (and reported) a different bucket that contains this base?
+                        // Reuse it -- no GetContainingObject, no duplicate yield -- and prime the cache.
+                        bool known = false;
+                        foreach ((ulong start, ulong end, ClrObject bucket) in resolvedBuckets)
                         {
-                            known = true;
-                            break;
+                            if (start <= info.Address && info.Address < end)
+                            {
+                                lastInterior = bucket;
+                                lastStart = start;
+                                lastEnd = end;
+                                known = true;
+                                break;
+                            }
                         }
+
+                        if (known)
+                            continue;
+
+                        obj = GetContainingObject(info.Address);
+                        if (!obj.IsValid)
+                            continue;
+
+                        lastInterior = obj;
+                        lastStart = obj.Address;
+                        lastEnd = obj.Address + obj.Size;
+                        resolvedBuckets.Add((lastStart, lastEnd, obj));
+                    }
+                    else
+                    {
+                        // The base points at the start of the storage object.
+                        obj = GetObject(info.Address);
+                        if (!obj.IsValid)
+                            continue;
                     }
 
-                    if (known)
-                        continue;
+                    ClrRootKind rootKind;
+                    bool isPinned;
+                    switch (info.Kind)
+                    {
+                        case AdditionalRootKind.StaticVariable:
+                            rootKind = ClrRootKind.StaticVar;
+                            isPinned = true;
+                            break;
 
-                    ClrObject bucket = GetContainingObject(info.Address);
-                    if (!bucket.IsValid)
-                        continue;
+                        case AdditionalRootKind.ThreadStaticVariable:
+                            rootKind = ClrRootKind.ThreadStaticVar;
+                            isPinned = false;
+                            break;
 
-                    resolvedBuckets.Add((bucket.Address, bucket.Address + bucket.Size));
-                    yield return new ClrRoot(info.Address, bucket, ClrRootKind.StaticVar, isInterior: false, isPinned: true);
+                        default:
+                            throw new NotImplementedException($"Unhandled {nameof(AdditionalRootKind)} '{info.Kind}'.");
+                    }
+
+                    yield return new ClrRoot(info.Address, obj, rootKind, isInterior: false, isPinned: isPinned);
                 }
             }
         }

--- a/src/Microsoft.Diagnostics.Runtime/ClrRootKind.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrRootKind.cs
@@ -49,5 +49,13 @@ namespace Microsoft.Diagnostics.Runtime
         /// The root is a SizedRef handle.
         /// </summary>
         SizedRefHandle = 8,
+
+        /// <summary>
+        /// The root is a thread static variable.  On .NET 9+ non-collectible thread statics are
+        /// rooted directly through the owning thread's thread-local storage (scanned by the GC as
+        /// part of the thread's roots) rather than through a GC handle, so they are reported here
+        /// instead of as a handle root.
+        /// </summary>
+        ThreadStaticVar = 9,
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/ClrRootKind.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrRootKind.cs
@@ -57,5 +57,16 @@ namespace Microsoft.Diagnostics.Runtime
         /// instead of as a handle root.
         /// </summary>
         ThreadStaticVar = 9,
+
+        /// <summary>
+        /// The root is a (regular, non-thread) static variable.  On .NET 9+ a type's GC statics
+        /// live in slots inside a shared pinned <see cref="System.Object"/>[] (the runtime's
+        /// PinnedHeapHandleTable bucket) that is kept alive by a single strong handle.  On Server
+        /// GC with DATAS the DAC's handle walker can fail to enumerate that strong handle, so the
+        /// bucket -- and everything reachable only through a static -- would otherwise have no
+        /// enumerable root.  These roots surface the bucket directly and are also included in
+        /// <see cref="ClrHeap.EnumerateRoots"/>.
+        /// </summary>
+        StaticVar = 10,
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacServiceProvider.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacServiceProvider.cs
@@ -137,7 +137,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
                 lock (_serviceLock)
                 {
                     _moduleHelper ??= new(_sos, _dac.TargetProperties);
-                    return _typeHelper ??= new DacTypeHelpers(_process, _sos, _sos6, _sos8, _sos14, _dataReader, _moduleHelper, _dac.TargetProperties);
+                    return _typeHelper ??= new DacTypeHelpers(_process, _sos, _sos6, _sos8, _sos14, _dataReader, _moduleHelper, _dac.TargetProperties, _clrInfo.Flavor, _clrInfo.Version?.Major ?? 0);
                 }
             }
 

--- a/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacTypeHelpers.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacTypeHelpers.cs
@@ -414,7 +414,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
                 }
 
                 if (gcStaticBase != 0)
-                    yield return new AdditionalRootInfo { Address = gcStaticBase, IsThreadStatic = false };
+                    yield return new AdditionalRootInfo { Address = gcStaticBase, Kind = AdditionalRootKind.StaticVariable, IsInteriorPointer = true };
 
                 // Thread-static base for this type on each live thread.
                 foreach (ulong threadAddress in threadAddresses)
@@ -433,7 +433,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
                     }
 
                     if (gcThreadBase != 0 && seenThreadStatic.Add(gcThreadBase))
-                        yield return new AdditionalRootInfo { Address = gcThreadBase, IsThreadStatic = true };
+                        yield return new AdditionalRootInfo { Address = gcThreadBase, Kind = AdditionalRootKind.ThreadStaticVariable, IsInteriorPointer = false };
                 }
             }
         }

--- a/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacTypeHelpers.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacTypeHelpers.cs
@@ -33,10 +33,11 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
 
         // Cache of per-module candidate MethodTables (types whose metadata declares a static
         // FieldDef).  The type-def map and metadata filter are thread-independent, so this is
-        // computed once per module and reused across every thread.  ConcurrentDictionary because
-        // EnumerateThreadStaticRoots may run on several threads at once: recomputing a module's
-        // (deterministic, immutable) candidate array is harmless, but reads must never tear.
-        private readonly ConcurrentDictionary<ulong, ulong[]> _threadStaticCandidates = new();
+        // computed once per module and reused for every static and thread-static base lookup.
+        // ConcurrentDictionary because EnumerateAdditionalRoots may run on several threads at once:
+        // recomputing a module's (deterministic, immutable) candidate array is harmless, but reads
+        // must never tear.
+        private readonly ConcurrentDictionary<ulong, ulong[]> _staticCandidates = new();
 
         public DacTypeHelpers(ClrDataProcess clrDataProcess, SOSDac sos, SOSDac6? sos6, SOSDac8? sos8, SosDac14? sos14, IDataReader dataReader, DacModuleHelpers moduleHelpers, TargetProperties target, ClrFlavor flavor, int clrVersionMajor)
         {
@@ -379,37 +380,67 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
             }
         }
 
-        public IEnumerable<ulong> EnumerateThreadStaticRoots(ulong moduleAddress, ulong threadAddress)
+        public IEnumerable<AdditionalRootInfo> EnumerateAdditionalRoots(ulong moduleAddress, ulong[] threadAddresses)
         {
-            // Thread statics only need special handling on .NET 9+ Core, where non-collectible
-            // thread statics live in the per-thread ThreadLocalData GC array (not a GC handle).
-            // _sos14 is required for the per-type GC base lookup and only exists on that runtime.
-            if (_flavor != ClrFlavor.Core || _clrVersionMajor < 9 || _sos14 is null || threadAddress == 0)
+            // On .NET 9 and 10 Core, two kinds of GC root are not surfaced by the normal handle/
+            // finalizer/stack walk and must be enumerated here:
+            //  * Regular statics: a type's GC statics live in slots inside a shared pinned Object[]
+            //    (the runtime's PinnedHeapHandleTable bucket) kept alive by a single strong handle.
+            //    On Server GC with DATAS the DAC's handle walker can miss that handle (it walks only
+            //    GCHeapCount() per-processor handle-table slots, fewer than the actual slot count once
+            //    the dynamic heap count is reduced), so the bucket -- and anything reachable only
+            //    through a static -- would otherwise have no enumerable root.
+            //  * Non-collectible thread statics: stored in the per-thread ThreadLocalData GC array
+            //    (scanned directly by the GC), not a GC handle.
+            // .NET 11+ enumerates the handle table and statics correctly, so this is scoped to 9/10.
+            // _sos14 is required for the per-type GC base lookups and only exists on those runtimes.
+            if (_flavor != ClrFlavor.Core || _clrVersionMajor < 9 || _clrVersionMajor > 10 || _sos14 is null)
                 yield break;
 
-            HashSet<ulong> seen = new();
-            foreach (ulong methodTable in GetThreadStaticCandidateTypes(moduleAddress))
+            HashSet<ulong> seenThreadStatic = new();
+            foreach (ulong methodTable in GetStaticCandidateTypes(moduleAddress))
             {
-                ulong gcBase;
+                // Regular static base for this type (interior to its pinned Object[] bucket).
+                ulong gcStaticBase;
                 try
                 {
-                    gcBase = GetGCThreadStaticBase(methodTable, threadAddress);
+                    gcStaticBase = GetGCStaticBase(methodTable);
                 }
                 catch
                 {
                     // A single corrupt MethodTable must not abort enumeration of all roots
                     // (EnumerateRoots is one lazy iterator); skip it like HasStaticFieldDef does.
-                    continue;
+                    gcStaticBase = 0;
                 }
 
-                if (gcBase != 0 && seen.Add(gcBase))
-                    yield return gcBase;
+                if (gcStaticBase != 0)
+                    yield return new AdditionalRootInfo { Address = gcStaticBase, IsThreadStatic = false };
+
+                // Thread-static base for this type on each live thread.
+                foreach (ulong threadAddress in threadAddresses)
+                {
+                    if (threadAddress == 0)
+                        continue;
+
+                    ulong gcThreadBase;
+                    try
+                    {
+                        gcThreadBase = GetGCThreadStaticBase(methodTable, threadAddress);
+                    }
+                    catch
+                    {
+                        continue;
+                    }
+
+                    if (gcThreadBase != 0 && seenThreadStatic.Add(gcThreadBase))
+                        yield return new AdditionalRootInfo { Address = gcThreadBase, IsThreadStatic = true };
+                }
             }
         }
 
-        private ulong[] GetThreadStaticCandidateTypes(ulong moduleAddress)
+        private ulong[] GetStaticCandidateTypes(ulong moduleAddress)
         {
-            if (_threadStaticCandidates.TryGetValue(moduleAddress, out ulong[]? cached))
+            if (_staticCandidates.TryGetValue(moduleAddress, out ulong[]? cached))
                 return cached;
 
             // Cheap pre-filter: keep only types whose metadata declares a static FieldDef, mirroring
@@ -432,8 +463,21 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
             // Concurrent callers may build this simultaneously; every result is identical and
             // immutable, so publishing any winner (last write wins) is correct.
             ulong[] result = candidates.ToArray();
-            _threadStaticCandidates[moduleAddress] = result;
+            _staticCandidates[moduleAddress] = result;
             return result;
+        }
+
+        private ulong GetGCStaticBase(ulong methodTable)
+        {
+            // The per-type GC static base is allocated up front but only points at real storage
+            // once the type is initialized; an uninitialized type or a type with no GC statics
+            // yields a null gcBase (=> 0, filtered by the caller).  The returned pointer is
+            // interior to the shared pinned Object[] that backs the module's GC statics.
+            if (_sos14!.GetMethodTableInitializationFlags(ClrDataAddress.FromTargetAddress(methodTable, _target)) != MethodTableInitializationFlags.MethodTableInitialized)
+                return 0;
+
+            (_, ClrDataAddress gcBase) = _sos14.GetStaticBaseAddress(ClrDataAddress.FromTargetAddress(methodTable, _target));
+            return gcBase.IsNull ? 0 : gcBase.ToAddress(_target);
         }
 
         private ulong GetGCThreadStaticBase(ulong methodTable, ulong threadAddress)

--- a/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacTypeHelpers.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacTypeHelpers.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Reflection;
@@ -27,8 +28,17 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
         private readonly IDataReader _dataReader;
         private readonly DacModuleHelpers _moduleHelpers;
         private readonly TargetProperties _target;
+        private readonly ClrFlavor _flavor;
+        private readonly int _clrVersionMajor;
 
-        public DacTypeHelpers(ClrDataProcess clrDataProcess, SOSDac sos, SOSDac6? sos6, SOSDac8? sos8, SosDac14? sos14, IDataReader dataReader, DacModuleHelpers moduleHelpers, TargetProperties target)
+        // Cache of per-module candidate MethodTables (types whose metadata declares a static
+        // FieldDef).  The type-def map and metadata filter are thread-independent, so this is
+        // computed once per module and reused across every thread.  ConcurrentDictionary because
+        // EnumerateThreadStaticRoots may run on several threads at once: recomputing a module's
+        // (deterministic, immutable) candidate array is harmless, but reads must never tear.
+        private readonly ConcurrentDictionary<ulong, ulong[]> _threadStaticCandidates = new();
+
+        public DacTypeHelpers(ClrDataProcess clrDataProcess, SOSDac sos, SOSDac6? sos6, SOSDac8? sos8, SosDac14? sos14, IDataReader dataReader, DacModuleHelpers moduleHelpers, TargetProperties target, ClrFlavor flavor, int clrVersionMajor)
         {
             _clrDataProcess = clrDataProcess;
             _sos = sos;
@@ -38,6 +48,8 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
             _dataReader = dataReader;
             _moduleHelpers = moduleHelpers;
             _target = target;
+            _flavor = flavor;
+            _clrVersionMajor = clrVersionMajor;
         }
 
         public bool GetTypeInfo(ulong methodTable, out TypeInfo info)
@@ -365,6 +377,96 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
 
                 return threadData.GCStaticDataStart.ToAddress(_target) + (uint)field.Offset;
             }
+        }
+
+        public IEnumerable<ulong> EnumerateThreadStaticRoots(ulong moduleAddress, ulong threadAddress)
+        {
+            // Thread statics only need special handling on .NET 9+ Core, where non-collectible
+            // thread statics live in the per-thread ThreadLocalData GC array (not a GC handle).
+            // _sos14 is required for the per-type GC base lookup and only exists on that runtime.
+            if (_flavor != ClrFlavor.Core || _clrVersionMajor < 9 || _sos14 is null || threadAddress == 0)
+                yield break;
+
+            HashSet<ulong> seen = new();
+            foreach (ulong methodTable in GetThreadStaticCandidateTypes(moduleAddress))
+            {
+                ulong gcBase;
+                try
+                {
+                    gcBase = GetGCThreadStaticBase(methodTable, threadAddress);
+                }
+                catch
+                {
+                    // A single corrupt MethodTable must not abort enumeration of all roots
+                    // (EnumerateRoots is one lazy iterator); skip it like HasStaticFieldDef does.
+                    continue;
+                }
+
+                if (gcBase != 0 && seen.Add(gcBase))
+                    yield return gcBase;
+            }
+        }
+
+        private ulong[] GetThreadStaticCandidateTypes(ulong moduleAddress)
+        {
+            if (_threadStaticCandidates.TryGetValue(moduleAddress, out ulong[]? cached))
+                return cached;
+
+            // Cheap pre-filter: keep only types whose metadata declares a static FieldDef, mirroring
+            // ClrModule.EnumerateTypesWithStaticFields. Null/unreadable metadata => no filter (slower
+            // but correct). GetMetadataReader returns null when metadata is unavailable.
+            IAbstractMetadataReader? metadata = _moduleHelpers.GetMetadataReader(moduleAddress);
+
+            List<ulong> candidates = new();
+            foreach ((ulong methodTable, int token) in _moduleHelpers.EnumerateTypeDefMap(moduleAddress))
+            {
+                if (methodTable == 0)
+                    continue;
+
+                if (metadata is not null && !HasStaticFieldDef(metadata, token))
+                    continue;
+
+                candidates.Add(methodTable);
+            }
+
+            // Concurrent callers may build this simultaneously; every result is identical and
+            // immutable, so publishing any winner (last write wins) is correct.
+            ulong[] result = candidates.ToArray();
+            _threadStaticCandidates[moduleAddress] = result;
+            return result;
+        }
+
+        private ulong GetGCThreadStaticBase(ulong methodTable, ulong threadAddress)
+        {
+            // The per-type GC thread-static base is allocated up front but only once the type is
+            // initialized; an uninitialized type, a type with no GC thread statics, or storage not
+            // yet allocated on this thread all yield a null gcBase (=> 0, filtered by the caller).
+            if (_sos14!.GetMethodTableInitializationFlags(ClrDataAddress.FromTargetAddress(methodTable, _target)) != MethodTableInitializationFlags.MethodTableInitialized)
+                return 0;
+
+            (_, ClrDataAddress gcBase) = _sos14.GetThreadStaticBaseAddress(ClrDataAddress.FromTargetAddress(methodTable, _target), ClrDataAddress.FromTargetAddress(threadAddress, _target));
+            return gcBase.IsNull ? 0 : gcBase.ToAddress(_target);
+        }
+
+        private static bool HasStaticFieldDef(IAbstractMetadataReader metadata, int typeToken)
+        {
+            try
+            {
+                foreach (FieldDefInfo info in metadata.EnumerateFields(typeToken))
+                {
+                    // Literal (const) fields have no runtime storage; require Static set, Literal clear.
+                    const System.Reflection.FieldAttributes StaticNonStorage =
+                        System.Reflection.FieldAttributes.Static | System.Reflection.FieldAttributes.Literal;
+                    if ((info.Attributes & StaticNonStorage) == System.Reflection.FieldAttributes.Static)
+                        return true;
+                }
+            }
+            catch
+            {
+                return true; // Unreadable metadata: fall back so the type is still considered.
+            }
+
+            return false;
         }
 
         private bool IsInitialized(in DomainLocalModuleData data, int token)

--- a/src/Microsoft.Diagnostics.Runtime/Interfaces/IClrHeap.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Interfaces/IClrHeap.cs
@@ -27,6 +27,7 @@ namespace Microsoft.Diagnostics.Runtime.Interfaces
         IEnumerable<IClrValue> EnumerateObjects(MemoryRange range, bool carefully = false);
         IEnumerable<IClrRoot> EnumerateRoots();
         IEnumerable<SyncBlock> EnumerateSyncBlocks();
+        IEnumerable<IClrRoot> EnumerateThreadStaticRoots();
         IClrValue FindNextObjectOnSegment(ulong address, bool carefully = false);
         IClrValue FindPreviousObjectOnSegment(ulong address, bool carefully = false);
         IClrValue GetObject(ulong objRef);

--- a/src/Microsoft.Diagnostics.Runtime/Interfaces/IClrHeap.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Interfaces/IClrHeap.cs
@@ -26,8 +26,8 @@ namespace Microsoft.Diagnostics.Runtime.Interfaces
         IEnumerable<IClrValue> EnumerateObjects(bool carefully);
         IEnumerable<IClrValue> EnumerateObjects(MemoryRange range, bool carefully = false);
         IEnumerable<IClrRoot> EnumerateRoots();
+        IEnumerable<IClrRoot> EnumerateAdditionalRoots();
         IEnumerable<SyncBlock> EnumerateSyncBlocks();
-        IEnumerable<IClrRoot> EnumerateThreadStaticRoots();
         IClrValue FindNextObjectOnSegment(ulong address, bool carefully = false);
         IClrValue FindPreviousObjectOnSegment(ulong address, bool carefully = false);
         IClrValue GetObject(ulong objRef);

--- a/src/TestTargets/GCRoot/GCRoot.cs
+++ b/src/TestTargets/GCRoot/GCRoot.cs
@@ -22,6 +22,12 @@ class GCRootTarget
     [ThreadStatic]
     static object ThreadStaticRoot;
 
+    // Rooted through a regular (non-thread) static field.  On .NET 9/10 a type's GC statics live
+    // in a shared pinned Object[] kept alive by a single strong handle; on Server GC + DATAS the
+    // DAC can fail to enumerate that handle, leaving static-rooted objects with no enumerable
+    // root.  This exercises ClrHeap.EnumerateAdditionalRoots (issue #1474).
+    static object StaticRoot;
+
     public static void Main(string[] args)
     {
         TargetType target = new TargetType();
@@ -54,6 +60,7 @@ class GCRootTarget
         AllocRoots(target, s, t);
 
         ThreadStaticRoot = new ThreadStaticTarget();
+        StaticRoot = new StaticTarget();
 
         throw new Exception();
         GC.KeepAlive(target);
@@ -95,5 +102,9 @@ class TargetType
 }
 
 class ThreadStaticTarget
+{
+}
+
+class StaticTarget
 {
 }

--- a/src/TestTargets/GCRoot/GCRoot.cs
+++ b/src/TestTargets/GCRoot/GCRoot.cs
@@ -16,6 +16,12 @@ class GCRootTarget
     static object TheRoot;
     static ConditionalWeakTable<SingleRef, TargetType> _dependent = new ConditionalWeakTable<SingleRef, TargetType>();
 
+    // Rooted ONLY through a [ThreadStatic] field.  On .NET 9+ thread statics live in the
+    // thread's ThreadLocalData (scanned directly by the GC) rather than a GC handle, so this
+    // exercises ClrHeap.EnumerateRoots' thread-static root enumeration (issue #1474).
+    [ThreadStatic]
+    static object ThreadStaticRoot;
+
     public static void Main(string[] args)
     {
         TargetType target = new TargetType();
@@ -46,6 +52,8 @@ class GCRootTarget
         // a single Object[] handle and stack roots may not include locals, so
         // without these handles only 1 root path would exist.
         AllocRoots(target, s, t);
+
+        ThreadStaticRoot = new ThreadStaticTarget();
 
         throw new Exception();
         GC.KeepAlive(target);
@@ -84,4 +92,8 @@ class TripleRef
 class TargetType
 {
 
+}
+
+class ThreadStaticTarget
+{
 }


### PR DESCRIPTION
**StaticVariables**:  The DATAS feature broke HandleTable walking.  When we downscale the number of GC heaps, this affected the dac's view of the HandleTable, skipping the difference between the number of processors (which is how many subtables were created) and the current GC count.  These used to always be in alignment but now are not.

**ThreadStaticVariables**: ThreadStatics are now handled completely separately from the rest of the code.  We need to update that in the cDac in the runtime, but for now we are able to find the right values and enumerate them.

However, full handle table walking is broken, and likely can't be fixed until .Net 11 releases.

Fixes #1474.