### PR TITLE
Don't unload the cDac

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/DacLibrary.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacLibrary.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
 using Microsoft.Diagnostics.Runtime.DacInterface;
+using Microsoft.Diagnostics.Runtime.Implementation;
 using Microsoft.Diagnostics.Runtime.Utilities;
 
 namespace Microsoft.Diagnostics.Runtime
@@ -90,6 +91,9 @@ namespace Microsoft.Diagnostics.Runtime
             // when inspecting the current process.  The DAC (libmscordaccore.so) shares internal
             // state with the running CLR (libcoreclr.so), and unloading it corrupts that state.
             // Suppress FreeLibrary when the target is the current process to avoid this.
+            //
+            // The cDAC (mscordaccore_universal) is a NativeAOT library that cannot be safely
+            // unloaded on any platform, so never free it either.
 #if NET6_0_OR_GREATER
             int currentPid = Environment.ProcessId;
 #else
@@ -97,8 +101,9 @@ namespace Microsoft.Diagnostics.Runtime
             using (Process p = Process.GetCurrentProcess())
                 currentPid = p.Id;
 #endif
-            bool suppressFree = !RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-                                && dataTarget.DataReader.ProcessId == currentPid;
+            bool suppressFree = DotNetClrInfoProvider.IsCDacFileName(dacPath)
+                                || (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                                    && dataTarget.DataReader.ProcessId == currentPid);
             OwningLibrary = new RefCountedFreeLibrary(dacLibrary, suppressFree);
 
             IntPtr initAddr = DataTarget.PlatformFunctions.GetLibraryExport(dacLibrary, "DAC_PAL_InitializeDLL");

--- a/src/Microsoft.Diagnostics.Runtime/Implementation/DotNetClrInfoProvider.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Implementation/DotNetClrInfoProvider.cs
@@ -32,9 +32,10 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
         private const string c_linuxCoreDbiFileName = "libmscordbi.so";
         private const string c_macOSCoreDbiFileName = "libmscordbi.dylib";
 
-        private const string c_windowsCDacFileName = "mscordaccore_universal.dll";
-        private const string c_linuxCDacFileName = "libmscordaccore_universal.so";
-        private const string c_macOSCDacFileName = "libmscordaccore_universal.dylib";
+        private const string c_cdacFileNameStem = "mscordaccore_universal";
+        private const string c_windowsCDacFileName = c_cdacFileNameStem + ".dll";
+        private const string c_linuxCDacFileName = "lib" + c_cdacFileNameStem + ".so";
+        private const string c_macOSCDacFileName = "lib" + c_cdacFileNameStem + ".dylib";
 
         private const string c_cdacContractDescriptorExport = "DotNetRuntimeContractDescriptor";
 
@@ -443,6 +444,21 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
                 return c_macOSCDacFileName;
 
             return null;
+        }
+
+        /// <summary>
+        /// Determines whether the given DAC path refers to the universal cDAC binary
+        /// (mscordaccore_universal.{dll,so,dylib}), regardless of platform or a "lib" prefix.
+        /// The cDAC is a NativeAOT library that shares no unload contract with its host and
+        /// must not be freed via FreeLibrary/dlclose, so callers use this to suppress freeing.
+        /// </summary>
+        internal static bool IsCDacFileName(string? path)
+        {
+            if (string.IsNullOrEmpty(path))
+                return false;
+
+            string fileName = Path.GetFileNameWithoutExtension(path!);
+            return fileName.IndexOf(c_cdacFileNameStem, StringComparison.OrdinalIgnoreCase) >= 0;
         }
 
         private static bool IsSupportedRuntime(ModuleInfo module, out ClrFlavor flavor)


### PR DESCRIPTION
It's not safe to unload nativeaot dlls, so do not unload the cDac.