### PR TITLE
ICLRSymbolProvider: add TryGetFieldOffset for type-field resolution

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/ClrSymbolProviderTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/ClrSymbolProviderTests.cs
@@ -236,6 +236,85 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             Assert.False(provider.WasCalled);
         }
 
+        [Fact]
+        public void TryGetFieldOffset_NullProvider_ReturnsNotImpl()
+        {
+            using SymbolProviderHarness h = SymbolProviderHarness.Create(provider: null);
+
+            uint offset = 0xdead;
+            int hr;
+            fixed (char* t = "S_P_CoreLib_System_Exception")
+            fixed (char* f = "_message")
+                hr = h.SymbolProvider.TryGetFieldOffset(moduleBase: 0, (IntPtr)t, (IntPtr)f, &offset);
+
+            Assert.Equal(HResult.E_NOTIMPL, hr);
+        }
+
+        [Fact]
+        public void TryGetFieldOffset_NullOutPointer_ReturnsInvalidArg()
+        {
+            RecordingSymbolProvider provider = new() { FieldLookupResult = true, FieldOffsetResult = 8 };
+            using SymbolProviderHarness h = SymbolProviderHarness.Create(provider);
+
+            int hr;
+            fixed (char* t = "S_P_CoreLib_System_Exception")
+            fixed (char* f = "_message")
+                hr = h.SymbolProvider.TryGetFieldOffset(moduleBase: 0, (IntPtr)t, (IntPtr)f, null);
+
+            Assert.Equal(HResult.E_INVALIDARG, hr);
+        }
+
+        [Fact]
+        public void TryGetFieldOffset_Success_WritesOffsetAndForwardsArgs()
+        {
+            RecordingSymbolProvider provider = new() { FieldLookupResult = true, FieldOffsetResult = 0x18 };
+            using SymbolProviderHarness h = SymbolProviderHarness.Create(provider);
+
+            uint offset = 0;
+            int hr;
+            fixed (char* t = "S_P_CoreLib_System_Exception")
+            fixed (char* f = "_innerException")
+                hr = h.SymbolProvider.TryGetFieldOffset(moduleBase: 0xBEEF0000, (IntPtr)t, (IntPtr)f, &offset);
+
+            Assert.Equal(HResult.S_OK, hr);
+            Assert.Equal(0x18u, offset);
+            Assert.Equal(0xBEEF0000u, provider.LastModuleBase);
+            Assert.Equal("S_P_CoreLib_System_Exception", provider.LastTypeName);
+            Assert.Equal("_innerException", provider.LastFieldName);
+        }
+
+        [Fact]
+        public void TryGetFieldOffset_ProviderReturnsFalse_ReturnsEFailAndZeroes()
+        {
+            RecordingSymbolProvider provider = new() { FieldLookupResult = false };
+            using SymbolProviderHarness h = SymbolProviderHarness.Create(provider);
+
+            uint offset = 0xdead;
+            int hr;
+            fixed (char* t = "S_P_CoreLib_System_Exception")
+            fixed (char* f = "_missing")
+                hr = h.SymbolProvider.TryGetFieldOffset(moduleBase: 0, (IntPtr)t, (IntPtr)f, &offset);
+
+            Assert.Equal(HResult.E_FAIL, hr);
+            Assert.Equal(0u, offset);
+        }
+
+        [Fact]
+        public void TryGetFieldOffset_EmptyTypeName_ReturnsInvalidArg()
+        {
+            RecordingSymbolProvider provider = new() { FieldLookupResult = true, FieldOffsetResult = 8 };
+            using SymbolProviderHarness h = SymbolProviderHarness.Create(provider);
+
+            uint offset = 0;
+            int hr;
+            fixed (char* t = "")
+            fixed (char* f = "_message")
+                hr = h.SymbolProvider.TryGetFieldOffset(moduleBase: 0, (IntPtr)t, (IntPtr)f, &offset);
+
+            Assert.Equal(HResult.E_INVALIDARG, hr);
+            Assert.False(provider.WasCalled);
+        }
+
         // -- helpers --------------------------------------------------------
 
         private sealed class RecordingSymbolProvider : IClrSymbolProvider
@@ -248,9 +327,14 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             public bool AddressLookupResult { get; set; }
             public ulong AddressResult { get; set; }
 
+            public bool FieldLookupResult { get; set; }
+            public uint FieldOffsetResult { get; set; }
+
             public ulong LastModuleBase { get; private set; }
             public ulong LastAddress { get; private set; }
             public string? LastName { get; private set; }
+            public string? LastTypeName { get; private set; }
+            public string? LastFieldName { get; private set; }
             public bool WasCalled { get; private set; }
 
             public bool TryGetSymbolName(ulong address, [NotNullWhen(true)] out string? symbolName, out ulong displacement)
@@ -278,6 +362,16 @@ namespace Microsoft.Diagnostics.Runtime.Tests
                 address = AddressLookupResult ? AddressResult : 0;
                 return AddressLookupResult;
             }
+
+            public bool TryGetFieldOffset(ulong moduleBase, string typeName, string fieldName, out uint offset)
+            {
+                WasCalled = true;
+                LastModuleBase = moduleBase;
+                LastTypeName = typeName;
+                LastFieldName = fieldName;
+                offset = FieldLookupResult ? FieldOffsetResult : 0;
+                return FieldLookupResult;
+            }
         }
 
         /// <summary>
@@ -300,11 +394,15 @@ namespace Microsoft.Diagnostics.Runtime.Tests
             public int TryGetSymbolAddress(ulong moduleBase, IntPtr name, ulong* pAddress)
                 => VTable.TryGetSymbolAddress(Self, moduleBase, name, pAddress);
 
+            public int TryGetFieldOffset(ulong moduleBase, IntPtr typeName, IntPtr fieldName, uint* pOffset)
+                => VTable.TryGetFieldOffset(Self, moduleBase, typeName, fieldName, pOffset);
+
             [StructLayout(LayoutKind.Sequential)]
             private readonly struct Vtable
             {
                 public readonly delegate* unmanaged[Stdcall]<IntPtr, ulong, uint, char*, uint*, ulong*, int> TryGetSymbolName;
                 public readonly delegate* unmanaged[Stdcall]<IntPtr, ulong, IntPtr, ulong*, int> TryGetSymbolAddress;
+                public readonly delegate* unmanaged[Stdcall]<IntPtr, ulong, IntPtr, IntPtr, uint*, int> TryGetFieldOffset;
             }
         }
 

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/DacDataTargetCOM.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/DacDataTargetCOM.cs
@@ -277,12 +277,13 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
         {
             public static IntPtr Create(IntPtr qi, IntPtr addRef, IntPtr release)
             {
-                IntPtr* vtblRaw = (IntPtr*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(ICLRSymbolProviderVtbl), IntPtr.Size * 5);
+                IntPtr* vtblRaw = (IntPtr*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(ICLRSymbolProviderVtbl), IntPtr.Size * 6);
                 vtblRaw[0] = qi;
                 vtblRaw[1] = addRef;
                 vtblRaw[2] = release;
                 vtblRaw[3] = (IntPtr)(delegate* unmanaged<IntPtr, ulong, uint, char*, uint*, ulong*, int>)&TryGetSymbolName;
                 vtblRaw[4] = (IntPtr)(delegate* unmanaged<IntPtr, ulong, IntPtr, ulong*, int>)&TryGetSymbolAddress;
+                vtblRaw[5] = (IntPtr)(delegate* unmanaged<IntPtr, ulong, IntPtr, IntPtr, uint*, int>)&TryGetFieldOffset;
 
                 return (IntPtr)vtblRaw;
             }
@@ -346,6 +347,38 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
                     if (provider.TryGetSymbolAddress(moduleBase, name, out ulong address) && address != 0)
                     {
                         *pAddress = address;
+                        return HResult.S_OK;
+                    }
+                    return HResult.E_FAIL;
+                }
+                catch
+                {
+                    return HResult.E_FAIL;
+                }
+            }
+
+            [UnmanagedCallersOnly]
+            private static int TryGetFieldOffset(IntPtr self, ulong moduleBase, IntPtr typeNamePtr, IntPtr fieldNamePtr, uint* pOffset)
+            {
+                if (pOffset is null)
+                    return HResult.E_INVALIDARG;
+                *pOffset = 0;
+
+                try
+                {
+                    DacDataTarget dacDataTarget = ComInterfaceDispatch.GetInstance<DacDataTarget>((ComInterfaceDispatch*)self);
+                    IClrSymbolProvider? provider = dacDataTarget.SymbolProvider;
+                    if (provider is null)
+                        return HResult.E_NOTIMPL;
+
+                    string? typeName = Marshal.PtrToStringUni(typeNamePtr);
+                    string? fieldName = Marshal.PtrToStringUni(fieldNamePtr);
+                    if (string.IsNullOrEmpty(typeName) || string.IsNullOrEmpty(fieldName))
+                        return HResult.E_INVALIDARG;
+
+                    if (provider.TryGetFieldOffset(moduleBase, typeName, fieldName, out uint offset))
+                    {
+                        *pOffset = offset;
                         return HResult.S_OK;
                     }
                     return HResult.E_FAIL;

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/LegacyDacDataTargetWrapper.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/LegacyDacDataTargetWrapper.cs
@@ -48,6 +48,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             builder = AddInterface(DacDataTarget.IID_ICLRSymbolProvider, false);
             builder.AddMethod(new TryGetSymbolNameDelegate(TryGetSymbolName));
             builder.AddMethod(new TryGetSymbolAddressDelegate(TryGetSymbolAddress));
+            builder.AddMethod(new TryGetFieldOffsetDelegate(TryGetFieldOffset));
             builder.Complete();
         }
 
@@ -183,8 +184,37 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             }
         }
 
+        private int TryGetFieldOffset(IntPtr _, ulong moduleBase, string typeName, string fieldName, uint* pOffset)
+        {
+            if (pOffset == null)
+                return HResult.E_INVALIDARG;
+            *pOffset = 0;
+
+            try
+            {
+                IClrSymbolProvider? provider = _dacDataTarget.SymbolProvider;
+                if (provider is null)
+                    return HResult.E_NOTIMPL;
+
+                if (string.IsNullOrEmpty(typeName) || string.IsNullOrEmpty(fieldName))
+                    return HResult.E_INVALIDARG;
+
+                if (provider.TryGetFieldOffset(moduleBase, typeName, fieldName, out uint offset))
+                {
+                    *pOffset = offset;
+                    return HResult.S_OK;
+                }
+                return HResult.E_FAIL;
+            }
+            catch
+            {
+                return HResult.E_FAIL;
+            }
+        }
+
         private delegate int TryGetSymbolNameDelegate(IntPtr self, ulong address, uint cchName, char* pName, uint* pcchNameActual, ulong* pDisplacement);
         private delegate int TryGetSymbolAddressDelegate(IntPtr self, ulong moduleBase, [In, MarshalAs(UnmanagedType.LPWStr)] string name, ulong* pAddress);
+        private delegate int TryGetFieldOffsetDelegate(IntPtr self, ulong moduleBase, [In, MarshalAs(UnmanagedType.LPWStr)] string typeName, [In, MarshalAs(UnmanagedType.LPWStr)] string fieldName, uint* pOffset);
 
         private delegate int GetMetadataDelegate(IntPtr self, [In][MarshalAs(UnmanagedType.LPWStr)] string fileName, int imageTimestamp, int imageSize,
                                                  IntPtr mvid, uint mdRva, uint flags, uint bufferSize, IntPtr buffer, int* dataSize);

--- a/src/Microsoft.Diagnostics.Runtime/IClrSymbolProvider.cs
+++ b/src/Microsoft.Diagnostics.Runtime/IClrSymbolProvider.cs
@@ -18,10 +18,14 @@ namespace Microsoft.Diagnostics.Runtime
         bool TryGetSymbolName(ulong address, [NotNullWhen(true)] out string? symbolName, out ulong displacement);
 
         /// <summary>
-        /// Resolves a <paramref name="symbolName"/> to its address. When
-        /// <paramref name="moduleBase"/> is non-zero the lookup is scoped to the module
-        /// loaded at that image base; otherwise it searches every loaded module.
+        /// Resolves a <paramref name="symbolName"/> to its address.
         /// </summary>
         bool TryGetSymbolAddress(ulong moduleBase, string symbolName, out ulong address);
+
+        /// <summary>
+        /// Resolves the byte offset of instance field <paramref name="fieldName"/>
+        /// on the type named <paramref name="typeName"/>.
+        /// </summary>
+        bool TryGetFieldOffset(ulong moduleBase, string typeName, string fieldName, out uint offset);
     }
 }


### PR DESCRIPTION
Adds a third method, TryGetFieldOffset, to the host-supplied IClrSymbolProvider and the ICLRSymbolProvider COM interface exposed by ClrMD's data-target wrapper. It resolves (typeName, fieldName) -> offset.

ICLRSymbolProvider is brand-new and has never shipped, so this is a breaking COM addition (a new vtable slot on the existing interface) rather than a separate interface, keeping all host-supplied symbol/type resolution on one contract.