### PR TITLE
Add thread AllocationContexts and TlsSlot

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/ThreadReaderTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/ThreadReaderTests.cs
@@ -7,6 +7,7 @@ using Microsoft.Diagnostics.Runtime.DacInterface;
 using Microsoft.Diagnostics.Runtime.DataReaders.Implementation;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.InteropServices;
 using Xunit;
 
 namespace Microsoft.Diagnostics.Runtime.Tests
@@ -102,7 +103,14 @@ namespace Microsoft.Diagnostics.Runtime.Tests
                 }
             });
 
-            Assert.NotNull(runtime.TlsSlotIndex);
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                Assert.NotNull(runtime.TlsSlotIndex);
+            }
+            else
+            {
+                Assert.Null(runtime.TlsSlotIndex);
+            }
         }
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/ThreadReaderTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/ThreadReaderTests.cs
@@ -75,5 +75,34 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             uint mainThreadId = runtime.GetMainThread().OSThreadId;
             Assert.Equal(mainThreadId, threadReader.EnumerateOSThreadIds().First());
         }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void ThreadAllocationContextAndTlsSlotIndex(bool singleFile)
+        {
+            using DataTarget dt = TestTargets.Types.LoadFullDump(singleFile);
+            using ClrRuntime runtime = dt.ClrVersions.Single().CreateRuntime();
+
+            IAbstractRuntime runtimeService = runtime.GetService<IAbstractRuntime>();
+            Assert.NotNull(runtimeService);
+
+            ClrThreadInfo[] threadInfos = runtimeService.EnumerateThreads(int.MaxValue).ToArray();
+            MemoryRange[] heapAllocationContexts = runtime.Heap.EnumerateAllocationContexts().ToArray();
+            Assert.NotEmpty(heapAllocationContexts);
+
+            Assert.All(runtime.Threads, thread =>
+            {
+                ClrThreadInfo threadInfo = Assert.Single(threadInfos, info => info.Address == thread.Address);
+                Assert.Equal(threadInfo.AllocationContext, thread.AllocationContext);
+
+                if (thread.AllocationContext.Length > 0)
+                {
+                    Assert.Contains(thread.AllocationContext, heapAllocationContexts);
+                }
+            });
+
+            Assert.NotNull(runtime.TlsSlotIndex);
+        }
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/AbstractDac/IAbstractRuntime.cs
+++ b/src/Microsoft.Diagnostics.Runtime/AbstractDac/IAbstractRuntime.cs
@@ -19,6 +19,11 @@ namespace Microsoft.Diagnostics.Runtime.AbstractDac
     /// </summary>
     public interface IAbstractRuntime
     {
+        /// <summary>
+        /// The CLR TLS slot index for this runtime, or null if it is unavailable.
+        /// </summary>
+        uint? TlsSlotIndex { get; }
+
         IEnumerable<ClrThreadInfo> EnumerateThreads(int maxCount);
         IEnumerable<AppDomainInfo> EnumerateAppDomains(int maxCount);
         IEnumerable<ulong> GetModuleList(ulong appDomain, int maxCount);
@@ -61,6 +66,11 @@ namespace Microsoft.Diagnostics.Runtime.AbstractDac
         /// The Windows TEB, if available, 0 otherwise.
         /// </summary>
         public ulong Teb { get; set; }
+
+        /// <summary>
+        /// The allocation context for this thread.
+        /// </summary>
+        public MemoryRange AllocationContext { get; set; }
 
         /// <summary>
         /// The base address range of the stack space for this thread.

--- a/src/Microsoft.Diagnostics.Runtime/ClrRuntime.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrRuntime.cs
@@ -95,6 +95,11 @@ namespace Microsoft.Diagnostics.Runtime
         /// </summary>
         public bool CanFlushData => GetService<IAbstractDacController>() is not null;
 
+        /// <summary>
+        /// Gets the CLR TLS slot index for this runtime, or null if it is unavailable.
+        /// </summary>
+        public uint? TlsSlotIndex => GetDacRuntime().TlsSlotIndex;
+
         internal T? GetService<T>() where T: class => (T?)_services.GetService(typeof(T));
         internal T GetServiceOrThrow<T>() where T : class => (T?)_services.GetService(typeof(T)) ?? throw new NotSupportedException($"This version of ClrMD does not support {typeof(T).FullName}");
 

--- a/src/Microsoft.Diagnostics.Runtime/ClrThread.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrThread.cs
@@ -36,6 +36,7 @@ namespace Microsoft.Diagnostics.Runtime
             LockCount = threadInfo.LockCount;
             StackBase = threadInfo.StackBase;
             StackLimit = threadInfo.StackLimit;
+            AllocationContext = threadInfo.AllocationContext;
             _exceptionInFlight = threadInfo.ExceptionInFlight;
             IsFinalizer = threadInfo.IsFinalizer;
             IsGc = threadInfo.IsGC;
@@ -114,6 +115,12 @@ namespace Microsoft.Diagnostics.Runtime
         /// Gets the limit of the stack for this thread, or 0 if the value could not be obtained.
         /// </summary>
         public ulong StackLimit { get; }
+
+        /// <summary>
+        /// Gets the allocation context for this thread. This range is used by the GC
+        /// for allocation and does not contain valid objects.
+        /// </summary>
+        public MemoryRange AllocationContext { get; }
 
         /// <summary>
         /// Enumerates the GC references (objects) on the stack.

--- a/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacRuntime.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacRuntime.cs
@@ -64,8 +64,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
 
                 lock (_sos.SyncRoot)
                 {
-                    uint result = _sos.GetTlsIndex();
-                    return result != uint.MaxValue ? result : null;
+                    return _sos.TryGetTlsIndex(out uint result) ? result : null;
                 }
             }
         }

--- a/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacRuntime.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacRuntime.cs
@@ -53,6 +53,15 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
                 return _sos.TryGetStressLogAddress(out ClrDataAddress addr) ? addr.ToAddress(_target) : 0;
         }
 
+        public uint? TlsSlotIndex
+        {
+            get
+            {
+                uint result = _sos.GetTlsIndex();
+                return result != uint.MaxValue ? result : null;
+            }
+        }
+
         public IEnumerable<ClrThreadInfo> EnumerateThreads(int maxCount)
         {
             // Materialize entirely under the DAC lock. The IDataReader.ReadPointer
@@ -104,6 +113,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
                     results.Add(new()
                     {
                         Address = threadAddress,
+                        AllocationContext = CreateAllocationContext(threadData),
                         AppDomain = threadData.Domain.ToAddress(_target),
                         ExceptionInFlight = ex,
                         GCMode = threadData.PreemptiveGCDisabled == 0 ? GCMode.Preemptive : GCMode.Cooperative,
@@ -124,6 +134,13 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
             }
 
             return (IEnumerable<ClrThreadInfo>?)results ?? Array.Empty<ClrThreadInfo>();
+        }
+
+        private MemoryRange CreateAllocationContext(in ThreadData threadData)
+        {
+            ulong start = threadData.AllocationContextPointer.ToAddress(_target);
+            ulong end = threadData.AllocationContextLimit.ToAddress(_target);
+            return start <= end ? new MemoryRange(start, end) : default;
         }
 
         public IEnumerable<AppDomainInfo> EnumerateAppDomains(int maxCount)

--- a/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacRuntime.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacRuntime.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
         private readonly SOSDac _sos;
         private readonly ISOSDac13? _sos13;
         private readonly TargetProperties _target;
+        private readonly bool _supportsTlsSlotIndex;
 
         public DacRuntime(ClrInfo clrInfo, ClrDataProcess dac, SOSDac sos, ISOSDac13? sos13, TargetProperties target)
         {
@@ -28,6 +29,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
             _sos = sos;
             _sos13 = sos13;
             _target = target;
+            _supportsTlsSlotIndex = clrInfo.ModuleInfo is PEModuleInfo;
 
             int version = 0;
             // This DAC request runs during lazy service construction (under _serviceLock);
@@ -57,8 +59,14 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
         {
             get
             {
-                uint result = _sos.GetTlsIndex();
-                return result != uint.MaxValue ? result : null;
+                if (!_supportsTlsSlotIndex)
+                    return null;
+
+                lock (_sos.SyncRoot)
+                {
+                    uint result = _sos.GetTlsIndex();
+                    return result != uint.MaxValue ? result : null;
+                }
             }
         }
 

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/SosDac.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/SosDac.cs
@@ -102,13 +102,10 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             }
         }
 
-        public uint GetTlsIndex()
+        public bool TryGetTlsIndex(out uint value)
         {
-            HResult hr = VTable.GetTLSIndex(Self, out uint index);
-            if (hr)
-                return index;
-
-            return uint.MaxValue;
+            HResult hr = VTable.GetTLSIndex(Self, out value);
+            return hr.IsOK;
         }
 
         public ClrDataAddress GetThreadFromThinlockId(uint id)

--- a/src/Microsoft.Diagnostics.Runtime/Interfaces/IClrRuntime.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Interfaces/IClrRuntime.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Diagnostics.Runtime.Interfaces
         IClrAppDomain? SharedDomain { get; }
         IClrAppDomain? SystemDomain { get; }
         ImmutableArray<IClrThread> Threads { get; }
+        uint? TlsSlotIndex { get; }
 
         IEnumerable<ClrNativeHeapInfo> EnumerateClrNativeHeaps();
         IEnumerable<IClrRoot> EnumerateHandles();

--- a/src/Microsoft.Diagnostics.Runtime/Interfaces/IClrThread.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Interfaces/IClrThread.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Diagnostics.Runtime.Interfaces
         ulong StackBase { get; }
         ulong StackLimit { get; }
         ClrThreadState State { get; }
+        MemoryRange AllocationContext { get; }
         bool IsFinalizer { get; }
         bool IsGc { get; }
         IEnumerable<IClrRoot> EnumerateStackRoots();


### PR DESCRIPTION
This pull request introduces support for exposing and testing thread allocation contexts and the CLR TLS slot index in the diagnostics runtime. The changes enhance the ability to inspect per-thread allocation information and the runtime's TLS slot, and add corresponding tests to ensure correctness.

**API and Model Enhancements:**

* Added a `TlsSlotIndex` property to the `IAbstractRuntime`, `IClrRuntime`, and `ClrRuntime` classes/interfaces, allowing clients to retrieve the CLR TLS slot index if available. [[1]](diffhunk://#diff-9da11aeaa7330d9861274ad828fdb7ee56f44f6170171d1b149bcb0388b59585R22-R26) [[2]](diffhunk://#diff-5a41bb0a61808a82d1b257cfacc0fa7c884a8e2821a6002cd410e3ab6254ec84R98-R102) [[3]](diffhunk://#diff-ce81be47e3be62aff2567e39862155e409ede781fa52289108084251535eca10R21)
* Added an `AllocationContext` property to `ClrThreadInfo`, `ClrThread`, and `IClrThread`, enabling access to each thread's allocation context as a `MemoryRange`. [[1]](diffhunk://#diff-9da11aeaa7330d9861274ad828fdb7ee56f44f6170171d1b149bcb0388b59585R70-R74) [[2]](diffhunk://#diff-adb2b7e0197c209886c14f8b4345ca6d9231214ead8f16e20b1c1745246a29e3R39) [[3]](diffhunk://#diff-adb2b7e0197c209886c14f8b4345ca6d9231214ead8f16e20b1c1745246a29e3R119-R124) [[4]](diffhunk://#diff-3ae179c39c6be6e50604db26292921b144e41b187b6ede1760ad3d9962be3111R23)

**Implementation Details:**

* Implemented retrieval of the TLS slot index and allocation context in `DacRuntime`, including a helper method to construct the allocation context from raw thread data. [[1]](diffhunk://#diff-5a6444e30a0da508502c5242304b79b190489ff189de32bc5da453bd6bfa02bdR56-R64) [[2]](diffhunk://#diff-5a6444e30a0da508502c5242304b79b190489ff189de32bc5da453bd6bfa02bdR116) [[3]](diffhunk://#diff-5a6444e30a0da508502c5242304b79b190489ff189de32bc5da453bd6bfa02bdR139-R145)

**Testing:**

* Added a new test `ThreadAllocationContextAndTlsSlotIndex` in `ThreadReaderTests.cs` to verify that allocation contexts and the TLS slot index are correctly exposed and consistent.