### PR TITLE
Delegate DAC signature verification decision to a predicate

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/DacLibrary.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacLibrary.cs
@@ -31,6 +31,13 @@ namespace Microsoft.Diagnostics.Runtime
             if (dataTarget.ClrVersions.Length == 0)
                 throw new ClrDiagnosticsException("Process is not a CLR process!");
 
+            if (string.IsNullOrEmpty(dacPath))
+                throw new ArgumentNullException(nameof(dacPath));
+
+            // Resolve to a canonical absolute path so the signature-verification override callback and the
+            // load below operate on a full path (callers may pass a relative or non-normalized path).
+            dacPath = Path.GetFullPath(dacPath);
+
             TargetProperties = new TargetProperties(pointerSize: dataTarget.DataReader.PointerSize);
 
             IDisposable? fileLock = null;
@@ -40,7 +47,14 @@ namespace Microsoft.Diagnostics.Runtime
                 // VerifyDacDll uses WinVerifyTrust, which only exists on windows.  For non-windows platforms, we do
                 // not verify signatures of the DAC.  We also do not download DACs from the internet on those platforms,
                 // leaving it up to the consumer of ClrMD to safely procure the DAC.
-                if (verifySignature && RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                // A host can override the verification decision per-DAC via DataTargetOptions.DacSignatureVerificationOverride,
+                // which takes priority over the VerifyDacOnWindows flag (verifySignature) passed down here. This lets a host
+                // trust a DAC it procured securely (e.g. a cDAC bundled in a signed tool package) while verifying others.
+                bool verify = verifySignature;
+                if (dataTarget.Options.DacSignatureVerificationOverride is { } shouldVerify)
+                    verify = shouldVerify(dacPath);
+
+                if (verify && RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 {
                     if (!AuthenticodeUtil.VerifyDacDll(dacPath, out fileLock))
                     {

--- a/src/Microsoft.Diagnostics.Runtime/DataTargetOptions.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DataTargetOptions.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -99,6 +100,14 @@ public class DataTargetOptions
     /// Note that disabling this option can lead to security risks, so it should only be disabled if you understand the implications.
     /// </summary>
     public bool VerifyDacOnWindows { get; init; } = true;
+
+    /// <summary>
+    /// An optional callback that decides, per DAC, whether ClrMD verifies its signature before loading it.
+    /// When non-null this takes priority over <see cref="VerifyDacOnWindows"/>: it is invoked with the full
+    /// (absolute) path of the DAC (or cDAC) ClrMD is about to load and if it returns <see langword="true"/>,
+    /// signature verification is performed; if it returns <see langword="false"/>, verification is skipped.
+    /// </summary>
+    public Func<string, bool>? DacSignatureVerificationOverride { get; init; }
 
     /// <summary>
     /// When true, <see cref="DataTarget.LoadDump(string, DataTargetOptions?)"/> will wrap the underlying


### PR DESCRIPTION
Add a new option on the `DataTargetOptions` to allow hosts to control, on a per-runtime basis, whether ClrMD verifies the signature of a DAC before loading it. This provides more flexibility and security for hosts that may have their own trust mechanisms or need to bypass verification for certain DACs they have procured securely. The override takes priority over `VerifyDacOnWindows`.