### PR TITLE
Fix segfault at shutdown: dispose Runtime in test fixture, guard finalizers

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/Fixtures/ObjectConnection.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/Fixtures/ObjectConnection.cs
@@ -57,6 +57,10 @@ namespace Microsoft.Diagnostics.Runtime.Tests.Fixtures
             return obj;
         }
 
-        void IDisposable.Dispose() => DataTarget?.Dispose();
+        void IDisposable.Dispose()
+        {
+            Runtime?.Dispose();
+            DataTarget?.Dispose();
+        }
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/DacLibrary.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacLibrary.cs
@@ -132,11 +132,13 @@ namespace Microsoft.Diagnostics.Runtime
             Dispose(false);
         }
 
-        private void Dispose(bool _)
+        private void Dispose(bool disposing)
         {
             if (!_disposed)
             {
-                _clrDataProcess?.Dispose();
+                if (disposing)
+                    _clrDataProcess?.Dispose();
+
                 OwningLibrary?.Release();
 
                 _disposed = true;

--- a/src/Microsoft.Diagnostics.Runtime/Utilities/COMInterop/CallableComWrapper.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Utilities/COMInterop/CallableComWrapper.cs
@@ -81,7 +81,11 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
         {
             if (!_disposed)
             {
-                Release();
+                if (disposing)
+                {
+                    Release();
+                }
+
                 Library?.Release();
                 _disposed = true;
             }


### PR DESCRIPTION
ObjectConnection<T>.Dispose() only disposed DataTarget but never ClrRuntime, leaking all DAC COM wrappers to the finalizer queue. With the fixed DAC (CLRDATA_REQUEST_REVISION >= 10) Release() now properly frees objects, so non-deterministic finalizer ordering causes use-after-free when one COM object is freed while another finalizer still dereferences its vtable.

- ObjectConnection: dispose Runtime before DataTarget (root cause)
- CallableCOMWrapper: skip Release() in finalizer path (defense)
- DacLibrary: skip _clrDataProcess.Dispose() in finalizer path (defense)