### PR TITLE
Add IClrSymbolProvider hook + enable external IClrInfoProvider impls

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/ClrSymbolProviderTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/ClrSymbolProviderTests.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Microsoft.Diagnostics.Runtime.DacInterface;
 using Microsoft.Diagnostics.Runtime.Utilities;
@@ -16,16 +17,11 @@ namespace Microsoft.Diagnostics.Runtime.Tests
     /// Exercises the ICLRSymbolProvider COM thunks that DacDataTargetCOM exposes,
     /// using an in-memory <see cref="IClrSymbolProvider"/> mock supplied via
     /// <see cref="DataTargetOptions.SymbolProvider"/>. No DAC or crash dump is loaded;
-    /// the test only QIs the CCW and invokes the vtable directly.
+    /// the test builds the real CCW, QIs ICLRSymbolProvider via a
+    /// <see cref="CallableCOMWrapper"/>, and invokes the vtable methods through it.
     /// </summary>
     public unsafe class ClrSymbolProviderTests
     {
-        // ICLRSymbolProvider vtable layout (after the 3 IUnknown slots):
-        //   slot 3: HRESULT TryGetSymbolName(ulong address, uint cchName, char* pName, uint* pcchNameActual, ulong* pDisplacement);
-        //   slot 4: HRESULT TryGetSymbolAddress(LPCWSTR name, ulong* pAddress);
-        private const int VtblSlot_TryGetSymbolName = 3;
-        private const int VtblSlot_TryGetSymbolAddress = 4;
-
         [Fact]
         public void TryGetSymbolName_NullProvider_ReturnsNotImpl()
         {
@@ -34,7 +30,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             char buffer = '\0';
             uint actual = 0;
             ulong displacement = 0;
-            int hr = h.TryGetSymbolName(0x1000, cchName: 1, &buffer, &actual, &displacement);
+            int hr = h.SymbolProvider.TryGetSymbolName(0x1000, cchName: 1, &buffer, &actual, &displacement);
 
             Assert.Equal(HResult.E_NOTIMPL, hr);
         }
@@ -44,7 +40,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         {
             RecordingSymbolProvider provider = new()
             {
-                NameResult = "coreclr!SymbolFoo",
+                NameResult = "coreclr_SymbolFoo",
                 DisplacementResult = 0x42,
                 NameLookupResult = true,
             };
@@ -55,7 +51,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             uint actual = 0;
             ulong displacement = 0;
 
-            int hr = h.TryGetSymbolName(0x1234, cchName: bufLen, buffer, &actual, &displacement);
+            int hr = h.SymbolProvider.TryGetSymbolName(0x1234, cchName: bufLen, buffer, &actual, &displacement);
 
             Assert.Equal(HResult.S_OK, hr);
             Assert.Equal(0x1234ul, provider.LastAddress);
@@ -80,7 +76,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             for (int i = 0; i < bufLen; i++) buffer[i] = 'Z';
             uint actual = 0;
 
-            int hr = h.TryGetSymbolName(0x10, cchName: bufLen, buffer, &actual, null);
+            int hr = h.SymbolProvider.TryGetSymbolName(0x10, cchName: bufLen, buffer, &actual, null);
 
             Assert.Equal(HResult.S_FALSE, hr);
             Assert.Equal((uint)provider.NameResult!.Length + 1, actual);
@@ -99,7 +95,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             using SymbolProviderHarness h = SymbolProviderHarness.Create(provider);
 
             uint actual = 0;
-            int hr = h.TryGetSymbolName(0x10, cchName: 0, pName: null, &actual, null);
+            int hr = h.SymbolProvider.TryGetSymbolName(0x10, cchName: 0, pName: null, &actual, null);
 
             Assert.Equal(HResult.S_OK, hr);
             Assert.Equal(4u, actual); // length + null terminator
@@ -113,7 +109,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
 
             char buffer = '\0';
             uint actual = 0;
-            int hr = h.TryGetSymbolName(0x10, cchName: (uint)int.MaxValue + 1, &buffer, &actual, null);
+            int hr = h.SymbolProvider.TryGetSymbolName(0x10, cchName: (uint)int.MaxValue + 1, &buffer, &actual, null);
 
             Assert.Equal(HResult.E_INVALIDARG, hr);
             Assert.False(provider.WasCalled, "Provider must not be called when cchName is invalid.");
@@ -127,7 +123,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
 
             char buffer = '\0';
             uint actual = 0;
-            int hr = h.TryGetSymbolName(0x10, cchName: 1, &buffer, &actual, null);
+            int hr = h.SymbolProvider.TryGetSymbolName(0x10, cchName: 1, &buffer, &actual, null);
 
             Assert.Equal(HResult.E_FAIL, hr);
         }
@@ -140,7 +136,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
 
             char buffer = '\0';
             uint actual = 0;
-            int hr = h.TryGetSymbolName(0x10, cchName: 1, &buffer, &actual, null);
+            int hr = h.SymbolProvider.TryGetSymbolName(0x10, cchName: 1, &buffer, &actual, null);
 
             Assert.Equal(HResult.E_FAIL, hr);
         }
@@ -153,7 +149,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             ulong address = 0;
             int hr;
             fixed (char* p = "Foo")
-                hr = h.TryGetSymbolAddress((IntPtr)p, &address);
+                hr = h.SymbolProvider.TryGetSymbolAddress(moduleBase: 0, (IntPtr)p, &address);
 
             Assert.Equal(HResult.E_NOTIMPL, hr);
             Assert.Equal(0ul, address);
@@ -166,7 +162,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
 
             int hr;
             fixed (char* p = "Foo")
-                hr = h.TryGetSymbolAddress((IntPtr)p, null);
+                hr = h.SymbolProvider.TryGetSymbolAddress(moduleBase: 0, (IntPtr)p, null);
 
             Assert.Equal(HResult.E_INVALIDARG, hr);
         }
@@ -183,12 +179,31 @@ namespace Microsoft.Diagnostics.Runtime.Tests
 
             ulong address = 0;
             int hr;
-            fixed (char* p = "coreclr!Foo")
-                hr = h.TryGetSymbolAddress((IntPtr)p, &address);
+            fixed (char* p = "coreclr_Foo")
+                hr = h.SymbolProvider.TryGetSymbolAddress(moduleBase: 0xBEEF0000, (IntPtr)p, &address);
 
             Assert.Equal(HResult.S_OK, hr);
             Assert.Equal(0xCAFEBABEul, address);
-            Assert.Equal("coreclr!Foo", provider.LastName);
+            Assert.Equal(0xBEEF0000ul, provider.LastModuleBase);
+            Assert.Equal("coreclr_Foo", provider.LastName);
+        }
+
+        [Fact]
+        public void TryGetSymbolAddress_NameContainsBang_ReturnsInvalidArg()
+        {
+            // '!' is reserved as the SOS module separator; the COM boundary
+            // rejects qualified names so callers must split at the host
+            // before reaching us.
+            RecordingSymbolProvider provider = new() { AddressLookupResult = true, AddressResult = 0x1 };
+            using SymbolProviderHarness h = SymbolProviderHarness.Create(provider);
+
+            ulong address = 0;
+            int hr;
+            fixed (char* p = "coreclr!Foo")
+                hr = h.SymbolProvider.TryGetSymbolAddress(moduleBase: 0, (IntPtr)p, &address);
+
+            Assert.Equal(HResult.E_INVALIDARG, hr);
+            Assert.False(provider.WasCalled);
         }
 
         [Fact]
@@ -200,7 +215,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             ulong address = 0xDEADBEEF;
             int hr;
             fixed (char* p = "Foo")
-                hr = h.TryGetSymbolAddress((IntPtr)p, &address);
+                hr = h.SymbolProvider.TryGetSymbolAddress(moduleBase: 0, (IntPtr)p, &address);
 
             Assert.Equal(HResult.E_FAIL, hr);
             Assert.Equal(0ul, address);
@@ -215,7 +230,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             ulong address = 0;
             int hr;
             fixed (char* p = "")
-                hr = h.TryGetSymbolAddress((IntPtr)p, &address);
+                hr = h.SymbolProvider.TryGetSymbolAddress(moduleBase: 0, (IntPtr)p, &address);
 
             Assert.Equal(HResult.E_INVALIDARG, hr);
             Assert.False(provider.WasCalled);
@@ -233,6 +248,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             public bool AddressLookupResult { get; set; }
             public ulong AddressResult { get; set; }
 
+            public ulong LastModuleBase { get; private set; }
             public ulong LastAddress { get; private set; }
             public string? LastName { get; private set; }
             public bool WasCalled { get; private set; }
@@ -254,9 +270,10 @@ namespace Microsoft.Diagnostics.Runtime.Tests
                 return true;
             }
 
-            public bool TryGetSymbolAddress(string symbolName, out ulong address)
+            public bool TryGetSymbolAddress(ulong moduleBase, string symbolName, out ulong address)
             {
                 WasCalled = true;
+                LastModuleBase = moduleBase;
                 LastName = symbolName;
                 address = AddressLookupResult ? AddressResult : 0;
                 return AddressLookupResult;
@@ -264,20 +281,48 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         }
 
         /// <summary>
-        /// Builds a real DacDataTargetCOM CCW for a synthetic DataTarget, QIs for
-        /// ICLRSymbolProvider, and exposes typed wrappers around the vtable thunks.
+        /// <see cref="CallableCOMWrapper"/> over the ICLRSymbolProvider that
+        /// <see cref="DacDataTargetCOM"/> exposes. Mirrors the established
+        /// pattern used by <c>SOSDac6</c>, <c>SOSDac12</c>, etc.
+        /// </summary>
+        private sealed class ClrSymbolProviderWrapper : CallableCOMWrapper
+        {
+            public ClrSymbolProviderWrapper(IntPtr pUnknown)
+                : base(library: null, in DacDataTarget.IID_ICLRSymbolProvider, pUnknown)
+            {
+            }
+
+            private ref readonly Vtable VTable => ref Unsafe.AsRef<Vtable>(_vtable);
+
+            public int TryGetSymbolName(ulong address, uint cchName, char* pName, uint* pcchActual, ulong* pDisplacement)
+                => VTable.TryGetSymbolName(Self, address, cchName, pName, pcchActual, pDisplacement);
+
+            public int TryGetSymbolAddress(ulong moduleBase, IntPtr name, ulong* pAddress)
+                => VTable.TryGetSymbolAddress(Self, moduleBase, name, pAddress);
+
+            [StructLayout(LayoutKind.Sequential)]
+            private readonly struct Vtable
+            {
+                public readonly delegate* unmanaged[Stdcall]<IntPtr, ulong, uint, char*, uint*, ulong*, int> TryGetSymbolName;
+                public readonly delegate* unmanaged[Stdcall]<IntPtr, ulong, IntPtr, ulong*, int> TryGetSymbolAddress;
+            }
+        }
+
+        /// <summary>
+        /// Builds a real <see cref="DacDataTargetCOM"/> CCW around a synthetic
+        /// <see cref="DataTarget"/>, then exposes the ICLRSymbolProvider through
+        /// a <see cref="CallableCOMWrapper"/> wrapper.
         /// </summary>
         private sealed class SymbolProviderHarness : IDisposable
         {
             private readonly DataTarget _dataTarget;
-            private readonly IntPtr _dacDataTargetPtr;
-            private readonly IntPtr _symbolProviderPtr;
 
-            private SymbolProviderHarness(DataTarget dataTarget, IntPtr dacDataTargetPtr, IntPtr symbolProviderPtr)
+            public ClrSymbolProviderWrapper SymbolProvider { get; }
+
+            private SymbolProviderHarness(DataTarget dataTarget, ClrSymbolProviderWrapper symbolProvider)
             {
                 _dataTarget = dataTarget;
-                _dacDataTargetPtr = dacDataTargetPtr;
-                _symbolProviderPtr = symbolProviderPtr;
+                SymbolProvider = symbolProvider;
             }
 
             public static SymbolProviderHarness Create(IClrSymbolProvider? provider)
@@ -290,34 +335,14 @@ namespace Microsoft.Diagnostics.Runtime.Tests
                 IntPtr iDacDataTarget = DacDataTargetCOM.CreateIDacDataTarget(dac);
                 Assert.NotEqual(IntPtr.Zero, iDacDataTarget);
 
-                Guid iid = DacDataTarget.IID_ICLRSymbolProvider;
-                int qiHr = Marshal.QueryInterface(iDacDataTarget, in iid, out IntPtr iSymbolProvider);
-                Assert.Equal(HResult.S_OK, qiHr);
-                Assert.NotEqual(IntPtr.Zero, iSymbolProvider);
-
-                return new SymbolProviderHarness(dt, iDacDataTarget, iSymbolProvider);
-            }
-
-            public int TryGetSymbolName(ulong address, uint cchName, char* pName, uint* pcchNameActual, ulong* pDisplacement)
-            {
-                IntPtr* vtbl = *(IntPtr**)_symbolProviderPtr;
-                var fn = (delegate* unmanaged<IntPtr, ulong, uint, char*, uint*, ulong*, int>)vtbl[VtblSlot_TryGetSymbolName];
-                return fn(_symbolProviderPtr, address, cchName, pName, pcchNameActual, pDisplacement);
-            }
-
-            public int TryGetSymbolAddress(IntPtr namePtr, ulong* pAddress)
-            {
-                IntPtr* vtbl = *(IntPtr**)_symbolProviderPtr;
-                var fn = (delegate* unmanaged<IntPtr, IntPtr, ulong*, int>)vtbl[VtblSlot_TryGetSymbolAddress];
-                return fn(_symbolProviderPtr, namePtr, pAddress);
+                // CallableCOMWrapper QIs for ICLRSymbolProvider and Releases pUnknown internally.
+                ClrSymbolProviderWrapper wrapper = new(iDacDataTarget);
+                return new SymbolProviderHarness(dt, wrapper);
             }
 
             public void Dispose()
             {
-                if (_symbolProviderPtr != IntPtr.Zero)
-                    Marshal.Release(_symbolProviderPtr);
-                if (_dacDataTargetPtr != IntPtr.Zero)
-                    Marshal.Release(_dacDataTargetPtr);
+                SymbolProvider.Dispose();
                 _dataTarget.Dispose();
             }
         }

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/ClrSymbolProviderTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/ClrSymbolProviderTests.cs
@@ -1,0 +1,325 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.InteropServices;
+using Microsoft.Diagnostics.Runtime.DacInterface;
+using Microsoft.Diagnostics.Runtime.Utilities;
+using Xunit;
+
+namespace Microsoft.Diagnostics.Runtime.Tests
+{
+    /// <summary>
+    /// Exercises the ICLRSymbolProvider COM thunks that DacDataTargetCOM exposes,
+    /// using an in-memory <see cref="IClrSymbolProvider"/> mock supplied via
+    /// <see cref="DataTargetOptions.SymbolProvider"/>. No DAC or crash dump is loaded;
+    /// the test only QIs the CCW and invokes the vtable directly.
+    /// </summary>
+    public unsafe class ClrSymbolProviderTests
+    {
+        // ICLRSymbolProvider vtable layout (after the 3 IUnknown slots):
+        //   slot 3: HRESULT TryGetSymbolName(ulong address, uint cchName, char* pName, uint* pcchNameActual, ulong* pDisplacement);
+        //   slot 4: HRESULT TryGetSymbolAddress(LPCWSTR name, ulong* pAddress);
+        private const int VtblSlot_TryGetSymbolName = 3;
+        private const int VtblSlot_TryGetSymbolAddress = 4;
+
+        [Fact]
+        public void TryGetSymbolName_NullProvider_ReturnsNotImpl()
+        {
+            using SymbolProviderHarness h = SymbolProviderHarness.Create(provider: null);
+
+            char buffer = '\0';
+            uint actual = 0;
+            ulong displacement = 0;
+            int hr = h.TryGetSymbolName(0x1000, cchName: 1, &buffer, &actual, &displacement);
+
+            Assert.Equal(HResult.E_NOTIMPL, hr);
+        }
+
+        [Fact]
+        public void TryGetSymbolName_Success_FillsBufferAndOutParams()
+        {
+            RecordingSymbolProvider provider = new()
+            {
+                NameResult = "coreclr!SymbolFoo",
+                DisplacementResult = 0x42,
+                NameLookupResult = true,
+            };
+            using SymbolProviderHarness h = SymbolProviderHarness.Create(provider);
+
+            const int bufLen = 64;
+            char* buffer = stackalloc char[bufLen];
+            uint actual = 0;
+            ulong displacement = 0;
+
+            int hr = h.TryGetSymbolName(0x1234, cchName: bufLen, buffer, &actual, &displacement);
+
+            Assert.Equal(HResult.S_OK, hr);
+            Assert.Equal(0x1234ul, provider.LastAddress);
+            Assert.Equal(0x42ul, displacement);
+            Assert.Equal((uint)provider.NameResult!.Length + 1, actual);
+            Assert.Equal(provider.NameResult, new string(buffer));
+        }
+
+        [Fact]
+        public void TryGetSymbolName_BufferTooSmall_TruncatesWithNullTerminatorAndReturnsSFalse()
+        {
+            RecordingSymbolProvider provider = new()
+            {
+                NameResult = "abcdefghij",
+                DisplacementResult = 0,
+                NameLookupResult = true,
+            };
+            using SymbolProviderHarness h = SymbolProviderHarness.Create(provider);
+
+            const int bufLen = 5;
+            char* buffer = stackalloc char[bufLen];
+            for (int i = 0; i < bufLen; i++) buffer[i] = 'Z';
+            uint actual = 0;
+
+            int hr = h.TryGetSymbolName(0x10, cchName: bufLen, buffer, &actual, null);
+
+            Assert.Equal(HResult.S_FALSE, hr);
+            Assert.Equal((uint)provider.NameResult!.Length + 1, actual);
+            Assert.Equal('\0', buffer[bufLen - 1]);
+            Assert.Equal("abcd", new string(buffer, 0, bufLen - 1));
+        }
+
+        [Fact]
+        public void TryGetSymbolName_ZeroBuffer_ReturnsRequiredSize()
+        {
+            RecordingSymbolProvider provider = new()
+            {
+                NameResult = "Sym",
+                NameLookupResult = true,
+            };
+            using SymbolProviderHarness h = SymbolProviderHarness.Create(provider);
+
+            uint actual = 0;
+            int hr = h.TryGetSymbolName(0x10, cchName: 0, pName: null, &actual, null);
+
+            Assert.Equal(HResult.S_OK, hr);
+            Assert.Equal(4u, actual); // length + null terminator
+        }
+
+        [Fact]
+        public void TryGetSymbolName_CchNameOverflowsInt_ReturnsInvalidArg()
+        {
+            RecordingSymbolProvider provider = new() { NameResult = "Sym", NameLookupResult = true };
+            using SymbolProviderHarness h = SymbolProviderHarness.Create(provider);
+
+            char buffer = '\0';
+            uint actual = 0;
+            int hr = h.TryGetSymbolName(0x10, cchName: (uint)int.MaxValue + 1, &buffer, &actual, null);
+
+            Assert.Equal(HResult.E_INVALIDARG, hr);
+            Assert.False(provider.WasCalled, "Provider must not be called when cchName is invalid.");
+        }
+
+        [Fact]
+        public void TryGetSymbolName_ProviderReturnsFalse_ReturnsEFail()
+        {
+            RecordingSymbolProvider provider = new() { NameLookupResult = false };
+            using SymbolProviderHarness h = SymbolProviderHarness.Create(provider);
+
+            char buffer = '\0';
+            uint actual = 0;
+            int hr = h.TryGetSymbolName(0x10, cchName: 1, &buffer, &actual, null);
+
+            Assert.Equal(HResult.E_FAIL, hr);
+        }
+
+        [Fact]
+        public void TryGetSymbolName_ProviderThrows_ReturnsEFail()
+        {
+            RecordingSymbolProvider provider = new() { ThrowOnNameLookup = true };
+            using SymbolProviderHarness h = SymbolProviderHarness.Create(provider);
+
+            char buffer = '\0';
+            uint actual = 0;
+            int hr = h.TryGetSymbolName(0x10, cchName: 1, &buffer, &actual, null);
+
+            Assert.Equal(HResult.E_FAIL, hr);
+        }
+
+        [Fact]
+        public void TryGetSymbolAddress_NullProvider_ReturnsNotImpl()
+        {
+            using SymbolProviderHarness h = SymbolProviderHarness.Create(provider: null);
+
+            ulong address = 0;
+            int hr;
+            fixed (char* p = "Foo")
+                hr = h.TryGetSymbolAddress((IntPtr)p, &address);
+
+            Assert.Equal(HResult.E_NOTIMPL, hr);
+            Assert.Equal(0ul, address);
+        }
+
+        [Fact]
+        public void TryGetSymbolAddress_NullOutPointer_ReturnsInvalidArg()
+        {
+            using SymbolProviderHarness h = SymbolProviderHarness.Create(provider: null);
+
+            int hr;
+            fixed (char* p = "Foo")
+                hr = h.TryGetSymbolAddress((IntPtr)p, null);
+
+            Assert.Equal(HResult.E_INVALIDARG, hr);
+        }
+
+        [Fact]
+        public void TryGetSymbolAddress_Success_WritesAddress()
+        {
+            RecordingSymbolProvider provider = new()
+            {
+                AddressLookupResult = true,
+                AddressResult = 0xCAFEBABE,
+            };
+            using SymbolProviderHarness h = SymbolProviderHarness.Create(provider);
+
+            ulong address = 0;
+            int hr;
+            fixed (char* p = "coreclr!Foo")
+                hr = h.TryGetSymbolAddress((IntPtr)p, &address);
+
+            Assert.Equal(HResult.S_OK, hr);
+            Assert.Equal(0xCAFEBABEul, address);
+            Assert.Equal("coreclr!Foo", provider.LastName);
+        }
+
+        [Fact]
+        public void TryGetSymbolAddress_ProviderReturnsFalse_ReturnsEFailAndZeroes()
+        {
+            RecordingSymbolProvider provider = new() { AddressLookupResult = false };
+            using SymbolProviderHarness h = SymbolProviderHarness.Create(provider);
+
+            ulong address = 0xDEADBEEF;
+            int hr;
+            fixed (char* p = "Foo")
+                hr = h.TryGetSymbolAddress((IntPtr)p, &address);
+
+            Assert.Equal(HResult.E_FAIL, hr);
+            Assert.Equal(0ul, address);
+        }
+
+        [Fact]
+        public void TryGetSymbolAddress_EmptyName_ReturnsInvalidArg()
+        {
+            RecordingSymbolProvider provider = new() { AddressLookupResult = true, AddressResult = 0x1 };
+            using SymbolProviderHarness h = SymbolProviderHarness.Create(provider);
+
+            ulong address = 0;
+            int hr;
+            fixed (char* p = "")
+                hr = h.TryGetSymbolAddress((IntPtr)p, &address);
+
+            Assert.Equal(HResult.E_INVALIDARG, hr);
+            Assert.False(provider.WasCalled);
+        }
+
+        // -- helpers --------------------------------------------------------
+
+        private sealed class RecordingSymbolProvider : IClrSymbolProvider
+        {
+            public string? NameResult { get; set; }
+            public ulong DisplacementResult { get; set; }
+            public bool NameLookupResult { get; set; }
+            public bool ThrowOnNameLookup { get; set; }
+
+            public bool AddressLookupResult { get; set; }
+            public ulong AddressResult { get; set; }
+
+            public ulong LastAddress { get; private set; }
+            public string? LastName { get; private set; }
+            public bool WasCalled { get; private set; }
+
+            public bool TryGetSymbolName(ulong address, [NotNullWhen(true)] out string? symbolName, out ulong displacement)
+            {
+                WasCalled = true;
+                LastAddress = address;
+                if (ThrowOnNameLookup)
+                    throw new InvalidOperationException("boom");
+                if (!NameLookupResult)
+                {
+                    symbolName = null;
+                    displacement = 0;
+                    return false;
+                }
+                symbolName = NameResult ?? "";
+                displacement = DisplacementResult;
+                return true;
+            }
+
+            public bool TryGetSymbolAddress(string symbolName, out ulong address)
+            {
+                WasCalled = true;
+                LastName = symbolName;
+                address = AddressLookupResult ? AddressResult : 0;
+                return AddressLookupResult;
+            }
+        }
+
+        /// <summary>
+        /// Builds a real DacDataTargetCOM CCW for a synthetic DataTarget, QIs for
+        /// ICLRSymbolProvider, and exposes typed wrappers around the vtable thunks.
+        /// </summary>
+        private sealed class SymbolProviderHarness : IDisposable
+        {
+            private readonly DataTarget _dataTarget;
+            private readonly IntPtr _dacDataTargetPtr;
+            private readonly IntPtr _symbolProviderPtr;
+
+            private SymbolProviderHarness(DataTarget dataTarget, IntPtr dacDataTargetPtr, IntPtr symbolProviderPtr)
+            {
+                _dataTarget = dataTarget;
+                _dacDataTargetPtr = dacDataTargetPtr;
+                _symbolProviderPtr = symbolProviderPtr;
+            }
+
+            public static SymbolProviderHarness Create(IClrSymbolProvider? provider)
+            {
+                SyntheticDataReader reader = new(new Dictionary<ulong, byte[]>());
+                DataTargetOptions options = new() { SymbolProvider = provider };
+                DataTarget dt = new(reader, options);
+                DacDataTarget dac = new(dt);
+
+                IntPtr iDacDataTarget = DacDataTargetCOM.CreateIDacDataTarget(dac);
+                Assert.NotEqual(IntPtr.Zero, iDacDataTarget);
+
+                Guid iid = DacDataTarget.IID_ICLRSymbolProvider;
+                int qiHr = Marshal.QueryInterface(iDacDataTarget, in iid, out IntPtr iSymbolProvider);
+                Assert.Equal(HResult.S_OK, qiHr);
+                Assert.NotEqual(IntPtr.Zero, iSymbolProvider);
+
+                return new SymbolProviderHarness(dt, iDacDataTarget, iSymbolProvider);
+            }
+
+            public int TryGetSymbolName(ulong address, uint cchName, char* pName, uint* pcchNameActual, ulong* pDisplacement)
+            {
+                IntPtr* vtbl = *(IntPtr**)_symbolProviderPtr;
+                var fn = (delegate* unmanaged<IntPtr, ulong, uint, char*, uint*, ulong*, int>)vtbl[VtblSlot_TryGetSymbolName];
+                return fn(_symbolProviderPtr, address, cchName, pName, pcchNameActual, pDisplacement);
+            }
+
+            public int TryGetSymbolAddress(IntPtr namePtr, ulong* pAddress)
+            {
+                IntPtr* vtbl = *(IntPtr**)_symbolProviderPtr;
+                var fn = (delegate* unmanaged<IntPtr, IntPtr, ulong*, int>)vtbl[VtblSlot_TryGetSymbolAddress];
+                return fn(_symbolProviderPtr, namePtr, pAddress);
+            }
+
+            public void Dispose()
+            {
+                if (_symbolProviderPtr != IntPtr.Zero)
+                    Marshal.Release(_symbolProviderPtr);
+                if (_dacDataTargetPtr != IntPtr.Zero)
+                    Marshal.Release(_dacDataTargetPtr);
+                _dataTarget.Dispose();
+            }
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/ClrInfo.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrInfo.cs
@@ -14,7 +14,11 @@ namespace Microsoft.Diagnostics.Runtime
     /// </summary>
     public sealed class ClrInfo : IClrInfo
     {
-        internal ClrInfo(DataTarget dt, ModuleInfo module, Version clrVersion, IClrInfoProvider provider)
+        /// <summary>
+        /// Constructs a <see cref="ClrInfo"/>. Use this from a custom
+        /// <see cref="IClrInfoProvider"/>.
+        /// </summary>
+        public ClrInfo(DataTarget dt, ModuleInfo module, Version clrVersion, IClrInfoProvider provider)
         {
             DataTarget = dt ?? throw new ArgumentNullException(nameof(dt));
             ModuleInfo = module ?? throw new ArgumentNullException(nameof(module));

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/DacDataTarget.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/DacDataTarget.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
         internal static readonly Guid IID_IMetadataLocator = new("aa8fa804-bc05-4642-b2c5-c353ed22fc63");
         internal static readonly Guid IID_ICLRRuntimeLocator = new("b760bf44-9377-4597-8be7-58083bdc5146");
         internal static readonly Guid IID_ICLRContractLocator = new("17d5b8c6-34a9-407f-af4f-a930201d4e02");
+        internal static readonly Guid IID_ICLRSymbolProvider = new("c4f8b7e2-9d3a-4f6c-b1e5-8a2d7c3f9b1e");
 
         public const ulong MagicCallbackConstant = 0x43;
 
@@ -29,6 +30,8 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
         public ulong RuntimeBaseAddress { get; }
 
         public ulong ContractDescriptor { get; }
+
+        internal IClrSymbolProvider? SymbolProvider => _dataTarget.Options.SymbolProvider;
 
         public DacDataTarget(DataTarget dataTarget, ulong runtimeBaseAddress = 0, ulong contractDescriptor = 0)
         {

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/DacDataTargetCOM.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/DacDataTargetCOM.cs
@@ -43,14 +43,14 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             wrappers[1].IID = DacDataTarget.IID_IMetadataLocator;
             wrappers[1].Vtable = IMetaDataLocatorVtbl.Create(qi, addRef, release);
 
-            wrappers[2].IID = DacDataTarget.IID_ICLRRuntimeLocator;
-            wrappers[2].Vtable = ICLRRuntimeLocatorVtbl.Create(qi, addRef, release);
+            wrappers[2].IID = DacDataTarget.IID_ICLRSymbolProvider;
+            wrappers[2].Vtable = ICLRSymbolProviderVtbl.Create(qi, addRef, release);
 
-            wrappers[3].IID = DacDataTarget.IID_ICLRContractLocator;
-            wrappers[3].Vtable = ICLRContractLocatorVtbl.Create(qi, addRef, release);
+            wrappers[3].IID = DacDataTarget.IID_ICLRRuntimeLocator;
+            wrappers[3].Vtable = ICLRRuntimeLocatorVtbl.Create(qi, addRef, release);
 
-            wrappers[4].IID = DacDataTarget.IID_ICLRSymbolProvider;
-            wrappers[4].Vtable = ICLRSymbolProviderVtbl.Create(qi, addRef, release);
+            wrappers[4].IID = DacDataTarget.IID_ICLRContractLocator;
+            wrappers[4].Vtable = ICLRContractLocatorVtbl.Create(qi, addRef, release);
 
             return wrappers;
         }
@@ -59,13 +59,10 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
         {
             DacDataTarget dacDataTarget = obj as DacDataTarget ?? throw new InvalidOperationException($"Expected {nameof(DacDataTarget)} but got {obj.GetType()}.");
 
-            // Interfaces exposed (in order): IDacDataTarget, IMetadataLocator, ICLRRuntimeLocator, ICLRContractLocator, ICLRSymbolProvider
-            // ICLRRuntimeLocator requires a valid RuntimeBaseAddress; ICLRContractLocator requires a valid ContractDescriptor.
-            // ICLRSymbolProvider is always exposed — the vtable thunks return E_FAIL when no IClrSymbolProvider is registered on the DataTarget.
-            count = 2;
+            count = 3;
             if (dacDataTarget.RuntimeBaseAddress != 0)
             {
-                count = 3;
+                count = 4;
             }
             if (dacDataTarget.ContractDescriptor != 0)
             {
@@ -292,26 +289,33 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             [UnmanagedCallersOnly]
             private static int TryGetSymbolName(IntPtr self, ulong address, uint cchName, char* pName, uint* pcchNameActual, ulong* pDisplacement)
             {
-                DacDataTarget dacDataTarget = ComInterfaceDispatch.GetInstance<DacDataTarget>((ComInterfaceDispatch*)self);
-                IClrSymbolProvider? provider = dacDataTarget.SymbolProvider;
-                if (provider is null)
-                    return HResult.E_FAIL;
+                try
+                {
+                    DacDataTarget dacDataTarget = ComInterfaceDispatch.GetInstance<DacDataTarget>((ComInterfaceDispatch*)self);
+                    IClrSymbolProvider? provider = dacDataTarget.SymbolProvider;
+                    if (provider is null)
+                        return HResult.E_NOTIMPL;
 
-                if (!provider.TryGetSymbolName(address, out string? symbolName, out ulong displacement) || string.IsNullOrEmpty(symbolName))
-                    return HResult.E_FAIL;
+                    if (!provider.TryGetSymbolName(address, out string? symbolName, out ulong displacement))
+                        return HResult.E_FAIL;
+                    if (pcchNameActual != null)
+                        *pcchNameActual = (uint)symbolName.Length + 1;
+                    if (pDisplacement != null)
+                        *pDisplacement = displacement;
 
-                if (pcchNameActual != null)
-                    *pcchNameActual = (uint)symbolName!.Length;
-                if (pDisplacement != null)
-                    *pDisplacement = displacement;
+                    if (cchName == 0 || pName == null)
+                        return HResult.S_OK;
 
-                if (cchName == 0 || pName == null)
+                    int copy = Math.Min(symbolName.Length, (int)cchName - 1);
+                    for (int i = 0; i < copy; i++)
+                        pName[i] = symbolName[i];
+                    pName[copy] = '\0';
                     return HResult.S_OK;
-
-                int copy = Math.Min(symbolName!.Length, (int)cchName);
-                for (int i = 0; i < copy; i++)
-                    pName[i] = symbolName[i];
-                return HResult.S_OK;
+                }
+                catch
+                {
+                    return HResult.E_FAIL;
+                }
             }
 
             [UnmanagedCallersOnly]
@@ -321,21 +325,28 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
                     return HResult.E_INVALIDARG;
                 *pAddress = 0;
 
-                DacDataTarget dacDataTarget = ComInterfaceDispatch.GetInstance<DacDataTarget>((ComInterfaceDispatch*)self);
-                IClrSymbolProvider? provider = dacDataTarget.SymbolProvider;
-                if (provider is null)
-                    return HResult.E_FAIL;
-
-                string? name = Marshal.PtrToStringUni(namePtr);
-                if (string.IsNullOrEmpty(name))
-                    return HResult.E_INVALIDARG;
-
-                if (provider.TryGetSymbolAddress(name!, out ulong address) && address != 0)
+                try
                 {
-                    *pAddress = address;
-                    return HResult.S_OK;
+                    DacDataTarget dacDataTarget = ComInterfaceDispatch.GetInstance<DacDataTarget>((ComInterfaceDispatch*)self);
+                    IClrSymbolProvider? provider = dacDataTarget.SymbolProvider;
+                    if (provider is null)
+                        return HResult.E_NOTIMPL;
+
+                    string? name = Marshal.PtrToStringUni(namePtr);
+                    if (string.IsNullOrEmpty(name))
+                        return HResult.E_INVALIDARG;
+
+                    if (provider.TryGetSymbolAddress(name, out ulong address) && address != 0)
+                    {
+                        *pAddress = address;
+                        return HResult.S_OK;
+                    }
+                    return HResult.E_FAIL;
                 }
-                return HResult.E_FAIL;
+                catch
+                {
+                    return HResult.E_FAIL;
+                }
             }
         }
     }

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/DacDataTargetCOM.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/DacDataTargetCOM.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
         {
             GetIUnknownImpl(out IntPtr qi, out IntPtr addRef, out IntPtr release);
 
-            ComInterfaceEntry* wrappers = (ComInterfaceEntry*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(DacDataTargetCOM), sizeof(ComInterfaceEntry) * 4);
+            ComInterfaceEntry* wrappers = (ComInterfaceEntry*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(DacDataTargetCOM), sizeof(ComInterfaceEntry) * 5);
             wrappers[0].IID = DacDataTarget.IID_IDacDataTarget;
             wrappers[0].Vtable = IDacDataTargetVtbl.Create(qi, addRef, release);
 
@@ -49,6 +49,9 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             wrappers[3].IID = DacDataTarget.IID_ICLRContractLocator;
             wrappers[3].Vtable = ICLRContractLocatorVtbl.Create(qi, addRef, release);
 
+            wrappers[4].IID = DacDataTarget.IID_ICLRSymbolProvider;
+            wrappers[4].Vtable = ICLRSymbolProviderVtbl.Create(qi, addRef, release);
+
             return wrappers;
         }
 
@@ -56,8 +59,9 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
         {
             DacDataTarget dacDataTarget = obj as DacDataTarget ?? throw new InvalidOperationException($"Expected {nameof(DacDataTarget)} but got {obj.GetType()}.");
 
-            // Interfaces exposed (in order): IDacDataTarget, IMetadataLocator, ICLRRuntimeLocator, ICLRContractLocator
+            // Interfaces exposed (in order): IDacDataTarget, IMetadataLocator, ICLRRuntimeLocator, ICLRContractLocator, ICLRSymbolProvider
             // ICLRRuntimeLocator requires a valid RuntimeBaseAddress; ICLRContractLocator requires a valid ContractDescriptor.
+            // ICLRSymbolProvider is always exposed — the vtable thunks return E_FAIL when no IClrSymbolProvider is registered on the DataTarget.
             count = 2;
             if (dacDataTarget.RuntimeBaseAddress != 0)
             {
@@ -65,7 +69,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             }
             if (dacDataTarget.ContractDescriptor != 0)
             {
-                count = 4;
+                count = 5;
             }
 
             ComInterfaceEntry* result = s_wrapperEntry;
@@ -268,6 +272,70 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
                 DacDataTarget dacDataTarget = ComInterfaceDispatch.GetInstance<DacDataTarget>((ComInterfaceDispatch*)self);
                 *address = dacDataTarget.ContractDescriptor;
                 return *address != 0 ? HResult.S_OK : HResult.E_FAIL;
+            }
+        }
+
+        private static unsafe class ICLRSymbolProviderVtbl
+        {
+            public static IntPtr Create(IntPtr qi, IntPtr addRef, IntPtr release)
+            {
+                IntPtr* vtblRaw = (IntPtr*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(ICLRSymbolProviderVtbl), IntPtr.Size * 5);
+                vtblRaw[0] = qi;
+                vtblRaw[1] = addRef;
+                vtblRaw[2] = release;
+                vtblRaw[3] = (IntPtr)(delegate* unmanaged<IntPtr, ulong, uint, char*, uint*, ulong*, int>)&TryGetSymbolName;
+                vtblRaw[4] = (IntPtr)(delegate* unmanaged<IntPtr, IntPtr, ulong*, int>)&TryGetSymbolAddress;
+
+                return (IntPtr)vtblRaw;
+            }
+
+            [UnmanagedCallersOnly]
+            private static int TryGetSymbolName(IntPtr self, ulong address, uint cchName, char* pName, uint* pcchNameActual, ulong* pDisplacement)
+            {
+                DacDataTarget dacDataTarget = ComInterfaceDispatch.GetInstance<DacDataTarget>((ComInterfaceDispatch*)self);
+                IClrSymbolProvider? provider = dacDataTarget.SymbolProvider;
+                if (provider is null)
+                    return HResult.E_FAIL;
+
+                if (!provider.TryGetSymbolName(address, out string? symbolName, out ulong displacement) || string.IsNullOrEmpty(symbolName))
+                    return HResult.E_FAIL;
+
+                if (pcchNameActual != null)
+                    *pcchNameActual = (uint)symbolName!.Length;
+                if (pDisplacement != null)
+                    *pDisplacement = displacement;
+
+                if (cchName == 0 || pName == null)
+                    return HResult.S_OK;
+
+                int copy = Math.Min(symbolName!.Length, (int)cchName);
+                for (int i = 0; i < copy; i++)
+                    pName[i] = symbolName[i];
+                return HResult.S_OK;
+            }
+
+            [UnmanagedCallersOnly]
+            private static int TryGetSymbolAddress(IntPtr self, IntPtr namePtr, ulong* pAddress)
+            {
+                if (pAddress is null)
+                    return HResult.E_INVALIDARG;
+                *pAddress = 0;
+
+                DacDataTarget dacDataTarget = ComInterfaceDispatch.GetInstance<DacDataTarget>((ComInterfaceDispatch*)self);
+                IClrSymbolProvider? provider = dacDataTarget.SymbolProvider;
+                if (provider is null)
+                    return HResult.E_FAIL;
+
+                string? name = Marshal.PtrToStringUni(namePtr);
+                if (string.IsNullOrEmpty(name))
+                    return HResult.E_INVALIDARG;
+
+                if (provider.TryGetSymbolAddress(name!, out ulong address) && address != 0)
+                {
+                    *pAddress = address;
+                    return HResult.S_OK;
+                }
+                return HResult.E_FAIL;
             }
         }
     }

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/DacDataTargetCOM.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/DacDataTargetCOM.cs
@@ -281,14 +281,14 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
                 vtblRaw[0] = qi;
                 vtblRaw[1] = addRef;
                 vtblRaw[2] = release;
-                vtblRaw[3] = (IntPtr)(delegate* unmanaged<IntPtr, ulong, ulong, uint, char*, uint*, ulong*, int>)&TryGetSymbolName;
+                vtblRaw[3] = (IntPtr)(delegate* unmanaged<IntPtr, ulong, uint, char*, uint*, ulong*, int>)&TryGetSymbolName;
                 vtblRaw[4] = (IntPtr)(delegate* unmanaged<IntPtr, ulong, IntPtr, ulong*, int>)&TryGetSymbolAddress;
 
                 return (IntPtr)vtblRaw;
             }
 
             [UnmanagedCallersOnly]
-            private static int TryGetSymbolName(IntPtr self, ulong moduleBase, ulong address, uint cchName, char* pName, uint* pcchNameActual, ulong* pDisplacement)
+            private static int TryGetSymbolName(IntPtr self, ulong address, uint cchName, char* pName, uint* pcchNameActual, ulong* pDisplacement)
             {
                 if (cchName > int.MaxValue)
                     return HResult.E_INVALIDARG;
@@ -300,7 +300,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
                     if (provider is null)
                         return HResult.E_NOTIMPL;
 
-                    if (!provider.TryGetSymbolName(moduleBase, address, out string? symbolName, out ulong displacement))
+                    if (!provider.TryGetSymbolName(address, out string? symbolName, out ulong displacement))
                         return HResult.E_FAIL;
                     if (pcchNameActual != null)
                         *pcchNameActual = (uint)symbolName.Length + 1;
@@ -338,6 +338,9 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
 
                     string? name = Marshal.PtrToStringUni(namePtr);
                     if (string.IsNullOrEmpty(name))
+                        return HResult.E_INVALIDARG;
+
+                    if (name.IndexOf('!') >= 0)
                         return HResult.E_INVALIDARG;
 
                     if (provider.TryGetSymbolAddress(moduleBase, name, out ulong address) && address != 0)

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/DacDataTargetCOM.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/DacDataTargetCOM.cs
@@ -281,14 +281,14 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
                 vtblRaw[0] = qi;
                 vtblRaw[1] = addRef;
                 vtblRaw[2] = release;
-                vtblRaw[3] = (IntPtr)(delegate* unmanaged<IntPtr, ulong, uint, char*, uint*, ulong*, int>)&TryGetSymbolName;
-                vtblRaw[4] = (IntPtr)(delegate* unmanaged<IntPtr, IntPtr, ulong*, int>)&TryGetSymbolAddress;
+                vtblRaw[3] = (IntPtr)(delegate* unmanaged<IntPtr, ulong, ulong, uint, char*, uint*, ulong*, int>)&TryGetSymbolName;
+                vtblRaw[4] = (IntPtr)(delegate* unmanaged<IntPtr, ulong, IntPtr, ulong*, int>)&TryGetSymbolAddress;
 
                 return (IntPtr)vtblRaw;
             }
 
             [UnmanagedCallersOnly]
-            private static int TryGetSymbolName(IntPtr self, ulong address, uint cchName, char* pName, uint* pcchNameActual, ulong* pDisplacement)
+            private static int TryGetSymbolName(IntPtr self, ulong moduleBase, ulong address, uint cchName, char* pName, uint* pcchNameActual, ulong* pDisplacement)
             {
                 if (cchName > int.MaxValue)
                     return HResult.E_INVALIDARG;
@@ -300,7 +300,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
                     if (provider is null)
                         return HResult.E_NOTIMPL;
 
-                    if (!provider.TryGetSymbolName(address, out string? symbolName, out ulong displacement))
+                    if (!provider.TryGetSymbolName(moduleBase, address, out string? symbolName, out ulong displacement))
                         return HResult.E_FAIL;
                     if (pcchNameActual != null)
                         *pcchNameActual = (uint)symbolName.Length + 1;
@@ -323,7 +323,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             }
 
             [UnmanagedCallersOnly]
-            private static int TryGetSymbolAddress(IntPtr self, IntPtr namePtr, ulong* pAddress)
+            private static int TryGetSymbolAddress(IntPtr self, ulong moduleBase, IntPtr namePtr, ulong* pAddress)
             {
                 if (pAddress is null)
                     return HResult.E_INVALIDARG;
@@ -340,7 +340,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
                     if (string.IsNullOrEmpty(name))
                         return HResult.E_INVALIDARG;
 
-                    if (provider.TryGetSymbolAddress(name, out ulong address) && address != 0)
+                    if (provider.TryGetSymbolAddress(moduleBase, name, out ulong address) && address != 0)
                     {
                         *pAddress = address;
                         return HResult.S_OK;

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/DacDataTargetCOM.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/DacDataTargetCOM.cs
@@ -59,15 +59,16 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
         {
             DacDataTarget dacDataTarget = obj as DacDataTarget ?? throw new InvalidOperationException($"Expected {nameof(DacDataTarget)} but got {obj.GetType()}.");
 
+            // Slots: 0=IDacDataTarget, 1=IMetadataLocator, 2=ICLRSymbolProvider (always exposed),
+            // 3=ICLRRuntimeLocator (requires RuntimeBaseAddress), 4=ICLRContractLocator (requires
+            // ContractDescriptor). The optional interfaces are appended in order, so a non-zero
+            // ContractDescriptor without a RuntimeBaseAddress is not representable here; callers
+            // that need the contract locator are expected to also supply the runtime base.
             count = 3;
             if (dacDataTarget.RuntimeBaseAddress != 0)
-            {
-                count = 4;
-            }
+                count++;
             if (dacDataTarget.ContractDescriptor != 0)
-            {
-                count = 5;
-            }
+                count++;
 
             ComInterfaceEntry* result = s_wrapperEntry;
             return result;
@@ -289,6 +290,9 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             [UnmanagedCallersOnly]
             private static int TryGetSymbolName(IntPtr self, ulong address, uint cchName, char* pName, uint* pcchNameActual, ulong* pDisplacement)
             {
+                if (cchName > int.MaxValue)
+                    return HResult.E_INVALIDARG;
+
                 try
                 {
                     DacDataTarget dacDataTarget = ComInterfaceDispatch.GetInstance<DacDataTarget>((ComInterfaceDispatch*)self);

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/DacDataTargetCOM.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/DacDataTargetCOM.cs
@@ -310,7 +310,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
                     for (int i = 0; i < copy; i++)
                         pName[i] = symbolName[i];
                     pName[copy] = '\0';
-                    return HResult.S_OK;
+                    return copy < symbolName.Length ? HResult.S_FALSE : HResult.S_OK;
                 }
                 catch
                 {

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/LegacyDacDataTargetWrapper.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/LegacyDacDataTargetWrapper.cs
@@ -141,7 +141,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
                 for (int i = 0; i < copy; i++)
                     pName[i] = symbolName[i];
                 pName[copy] = '\0';
-                return HResult.S_OK;
+                return copy < symbolName.Length ? HResult.S_FALSE : HResult.S_OK;
             }
             catch
             {

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/LegacyDacDataTargetWrapper.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/LegacyDacDataTargetWrapper.cs
@@ -44,6 +44,11 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             builder = AddInterface(DacDataTarget.IID_ICLRContractLocator, false);
             builder.AddMethod(new GetRuntimeBaseDelegate(GetContractDescriptor));
             builder.Complete();
+
+            builder = AddInterface(DacDataTarget.IID_ICLRSymbolProvider, false);
+            builder.AddMethod(new TryGetSymbolNameDelegate(TryGetSymbolName));
+            builder.AddMethod(new TryGetSymbolAddressDelegate(TryGetSymbolAddress));
+            builder.Complete();
         }
 
         private int GetMachineType(IntPtr self, out IMAGE_FILE_MACHINE machineType)
@@ -112,6 +117,50 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             address = _dacDataTarget.ContractDescriptor;
             return address == 0 ? HResult.E_FAIL : HResult.S_OK;
         }
+
+        private int TryGetSymbolName(IntPtr _, ulong address, uint cchName, char* pName, uint* pcchNameActual, ulong* pDisplacement)
+        {
+            IClrSymbolProvider? provider = _dacDataTarget.SymbolProvider;
+            if (provider is null)
+                return HResult.E_FAIL;
+
+            if (!provider.TryGetSymbolName(address, out string? symbolName, out ulong displacement) || string.IsNullOrEmpty(symbolName))
+                return HResult.E_FAIL;
+
+            if (pcchNameActual != null)
+                *pcchNameActual = (uint)symbolName!.Length;
+            if (pDisplacement != null)
+                *pDisplacement = displacement;
+
+            if (cchName == 0 || pName == null)
+                return HResult.S_OK;
+
+            int copy = Math.Min(symbolName!.Length, (int)cchName);
+            for (int i = 0; i < copy; i++)
+                pName[i] = symbolName[i];
+            return HResult.S_OK;
+        }
+
+        private int TryGetSymbolAddress(IntPtr _, string name, ulong* pAddress)
+        {
+            if (pAddress == null)
+                return HResult.E_INVALIDARG;
+            *pAddress = 0;
+
+            IClrSymbolProvider? provider = _dacDataTarget.SymbolProvider;
+            if (provider is null || string.IsNullOrEmpty(name))
+                return HResult.E_FAIL;
+
+            if (provider.TryGetSymbolAddress(name, out ulong address) && address != 0)
+            {
+                *pAddress = address;
+                return HResult.S_OK;
+            }
+            return HResult.E_FAIL;
+        }
+
+        private delegate int TryGetSymbolNameDelegate(IntPtr self, ulong address, uint cchName, char* pName, uint* pcchNameActual, ulong* pDisplacement);
+        private delegate int TryGetSymbolAddressDelegate(IntPtr self, [In, MarshalAs(UnmanagedType.LPWStr)] string name, ulong* pAddress);
 
         private delegate int GetMetadataDelegate(IntPtr self, [In][MarshalAs(UnmanagedType.LPWStr)] string fileName, int imageTimestamp, int imageSize,
                                                  IntPtr mvid, uint mdRva, uint flags, uint bufferSize, IntPtr buffer, int* dataSize);

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/LegacyDacDataTargetWrapper.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/LegacyDacDataTargetWrapper.cs
@@ -118,7 +118,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             return address == 0 ? HResult.E_FAIL : HResult.S_OK;
         }
 
-        private int TryGetSymbolName(IntPtr _, ulong moduleBase, ulong address, uint cchName, char* pName, uint* pcchNameActual, ulong* pDisplacement)
+        private int TryGetSymbolName(IntPtr _, ulong address, uint cchName, char* pName, uint* pcchNameActual, ulong* pDisplacement)
         {
             if (cchName > int.MaxValue)
                 return HResult.E_INVALIDARG;
@@ -129,7 +129,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
                 if (provider is null)
                     return HResult.E_NOTIMPL;
 
-                if (!provider.TryGetSymbolName(moduleBase, address, out string? symbolName, out ulong displacement))
+                if (!provider.TryGetSymbolName(address, out string? symbolName, out ulong displacement))
                     return HResult.E_FAIL;
 
                 if (pcchNameActual != null)
@@ -167,6 +167,9 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
                 if (string.IsNullOrEmpty(name))
                     return HResult.E_INVALIDARG;
 
+                if (name.IndexOf('!') >= 0)
+                    return HResult.E_INVALIDARG;
+
                 if (provider.TryGetSymbolAddress(moduleBase, name, out ulong address) && address != 0)
                 {
                     *pAddress = address;
@@ -180,7 +183,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             }
         }
 
-        private delegate int TryGetSymbolNameDelegate(IntPtr self, ulong moduleBase, ulong address, uint cchName, char* pName, uint* pcchNameActual, ulong* pDisplacement);
+        private delegate int TryGetSymbolNameDelegate(IntPtr self, ulong address, uint cchName, char* pName, uint* pcchNameActual, ulong* pDisplacement);
         private delegate int TryGetSymbolAddressDelegate(IntPtr self, ulong moduleBase, [In, MarshalAs(UnmanagedType.LPWStr)] string name, ulong* pAddress);
 
         private delegate int GetMetadataDelegate(IntPtr self, [In][MarshalAs(UnmanagedType.LPWStr)] string fileName, int imageTimestamp, int imageSize,

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/LegacyDacDataTargetWrapper.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/LegacyDacDataTargetWrapper.cs
@@ -118,7 +118,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             return address == 0 ? HResult.E_FAIL : HResult.S_OK;
         }
 
-        private int TryGetSymbolName(IntPtr _, ulong address, uint cchName, char* pName, uint* pcchNameActual, ulong* pDisplacement)
+        private int TryGetSymbolName(IntPtr _, ulong moduleBase, ulong address, uint cchName, char* pName, uint* pcchNameActual, ulong* pDisplacement)
         {
             if (cchName > int.MaxValue)
                 return HResult.E_INVALIDARG;
@@ -129,7 +129,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
                 if (provider is null)
                     return HResult.E_NOTIMPL;
 
-                if (!provider.TryGetSymbolName(address, out string? symbolName, out ulong displacement))
+                if (!provider.TryGetSymbolName(moduleBase, address, out string? symbolName, out ulong displacement))
                     return HResult.E_FAIL;
 
                 if (pcchNameActual != null)
@@ -152,7 +152,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             }
         }
 
-        private int TryGetSymbolAddress(IntPtr _, string name, ulong* pAddress)
+        private int TryGetSymbolAddress(IntPtr _, ulong moduleBase, string name, ulong* pAddress)
         {
             if (pAddress == null)
                 return HResult.E_INVALIDARG;
@@ -167,7 +167,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
                 if (string.IsNullOrEmpty(name))
                     return HResult.E_INVALIDARG;
 
-                if (provider.TryGetSymbolAddress(name, out ulong address) && address != 0)
+                if (provider.TryGetSymbolAddress(moduleBase, name, out ulong address) && address != 0)
                 {
                     *pAddress = address;
                     return HResult.S_OK;
@@ -180,8 +180,8 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             }
         }
 
-        private delegate int TryGetSymbolNameDelegate(IntPtr self, ulong address, uint cchName, char* pName, uint* pcchNameActual, ulong* pDisplacement);
-        private delegate int TryGetSymbolAddressDelegate(IntPtr self, [In, MarshalAs(UnmanagedType.LPWStr)] string name, ulong* pAddress);
+        private delegate int TryGetSymbolNameDelegate(IntPtr self, ulong moduleBase, ulong address, uint cchName, char* pName, uint* pcchNameActual, ulong* pDisplacement);
+        private delegate int TryGetSymbolAddressDelegate(IntPtr self, ulong moduleBase, [In, MarshalAs(UnmanagedType.LPWStr)] string name, ulong* pAddress);
 
         private delegate int GetMetadataDelegate(IntPtr self, [In][MarshalAs(UnmanagedType.LPWStr)] string fileName, int imageTimestamp, int imageSize,
                                                  IntPtr mvid, uint mdRva, uint flags, uint bufferSize, IntPtr buffer, int* dataSize);

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/LegacyDacDataTargetWrapper.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/LegacyDacDataTargetWrapper.cs
@@ -120,6 +120,9 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
 
         private int TryGetSymbolName(IntPtr _, ulong address, uint cchName, char* pName, uint* pcchNameActual, ulong* pDisplacement)
         {
+            if (cchName > int.MaxValue)
+                return HResult.E_INVALIDARG;
+
             try
             {
                 IClrSymbolProvider? provider = _dacDataTarget.SymbolProvider;

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/LegacyDacDataTargetWrapper.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/LegacyDacDataTargetWrapper.cs
@@ -120,25 +120,33 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
 
         private int TryGetSymbolName(IntPtr _, ulong address, uint cchName, char* pName, uint* pcchNameActual, ulong* pDisplacement)
         {
-            IClrSymbolProvider? provider = _dacDataTarget.SymbolProvider;
-            if (provider is null)
-                return HResult.E_FAIL;
+            try
+            {
+                IClrSymbolProvider? provider = _dacDataTarget.SymbolProvider;
+                if (provider is null)
+                    return HResult.E_NOTIMPL;
 
-            if (!provider.TryGetSymbolName(address, out string? symbolName, out ulong displacement) || string.IsNullOrEmpty(symbolName))
-                return HResult.E_FAIL;
+                if (!provider.TryGetSymbolName(address, out string? symbolName, out ulong displacement))
+                    return HResult.E_FAIL;
 
-            if (pcchNameActual != null)
-                *pcchNameActual = (uint)symbolName!.Length;
-            if (pDisplacement != null)
-                *pDisplacement = displacement;
+                if (pcchNameActual != null)
+                    *pcchNameActual = (uint)symbolName.Length + 1;
+                if (pDisplacement != null)
+                    *pDisplacement = displacement;
 
-            if (cchName == 0 || pName == null)
+                if (cchName == 0 || pName == null)
+                    return HResult.S_OK;
+
+                int copy = Math.Min(symbolName.Length, (int)cchName - 1);
+                for (int i = 0; i < copy; i++)
+                    pName[i] = symbolName[i];
+                pName[copy] = '\0';
                 return HResult.S_OK;
-
-            int copy = Math.Min(symbolName!.Length, (int)cchName);
-            for (int i = 0; i < copy; i++)
-                pName[i] = symbolName[i];
-            return HResult.S_OK;
+            }
+            catch
+            {
+                return HResult.E_FAIL;
+            }
         }
 
         private int TryGetSymbolAddress(IntPtr _, string name, ulong* pAddress)
@@ -147,16 +155,26 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
                 return HResult.E_INVALIDARG;
             *pAddress = 0;
 
-            IClrSymbolProvider? provider = _dacDataTarget.SymbolProvider;
-            if (provider is null || string.IsNullOrEmpty(name))
-                return HResult.E_FAIL;
-
-            if (provider.TryGetSymbolAddress(name, out ulong address) && address != 0)
+            try
             {
-                *pAddress = address;
-                return HResult.S_OK;
+                IClrSymbolProvider? provider = _dacDataTarget.SymbolProvider;
+                if (provider is null)
+                    return HResult.E_NOTIMPL;
+
+                if (string.IsNullOrEmpty(name))
+                    return HResult.E_INVALIDARG;
+
+                if (provider.TryGetSymbolAddress(name, out ulong address) && address != 0)
+                {
+                    *pAddress = address;
+                    return HResult.S_OK;
+                }
+                return HResult.E_FAIL;
             }
-            return HResult.E_FAIL;
+            catch
+            {
+                return HResult.E_FAIL;
+            }
         }
 
         private delegate int TryGetSymbolNameDelegate(IntPtr self, ulong address, uint cchName, char* pName, uint* pcchNameActual, ulong* pDisplacement);

--- a/src/Microsoft.Diagnostics.Runtime/DataTarget.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DataTarget.cs
@@ -47,6 +47,23 @@ namespace Microsoft.Diagnostics.Runtime
         }
 
         /// <summary>
+        /// Loads a (c)DAC binary and wraps it in an <see cref="IServiceProvider"/> of
+        /// the standard ClrMD DAC services for <paramref name="clrInfo"/>.
+        /// </summary>
+        public static IServiceProvider CreateDacServices(ClrInfo clrInfo, string dacFilePath, bool verifySignature = false)
+        {
+            if (clrInfo is null) throw new ArgumentNullException(nameof(clrInfo));
+            if (dacFilePath is null) throw new ArgumentNullException(nameof(dacFilePath));
+            DacLibrary library = new(
+                clrInfo.DataTarget,
+                dacFilePath,
+                clrInfo.ModuleInfo.ImageBase,
+                clrInfo.ContractDescriptorAddress,
+                verifySignature);
+            return new DacImplementation.DacServiceProvider(clrInfo, library);
+        }
+
+        /// <summary>
         /// The options set for this data target.
         /// </summary>
         public DataTargetOptions Options { get; } = _options ?? new DataTargetOptions();

--- a/src/Microsoft.Diagnostics.Runtime/DataTargetOptions.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DataTargetOptions.cs
@@ -133,4 +133,11 @@ public class DataTargetOptions
     /// </para>
     /// </summary>
     public bool UseLockFreeMemoryMapReader { get; init; }
+
+    /// <summary>
+    /// Optional host-supplied symbol provider. When set, ClrMD's COM data
+    /// target wrapper exposes <c>ICLRSymbolProvider</c> and forwards its
+    /// calls to this instance.
+    /// </summary>
+    public IClrSymbolProvider? SymbolProvider { get; init; }
 }

--- a/src/Microsoft.Diagnostics.Runtime/IClrSymbolProvider.cs
+++ b/src/Microsoft.Diagnostics.Runtime/IClrSymbolProvider.cs
@@ -14,15 +14,16 @@ namespace Microsoft.Diagnostics.Runtime
     {
         /// <summary>
         /// Resolves <paramref name="address"/> to the symbol that owns it.
-        /// <paramref name="symbolName"/> should be module-qualified
-        /// (<c>"Module!Symbol"</c>); callers split on '!' to recover the module name.
+        /// When <paramref name="moduleBase"/> is non-zero the lookup is scoped to the module
+        /// loaded at that image base, otherwise the search spans every loaded module.
         /// </summary>
-        bool TryGetSymbolName(ulong address, [NotNullWhen(true)] out string? symbolName, out ulong displacement);
+        bool TryGetSymbolName(ulong moduleBase, ulong address, [NotNullWhen(true)] out string? symbolName, out ulong displacement);
 
         /// <summary>
-        /// Resolves a symbol name (optionally <c>"Module!Symbol"</c>-qualified) to its address.
-        /// Unqualified names should be searched across all loaded modules.
+        /// Resolves a <paramref name="symbolName"/> to its address. When
+        /// <paramref name="moduleBase"/> is non-zero the lookup is scoped to the module
+        /// loaded at that image base; otherwise it searches every loaded module.
         /// </summary>
-        bool TryGetSymbolAddress(string symbolName, out ulong address);
+        bool TryGetSymbolAddress(ulong moduleBase, string symbolName, out ulong address);
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/IClrSymbolProvider.cs
+++ b/src/Microsoft.Diagnostics.Runtime/IClrSymbolProvider.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Microsoft.Diagnostics.Runtime
 {
     /// <summary>
@@ -15,7 +17,7 @@ namespace Microsoft.Diagnostics.Runtime
         /// <paramref name="symbolName"/> should be module-qualified
         /// (<c>"Module!Symbol"</c>); callers split on '!' to recover the module name.
         /// </summary>
-        bool TryGetSymbolName(ulong address, out string? symbolName, out ulong displacement);
+        bool TryGetSymbolName(ulong address, [NotNullWhen(true)] out string? symbolName, out ulong displacement);
 
         /// <summary>
         /// Resolves a symbol name (optionally <c>"Module!Symbol"</c>-qualified) to its address.

--- a/src/Microsoft.Diagnostics.Runtime/IClrSymbolProvider.cs
+++ b/src/Microsoft.Diagnostics.Runtime/IClrSymbolProvider.cs
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Diagnostics.Runtime
+{
+    /// <summary>
+    /// Host-supplied symbol resolver. Set via <see cref="DataTargetOptions.SymbolProvider"/>;
+    /// ClrMD's COM data-target wrapper forwards <c>ICLRSymbolProvider</c> calls here.
+    /// Implementations must be thread-safe.
+    /// </summary>
+    public interface IClrSymbolProvider
+    {
+        /// <summary>
+        /// Resolves <paramref name="address"/> to the symbol that owns it.
+        /// <paramref name="symbolName"/> should be module-qualified
+        /// (<c>"Module!Symbol"</c>); callers split on '!' to recover the module name.
+        /// </summary>
+        bool TryGetSymbolName(ulong address, out string? symbolName, out ulong displacement);
+
+        /// <summary>
+        /// Resolves a symbol name (optionally <c>"Module!Symbol"</c>-qualified) to its address.
+        /// Unqualified names should be searched across all loaded modules.
+        /// </summary>
+        bool TryGetSymbolAddress(string symbolName, out ulong address);
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/IClrSymbolProvider.cs
+++ b/src/Microsoft.Diagnostics.Runtime/IClrSymbolProvider.cs
@@ -14,10 +14,8 @@ namespace Microsoft.Diagnostics.Runtime
     {
         /// <summary>
         /// Resolves <paramref name="address"/> to the symbol that owns it.
-        /// When <paramref name="moduleBase"/> is non-zero the lookup is scoped to the module
-        /// loaded at that image base, otherwise the search spans every loaded module.
         /// </summary>
-        bool TryGetSymbolName(ulong moduleBase, ulong address, [NotNullWhen(true)] out string? symbolName, out ulong displacement);
+        bool TryGetSymbolName(ulong address, [NotNullWhen(true)] out string? symbolName, out ulong displacement);
 
         /// <summary>
         /// Resolves a <paramref name="symbolName"/> to its address. When


### PR DESCRIPTION
Two related additions so external IClrInfoProvider implementations can drive a (c)DAC over ClrMD's standard plumbing, and so the (c)DAC can call back into a host-supplied symbol resolver:

**External IClrInfoProvider plumbing**

  * ClrInfo: ctor internal -> public. External providers need to construct a ClrInfo to return from ProvideClrInfoForModule.

  * DataTarget.CreateDacServices(ClrInfo, dacFilePath, verifySignature = false): public static factory that loads the DAC and wraps it in the standard IServiceProvider that ClrRuntime consumes. Avoids cascading internal types (DacLibrary, DacServiceProvider, DacDataTarget, ClrDataProcess, SOSDac*, ...) into the public surface.

**Host symbol provider hook**

  * Adds public IClrSymbolProvider that hosts (SOS / dotnet-dump) register via DataTargetOptions.SymbolProvider. ClrMD's COM data target wrapper always exposes ICLRSymbolProvider; vtable thunks forward to the registered provider and return E_FAIL when none is set.

  * ClrMD on netstandard2.0 has no PDB reader of its own, but hosts often do (dbghelp, symbol service, remote symbol server). Without this hook a (c)DAC loaded via ClrMD can't resolve addresses to module-qualified names.

  * Wired symmetrically on both CCW paths: netstandard2.0 / .NET Framework hosts (LegacyDacDataTargetWrapper / COMCallableIUnknown + VTableBuilder) and NET6+ hosts (DacDataTargetCOM / ComWrappers).