### PR TITLE
Fix ELF core dump ImageSize to include PT_LOAD anonymous tail

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/DataReaders/Core/CoreDumpReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DataReaders/Core/CoreDumpReader.cs
@@ -115,7 +115,37 @@ namespace Microsoft.Diagnostics.Runtime
             string path = image.FileName.Replace(" (deleted)", "");
             if (file is not null)
             {
-                long size = image.Size > long.MaxValue ? long.MaxValue : unchecked((long)image.Size);
+                // ElfLoadedImage.Size is derived from core NT_FILE notes, which only cover
+                // file-backed VMAs. When a PT_LOAD segment has MemSiz > FileSiz (e.g. .bss
+                // or another NOBITS section), the loader splits the mapping into a
+                // file-backed VMA plus an anonymous zero-fill VMA. The anonymous portion
+                // has no filename in /proc/self/maps and therefore does not appear in
+                // NT_FILE, so the NT_FILE-derived span under-reports the module's true
+                // memory footprint. Fall back to the ELF PT_LOAD headers' MemSiz to
+                // recover the anon tail; keep the larger of the two so we never regress
+                // modules where the on-disk metric happened to be more generous.
+                ulong sizeU = image.Size;
+                ulong minVA = ulong.MaxValue;
+                ulong maxEnd = 0;
+                foreach (ElfProgramHeader ph in file.ProgramHeaders)
+                {
+                    if (ph.Type == ElfProgramHeaderType.Load)
+                    {
+                        if (ph.VirtualAddress < minVA)
+                            minVA = ph.VirtualAddress;
+                        ulong end = ph.VirtualAddress + ph.VirtualSize;
+                        if (end > maxEnd)
+                            maxEnd = end;
+                    }
+                }
+                if (maxEnd > minVA)
+                {
+                    ulong ptLoadSize = maxEnd - minVA;
+                    if (ptLoadSize > sizeU)
+                        sizeU = ptLoadSize;
+                }
+
+                long size = sizeU > long.MaxValue ? long.MaxValue : unchecked((long)sizeU);
                 return new ElfModuleInfo(this, file, image.BaseAddress, size, path);
             }
 


### PR DESCRIPTION
### Problem
`ElfLoadedImage.Size` is derived from core-dump `NT_FILE` notes, which only cover file-backed VMAs. When a `PT_LOAD` segment has `MemSiz > FileSiz` (for example an executable with a large `.bss` or other `NOBITS` section), the kernel splits the mapping into a file-backed VMA plus an anonymous zero-fill VMA. The anonymous portion has no filename in `/proc/self/maps` and does not appear in `NT_FILE`, so the `NT_FILE`-derived module size under-reports the module's true memory footprint.

For CoreCLR this only manifests as a small tail beyond .bss, but for NativeAOT the entire .hydrated section (containing every MethodTable and hydrated static) lives in the anonymous portion. As a result, address-to-module lookups by consumers fail in SOS.

As a result, address-to-module lookups for any address that falls in the anonymous tail return no module, even though the address is part of the module's loaded image.

### Fix
Widen the reported module size in `CoreDumpReader.CreateModuleInfo` by scanning the ELF `PT_LOAD` program headers' `MemSiz`, keeping the larger of the `NT_FILE`-derived size and the `PT_LOAD`-derived `max(vaddr+memsz) - min(vaddr)` span so we never regress modules where the on-disk metric happened to be more generous.