### PR TITLE
Enhance StressLog to resolve format strings from module images

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/StressLog/Internal/ModuleImageReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/StressLog/Internal/ModuleImageReader.cs
@@ -101,9 +101,18 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
                 List<ModuleImage> list = new();
                 foreach (ModuleInfo info in _dataTarget.EnumerateModules())
                 {
-                    // Only ELF images are resolved today; that is the
-                    // demonstrated gap (Linux coredumps strip .rodata).
-                    if (info.Kind != ModuleKind.Elf)
+                    // Resolve ELF module images. Some data readers report a
+                    // real ModuleKind; others (notably the dotnet/diagnostics
+                    // IDataReader bridge used by dotnet-dump and SOS) report
+                    // every module as ModuleKind.Unknown. On a Linux target,
+                    // admit Unknown modules too and let ModuleImage validate
+                    // them by attempting an ELF parse: a non-ELF file simply
+                    // yields no bytes. Without this, the on-disk .rodata
+                    // fallback never engages under dotnet-dump and every
+                    // message renders as <unresolved-format>.
+                    bool elfCandidate = info.Kind == ModuleKind.Elf
+                        || (info.Kind == ModuleKind.Unknown && _platform == OSPlatform.Linux);
+                    if (!elfCandidate)
                         continue;
                     if (info.ImageBase == 0 || info.ImageSize <= 0)
                         continue;

--- a/src/Microsoft.Diagnostics.Runtime/StressLog/Internal/ModuleImageReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/StressLog/Internal/ModuleImageReader.cs
@@ -159,7 +159,12 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
                 _info = info;
                 _dataTarget = dataTarget;
                 _platform = platform;
-                ImageEnd = info.ImageBase + (ulong)info.ImageSize;
+
+                // Saturate rather than wrap: a corrupt reader can report an
+                // ImageSize that pushes ImageBase + ImageSize past ulong.MaxValue,
+                // which would make ImageEnd < ImageBase and silently hide the module.
+                ulong size = (ulong)info.ImageSize;
+                ImageEnd = info.ImageBase > ulong.MaxValue - size ? ulong.MaxValue : info.ImageBase + size;
             }
 
             public ulong ImageBase => _info.ImageBase;
@@ -194,10 +199,19 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
                     {
                         if (ph.Type != ElfProgramHeaderType.Load || ph.FileSize == 0)
                             continue;
+
+                        // Guard against ulong wrap from a corrupt/hostile header
+                        // before using the segment's vaddr range.
+                        if (ph.FileSize > ulong.MaxValue - ph.VirtualAddress)
+                            continue;
                         if (fileVaddr < ph.VirtualAddress || fileVaddr >= ph.VirtualAddress + ph.FileSize)
                             continue;
 
                         ulong segmentOffset = fileVaddr - ph.VirtualAddress;
+
+                        // Guard against ulong wrap when translating to a file offset.
+                        if (segmentOffset > ulong.MaxValue - ph.FileOffset)
+                            return 0;
                         ulong fileOffset = ph.FileOffset + segmentOffset;
 
                         // Do not read past this segment's file-backed bytes.
@@ -208,8 +222,11 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
                         return elf.Reader.ReadBytes(fileOffset, buffer.Slice(0, toRead));
                     }
                 }
-                catch (IOException)
+                catch (Exception ex) when (ex is IOException or InvalidDataException or OverflowException or ArgumentException)
                 {
+                    // A corrupt or hostile module image (e.g. lazy program-header
+                    // parsing throws InvalidDataException, or out-of-range offsets)
+                    // must degrade to <unresolved-format>, never crash enumeration.
                     return 0;
                 }
 
@@ -258,13 +275,14 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
 
             private string? LocateFile()
             {
-                // The path recorded in the dump, if it happens to resolve on
-                // this machine (e.g. analyzing a dump on the box that made it).
-                if (!string.IsNullOrEmpty(_info.FileName) && File.Exists(_info.FileName))
-                    return _info.FileName;
-
-                // Otherwise locate the binary by its build id through the
-                // configured file locator (symbol server / local cache).
+                // The module path recorded in the dump is untrusted input: a
+                // crafted dump could point it at a UNC share (triggering an
+                // outbound SMB authentication / NTLM-hash leak when probed) or at
+                // an arbitrary local file. We therefore never open the recorded
+                // path directly. Instead, locate the binary by its build id
+                // through the configured file locator (symbol server / local
+                // cache), which keys on the file's base name plus build id rather
+                // than the dump-supplied path.
                 IFileLocator? locator = _dataTarget.FileLocator;
                 if (locator is null || _info.BuildId.IsDefaultOrEmpty)
                     return null;

--- a/src/Microsoft.Diagnostics.Runtime/StressLog/Internal/ModuleImageReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/StressLog/Internal/ModuleImageReader.cs
@@ -1,0 +1,270 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.InteropServices;
+using Microsoft.Diagnostics.Runtime.Utilities;
+
+namespace Microsoft.Diagnostics.Runtime.StressLogs.Internal
+{
+    /// <summary>
+    /// An <see cref="IMemoryReader"/> that satisfies reads from dump memory
+    /// first and, when the dump does not back the requested range, falls back
+    /// to the on-disk image of the module that contains the address.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// ELF coredumps (and Windows minidumps) routinely omit file-backed,
+    /// read-only pages such as a module's <c>.rodata</c> section, since those
+    /// bytes can be recovered from the binary on disk. Stress log format
+    /// strings live in <c>.rodata</c>, so without this fallback every message
+    /// renders as <c>&lt;unresolved-format&gt;</c> on a typical Linux dump. SOS
+    /// gets this for free because dbgeng's <c>ReadVirtual</c> transparently
+    /// maps loaded module images into the target's address space.
+    /// </para>
+    /// <para>
+    /// The fallback is read-only and engages only when the dump read does not
+    /// fully satisfy the request and the address falls inside a known module's
+    /// image. Structural reads (chunk buffers, thread headers, heap-resident
+    /// argument strings) are backed by the dump and never reach the fallback,
+    /// so this cannot mask a genuinely missing region of the log. Today only
+    /// ELF modules are resolved; other module kinds fall through to the
+    /// primary reader's result.
+    /// </para>
+    /// </remarks>
+    internal sealed class ModuleImageReader : CommonMemoryReader, IDisposable
+    {
+        private readonly IMemoryReader _primary;
+        private readonly DataTarget _dataTarget;
+        private readonly OSPlatform _platform;
+        private readonly object _gate = new();
+
+        private ModuleImage[]? _modules;
+        private bool _disposed;
+
+        public ModuleImageReader(IMemoryReader primary, DataTarget dataTarget)
+        {
+            _primary = primary ?? throw new ArgumentNullException(nameof(primary));
+            _dataTarget = dataTarget ?? throw new ArgumentNullException(nameof(dataTarget));
+            _platform = dataTarget.DataReader.TargetPlatform;
+        }
+
+        public override int PointerSize => _primary.PointerSize;
+
+        public override int Read(ulong address, Span<byte> buffer)
+        {
+            int got = _primary.Read(address, buffer);
+            if (got == buffer.Length || buffer.Length == 0)
+                return got;
+
+            // The dump did not fully back this range. If the address lies
+            // inside a module's image, recover the bytes from the binary on
+            // disk; otherwise keep whatever the dump returned.
+            int fromImage = TryReadFromModuleImage(address, buffer);
+            return fromImage > got ? fromImage : got;
+        }
+
+        private int TryReadFromModuleImage(ulong address, Span<byte> buffer)
+        {
+            ModuleImage? module = FindModule(address);
+            return module is null ? 0 : module.Read(address, buffer);
+        }
+
+        private ModuleImage? FindModule(ulong address)
+        {
+            ModuleImage[] modules = EnsureModules();
+
+            // Module counts are small (tens), so a linear scan is fine and
+            // avoids the bookkeeping of keeping the list sorted.
+            foreach (ModuleImage module in modules)
+            {
+                if (address >= module.ImageBase && address < module.ImageEnd)
+                    return module;
+            }
+
+            return null;
+        }
+
+        private ModuleImage[] EnsureModules()
+        {
+            ModuleImage[]? modules = _modules;
+            if (modules is not null)
+                return modules;
+
+            lock (_gate)
+            {
+                if (_modules is not null)
+                    return _modules;
+
+                List<ModuleImage> list = new();
+                foreach (ModuleInfo info in _dataTarget.EnumerateModules())
+                {
+                    // Only ELF images are resolved today; that is the
+                    // demonstrated gap (Linux coredumps strip .rodata).
+                    if (info.Kind != ModuleKind.Elf)
+                        continue;
+                    if (info.ImageBase == 0 || info.ImageSize <= 0)
+                        continue;
+
+                    list.Add(new ModuleImage(info, _dataTarget, _platform));
+                }
+
+                _modules = list.ToArray();
+                return _modules;
+            }
+        }
+
+        public void Dispose()
+        {
+            if (_disposed)
+                return;
+            _disposed = true;
+
+            ModuleImage[]? modules = _modules;
+            if (modules is not null)
+            {
+                foreach (ModuleImage module in modules)
+                    module.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// A single module whose on-disk image can be read by virtual address.
+        /// The backing <see cref="ElfFile"/> is opened lazily on first use and
+        /// reused for subsequent reads.
+        /// </summary>
+        private sealed class ModuleImage : IDisposable
+        {
+            private readonly ModuleInfo _info;
+            private readonly DataTarget _dataTarget;
+            private readonly OSPlatform _platform;
+            private readonly object _gate = new();
+
+            private ElfFile? _elf;
+            private bool _resolved;
+
+            public ModuleImage(ModuleInfo info, DataTarget dataTarget, OSPlatform platform)
+            {
+                _info = info;
+                _dataTarget = dataTarget;
+                _platform = platform;
+                ImageEnd = info.ImageBase + (ulong)info.ImageSize;
+            }
+
+            public ulong ImageBase => _info.ImageBase;
+
+            public ulong ImageEnd { get; }
+
+            public int Read(ulong address, Span<byte> buffer)
+            {
+                ElfFile? elf = EnsureElf();
+                if (elf is null)
+                    return 0;
+
+                // The module is loaded at ImageBase. A runtime address maps to
+                // the file's own virtual-address space by subtracting the load
+                // base; for shared objects the lowest p_vaddr is 0, so this is
+                // simply (address - ImageBase).
+                //
+                // We translate that file virtual address to a file offset by
+                // walking the PT_LOAD program headers ourselves rather than
+                // going through ElfFile.VirtualAddressReader. The shared
+                // ElfVirtualAddressSpace locates segments with a binary search
+                // that assumes non-overlapping, vaddr-sorted segments; a module
+                // image nests smaller headers (PT_PHDR, PT_NOTE, ...) inside the
+                // first large PT_LOAD, so that search can step past the
+                // enclosing segment and fail to find it. Coredumps never hit
+                // this because their PT_LOADs do not overlap.
+                ulong fileVaddr = address - _info.ImageBase;
+
+                try
+                {
+                    foreach (ElfProgramHeader ph in elf.ProgramHeaders)
+                    {
+                        if (ph.Type != ElfProgramHeaderType.Load || ph.FileSize == 0)
+                            continue;
+                        if (fileVaddr < ph.VirtualAddress || fileVaddr >= ph.VirtualAddress + ph.FileSize)
+                            continue;
+
+                        ulong segmentOffset = fileVaddr - ph.VirtualAddress;
+                        ulong fileOffset = ph.FileOffset + segmentOffset;
+
+                        // Do not read past this segment's file-backed bytes.
+                        int toRead = (int)Math.Min((ulong)buffer.Length, ph.FileSize - segmentOffset);
+                        if (toRead <= 0)
+                            return 0;
+
+                        return elf.Reader.ReadBytes(fileOffset, buffer.Slice(0, toRead));
+                    }
+                }
+                catch (IOException)
+                {
+                    return 0;
+                }
+
+                return 0;
+            }
+
+            private ElfFile? EnsureElf()
+            {
+                if (_resolved)
+                    return _elf;
+
+                lock (_gate)
+                {
+                    if (_resolved)
+                        return _elf;
+
+                    _elf = TryOpenElf();
+                    _resolved = true;
+                    return _elf;
+                }
+            }
+
+            private ElfFile? TryOpenElf()
+            {
+                string? path = LocateFile();
+                if (path is null)
+                    return null;
+
+                try
+                {
+                    return new ElfFile(path);
+                }
+                catch (IOException)
+                {
+                    return null;
+                }
+                catch (UnauthorizedAccessException)
+                {
+                    return null;
+                }
+                catch (InvalidDataException)
+                {
+                    return null;
+                }
+            }
+
+            private string? LocateFile()
+            {
+                // The path recorded in the dump, if it happens to resolve on
+                // this machine (e.g. analyzing a dump on the box that made it).
+                if (!string.IsNullOrEmpty(_info.FileName) && File.Exists(_info.FileName))
+                    return _info.FileName;
+
+                // Otherwise locate the binary by its build id through the
+                // configured file locator (symbol server / local cache).
+                IFileLocator? locator = _dataTarget.FileLocator;
+                if (locator is null || _info.BuildId.IsDefaultOrEmpty)
+                    return null;
+
+                string? found = locator.FindPEImage(_info.FileName, SymbolProperties.Self, _info.BuildId, _platform, checkProperties: false);
+                return !string.IsNullOrEmpty(found) && File.Exists(found) ? found : null;
+            }
+
+            public void Dispose() => _elf?.Dispose();
+        }
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/StressLog/StressLog.cs
+++ b/src/Microsoft.Diagnostics.Runtime/StressLog/StressLog.cs
@@ -183,12 +183,30 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs
                 return false;
             }
 
-            // Stress log format strings live in a module's read-only data,
-            // which Linux coredumps (and minidumps) frequently strip out. Wrap
-            // the dump reader so format-string and string-argument reads can
-            // fall back to the module image on disk; without this, every
-            // message would render as "<unresolved-format>".
-            DataTarget dataTarget = runtime.DataTarget;
+            return TryOpen(runtime.DataTarget, address, out stressLog, out failureReason);
+        }
+
+        /// <summary>
+        /// Open the stress log located at <paramref name="address"/> in the given
+        /// <paramref name="dataTarget"/>. Unlike the <see cref="IDataReader"/>
+        /// overload, this wires up an on-disk module-image fallback so that
+        /// format strings and <c>%s</c>/<c>%S</c> argument strings living in a
+        /// module's read-only data can be recovered when the dump itself strips
+        /// those file-backed pages (common for Linux coredumps and minidumps);
+        /// without it every message would render as <c>&lt;unresolved-format&gt;</c>.
+        /// The returned <see cref="StressLog"/> owns the fallback reader and
+        /// releases it on <see cref="Dispose"/>.
+        /// </summary>
+        public static bool TryOpen(DataTarget dataTarget, ulong address, out StressLog? stressLog, out string? failureReason)
+        {
+            stressLog = null;
+            failureReason = null;
+            if (dataTarget is null)
+            {
+                failureReason = "DataTarget is null.";
+                return false;
+            }
+
             ModuleImageReader formatReader = new(dataTarget.DataReader, dataTarget);
             if (!TryOpen(dataTarget.DataReader, address, formatReader, out stressLog, out failureReason))
             {

--- a/src/Microsoft.Diagnostics.Runtime/StressLog/StressLog.cs
+++ b/src/Microsoft.Diagnostics.Runtime/StressLog/StressLog.cs
@@ -37,6 +37,7 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs
     public sealed class StressLog : IDisposable
     {
         private readonly IDataReader _reader;
+        private readonly IMemoryReader _formatReader;
         private readonly StressLogLayout _layout;
         private readonly StressLogOptions _options;
         private readonly AllocationBudget _budget;
@@ -58,6 +59,7 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs
         private bool _disposed;
 
         private StressLog(IDataReader reader,
+                          IMemoryReader? formatReader,
                           StressLogLayout layout,
                           StressLogOptions options,
                           AllocationBudget budget,
@@ -75,6 +77,7 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs
                           int? chunkCount)
         {
             _reader = reader;
+            _formatReader = formatReader ?? reader;
             _layout = layout;
             _options = options;
             _budget = budget;
@@ -90,7 +93,7 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs
             _maxSizePerThread = maxSizePerThread;
             _maxSizeTotal = maxSizeTotal;
             _chunkCount = chunkCount;
-            _formatCache = new FormatStringCache(reader, budget, options.MaxFormatStringLength, options.MaxFormatStringCacheEntries);
+            _formatCache = new FormatStringCache(_formatReader, budget, options.MaxFormatStringLength, options.MaxFormatStringCacheEntries);
         }
 
         /// <summary>
@@ -180,7 +183,20 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs
                 return false;
             }
 
-            return TryOpen(runtime.DataTarget.DataReader, address, out stressLog, out failureReason);
+            // Stress log format strings live in a module's read-only data,
+            // which Linux coredumps (and minidumps) frequently strip out. Wrap
+            // the dump reader so format-string and string-argument reads can
+            // fall back to the module image on disk; without this, every
+            // message would render as "<unresolved-format>".
+            DataTarget dataTarget = runtime.DataTarget;
+            ModuleImageReader formatReader = new(dataTarget.DataReader, dataTarget);
+            if (!TryOpen(dataTarget.DataReader, address, formatReader, out stressLog, out failureReason))
+            {
+                formatReader.Dispose();
+                return false;
+            }
+
+            return true;
         }
 
         /// <summary>
@@ -193,6 +209,16 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs
         /// <see cref="StressLog"/> is owned by the caller and must be disposed.
         /// </summary>
         public static bool TryOpen(IDataReader reader, ulong address, out StressLog? stressLog, out string? failureReason)
+            => TryOpen(reader, address, formatReader: null, out stressLog, out failureReason);
+
+        /// <summary>
+        /// Open the stress log, optionally supplying a <paramref name="formatReader"/>
+        /// used to recover format-string and string-argument bytes (for example
+        /// a reader that falls back to module images on disk). When
+        /// <paramref name="formatReader"/> is <see langword="null"/> the dump
+        /// <paramref name="reader"/> is used for those reads as well.
+        /// </summary>
+        internal static bool TryOpen(IDataReader reader, ulong address, IMemoryReader? formatReader, out StressLog? stressLog, out string? failureReason)
         {
             stressLog = null;
             failureReason = null;
@@ -262,11 +288,11 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs
 
             if (isMemoryMapped)
             {
-                stressLog = OpenMemoryMapped(reader, layout, options, budget, header);
+                stressLog = OpenMemoryMapped(reader, formatReader, layout, options, budget, header);
             }
             else
             {
-                stressLog = OpenInProcess(reader, layout, options, budget, header.Slice(0, layout.InProcHeaderSize));
+                stressLog = OpenInProcess(reader, formatReader, layout, options, budget, header.Slice(0, layout.InProcHeaderSize));
             }
 
             if (stressLog is null)
@@ -278,6 +304,7 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs
         }
 
         private static StressLog? OpenInProcess(IDataReader reader,
+                                                IMemoryReader? formatReader,
                                                 StressLogLayout layout,
                                                 StressLogOptions options,
                                                 AllocationBudget budget,
@@ -351,11 +378,12 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs
             // module table in CoreCLR; Framework V1 predates it and uses V3.
             bool isV4 = variant == StressLogVariant.Core;
 
-            return new StressLog(reader, layout, options, budget, modules, logs, tickFreq, startTs, startTimeUtc, isV4: isV4, variant: variant,
+            return new StressLog(reader, formatReader, layout, options, budget, modules, logs, tickFreq, startTs, startTimeUtc, isV4: isV4, variant: variant,
                 facilitiesToLog: facilitiesToLog, levelToLog: levelToLog, maxSizePerThread: maxSizePerThread, maxSizeTotal: maxSizeTotal, chunkCount: chunkCount);
         }
 
         private static StressLog? OpenMemoryMapped(IDataReader reader,
+                                                   IMemoryReader? formatReader,
                                                    StressLogLayout layout,
                                                    StressLogOptions options,
                                                    AllocationBudget budget,
@@ -381,7 +409,7 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs
 
             StressLogModuleTable modules = StressLogModuleTable.BuildMemoryMapped(layout, entries, maxOffset);
 
-            return new StressLog(reader, layout, options, budget, modules, logs, tickFreq, startTs, startTimeUtc: null, isV4: true, variant: StressLogVariant.Core,
+            return new StressLog(reader, formatReader, layout, options, budget, modules, logs, tickFreq, startTs, startTimeUtc: null, isV4: true, variant: StressLogVariant.Core,
                 facilitiesToLog: null, levelToLog: null, maxSizePerThread: null, maxSizeTotal: null, chunkCount: null);
         }
 
@@ -535,7 +563,7 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs
 
             // Each enumeration owns its own context so concurrent foreach loops
             // do not clobber each other's argument scratch / current iterator.
-            ArgumentResolver argResolver = new ArgumentResolver(_reader, _options.MaxStringArgumentLength, _layout.PointerSize);
+            ArgumentResolver argResolver = new ArgumentResolver(_formatReader, _options.MaxStringArgumentLength, _layout.PointerSize);
             StressLogEnumerationContext context = new StressLogEnumerationContext(this, argResolver);
 
             List<ThreadIterator> iterators = new();
@@ -709,6 +737,12 @@ namespace Microsoft.Diagnostics.Runtime.StressLogs
         {
             if (_disposed) return;
             _disposed = true;
+
+            // Dispose a format reader we own (the module-image fallback wraps
+            // the dump reader but holds its own ElfFile handles). The dump
+            // reader itself is owned by the DataTarget, so we never dispose it.
+            if (!ReferenceEquals(_formatReader, _reader) && _formatReader is IDisposable disposable)
+                disposable.Dispose();
         }
     }
 }


### PR DESCRIPTION
This pull request adds support for recovering stress log format strings and string arguments from module images on disk when they are missing from memory dumps, which is common in Linux coredumps and Windows minidumps. The main change is the introduction of a fallback memory reader that attempts to read missing data from ELF module files, ensuring that log messages are properly rendered instead of showing unresolved formats. The changes also ensure proper resource management by disposing of the fallback reader when the stress log is disposed.

**Stress log memory reading improvements:**

* Added a new `ModuleImageReader` class in `ModuleImageReader.cs` that implements an `IMemoryReader` capable of reading from both dump memory and, as a fallback, from on-disk ELF module images when format strings or string arguments are missing from the dump. This addresses the issue of missing `.rodata` sections in typical Linux and minidump files, allowing proper log message resolution.

* Updated `StressLog` to optionally use an `IMemoryReader` (the new fallback reader) for format strings, instead of always using the dump's `IDataReader`. This includes changes to the constructor, fields, and methods to accept and use the fallback reader where appropriate. [[1]](diffhunk://#diff-4eb448cff27aca71a5ad6ca9b12a7a049fdb0468af20d3c3862b661725a0255aR40) [[2]](diffhunk://#diff-4eb448cff27aca71a5ad6ca9b12a7a049fdb0468af20d3c3862b661725a0255aR62) [[3]](diffhunk://#diff-4eb448cff27aca71a5ad6ca9b12a7a049fdb0468af20d3c3862b661725a0255aR80) [[4]](diffhunk://#diff-4eb448cff27aca71a5ad6ca9b12a7a049fdb0468af20d3c3862b661725a0255aL93-R96) [[5]](diffhunk://#diff-4eb448cff27aca71a5ad6ca9b12a7a049fdb0468af20d3c3862b661725a0255aL538-R584)

**API and resource management enhancements:**

* Added a new overload for `StressLog.TryOpen` that accepts a `DataTarget` and wires up the module-image fallback reader automatically, ensuring that format strings can be recovered from disk when missing in the dump. The fallback reader is disposed when the `StressLog` is disposed. [[1]](diffhunk://#diff-4eb448cff27aca71a5ad6ca9b12a7a049fdb0468af20d3c3862b661725a0255aL183-R217) [[2]](diffhunk://#diff-4eb448cff27aca71a5ad6ca9b12a7a049fdb0468af20d3c3862b661725a0255aR230-R239) [[3]](diffhunk://#diff-4eb448cff27aca71a5ad6ca9b12a7a049fdb0468af20d3c3862b661725a0255aR758-R763)

* Refactored internal logic for opening stress logs (`OpenInProcess`, `OpenMemoryMapped`) to accept and propagate the optional fallback reader, ensuring that all code paths can benefit from the improved format string recovery. [[1]](diffhunk://#diff-4eb448cff27aca71a5ad6ca9b12a7a049fdb0468af20d3c3862b661725a0255aL265-R313) [[2]](diffhunk://#diff-4eb448cff27aca71a5ad6ca9b12a7a049fdb0468af20d3c3862b661725a0255aR325) [[3]](diffhunk://#diff-4eb448cff27aca71a5ad6ca9b12a7a049fdb0468af20d3c3862b661725a0255aL354-R404) [[4]](diffhunk://#diff-4eb448cff27aca71a5ad6ca9b12a7a049fdb0468af20d3c3862b661725a0255aL384-R430)