### PR TITLE
ClrRuntime: content-based BCL fallback via System.Object's MethodTable

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/ClrRuntime.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrRuntime.cs
@@ -563,6 +563,21 @@ namespace Microsoft.Diagnostics.Runtime
                 domain.Modules = moduleBuilder.MoveOrCopyToImmutable();
             }
 
+            // Content-based BCL fallback
+            if (bcl is null)
+            {
+                IAbstractHeap? heap = GetService<IAbstractHeap>();
+                IAbstractTypeHelpers? typeHelpers = GetService<IAbstractTypeHelpers>();
+                ulong objectMt = heap?.State.ObjectMethodTable ?? 0;
+                if (objectMt != 0
+                    && typeHelpers is not null
+                    && typeHelpers.GetTypeInfo(objectMt, out TypeInfo info)
+                    && info.ModuleAddress != 0)
+                {
+                    modules.TryGetValue(info.ModuleAddress, out bcl);
+                }
+            }
+
             return new(system, shared, builder.MoveOrCopyToImmutable(), modules.Values.ToArray(), bcl);
         }
 


### PR DESCRIPTION
When the existing filename-match heuristic (MSCORLIB / SYSTEM.PRIVATE.CORELIB) doesn't identify a BCL module, fall back to looking up which enumerated module owns System.Object's MethodTable. This is the authoritative answer regardless of how modules are named on disk, and helps any host that vends modules whose names don't match the well-known set (custom IXCLRDataProcess implementations, dump readers that rewrite module paths, runtimes where CoreLib is merged into another image, etc.).

Uses IAbstractHeap.State.ObjectMethodTable + IAbstractTypeHelpers.GetTypeInfo to resolve the owning module address, then looks it up in the just-built modules dictionary. Both APIs are already required for ClrTypeFactory to construct System.Object, so this introduces no new surface area on the IAbstractDac contract.

Layered AFTER the filename-match path so existing hosts continue to hit the cheap O(modules) match and never need to walk the type system.