### PR TITLE
AddLoadedRuntime

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/ClrObjectTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/ClrObjectTests.cs
@@ -34,7 +34,11 @@ namespace Microsoft.Diagnostics.Runtime.Tests
                     throw new InvalidOperationException($"Could not find {typeName} on heap.");
             }
 
-            public void Dispose() => DataTarget.Dispose();
+            public void Dispose()
+            {
+                Runtime.Dispose();
+                DataTarget.Dispose();
+            }
         }
 
         [Theory, MemberData(nameof(Variants))]

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/ClrSymbolProviderTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/ClrSymbolProviderTests.cs
@@ -382,7 +382,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
         private sealed class ClrSymbolProviderWrapper : CallableCOMWrapper
         {
             public ClrSymbolProviderWrapper(IntPtr pUnknown)
-                : base(library: null, in DacDataTarget.IID_ICLRSymbolProvider, pUnknown)
+                : base(in DacDataTarget.IID_ICLRSymbolProvider, pUnknown)
             {
             }
 

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/DataTargetTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/DataTargetTests.cs
@@ -1,14 +1,60 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.IO;
 using System.Linq;
+using Microsoft.Diagnostics.Runtime.DacInterface;
 using Xunit;
 
 namespace Microsoft.Diagnostics.Runtime.Tests
 {
     public class DataTargetTests
     {
+        [Fact]
+        public void AddLoadedRuntime_ForeignClrDataProcess_MatchesNormalRuntime()
+        {
+            // Validates the host-supplied IXCLRDataProcess path (used by SOS). We stand in for the host by
+            // producing a fresh IXCLRDataProcess from ClrMD's own DAC, then feeding the raw pointer through
+            // AddLoadedRuntime and confirming the resulting runtime walks the heap identically.
+            using DataTarget dt = TestTargets.Types.LoadFullDump();
+            ClrInfo clrInfo = dt.ClrVersions.Single();
+
+            using ClrRuntime baseline = clrInfo.CreateRuntime();
+            (ulong Address, string Type)[] expected = baseline.Heap.EnumerateObjects()
+                                                               .Take(2000)
+                                                               .Select(o => (o.Address, o.Type?.Name ?? ""))
+                                                               .ToArray();
+
+            DacLibrary dac = baseline.GetService<DacLibrary>();
+            Assert.NotNull(dac);
+
+            // A host would create its own IXCLRDataProcess; here we clone one from the DAC (this AddRefs it).
+            using ClrDataProcess process = dac.CreateClrDataProcess();
+            IntPtr pClrDataProcess = process.DangerousGetHandle();
+
+            ClrInfo hosted = new(dt, clrInfo.ModuleInfo, clrInfo.Version)
+            {
+                Flavor = clrInfo.Flavor,
+                IsSingleFile = clrInfo.IsSingleFile,
+            };
+
+            Assert.Same(hosted, dt.AddLoadedRuntime(hosted, pClrDataProcess));
+
+            using ClrRuntime foreign = hosted.CreateRuntime();
+            (ulong Address, string Type)[] actual = foreign.Heap.EnumerateObjects()
+                                                             .Take(2000)
+                                                             .Select(o => (o.Address, o.Type?.Name ?? ""))
+                                                             .ToArray();
+
+            Assert.Equal(expected.Length, actual.Length);
+            for (int i = 0; i < expected.Length; i++)
+            {
+                Assert.Equal(expected[i].Address, actual[i].Address);
+                Assert.Equal(expected[i].Type, actual[i].Type);
+            }
+        }
+
         [Theory]
         [InlineData(false)]
         [InlineData(true)]

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/DataTargetTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/DataTargetTests.cs
@@ -12,6 +12,37 @@ namespace Microsoft.Diagnostics.Runtime.Tests
     public class DataTargetTests
     {
         [Fact]
+        public void SkipRuntimeEnumeration_ClrVersionsIsEmpty()
+        {
+            // With SkipRuntimeEnumeration set, ClrMD performs no detection and ClrVersions is empty until a
+            // host registers a runtime explicitly.
+            using DataTarget dt = TestTargets.Types.LoadFullDump(options: new DataTargetOptions { SkipRuntimeEnumeration = true });
+            Assert.Empty(dt.ClrVersions);
+        }
+
+        [Fact]
+        public void AddLoadedRuntime_ReplacesRuntimeWithSameModuleInfo()
+        {
+            // Registering a runtime for a ModuleInfo that already has one (e.g. ClrMD detected it) replaces
+            // the existing entry rather than adding a duplicate.
+            using DataTarget dt = TestTargets.Types.LoadFullDump();
+            ClrInfo detected = dt.ClrVersions.Single();
+            int originalCount = dt.ClrVersions.Length;
+
+            ClrInfo hosted = new(dt, detected.ModuleInfo, detected.Version)
+            {
+                Flavor = detected.Flavor,
+                IsSingleFile = detected.IsSingleFile,
+            };
+
+            dt.AddLoadedRuntime(hosted, () => IntPtr.Zero);
+
+            Assert.Equal(originalCount, dt.ClrVersions.Length);
+            Assert.Same(hosted, dt.ClrVersions.Single(c => ReferenceEquals(c.ModuleInfo, detected.ModuleInfo)));
+            Assert.DoesNotContain(detected, dt.ClrVersions);
+        }
+
+        [Fact]
         public void AddLoadedRuntime_ForeignClrDataProcess_MatchesNormalRuntime()
         {
             // Validates the host-supplied IXCLRDataProcess path (used by SOS). We stand in for the host by

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/DataTargetTests.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/DataTargetTests.cs
@@ -12,6 +12,28 @@ namespace Microsoft.Diagnostics.Runtime.Tests
     public class DataTargetTests
     {
         [Fact]
+        public void AddLoadedRuntime_BeforeClrVersions_DoesNotSuppressEnumeration()
+        {
+            // Registering a runtime before ClrVersions is first queried must NOT suppress ClrMD's own
+            // enumeration (only DataTargetOptions.SkipRuntimeEnumeration does that). The registered runtime
+            // and the ClrMD-detected runtime should both appear.
+            using DataTarget dt = TestTargets.Types.LoadFullDump();
+
+            // Pick a non-runtime module so our registration can't dedup-collide with the detected runtime.
+            ModuleInfo nonRuntime = dt.EnumerateModules().First(m =>
+                m.FileName != null && m.FileName.IndexOf("clr", StringComparison.OrdinalIgnoreCase) < 0);
+
+            ClrInfo hosted = new(dt, nonRuntime, new Version(1, 0, 0, 0)) { Flavor = ClrFlavor.Core };
+            dt.AddLoadedRuntime(hosted, () => IntPtr.Zero);
+
+            System.Collections.Immutable.ImmutableArray<ClrInfo> versions = dt.ClrVersions;
+
+            Assert.Contains(hosted, versions);
+            // Enumeration still ran, so the real detected runtime is present in addition to our registration.
+            Assert.Contains(versions, v => !ReferenceEquals(v, hosted));
+        }
+
+        [Fact]
         public void SkipRuntimeEnumeration_ClrVersionsIsEmpty()
         {
             // With SkipRuntimeEnumeration set, ClrMD performs no detection and ClrVersions is empty until a

--- a/src/Microsoft.Diagnostics.Runtime.Tests/src/TestTargets.cs
+++ b/src/Microsoft.Diagnostics.Runtime.Tests/src/TestTargets.cs
@@ -235,6 +235,7 @@ namespace Microsoft.Diagnostics.Runtime.Tests
                 VerifyDacOnWindows = false,
                 UseLockFreeMemoryMapReader = src.UseLockFreeMemoryMapReader,
                 ForceCompleteRuntimeEnumeration = src.ForceCompleteRuntimeEnumeration,
+                SkipRuntimeEnumeration = src.SkipRuntimeEnumeration,
             };
 
             return DataTarget.LoadDump(path, merged);

--- a/src/Microsoft.Diagnostics.Runtime/ClrInfo.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrInfo.cs
@@ -27,14 +27,42 @@ namespace Microsoft.Diagnostics.Runtime
         }
 
         /// <summary>
+        /// Constructs a <see cref="ClrInfo"/> for a runtime whose DAC data-access interface
+        /// (<c>IXCLRDataProcess</c>) is supplied by the host through
+        /// <see cref="DataTarget.AddLoadedRuntime(ClrInfo, IntPtr, object?)"/>. Use this when the host
+        /// (e.g. SOS) performs its own runtime detection and DAC/cDAC construction instead of relying on
+        /// ClrMD's <see cref="IClrInfoProvider"/> discovery.
+        /// </summary>
+        public ClrInfo(DataTarget dt, ModuleInfo module, Version clrVersion)
+        {
+            DataTarget = dt ?? throw new ArgumentNullException(nameof(dt));
+            ModuleInfo = module ?? throw new ArgumentNullException(nameof(module));
+            Version = clrVersion ?? throw new ArgumentNullException(nameof(clrVersion));
+        }
+
+        /// <summary>
         /// The DataTarget containing this ClrInfo.
         /// </summary>
         public DataTarget DataTarget { get; }
 
         /// <summary>
-        /// The IClrInfoProvider which created this ClrInfo.
+        /// The IClrInfoProvider which created this ClrInfo, or <see langword="null"/> when this ClrInfo was
+        /// created for a host-supplied runtime (see <see cref="DataTarget.AddLoadedRuntime(ClrInfo, IntPtr, object?)"/>).
         /// </summary>
-        internal IClrInfoProvider ClrInfoProvider { get; }
+        internal IClrInfoProvider? ClrInfoProvider { get; }
+
+        /// <summary>
+        /// A factory that produces the host-owned <c>IXCLRDataProcess</c> pointer for this runtime, set by
+        /// <see cref="DataTarget.AddLoadedRuntime(ClrInfo, System.Func{IntPtr}, object?)"/>. When non-null,
+        /// <see cref="CreateRuntime()"/> uses it instead of loading a DAC through <see cref="ClrInfoProvider"/>.
+        /// </summary>
+        internal Func<IntPtr>? ClrDataProcessFactory { get; set; }
+
+        /// <summary>
+        /// The lock that serializes DAC calls for a host-supplied runtime. May be shared with the host so its
+        /// own DAC usage is serialized against ClrMD's.
+        /// </summary>
+        internal object? DacLock { get; set; }
 
         IDataTarget IClrInfo.DataTarget => DataTarget;
 
@@ -133,7 +161,28 @@ namespace Microsoft.Diagnostics.Runtime
         {
             try
             {
-                IServiceProvider services = ClrInfoProvider.GetDacServices(this, dacPath, ignoreMismatch, DataTarget.Options.VerifyDacOnWindows);
+                IServiceProvider services;
+                if (ClrDataProcessFactory is not null)
+                {
+                    // Host-supplied runtime: build DAC services over the host's IXCLRDataProcess instead of
+                    // loading a DAC ourselves. The provided dacPath/ignoreMismatch do not apply here.
+                    IntPtr clrDataProcess = ClrDataProcessFactory();
+                    if (clrDataProcess == IntPtr.Zero)
+                        throw new ClrDiagnosticsException("The IXCLRDataProcess factory returned a null pointer.");
+
+                    services = new DacImplementation.DacServiceProvider(this, clrDataProcess, DacLock ?? new object());
+                }
+                else if (ClrInfoProvider is not null)
+                {
+                    services = ClrInfoProvider.GetDacServices(this, dacPath, ignoreMismatch, DataTarget.Options.VerifyDacOnWindows);
+                }
+                else
+                {
+                    throw new InvalidOperationException(
+                        "This ClrInfo cannot create a runtime: it has neither an IClrInfoProvider nor a host-supplied IXCLRDataProcess. " +
+                        "Register it via DataTarget.AddLoadedRuntime before calling CreateRuntime.");
+                }
+
                 return new ClrRuntime(this, services);
             }
             catch (Exception ex) when (DataTarget.DataReader is IDumpInfoProvider { IsCreatedByDotNetRuntime: false } provider)

--- a/src/Microsoft.Diagnostics.Runtime/ClrInfo.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrInfo.cs
@@ -156,7 +156,7 @@ namespace Microsoft.Diagnostics.Runtime
                     if (clrDataProcess == IntPtr.Zero)
                         throw new ClrDiagnosticsException("The IXCLRDataProcess factory returned a null pointer.");
 
-                    services = new DacServiceProvider(this, clrDataProcess, DacLock ?? new object());
+                    services = new DacServiceProvider(this, clrDataProcess, DacLock ?? throw new InvalidOperationException("A registered runtime must have a non-null DacLock."));
                 }
                 else
                 {

--- a/src/Microsoft.Diagnostics.Runtime/ClrInfo.cs
+++ b/src/Microsoft.Diagnostics.Runtime/ClrInfo.cs
@@ -4,7 +4,11 @@
 using System;
 using System.Collections.Immutable;
 using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
 using Microsoft.Diagnostics.Runtime.AbstractDac;
+using Microsoft.Diagnostics.Runtime.DacImplementation;
+using Microsoft.Diagnostics.Runtime.Implementation;
 using Microsoft.Diagnostics.Runtime.Interfaces;
 
 namespace Microsoft.Diagnostics.Runtime
@@ -15,23 +19,11 @@ namespace Microsoft.Diagnostics.Runtime
     public sealed class ClrInfo : IClrInfo
     {
         /// <summary>
-        /// Constructs a <see cref="ClrInfo"/>. Use this from a custom
-        /// <see cref="IClrInfoProvider"/>.
-        /// </summary>
-        public ClrInfo(DataTarget dt, ModuleInfo module, Version clrVersion, IClrInfoProvider provider)
-        {
-            DataTarget = dt ?? throw new ArgumentNullException(nameof(dt));
-            ModuleInfo = module ?? throw new ArgumentNullException(nameof(module));
-            ClrInfoProvider = provider ?? throw new ArgumentNullException(nameof(provider));
-            Version = clrVersion ?? throw new ArgumentNullException(nameof(clrVersion));
-        }
-
-        /// <summary>
         /// Constructs a <see cref="ClrInfo"/> for a runtime whose DAC data-access interface
         /// (<c>IXCLRDataProcess</c>) is supplied by the host through
         /// <see cref="DataTarget.AddLoadedRuntime(ClrInfo, IntPtr, object?)"/>. Use this when the host
         /// (e.g. SOS) performs its own runtime detection and DAC/cDAC construction instead of relying on
-        /// ClrMD's <see cref="IClrInfoProvider"/> discovery.
+        /// ClrMD's discovery.
         /// </summary>
         public ClrInfo(DataTarget dt, ModuleInfo module, Version clrVersion)
         {
@@ -46,15 +38,9 @@ namespace Microsoft.Diagnostics.Runtime
         public DataTarget DataTarget { get; }
 
         /// <summary>
-        /// The IClrInfoProvider which created this ClrInfo, or <see langword="null"/> when this ClrInfo was
-        /// created for a host-supplied runtime (see <see cref="DataTarget.AddLoadedRuntime(ClrInfo, IntPtr, object?)"/>).
-        /// </summary>
-        internal IClrInfoProvider? ClrInfoProvider { get; }
-
-        /// <summary>
         /// A factory that produces the host-owned <c>IXCLRDataProcess</c> pointer for this runtime, set by
         /// <see cref="DataTarget.AddLoadedRuntime(ClrInfo, System.Func{IntPtr}, object?)"/>. When non-null,
-        /// <see cref="CreateRuntime()"/> uses it instead of loading a DAC through <see cref="ClrInfoProvider"/>.
+        /// <see cref="CreateRuntime()"/> uses it instead of resolving and loading a DAC for this runtime.
         /// </summary>
         internal Func<IntPtr>? ClrDataProcessFactory { get; set; }
 
@@ -170,17 +156,13 @@ namespace Microsoft.Diagnostics.Runtime
                     if (clrDataProcess == IntPtr.Zero)
                         throw new ClrDiagnosticsException("The IXCLRDataProcess factory returned a null pointer.");
 
-                    services = new DacImplementation.DacServiceProvider(this, clrDataProcess, DacLock ?? new object());
-                }
-                else if (ClrInfoProvider is not null)
-                {
-                    services = ClrInfoProvider.GetDacServices(this, dacPath, ignoreMismatch, DataTarget.Options.VerifyDacOnWindows);
+                    services = new DacServiceProvider(this, clrDataProcess, DacLock ?? new object());
                 }
                 else
                 {
-                    throw new InvalidOperationException(
-                        "This ClrInfo cannot create a runtime: it has neither an IClrInfoProvider nor a host-supplied IXCLRDataProcess. " +
-                        "Register it via DataTarget.AddLoadedRuntime before calling CreateRuntime.");
+                    // Normal path: resolve and load a matching DAC for this runtime, then build DAC services.
+                    DacLibrary library = GetDacLibraryFromPath(dacPath, ignoreMismatch, DataTarget.Options.VerifyDacOnWindows);
+                    services = new DacServiceProvider(this, library);
                 }
 
                 return new ClrRuntime(this, services);
@@ -193,6 +175,89 @@ namespace Microsoft.Diagnostics.Runtime
                     $"Recollect the dump using createdump or set DOTNET_DbgEnableMiniDump=1. Original error: {ex.Message}",
                     ex);
             }
+        }
+
+        private DacLibrary GetDacLibraryFromPath(string? dacPath, bool ignoreMismatch, bool verifySignature)
+        {
+            if (dacPath is not null)
+                return CreateDacFromPath(dacPath, ignoreMismatch, verifySignature);
+
+            OSPlatform currentPlatform = DotNetClrInfoProvider.GetCurrentPlatform();
+            Architecture currentArch = RuntimeInformation.ProcessArchitecture;
+            Exception? exception = null;
+            bool foundOne = false;
+
+            IFileLocator? locator = DataTarget.FileLocator;
+
+            foreach (DebugLibraryInfo dac in DebuggingLibraries.Where(r => r.Kind == DebugLibraryKind.Dac && r.Platform == currentPlatform && r.TargetArchitecture == currentArch))
+            {
+                foundOne = true;
+
+                // If we have a full path, use it.  We already validated that the CLR matches.
+                if (Path.GetFileName(dac.FileName) != dac.FileName)
+                {
+                    dacPath = dac.FileName;
+                }
+                else
+                {
+                    // The properties we are requesting under may not be the actual file properties, so don't request them.
+
+                    if (locator != null)
+                    {
+                        if (!dac.IndexBuildId.IsDefaultOrEmpty)
+                        {
+                            dacPath = locator.FindPEImage(dac.FileName, SymbolProperties.Coreclr, dac.IndexBuildId, DataTarget.DataReader.TargetPlatform, checkProperties: false);
+                        }
+                        else if (dac.IndexTimeStamp != 0 && dac.IndexFileSize != 0)
+                        {
+                            if (dac.Platform == OSPlatform.Windows)
+                                dacPath = DataTarget.FileLocator?.FindPEImage(dac.FileName, dac.IndexTimeStamp, dac.IndexFileSize, checkProperties: false);
+                        }
+                    }
+                }
+
+                if (dacPath is not null && File.Exists(dacPath))
+                {
+                    try
+                    {
+                        // If we get the file from the symbol server, assume mismatches are expected.  Sometimes we replace dacs on the symbol
+                        // server to fix bugs.  If it's archived under the right path, use it.
+                        return CreateDacFromPath(dacPath, ignoreMismatch: true, verifySignature);
+                    }
+                    catch (Exception ex)
+                    {
+                        exception ??= ex;
+                        dacPath = null;
+                    }
+                }
+            }
+
+            if (exception is not null)
+                throw exception;
+
+            // We should have had at least one dac enumerated if this is a supported scenario.
+            if (!foundOne)
+                throw new InvalidOperationException($"Debugging a '{DataTarget.DataReader.TargetPlatform}' crash is not supported on '{currentPlatform}'.");
+
+            if (currentPlatform == OSPlatform.Windows)
+                throw new FileNotFoundException("Could not find matching DAC for this runtime.");
+
+            throw new FileNotFoundException("Could not find matching DAC for this runtime.  Note that symbol server download of the DAC is disabled for this platform.");
+        }
+
+        private DacLibrary CreateDacFromPath(string dacPath, bool ignoreMismatch, bool verifySignature)
+        {
+            if (!File.Exists(dacPath))
+                throw new FileNotFoundException(dacPath);
+
+            if (!ignoreMismatch && !IsSingleFile)
+            {
+                DataTarget.PlatformFunctions.GetFileVersion(dacPath, out int major, out int minor, out int revision, out int patch);
+                if (major != Version.Major || minor != Version.Minor || revision != Version.Build || patch != Version.Revision)
+                    throw new ClrDiagnosticsException($"Mismatched dac. Dac version: {major}.{minor}.{revision}.{patch}, expected: {Version}.");
+            }
+
+            return new(DataTarget, dacPath, ModuleInfo.ImageBase, ContractDescriptorAddress, verifySignature);
         }
 
         IClrRuntime IClrInfo.CreateRuntime() => CreateRuntime();

--- a/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacHeap.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacHeap.cs
@@ -22,7 +22,6 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
         private readonly IMemoryReader _memoryReader;
         private readonly TargetProperties _target;
         private readonly GCState _gcState;
-        private readonly ThinLockLayout _thinLockLayout;
         private readonly HashSet<ulong> _validMethodTables = new();
 
         private const uint LegacySyncBlockRecLevelMask = 0x0000FC00;
@@ -34,14 +33,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
         private const uint SyncBlockSpinLock = 0x10000000;
         private const uint SyncBlockHashOrSyncBlockIndex = 0x08000000;
 
-        internal enum ThinLockLayout
-        {
-            Legacy,
-            Large,
-            LargeWithLegacyFallback,
-        }
-
-        public DacHeap(SOSDac sos, SOSDac8? sos8, SosDac12? sos12, ISOSDac16? sos16, IMemoryReader reader, TargetProperties target, ThinLockLayout thinLockLayout, in GCInfo gcInfo, in CommonMethodTables commonMethodTables)
+        public DacHeap(SOSDac sos, SOSDac8? sos8, SosDac12? sos12, ISOSDac16? sos16, IMemoryReader reader, TargetProperties target, in GCInfo gcInfo, in CommonMethodTables commonMethodTables)
         {
             _sos = sos;
             _sos8 = sos8;
@@ -49,7 +41,6 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
             _sos16 = sos16;
             _memoryReader = reader;
             _target = target;
-            _thinLockLayout = thinLockLayout;
 
             _gcState = new()
             {
@@ -419,7 +410,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
 
         public (ulong Thread, int Recursion) GetThinLock(uint header)
         {
-            if (!TryGetThinLock(header, _thinLockLayout, out ulong threadAddress, out uint recursion))
+            if (!TryGetThinLock(header, _target.ThinLockLayout, out ulong threadAddress, out uint recursion))
                 return default;
 
             return (threadAddress, recursion.ToSigned());

--- a/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacModuleHelpers.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacModuleHelpers.cs
@@ -103,7 +103,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
                     nint qiResult = module.QueryInterface(MetadataImport.IID_IMetaDataImport);
                     if (qiResult != 0)
                     {
-                        import = new(module.Library, qiResult);
+                        import = new(qiResult);
                     }
                 }
             }

--- a/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacServiceProvider.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacServiceProvider.cs
@@ -12,8 +12,9 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
     {
         private readonly ClrInfo _clrInfo;
         private readonly IDataReader _dataReader;
+        private readonly TargetProperties _target;
 
-        private readonly DacLibrary _dac;
+        private readonly DacLibrary? _dac;
         private readonly ClrDataProcess _process;
         private readonly SOSDac _sos;
         private readonly SOSDac6? _sos6;
@@ -46,6 +47,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
         {
             _clrInfo = clrInfo;
             _dataReader = _clrInfo.DataTarget.DataReader;
+            _target = new TargetProperties(pointerSize: _dataReader.PointerSize);
 
             _dac = library;
             _process = library.CreateClrDataProcess();
@@ -85,7 +87,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
                 _sos14?.Dispose();
                 _sos16?.Dispose();
                 _sos17?.Dispose();
-                _dac.Dispose();
+                _dac?.Dispose();
                 _moduleHelper?.Dispose();
             }
         }
@@ -102,7 +104,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
                 if (r is not null)
                     return r;
                 lock (_serviceLock)
-                    return _runtime ??= new DacRuntime(_clrInfo, _process, _sos, _sos13, _dac.TargetProperties);
+                    return _runtime ??= new DacRuntime(_clrInfo, _process, _sos, _sos13, _target);
             }
 
             if (serviceType == typeof(IAbstractHeap))
@@ -126,7 +128,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
                     }
 
                     if (initialized)
-                        return _heapHelper = new DacHeap(_sos, _sos8, _sos12, _sos16, _dataReader, _dac.TargetProperties, DacHeap.GetThinLockLayout(_clrInfo.Flavor, _clrInfo.Version), data, mts);
+                        return _heapHelper = new DacHeap(_sos, _sos8, _sos12, _sos16, _dataReader, _target, DacHeap.GetThinLockLayout(_clrInfo.Flavor, _clrInfo.Version), data, mts);
 
                     return null;
                 }
@@ -139,8 +141,8 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
                     return t;
                 lock (_serviceLock)
                 {
-                    _moduleHelper ??= new(_sos, _dac.TargetProperties);
-                    return _typeHelper ??= new DacTypeHelpers(_process, _sos, _sos6, _sos8, _sos14, _dataReader, _moduleHelper, _dac.TargetProperties, _clrInfo.Flavor, _clrInfo.Version?.Major ?? 0);
+                    _moduleHelper ??= new(_sos, _target);
+                    return _typeHelper ??= new DacTypeHelpers(_process, _sos, _sos6, _sos8, _sos14, _dataReader, _moduleHelper, _target, _clrInfo.Flavor, _clrInfo.Version?.Major ?? 0);
                 }
             }
 
@@ -150,7 +152,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
                 if (n is not null)
                     return n;
                 lock (_serviceLock)
-                    return _nativeHeaps ??= new DacNativeHeaps(_clrInfo, _sos, _sos13, _dataReader, _dac.TargetProperties);
+                    return _nativeHeaps ??= new DacNativeHeaps(_clrInfo, _sos, _sos13, _dataReader, _target);
             }
 
             if (serviceType == typeof(IAbstractModuleHelpers))
@@ -159,7 +161,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
                 if (m is not null)
                     return m;
                 lock (_serviceLock)
-                    return _moduleHelper ??= new DacModuleHelpers(_sos, _dac.TargetProperties);
+                    return _moduleHelper ??= new DacModuleHelpers(_sos, _target);
             }
 
             if (serviceType == typeof(IAbstractComHelpers))
@@ -168,7 +170,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
                 if (c is not null)
                     return c;
                 lock (_serviceLock)
-                    return _com ??= new DacComHelpers(_sos, _dac.TargetProperties);
+                    return _com ??= new DacComHelpers(_sos, _target);
             }
 
             if (serviceType == typeof(IAbstractLegacyThreadPool))
@@ -177,7 +179,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
                 if (p is not null)
                     return p;
                 lock (_serviceLock)
-                    return _threadPool ??= new DacLegacyThreadPool(_sos, _dac.TargetProperties);
+                    return _threadPool ??= new DacLegacyThreadPool(_sos, _target);
             }
 
             if (serviceType == typeof(IAbstractMethodLocator))
@@ -186,7 +188,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
                 if (l is not null)
                     return l;
                 lock (_serviceLock)
-                    return _methodLocator ??= new DacMethodLocator(_sos, _dataReader, _dac.TargetProperties);
+                    return _methodLocator ??= new DacMethodLocator(_sos, _dataReader, _target);
             }
 
             if (serviceType == typeof(IAbstractThreadHelpers))
@@ -195,7 +197,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
                 if (th is not null)
                     return th;
                 lock (_serviceLock)
-                    return _threadHelper ??= new DacThreadHelpers(_process, _sos, _dataReader, _dac.TargetProperties);
+                    return _threadHelper ??= new DacThreadHelpers(_process, _sos, _dataReader, _target);
             }
 
             if (serviceType == typeof(IAbstractStressLog))
@@ -207,7 +209,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
                 if (s is not null)
                     return s;
                 lock (_serviceLock)
-                    return _stressLog ??= new DacStressLog(_sos, _sos17, _dac.TargetProperties);
+                    return _stressLog ??= new DacStressLog(_sos, _sos17, _target);
             }
 
             if (serviceType == typeof(IAbstractDacController))

--- a/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacServiceProvider.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacServiceProvider.cs
@@ -58,7 +58,6 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
             _sos16 = _process.CreateSOSDacInterface16();
             _sos17 = _process.CreateSOSDacInterface17();
 
-            library.DacDataTarget.SetMagicCallback(_process.Flush);
             IsThreadSafe = _sos13 is not null || RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
         }
 
@@ -240,37 +239,8 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
                 {
                     _sos13.LockedFlush();
                 }
-                else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                {
-                    // IXClrDataProcess::Flush is unfortunately not wrapped with DAC_ENTER.  This means that
-                    // when it starts deleting memory, it's completely unsynchronized with parallel reads
-                    // and writes, leading to heap corruption and other issues.  This means that in order to
-                    // properly clear dac data structures, we need to trick the dac into entering the critical
-                    // section for us so we can call Flush safely then.
-
-                    // To accomplish this, we set a hook in our implementation of IDacDataTarget::ReadVirtual
-                    // which will call IXClrDataProcess::Flush if the dac tries to read the address set by
-                    // MagicCallbackConstant.  Additionally we make sure this doesn't interfere with other
-                    // reads by 1) Ensuring that the address is in kernel space, 2) only calling when we've
-                    // entered a special context.
-
-                    _dac.DacDataTarget.EnterMagicCallbackContext();
-                    try
-                    {
-                        _sos.GetWorkRequestData(ClrDataAddress.FromTargetAddress(DacDataTarget.MagicCallbackConstant, _dac.TargetProperties), out _);
-                    }
-                    finally
-                    {
-                        _dac.DacDataTarget.ExitMagicCallbackContext();
-                    }
-                }
                 else
                 {
-                    // On Linux/MacOS, skip the above workaround because calling Flush() in the DAC data target's
-                    // ReadVirtual function can cause a SEGSIGV because of an access of freed memory causing the
-                    // tool/app running CLRMD to crash. On Windows, it would be caught by the SEH try/catch handler
-                    // in DAC enter/leave code.
-
                     _process.Flush();
                 }
             }

--- a/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacServiceProvider.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacServiceProvider.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
             Marshal.AddRef(clrDataProcess);
 
             TargetProperties target = new(pointerSize: clrInfo.DataTarget.DataReader.PointerSize);
-            return new ClrDataProcess(library: null, dacLock, target, clrDataProcess);
+            return new ClrDataProcess(dacLock, target, clrDataProcess);
         }
 
         public void Dispose()
@@ -118,6 +118,11 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
 
                 _disposed = true;
                 _sos13?.LockedFlush();
+                // Dispose every COM wrapper (releasing its interface into the DAC module) BEFORE freeing the
+                // module via _dac. The wrappers no longer hold a reference to the module's RefCountedFreeLibrary,
+                // so the module stays loaded only because _dac owns the single reference; releasing a wrapper
+                // after FreeLibrary would call into unloaded code. _moduleHelper holds MetadataImport/ClrDataModule
+                // wrappers, so it must be disposed here too, before _dac.
                 _process.Dispose();
                 _sos.Dispose();
                 _sos6?.Dispose();
@@ -127,8 +132,8 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
                 _sos14?.Dispose();
                 _sos16?.Dispose();
                 _sos17?.Dispose();
-                _dac?.Dispose();
                 _moduleHelper?.Dispose();
+                _dac?.Dispose();
             }
         }
 

--- a/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacServiceProvider.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacServiceProvider.cs
@@ -44,13 +44,36 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
         private readonly object _serviceLock = new();
 
         public DacServiceProvider(ClrInfo clrInfo, DacLibrary library)
+            : this(clrInfo, library, library.CreateClrDataProcess())
+        {
+        }
+
+        /// <summary>
+        /// Constructs a <see cref="DacServiceProvider"/> over an <c>IXCLRDataProcess</c> that the host
+        /// (e.g. SOS) created and owns. ClrMD does not own or unload the underlying DAC module. The host
+        /// retains its own reference to <paramref name="clrDataProcess"/>: this constructor adds a reference
+        /// (balanced by a release on <see cref="Dispose"/>) so the host's reference is unaffected, but the
+        /// host must keep the pointer alive for the lifetime of the resulting runtime.
+        /// </summary>
+        /// <param name="clrInfo">The runtime this DAC represents.</param>
+        /// <param name="clrDataProcess">A host-owned <c>IXCLRDataProcess</c> pointer.</param>
+        /// <param name="dacLock">
+        /// The lock that serializes all DAC calls. Pass the host's lock to serialize the host's own DAC
+        /// usage against ClrMD's; the DAC is not thread-safe and concurrent calls corrupt its state.
+        /// </param>
+        public DacServiceProvider(ClrInfo clrInfo, IntPtr clrDataProcess, object dacLock)
+            : this(clrInfo, dac: null, CreateForeignProcess(clrInfo, clrDataProcess, dacLock))
+        {
+        }
+
+        private DacServiceProvider(ClrInfo clrInfo, DacLibrary? dac, ClrDataProcess process)
         {
             _clrInfo = clrInfo;
             _dataReader = _clrInfo.DataTarget.DataReader;
             _target = new TargetProperties(pointerSize: _dataReader.PointerSize);
 
-            _dac = library;
-            _process = library.CreateClrDataProcess();
+            _dac = dac;
+            _process = process;
             _sos = _process.CreateSOSDacInterface() ?? throw new InvalidOperationException($"Could not create ISOSDacInterface.");
             _sos6 = _process.CreateSOSDacInterface6();
             _sos8 = _process.CreateSOSDacInterface8();
@@ -61,6 +84,23 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
             _sos17 = _process.CreateSOSDacInterface17();
 
             IsThreadSafe = _sos13 is not null || RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+        }
+
+        private static ClrDataProcess CreateForeignProcess(ClrInfo clrInfo, IntPtr clrDataProcess, object dacLock)
+        {
+            if (clrDataProcess == IntPtr.Zero)
+                throw new ArgumentNullException(nameof(clrDataProcess));
+            if (dacLock is null)
+                throw new ArgumentNullException(nameof(dacLock));
+
+            // The ClrDataProcess wrapper's constructor does QueryInterface + Release(pUnknown), which is
+            // reference-count-neutral on the object but consumes the reference identity we pass in. AddRef
+            // here so the host keeps its own reference; the wrapper releases exactly this added reference
+            // when the process is disposed, leaving the host's reference intact.
+            Marshal.AddRef(clrDataProcess);
+
+            TargetProperties target = new(pointerSize: clrInfo.DataTarget.DataReader.PointerSize);
+            return new ClrDataProcess(library: null, dacLock, target, clrDataProcess);
         }
 
         public void Dispose()

--- a/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacServiceProvider.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacServiceProvider.cs
@@ -70,7 +70,8 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
         {
             _clrInfo = clrInfo;
             _dataReader = _clrInfo.DataTarget.DataReader;
-            _target = new TargetProperties(pointerSize: _dataReader.PointerSize);
+            ThinLockLayout thinlockLayout = DacHeap.GetThinLockLayout(_clrInfo.Flavor, _clrInfo.Version);
+            _target = new TargetProperties(thinlockLayout, _dataReader.PointerSize);
 
             _dac = dac;
             _process = process;
@@ -99,7 +100,8 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
             // when the process is disposed, leaving the host's reference intact.
             Marshal.AddRef(clrDataProcess);
 
-            TargetProperties target = new(pointerSize: clrInfo.DataTarget.DataReader.PointerSize);
+            ThinLockLayout thinlockLayout = DacHeap.GetThinLockLayout(clrInfo.Flavor, clrInfo.Version);
+            TargetProperties target = new(thinlockLayout, clrInfo.DataTarget.DataReader.PointerSize);
             return new ClrDataProcess(dacLock, target, clrDataProcess);
         }
 
@@ -173,7 +175,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
                     }
 
                     if (initialized)
-                        return _heapHelper = new DacHeap(_sos, _sos8, _sos12, _sos16, _dataReader, _target, DacHeap.GetThinLockLayout(_clrInfo.Flavor, _clrInfo.Version), data, mts);
+                        return _heapHelper = new DacHeap(_sos, _sos8, _sos12, _sos16, _dataReader, _target, data, mts);
 
                     return null;
                 }

--- a/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacServiceProvider.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacServiceProvider.cs
@@ -70,19 +70,40 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
         {
             _clrInfo = clrInfo;
             _dataReader = _clrInfo.DataTarget.DataReader;
-            ThinLockLayout thinlockLayout = DacHeap.GetThinLockLayout(_clrInfo.Flavor, _clrInfo.Version);
-            _target = new TargetProperties(thinlockLayout, _dataReader.PointerSize);
+            ThinLockLayout thinLockLayout = DacHeap.GetThinLockLayout(_clrInfo.Flavor, _clrInfo.Version);
+            _target = new TargetProperties(thinLockLayout, _dataReader.PointerSize);
 
             _dac = dac;
             _process = process;
-            _sos = _process.CreateSOSDacInterface() ?? throw new InvalidOperationException($"Could not create ISOSDacInterface.");
-            _sos6 = _process.CreateSOSDacInterface6();
-            _sos8 = _process.CreateSOSDacInterface8();
-            _sos12 = _process.CreateSOSDacInterface12();
-            _sos13 = _process.CreateSOSDacInterface13();
-            _sos14 = _process.CreateSOSDacInterface14();
-            _sos16 = _process.CreateSOSDacInterface16();
-            _sos17 = _process.CreateSOSDacInterface17();
+            try
+            {
+                _sos = _process.CreateSOSDacInterface() ?? throw new InvalidOperationException($"Could not create ISOSDacInterface.");
+                _sos6 = _process.CreateSOSDacInterface6();
+                _sos8 = _process.CreateSOSDacInterface8();
+                _sos12 = _process.CreateSOSDacInterface12();
+                _sos13 = _process.CreateSOSDacInterface13();
+                _sos14 = _process.CreateSOSDacInterface14();
+                _sos16 = _process.CreateSOSDacInterface16();
+                _sos17 = _process.CreateSOSDacInterface17();
+            }
+            catch
+            {
+                // Construction failed after we took ownership of the process (and, on the host path, its
+                // AddRef'd IXCLRDataProcess). Release everything created here so the pointer/interfaces do
+                // not leak. Disposing _process releases the reference CreateForeignProcess added.
+                SOSDac? sos = _sos;
+                sos?.Dispose();
+                _sos6?.Dispose();
+                _sos8?.Dispose();
+                _sos12?.Dispose();
+                _sos13?.Dispose();
+                _sos14?.Dispose();
+                _sos16?.Dispose();
+                _sos17?.Dispose();
+                _process.Dispose();
+                _dac?.Dispose();
+                throw;
+            }
 
             IsThreadSafe = _sos13 is not null || RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
         }
@@ -99,16 +120,27 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
             // here so the host keeps its own reference; the wrapper releases exactly this added reference
             // when the process is disposed, leaving the host's reference intact.
             Marshal.AddRef(clrDataProcess);
-
-            ThinLockLayout thinlockLayout = DacHeap.GetThinLockLayout(clrInfo.Flavor, clrInfo.Version);
-            TargetProperties target = new(thinlockLayout, clrInfo.DataTarget.DataReader.PointerSize);
-            return new ClrDataProcess(dacLock, target, clrDataProcess);
+            try
+            {
+                // This TargetProperties feeds only pointer-size address translation (ClrDataProcess/SosDac12);
+                // its ThinLockLayout is never consumed here, so the conservative Legacy layout is used. The
+                // canonical layout is computed once per runtime in the DacServiceProvider constructor.
+                TargetProperties target = new(ThinLockLayout.Legacy, clrInfo.DataTarget.DataReader.PointerSize);
+                return new ClrDataProcess(dacLock, target, clrDataProcess);
+            }
+            catch
+            {
+                // The wrapper's QueryInterface failed (or another failure occurred) before it took ownership
+                // of our added reference; release it so the host pointer's refcount is left unchanged.
+                Marshal.Release(clrDataProcess);
+                throw;
+            }
         }
 
         public void Dispose()
         {
             if (_disposed)
-                throw new ObjectDisposedException(GetType().FullName);
+                return;
 
             // Serialize teardown against in-flight DAC reads: every DAC entry point takes
             // _sos.SyncRoot (== _dac.SyncRoot), so disposing the native/COM wrappers under

--- a/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacTypeHelpers.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacTypeHelpers.cs
@@ -544,24 +544,29 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
             {
                 foreach (ClrDataMethod method in _clrDataProcess.EnumerateMethodInstancesByAddress(ClrDataAddress.FromTargetAddress(ip, _target)))
                 {
-                    ILToNativeMap[]? map = method.GetILToNativeMap();
-                    if (map != null)
+                    try
                     {
-                        for (int i = 0; i < map.Length; i++)
+                        ILToNativeMap[]? map = method.GetILToNativeMap();
+                        if (map != null)
                         {
-                            if (map[i].StartAddress > map[i].EndAddress)
+                            for (int i = 0; i < map.Length; i++)
                             {
-                                if (i + 1 == map.Length)
-                                    map[i].EndAddress = FindEnd(hotCold, map[i].StartAddress);
-                                else
-                                    map[i].EndAddress = map[i + 1].StartAddress - 1;
+                                if (map[i].StartAddress > map[i].EndAddress)
+                                {
+                                    if (i + 1 == map.Length)
+                                        map[i].EndAddress = FindEnd(hotCold, map[i].StartAddress);
+                                    else
+                                        map[i].EndAddress = map[i + 1].StartAddress - 1;
+                                }
                             }
+
+                            result.AddRange(map);
                         }
-
-                        result.AddRange(map);
                     }
-
-                    method.Dispose();
+                    finally
+                    {
+                        method.Dispose();
+                    }
                 }
             }
 

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/ClrDataMethod.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/ClrDataMethod.cs
@@ -12,8 +12,8 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
     {
         private static readonly Guid IID_IXCLRDataMethodInstance = new("ECD73800-22CA-4b0d-AB55-E9BA7E6318A5");
 
-        public ClrDataMethod(RefCountedFreeLibrary? library, IntPtr pUnk)
-            : base(library, IID_IXCLRDataMethodInstance, pUnk)
+        public ClrDataMethod(IntPtr pUnk)
+            : base(IID_IXCLRDataMethodInstance, pUnk)
         {
         }
 

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/ClrDataMethod.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/ClrDataMethod.cs
@@ -12,8 +12,8 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
     {
         private static readonly Guid IID_IXCLRDataMethodInstance = new("ECD73800-22CA-4b0d-AB55-E9BA7E6318A5");
 
-        public ClrDataMethod(DacLibrary library, IntPtr pUnk)
-            : base(library?.OwningLibrary, IID_IXCLRDataMethodInstance, pUnk)
+        public ClrDataMethod(RefCountedFreeLibrary? library, IntPtr pUnk)
+            : base(library, IID_IXCLRDataMethodInstance, pUnk)
         {
         }
 

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/ClrDataModule.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/ClrDataModule.cs
@@ -15,8 +15,8 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
 
         private static readonly Guid IID_IXCLRDataModule = new("88E32849-0A0A-4cb0-9022-7CD2E9E139E2");
 
-        public ClrDataModule(RefCountedFreeLibrary? library, IntPtr pUnknown)
-            : base(library, IID_IXCLRDataModule, pUnknown)
+        public ClrDataModule(IntPtr pUnknown)
+            : base(IID_IXCLRDataModule, pUnknown)
         {
         }
 

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/ClrDataModule.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/ClrDataModule.cs
@@ -15,8 +15,8 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
 
         private static readonly Guid IID_IXCLRDataModule = new("88E32849-0A0A-4cb0-9022-7CD2E9E139E2");
 
-        public ClrDataModule(DacLibrary library, IntPtr pUnknown)
-            : base(library?.OwningLibrary, IID_IXCLRDataModule, pUnknown)
+        public ClrDataModule(RefCountedFreeLibrary? library, IntPtr pUnknown)
+            : base(library, IID_IXCLRDataModule, pUnknown)
         {
         }
 

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/ClrDataProcess.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/ClrDataProcess.cs
@@ -19,8 +19,8 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
         private readonly object _syncRoot;
         private readonly TargetProperties _target;
 
-        public ClrDataProcess(RefCountedFreeLibrary? library, object syncRoot, TargetProperties target, IntPtr pUnknown)
-            : base(library, IID_IXCLRDataProcess, pUnknown)
+        public ClrDataProcess(object syncRoot, TargetProperties target, IntPtr pUnknown)
+            : base(IID_IXCLRDataProcess, pUnknown)
         {
             _syncRoot = syncRoot;
             _target = target;
@@ -42,7 +42,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
 
             try
             {
-                return new SOSDac(Library, _syncRoot, result);
+                return new SOSDac(_syncRoot, result);
             }
             catch (InvalidOperationException)
             {
@@ -58,7 +58,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
 
             try
             {
-                return new SOSDac6(Library, result);
+                return new SOSDac6(result);
             }
             catch (InvalidOperationException)
             {
@@ -74,7 +74,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
 
             try
             {
-                return new SOSDac8(Library, result);
+                return new SOSDac8(result);
             }
             catch (InvalidOperationException)
             {
@@ -90,7 +90,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
 
             try
             {
-                return new SosDac12(Library, _target, result);
+                return new SosDac12(_target, result);
             }
             catch (InvalidOperationException)
             {
@@ -105,7 +105,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             {
                 try
                 {
-                    return new SOSDac13(Library, result);
+                    return new SOSDac13(result);
                 }
                 catch (InvalidOperationException)
                 {
@@ -117,7 +117,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             {
                 try
                 {
-                    return new SOSDac13Old(Library, result);
+                    return new SOSDac13Old(result);
                 }
                 catch (InvalidOperationException)
                 {
@@ -135,7 +135,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
 
             try
             {
-                return new SosDac14(Library, result);
+                return new SosDac14(result);
             }
             catch (InvalidOperationException)
             {
@@ -151,7 +151,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
 
             try
             {
-                return new SOSDac16(Library, result);
+                return new SOSDac16(result);
             }
             catch (InvalidOperationException)
             {
@@ -167,7 +167,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
 
             try
             {
-                return new SosDac17(Library, result);
+                return new SosDac17(result);
             }
             catch (InvalidOperationException)
             {
@@ -193,13 +193,13 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             if (!hr)
                 return null;
 
-            using ClrDataTask dataTask = new(Library, pUnkTask);
+            using ClrDataTask dataTask = new(pUnkTask);
             // There's a bug in certain runtimes where we will fail to release data deep in the runtime
             // when a C++ exception occurs while constructing a ClrDataStackWalk.  This is a workaround
             // for the largest of the leaks caused by this issue.
             //     https://github.com/Microsoft/clrmd/issues/47
             int count = AddRef();
-            ClrStackWalk? res = dataTask.CreateStackWalk(Library, flags);
+            ClrStackWalk? res = dataTask.CreateStackWalk(flags);
             int released = Release();
             if (released == count && res is null)
                 Release();
@@ -217,7 +217,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             try
             {
                 while (VTable.EnumMethodInstanceByAddress(Self, ref handle, out IntPtr method) == HResult.S_OK)
-                    result.Add(new ClrDataMethod(Library, method));
+                    result.Add(new ClrDataMethod(method));
             }
             finally
             {

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/ClrDataProcess.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/ClrDataProcess.cs
@@ -16,19 +16,22 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
     internal sealed unsafe class ClrDataProcess : CallableCOMWrapper
     {
         private static readonly Guid IID_IXCLRDataProcess = new("5c552ab6-fc09-4cb3-8e36-22fa03c798b7");
-        private readonly DacLibrary _library;
+        private readonly object _syncRoot;
+        private readonly TargetProperties _target;
 
-        public ClrDataProcess(DacLibrary library, IntPtr pUnknown)
-            : base(library.OwningLibrary, IID_IXCLRDataProcess, pUnknown)
+        public ClrDataProcess(RefCountedFreeLibrary? library, object syncRoot, TargetProperties target, IntPtr pUnknown)
+            : base(library, IID_IXCLRDataProcess, pUnknown)
         {
-            _library = library;
+            _syncRoot = syncRoot;
+            _target = target;
         }
 
         private ref readonly IXCLRDataProcessVTable VTable => ref Unsafe.AsRef<IXCLRDataProcessVTable>(_vtable);
 
-        public ClrDataProcess(DacLibrary library, CallableCOMWrapper toClone) : base(toClone)
+        public ClrDataProcess(object syncRoot, TargetProperties target, CallableCOMWrapper toClone) : base(toClone)
         {
-            _library = library;
+            _syncRoot = syncRoot;
+            _target = target;
         }
 
         public SOSDac? CreateSOSDacInterface()
@@ -39,7 +42,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
 
             try
             {
-                return new SOSDac(_library, result);
+                return new SOSDac(Library, _syncRoot, result);
             }
             catch (InvalidOperationException)
             {
@@ -55,7 +58,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
 
             try
             {
-                return new SOSDac6(_library, result);
+                return new SOSDac6(Library, result);
             }
             catch (InvalidOperationException)
             {
@@ -71,7 +74,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
 
             try
             {
-                return new SOSDac8(_library, result);
+                return new SOSDac8(Library, result);
             }
             catch (InvalidOperationException)
             {
@@ -87,7 +90,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
 
             try
             {
-                return new SosDac12(_library, result);
+                return new SosDac12(Library, _target, result);
             }
             catch (InvalidOperationException)
             {
@@ -102,7 +105,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             {
                 try
                 {
-                    return new SOSDac13(_library, result);
+                    return new SOSDac13(Library, result);
                 }
                 catch (InvalidOperationException)
                 {
@@ -114,7 +117,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             {
                 try
                 {
-                    return new SOSDac13Old(_library, result);
+                    return new SOSDac13Old(Library, result);
                 }
                 catch (InvalidOperationException)
                 {
@@ -132,7 +135,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
 
             try
             {
-                return new SosDac14(_library, result);
+                return new SosDac14(Library, result);
             }
             catch (InvalidOperationException)
             {
@@ -148,7 +151,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
 
             try
             {
-                return new SOSDac16(_library, result);
+                return new SOSDac16(Library, result);
             }
             catch (InvalidOperationException)
             {
@@ -164,7 +167,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
 
             try
             {
-                return new SosDac17(_library, result);
+                return new SosDac17(Library, result);
             }
             catch (InvalidOperationException)
             {
@@ -190,13 +193,13 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             if (!hr)
                 return null;
 
-            using ClrDataTask dataTask = new(_library, pUnkTask);
+            using ClrDataTask dataTask = new(Library, pUnkTask);
             // There's a bug in certain runtimes where we will fail to release data deep in the runtime
             // when a C++ exception occurs while constructing a ClrDataStackWalk.  This is a workaround
             // for the largest of the leaks caused by this issue.
             //     https://github.com/Microsoft/clrmd/issues/47
             int count = AddRef();
-            ClrStackWalk? res = dataTask.CreateStackWalk(_library, flags);
+            ClrStackWalk? res = dataTask.CreateStackWalk(Library, flags);
             int released = Release();
             if (released == count && res is null)
                 Release();
@@ -214,7 +217,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             try
             {
                 while (VTable.EnumMethodInstanceByAddress(Self, ref handle, out IntPtr method) == HResult.S_OK)
-                    result.Add(new ClrDataMethod(_library, method));
+                    result.Add(new ClrDataMethod(Library, method));
             }
             finally
             {

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/ClrDataTask.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/ClrDataTask.cs
@@ -13,20 +13,20 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
     {
         private static readonly Guid IID_IXCLRDataTask = new("A5B0BEEA-EC62-4618-8012-A24FFC23934C");
 
-        public ClrDataTask(RefCountedFreeLibrary? library, IntPtr pUnk)
-            : base(library, IID_IXCLRDataTask, pUnk)
+        public ClrDataTask(IntPtr pUnk)
+            : base(IID_IXCLRDataTask, pUnk)
         {
         }
 
         private ref readonly ClrDataTaskVTable VTable => ref Unsafe.AsRef<ClrDataTaskVTable>(_vtable);
 
-        public ClrStackWalk? CreateStackWalk(RefCountedFreeLibrary? library, uint flags)
+        public ClrStackWalk? CreateStackWalk(uint flags)
         {
             HResult hr = VTable.CreateStackWalk(Self, flags, out IntPtr pUnk);
             if (!hr)
                 return null;
 
-            return new ClrStackWalk(library, pUnk);
+            return new ClrStackWalk(pUnk);
         }
     }
 

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/ClrDataTask.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/ClrDataTask.cs
@@ -13,14 +13,14 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
     {
         private static readonly Guid IID_IXCLRDataTask = new("A5B0BEEA-EC62-4618-8012-A24FFC23934C");
 
-        public ClrDataTask(DacLibrary library, IntPtr pUnk)
-            : base(library.OwningLibrary, IID_IXCLRDataTask, pUnk)
+        public ClrDataTask(RefCountedFreeLibrary? library, IntPtr pUnk)
+            : base(library, IID_IXCLRDataTask, pUnk)
         {
         }
 
         private ref readonly ClrDataTaskVTable VTable => ref Unsafe.AsRef<ClrDataTaskVTable>(_vtable);
 
-        public ClrStackWalk? CreateStackWalk(DacLibrary library, uint flags)
+        public ClrStackWalk? CreateStackWalk(RefCountedFreeLibrary? library, uint flags)
         {
             HResult hr = VTable.CreateStackWalk(Self, flags, out IntPtr pUnk);
             if (!hr)

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/ClrStackWalk.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/ClrStackWalk.cs
@@ -12,8 +12,8 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
     {
         private static readonly Guid IID_IXCLRDataStackWalk = new("E59D8D22-ADA7-49a2-89B5-A415AFCFC95F");
 
-        public ClrStackWalk(RefCountedFreeLibrary? library, IntPtr pUnk)
-            : base(library, IID_IXCLRDataStackWalk, pUnk)
+        public ClrStackWalk(IntPtr pUnk)
+            : base(IID_IXCLRDataStackWalk, pUnk)
         {
         }
 

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/ClrStackWalk.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/ClrStackWalk.cs
@@ -12,8 +12,8 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
     {
         private static readonly Guid IID_IXCLRDataStackWalk = new("E59D8D22-ADA7-49a2-89B5-A415AFCFC95F");
 
-        public ClrStackWalk(DacLibrary library, IntPtr pUnk)
-            : base(library.OwningLibrary, IID_IXCLRDataStackWalk, pUnk)
+        public ClrStackWalk(RefCountedFreeLibrary? library, IntPtr pUnk)
+            : base(library, IID_IXCLRDataStackWalk, pUnk)
         {
         }
 

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/DacDataTarget.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/DacDataTarget.cs
@@ -51,7 +51,9 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
 
         public int PointerSize => _dataTarget.DataReader.PointerSize;
 
-        public TargetProperties TargetProperties => _targetProperties ??= new TargetProperties(pointerSize: PointerSize);
+        // Used only for pointer-size address translation in ReadVirtual; ThinLockLayout is never read
+        // here, so the conservative Legacy layout is used.
+        public TargetProperties TargetProperties => _targetProperties ??= new TargetProperties(ThinLockLayout.Legacy, PointerSize);
         private TargetProperties? _targetProperties;
 
         public void Flush()

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/DacDataTarget.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/DacDataTarget.cs
@@ -5,7 +5,6 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
-using System.Threading;
 using Microsoft.Diagnostics.Runtime.Utilities;
 
 namespace Microsoft.Diagnostics.Runtime.DacInterface
@@ -18,14 +17,9 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
         internal static readonly Guid IID_ICLRContractLocator = new("17d5b8c6-34a9-407f-af4f-a930201d4e02");
         internal static readonly Guid IID_ICLRSymbolProvider = new("c4f8b7e2-9d3a-4f6c-b1e5-8a2d7c3f9b1e");
 
-        public const ulong MagicCallbackConstant = 0x43;
-
         private readonly DataTarget _dataTarget;
         private readonly IDataReader _dataReader;
         private volatile ModuleInfo[]? _modules;
-
-        private Action? _callback;
-        private volatile int _callbackContext;
 
         public ulong RuntimeBaseAddress { get; }
 
@@ -40,12 +34,6 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             RuntimeBaseAddress = runtimeBaseAddress;
             ContractDescriptor = contractDescriptor;
         }
-
-        public void EnterMagicCallbackContext() => Interlocked.Increment(ref _callbackContext);
-
-        public void ExitMagicCallbackContext() => Interlocked.Decrement(ref _callbackContext);
-
-        public void SetMagicCallback(Action flushCallback) => _callback = flushCallback;
 
         public IMAGE_FILE_MACHINE MachineType
         {
@@ -125,14 +113,6 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
         {
             ulong address = cda.ToAddress(TargetProperties);
             Span<byte> span = new(buffer.ToPointer(), bytesRequested);
-
-            if (address == MagicCallbackConstant && _callbackContext > 0)
-            {
-                // See comment in RuntimeBuilder.FlushDac
-                _callback?.Invoke();
-                bytesRead = 0;
-                return false;
-            }
 
             int read = _dataReader.Read(address, span);
             if (read > 0)

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/MetadataImport.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/MetadataImport.cs
@@ -17,8 +17,8 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
     {
         public static readonly Guid IID_IMetaDataImport = new("7DAC8207-D3AE-4c75-9B67-92801A497D44");
 
-        public MetadataImport(RefCountedFreeLibrary? library, IntPtr pUnknown)
-            : base(library, IID_IMetaDataImport, pUnknown)
+        public MetadataImport(IntPtr pUnknown)
+            : base(IID_IMetaDataImport, pUnknown)
         {
         }
 

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/MetadataImport.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/MetadataImport.cs
@@ -22,11 +22,6 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
         {
         }
 
-        public MetadataImport(DacLibrary library, IntPtr pUnknown)
-            : base(library?.OwningLibrary, IID_IMetaDataImport, pUnknown)
-        {
-        }
-
         private ref readonly IMetaDataImportVTable VTable => ref Unsafe.AsRef<IMetaDataImportVTable>(_vtable);
 
         public IEnumerable<int> EnumerateInterfaceImpls(int token)

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/SOSDac12.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/SOSDac12.cs
@@ -17,10 +17,10 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
 
         private readonly TargetProperties _target;
 
-        public SosDac12(DacLibrary library, IntPtr ptr)
-            : base(library.OwningLibrary, IID_ISOSDac12, ptr)
+        public SosDac12(RefCountedFreeLibrary? library, TargetProperties target, IntPtr ptr)
+            : base(library, IID_ISOSDac12, ptr)
         {
-            _target = library.TargetProperties;
+            _target = target;
         }
 
         private ref readonly ISOSDac12VTable VTable => ref Unsafe.AsRef<ISOSDac12VTable>(_vtable);

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/SOSDac12.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/SOSDac12.cs
@@ -17,8 +17,8 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
 
         private readonly TargetProperties _target;
 
-        public SosDac12(RefCountedFreeLibrary? library, TargetProperties target, IntPtr ptr)
-            : base(library, IID_ISOSDac12, ptr)
+        public SosDac12(TargetProperties target, IntPtr ptr)
+            : base(IID_ISOSDac12, ptr)
         {
             _target = target;
         }

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/SOSDac13Old.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/SOSDac13Old.cs
@@ -17,8 +17,8 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
     {
         internal static readonly Guid IID_ISOSDac13 = new("3176a8ed-597b-4f54-a71f-83695c6a8c5d");
 
-        public SOSDac13Old(DacLibrary library, IntPtr ptr)
-            : base(library.OwningLibrary, IID_ISOSDac13, ptr)
+        public SOSDac13Old(RefCountedFreeLibrary? library, IntPtr ptr)
+            : base(library, IID_ISOSDac13, ptr)
         {
         }
 

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/SOSDac13Old.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/SOSDac13Old.cs
@@ -17,8 +17,8 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
     {
         internal static readonly Guid IID_ISOSDac13 = new("3176a8ed-597b-4f54-a71f-83695c6a8c5d");
 
-        public SOSDac13Old(RefCountedFreeLibrary? library, IntPtr ptr)
-            : base(library, IID_ISOSDac13, ptr)
+        public SOSDac13Old(IntPtr ptr)
+            : base(IID_ISOSDac13, ptr)
         {
         }
 

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/SosDac.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/SosDac.cs
@@ -21,31 +21,31 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
     {
         internal static readonly Guid IID_ISOSDac = new("436f00f2-b42a-4b9f-870c-e73db66ae930");
 
-        private readonly DacLibrary _library;
+        private readonly object _syncRoot;
         private readonly Dictionary<int, string> _regNames = new();
         private readonly Dictionary<ClrDataAddress, string> _frameNames = new();
 
         // CLRDATA_REQUEST_REVISION version from the DAC
         public int DacVersion { get; set; }
 
-        public SOSDac(DacLibrary library, IntPtr ptr)
-            : base(library.OwningLibrary, IID_ISOSDac, ptr)
+        public SOSDac(RefCountedFreeLibrary? library, object syncRoot, IntPtr ptr)
+            : base(library, IID_ISOSDac, ptr)
         {
-            _library = library;
+            _syncRoot = syncRoot;
         }
 
         private ref readonly ISOSDacVTable VTable => ref Unsafe.AsRef<ISOSDacVTable>(_vtable);
 
-        public SOSDac(DacLibrary lib, CallableCOMWrapper toClone) : base(toClone)
+        public SOSDac(object syncRoot, CallableCOMWrapper toClone) : base(toClone)
         {
-            _library = lib;
+            _syncRoot = syncRoot;
         }
 
         /// <summary>
         /// Process-wide lock that serializes stateful DAC enumerations (stack walks, etc.).
         /// See <see cref="DacLibrary.SyncRoot"/> for the rationale.
         /// </summary>
-        internal object SyncRoot => _library.SyncRoot;
+        internal object SyncRoot => _syncRoot;
 
         public RejitData[] GetRejitData(ClrDataAddress md, ClrDataAddress ip = default)
         {
@@ -360,7 +360,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
 
             HResult hr = VTable.GetModule(Self, module.ToInteropAddress(), out IntPtr iunk);
             if (hr)
-                return new ClrDataModule(_library, iunk);
+                return new ClrDataModule(Library, iunk);
 
             return null;
         }
@@ -384,7 +384,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
 
             try
             {
-                return new MetadataImport(_library, iunk);
+                return new MetadataImport(Library, iunk);
             }
             catch (InvalidCastException)
             {
@@ -756,7 +756,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
                 HResult hr = VTable.GetHandleEnumForTypes(Self, ptr, types.Length, out IntPtr ptrEnum);
                 if (hr)
                 {
-                    SOSHandleEnum result = new(_library, ptrEnum);
+                    SOSHandleEnum result = new(Library, ptrEnum);
                     ReleaseLeakedDacRef(result, nameof(ISOSDacVTable.GetHandleEnumForTypes));
                     return result;
                 }
@@ -770,7 +770,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             HResult hr = VTable.GetHandleEnum(Self, out IntPtr ptrEnum);
             if (hr)
             {
-                SOSHandleEnum result = new(_library, ptrEnum);
+                SOSHandleEnum result = new(Library, ptrEnum);
                 ReleaseLeakedDacRef(result, nameof(ISOSDacVTable.GetHandleEnum));
                 return result;
             }
@@ -784,7 +784,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
 
             if (hr)
             {
-                SOSStackRefEnum result = new(_library, ptrEnum);
+                SOSStackRefEnum result = new(Library, ptrEnum);
                 ReleaseLeakedDacRef(result, nameof(ISOSDacVTable.GetStackReferences));
                 return result;
             }

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/SosDac.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/SosDac.cs
@@ -28,8 +28,8 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
         // CLRDATA_REQUEST_REVISION version from the DAC
         public int DacVersion { get; set; }
 
-        public SOSDac(RefCountedFreeLibrary? library, object syncRoot, IntPtr ptr)
-            : base(library, IID_ISOSDac, ptr)
+        public SOSDac(object syncRoot, IntPtr ptr)
+            : base(IID_ISOSDac, ptr)
         {
             _syncRoot = syncRoot;
         }
@@ -360,7 +360,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
 
             HResult hr = VTable.GetModule(Self, module.ToInteropAddress(), out IntPtr iunk);
             if (hr)
-                return new ClrDataModule(Library, iunk);
+                return new ClrDataModule(iunk);
 
             return null;
         }
@@ -384,7 +384,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
 
             try
             {
-                return new MetadataImport(Library, iunk);
+                return new MetadataImport(iunk);
             }
             catch (InvalidCastException)
             {
@@ -756,7 +756,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
                 HResult hr = VTable.GetHandleEnumForTypes(Self, ptr, types.Length, out IntPtr ptrEnum);
                 if (hr)
                 {
-                    SOSHandleEnum result = new(Library, ptrEnum);
+                    SOSHandleEnum result = new(ptrEnum);
                     ReleaseLeakedDacRef(result, nameof(ISOSDacVTable.GetHandleEnumForTypes));
                     return result;
                 }
@@ -770,7 +770,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
             HResult hr = VTable.GetHandleEnum(Self, out IntPtr ptrEnum);
             if (hr)
             {
-                SOSHandleEnum result = new(Library, ptrEnum);
+                SOSHandleEnum result = new(ptrEnum);
                 ReleaseLeakedDacRef(result, nameof(ISOSDacVTable.GetHandleEnum));
                 return result;
             }
@@ -784,7 +784,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
 
             if (hr)
             {
-                SOSStackRefEnum result = new(Library, ptrEnum);
+                SOSStackRefEnum result = new(ptrEnum);
                 ReleaseLeakedDacRef(result, nameof(ISOSDacVTable.GetStackReferences));
                 return result;
             }

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/SosDac13.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/SosDac13.cs
@@ -15,14 +15,11 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
     /// </summary>
     internal sealed unsafe class SOSDac13 : CallableCOMWrapper, ISOSDac13
     {
-        private readonly DacLibrary _library;
-
         internal static readonly Guid IID_ISOSDac13 = new("3176a8ed-597b-4f54-a71f-83695c6a8c5e");
 
-        public SOSDac13(DacLibrary library, IntPtr ptr)
-            : base(library.OwningLibrary, IID_ISOSDac13, ptr)
+        public SOSDac13(RefCountedFreeLibrary? library, IntPtr ptr)
+            : base(library, IID_ISOSDac13, ptr)
         {
-            _library = library;
         }
 
         private ref readonly ISOSDac13VTable VTable => ref Unsafe.AsRef<ISOSDac13VTable>(_vtable);
@@ -97,19 +94,19 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
         public SosMemoryEnum? GetHandleTableRegions()
         {
             HResult hr = VTable.GetHandleTableMemoryRegions(Self, out nint pUnk);
-            return hr ? new SosMemoryEnum(_library, pUnk) : null;
+            return hr ? new SosMemoryEnum(Library, pUnk) : null;
         }
 
         public SosMemoryEnum? GetGCBookkeepingMemoryRegions()
         {
             HResult hr = VTable.GetGCBookkeepingMemoryRegions(Self, out nint pUnk);
-            return hr ? new SosMemoryEnum(_library, pUnk) : null;
+            return hr ? new SosMemoryEnum(Library, pUnk) : null;
         }
 
         public SosMemoryEnum? GetGCFreeRegions()
         {
             HResult hr = VTable.GetGCFreeRegions(Self, out nint pUnk);
-            return hr ? new SosMemoryEnum(_library, pUnk) : null;
+            return hr ? new SosMemoryEnum(Library, pUnk) : null;
         }
 
         public void LockedFlush()

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/SosDac13.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/SosDac13.cs
@@ -17,8 +17,8 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
     {
         internal static readonly Guid IID_ISOSDac13 = new("3176a8ed-597b-4f54-a71f-83695c6a8c5e");
 
-        public SOSDac13(RefCountedFreeLibrary? library, IntPtr ptr)
-            : base(library, IID_ISOSDac13, ptr)
+        public SOSDac13(IntPtr ptr)
+            : base(IID_ISOSDac13, ptr)
         {
         }
 
@@ -94,19 +94,19 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
         public SosMemoryEnum? GetHandleTableRegions()
         {
             HResult hr = VTable.GetHandleTableMemoryRegions(Self, out nint pUnk);
-            return hr ? new SosMemoryEnum(Library, pUnk) : null;
+            return hr ? new SosMemoryEnum(pUnk) : null;
         }
 
         public SosMemoryEnum? GetGCBookkeepingMemoryRegions()
         {
             HResult hr = VTable.GetGCBookkeepingMemoryRegions(Self, out nint pUnk);
-            return hr ? new SosMemoryEnum(Library, pUnk) : null;
+            return hr ? new SosMemoryEnum(pUnk) : null;
         }
 
         public SosMemoryEnum? GetGCFreeRegions()
         {
             HResult hr = VTable.GetGCFreeRegions(Self, out nint pUnk);
-            return hr ? new SosMemoryEnum(Library, pUnk) : null;
+            return hr ? new SosMemoryEnum(pUnk) : null;
         }
 
         public void LockedFlush()

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/SosDac14.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/SosDac14.cs
@@ -16,8 +16,8 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
     {
         internal static readonly Guid IID_ISOSDac14 = new("9aa22aca-6dc6-4a0c-b4e0-70d2416b9837");
 
-        public SosDac14(RefCountedFreeLibrary? library, IntPtr ptr)
-            : base(library, IID_ISOSDac14, ptr)
+        public SosDac14(IntPtr ptr)
+            : base(IID_ISOSDac14, ptr)
         {
         }
 

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/SosDac14.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/SosDac14.cs
@@ -16,8 +16,8 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
     {
         internal static readonly Guid IID_ISOSDac14 = new("9aa22aca-6dc6-4a0c-b4e0-70d2416b9837");
 
-        public SosDac14(DacLibrary library, IntPtr ptr)
-            : base(library.OwningLibrary, IID_ISOSDac14, ptr)
+        public SosDac14(RefCountedFreeLibrary? library, IntPtr ptr)
+            : base(library, IID_ISOSDac14, ptr)
         {
         }
 

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/SosDac16.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/SosDac16.cs
@@ -17,8 +17,8 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
     {
         internal static readonly Guid IID_ISOSDac16 = new("4ba12ff8-daac-4e43-ac56-98cf8d5c595d");
 
-        public SOSDac16(DacLibrary library, IntPtr ptr)
-            : base(library.OwningLibrary, IID_ISOSDac16, ptr)
+        public SOSDac16(RefCountedFreeLibrary? library, IntPtr ptr)
+            : base(library, IID_ISOSDac16, ptr)
         {
         }
 

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/SosDac16.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/SosDac16.cs
@@ -17,8 +17,8 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
     {
         internal static readonly Guid IID_ISOSDac16 = new("4ba12ff8-daac-4e43-ac56-98cf8d5c595d");
 
-        public SOSDac16(RefCountedFreeLibrary? library, IntPtr ptr)
-            : base(library, IID_ISOSDac16, ptr)
+        public SOSDac16(IntPtr ptr)
+            : base(IID_ISOSDac16, ptr)
         {
         }
 

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/SosDac17.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/SosDac17.cs
@@ -15,8 +15,8 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
     {
         internal static readonly Guid IID_ISOSDacInterface17 = new("2f4bb585-ed50-479e-bbe0-10a95a5da3bb");
 
-        public SosDac17(RefCountedFreeLibrary? library, IntPtr ptr)
-            : base(library, IID_ISOSDacInterface17, ptr)
+        public SosDac17(IntPtr ptr)
+            : base(IID_ISOSDacInterface17, ptr)
         {
         }
 
@@ -41,7 +41,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
 
             try
             {
-                return new SosStressLogThreadEnum(Library, ptr);
+                return new SosStressLogThreadEnum(ptr);
             }
             catch (InvalidOperationException)
             {
@@ -57,7 +57,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
 
             try
             {
-                return new SosStressLogMsgEnum(Library, ptr);
+                return new SosStressLogMsgEnum(ptr);
             }
             catch (InvalidOperationException)
             {
@@ -73,7 +73,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
 
             try
             {
-                return new SosMemoryEnum(Library, ptr);
+                return new SosMemoryEnum(ptr);
             }
             catch (InvalidOperationException)
             {
@@ -98,8 +98,8 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
     {
         internal static readonly Guid IID_ISOSStressLogThreadEnum = new("94a2bd3d-ab3d-43bf-81d8-3ae96b8e33cd");
 
-        public SosStressLogThreadEnum(RefCountedFreeLibrary? library, IntPtr pUnk)
-            : base(library, IID_ISOSStressLogThreadEnum, pUnk)
+        public SosStressLogThreadEnum(IntPtr pUnk)
+            : base(IID_ISOSStressLogThreadEnum, pUnk)
         {
         }
 
@@ -142,8 +142,8 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
     {
         internal static readonly Guid IID_ISOSStressLogMsgEnum = new("437cb033-afe7-4c0f-a4a7-82c891bc049e");
 
-        public SosStressLogMsgEnum(RefCountedFreeLibrary? library, IntPtr pUnk)
-            : base(library, IID_ISOSStressLogMsgEnum, pUnk)
+        public SosStressLogMsgEnum(IntPtr pUnk)
+            : base(IID_ISOSStressLogMsgEnum, pUnk)
         {
         }
 

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/SosDac17.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/SosDac17.cs
@@ -15,12 +15,9 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
     {
         internal static readonly Guid IID_ISOSDacInterface17 = new("2f4bb585-ed50-479e-bbe0-10a95a5da3bb");
 
-        private readonly DacLibrary _library;
-
-        public SosDac17(DacLibrary library, IntPtr ptr)
-            : base(library.OwningLibrary, IID_ISOSDacInterface17, ptr)
+        public SosDac17(RefCountedFreeLibrary? library, IntPtr ptr)
+            : base(library, IID_ISOSDacInterface17, ptr)
         {
-            _library = library;
         }
 
         private ref readonly ISOSDacInterface17VTable VTable => ref Unsafe.AsRef<ISOSDacInterface17VTable>(_vtable);
@@ -44,7 +41,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
 
             try
             {
-                return new SosStressLogThreadEnum(_library, ptr);
+                return new SosStressLogThreadEnum(Library, ptr);
             }
             catch (InvalidOperationException)
             {
@@ -60,7 +57,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
 
             try
             {
-                return new SosStressLogMsgEnum(_library, ptr);
+                return new SosStressLogMsgEnum(Library, ptr);
             }
             catch (InvalidOperationException)
             {
@@ -76,7 +73,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
 
             try
             {
-                return new SosMemoryEnum(_library, ptr);
+                return new SosMemoryEnum(Library, ptr);
             }
             catch (InvalidOperationException)
             {
@@ -101,8 +98,8 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
     {
         internal static readonly Guid IID_ISOSStressLogThreadEnum = new("94a2bd3d-ab3d-43bf-81d8-3ae96b8e33cd");
 
-        public SosStressLogThreadEnum(DacLibrary library, IntPtr pUnk)
-            : base(library?.OwningLibrary, IID_ISOSStressLogThreadEnum, pUnk)
+        public SosStressLogThreadEnum(RefCountedFreeLibrary? library, IntPtr pUnk)
+            : base(library, IID_ISOSStressLogThreadEnum, pUnk)
         {
         }
 
@@ -145,8 +142,8 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
     {
         internal static readonly Guid IID_ISOSStressLogMsgEnum = new("437cb033-afe7-4c0f-a4a7-82c891bc049e");
 
-        public SosStressLogMsgEnum(DacLibrary library, IntPtr pUnk)
-            : base(library?.OwningLibrary, IID_ISOSStressLogMsgEnum, pUnk)
+        public SosStressLogMsgEnum(RefCountedFreeLibrary? library, IntPtr pUnk)
+            : base(library, IID_ISOSStressLogMsgEnum, pUnk)
         {
         }
 

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/SosDac6.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/SosDac6.cs
@@ -15,8 +15,8 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
     {
         internal static readonly Guid IID_ISOSDac6 = new("11206399-4B66-4EDB-98EA-85654E59AD45");
 
-        public SOSDac6(DacLibrary library, IntPtr ptr)
-            : base(library.OwningLibrary, IID_ISOSDac6, ptr)
+        public SOSDac6(RefCountedFreeLibrary? library, IntPtr ptr)
+            : base(library, IID_ISOSDac6, ptr)
         {
         }
 

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/SosDac6.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/SosDac6.cs
@@ -15,8 +15,8 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
     {
         internal static readonly Guid IID_ISOSDac6 = new("11206399-4B66-4EDB-98EA-85654E59AD45");
 
-        public SOSDac6(RefCountedFreeLibrary? library, IntPtr ptr)
-            : base(library, IID_ISOSDac6, ptr)
+        public SOSDac6(IntPtr ptr)
+            : base(IID_ISOSDac6, ptr)
         {
         }
 

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/SosDac8.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/SosDac8.cs
@@ -15,8 +15,8 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
     {
         internal static readonly Guid IID_ISOSDac8 = new("c12f35a9-e55c-4520-a894-b3dc5165dfce");
 
-        public SOSDac8(DacLibrary library, IntPtr ptr)
-            : base(library.OwningLibrary, IID_ISOSDac8, ptr)
+        public SOSDac8(RefCountedFreeLibrary? library, IntPtr ptr)
+            : base(library, IID_ISOSDac8, ptr)
         {
         }
 

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/SosDac8.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/SosDac8.cs
@@ -15,8 +15,8 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
     {
         internal static readonly Guid IID_ISOSDac8 = new("c12f35a9-e55c-4520-a894-b3dc5165dfce");
 
-        public SOSDac8(RefCountedFreeLibrary? library, IntPtr ptr)
-            : base(library, IID_ISOSDac8, ptr)
+        public SOSDac8(IntPtr ptr)
+            : base(IID_ISOSDac8, ptr)
         {
         }
 

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/SosHandleEnum.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/SosHandleEnum.cs
@@ -15,8 +15,8 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
 
         private static readonly Guid IID_ISOSHandleEnum = new("3E269830-4A2B-4301-8EE2-D6805B29B2FA");
 
-        public SOSHandleEnum(DacLibrary library, IntPtr pUnk)
-            : base(library?.OwningLibrary, IID_ISOSHandleEnum, pUnk)
+        public SOSHandleEnum(RefCountedFreeLibrary? library, IntPtr pUnk)
+            : base(library, IID_ISOSHandleEnum, pUnk)
         {
         }
 

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/SosHandleEnum.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/SosHandleEnum.cs
@@ -15,8 +15,8 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
 
         private static readonly Guid IID_ISOSHandleEnum = new("3E269830-4A2B-4301-8EE2-D6805B29B2FA");
 
-        public SOSHandleEnum(RefCountedFreeLibrary? library, IntPtr pUnk)
-            : base(library, IID_ISOSHandleEnum, pUnk)
+        public SOSHandleEnum(IntPtr pUnk)
+            : base(IID_ISOSHandleEnum, pUnk)
         {
         }
 

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/SosMemoryEnum.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/SosMemoryEnum.cs
@@ -14,8 +14,8 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
     {
         private ref readonly ISOSMemoryEnumVtable VTable => ref Unsafe.AsRef<ISOSMemoryEnumVtable>(_vtable);
         public static readonly Guid IID_ISOSMemoryEnum = new("E4B860EC-337A-40C0-A591-F09A9680690F");
-        public SosMemoryEnum(RefCountedFreeLibrary? library, IntPtr pUnk)
-            : base(library, IID_ISOSMemoryEnum, pUnk)
+        public SosMemoryEnum(IntPtr pUnk)
+            : base(IID_ISOSMemoryEnum, pUnk)
         {
         }
 

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/SosMemoryEnum.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/SosMemoryEnum.cs
@@ -14,8 +14,8 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
     {
         private ref readonly ISOSMemoryEnumVtable VTable => ref Unsafe.AsRef<ISOSMemoryEnumVtable>(_vtable);
         public static readonly Guid IID_ISOSMemoryEnum = new("E4B860EC-337A-40C0-A591-F09A9680690F");
-        public SosMemoryEnum(DacLibrary library, IntPtr pUnk)
-            : base(library?.OwningLibrary, IID_ISOSMemoryEnum, pUnk)
+        public SosMemoryEnum(RefCountedFreeLibrary? library, IntPtr pUnk)
+            : base(library, IID_ISOSMemoryEnum, pUnk)
         {
         }
 

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/SosStackRefEnum.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/SosStackRefEnum.cs
@@ -14,8 +14,8 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
         private readonly List<nint> _data = new();
         private static readonly Guid IID_ISOSStackRefEnum = new("8FA642BD-9F10-4799-9AA3-512AE78C77EE");
 
-        public SOSStackRefEnum(DacLibrary library, IntPtr pUnk)
-            : base(library?.OwningLibrary, IID_ISOSStackRefEnum, pUnk)
+        public SOSStackRefEnum(RefCountedFreeLibrary? library, IntPtr pUnk)
+            : base(library, IID_ISOSStackRefEnum, pUnk)
         {
         }
 

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/SosStackRefEnum.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/SosStackRefEnum.cs
@@ -14,8 +14,8 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
         private readonly List<nint> _data = new();
         private static readonly Guid IID_ISOSStackRefEnum = new("8FA642BD-9F10-4799-9AA3-512AE78C77EE");
 
-        public SOSStackRefEnum(RefCountedFreeLibrary? library, IntPtr pUnk)
-            : base(library, IID_ISOSStackRefEnum, pUnk)
+        public SOSStackRefEnum(IntPtr pUnk)
+            : base(IID_ISOSStackRefEnum, pUnk)
         {
         }
 

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/TargetProperties.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/TargetProperties.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
 {
     /// <summary>
     /// Immutable target-process properties used throughout the DAC implementation.
-    /// A single <see cref="TargetProperties"/> instance is owned by <see cref="DacLibrary"/>
+    /// The canonical instance for a runtime is created by <see cref="DacImplementation.DacServiceProvider"/>
     /// and passed to DAC wrappers. Future target-level facts (endianness, machine type, etc.)
     /// can be added here without re-plumbing every DAC wrapper.
     /// </summary>
@@ -16,14 +16,19 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
         /// <summary>
         /// Creates target properties for the specified pointer size.
         /// </summary>
+        /// <param name="thinlockLayout">The layout of thin locks in the target process.</param>
         /// <param name="pointerSize">The target process pointer size (4 or 8).</param>
-        public TargetProperties(int pointerSize)
+        public TargetProperties(ThinLockLayout thinlockLayout, int pointerSize)
         {
             if (pointerSize != 4 && pointerSize != 8)
                 throw new ArgumentOutOfRangeException(nameof(pointerSize), pointerSize, "Pointer size must be 4 or 8.");
 
+            ThinLockLayout = thinlockLayout;
             PointerSize = pointerSize;
         }
+
+        /// <summary>Layout of thin locks in the target process.</summary>
+        public ThinLockLayout ThinLockLayout { get; }
 
         /// <summary>Pointer size in bytes (4 or 8).</summary>
         public int PointerSize { get; }

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/TargetProperties.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/TargetProperties.cs
@@ -16,14 +16,14 @@ namespace Microsoft.Diagnostics.Runtime.DacInterface
         /// <summary>
         /// Creates target properties for the specified pointer size.
         /// </summary>
-        /// <param name="thinlockLayout">The layout of thin locks in the target process.</param>
+        /// <param name="thinLockLayout">The layout of thin locks in the target process.</param>
         /// <param name="pointerSize">The target process pointer size (4 or 8).</param>
-        public TargetProperties(ThinLockLayout thinlockLayout, int pointerSize)
+        public TargetProperties(ThinLockLayout thinLockLayout, int pointerSize)
         {
             if (pointerSize != 4 && pointerSize != 8)
                 throw new ArgumentOutOfRangeException(nameof(pointerSize), pointerSize, "Pointer size must be 4 or 8.");
 
-            ThinLockLayout = thinlockLayout;
+            ThinLockLayout = thinLockLayout;
             PointerSize = pointerSize;
         }
 

--- a/src/Microsoft.Diagnostics.Runtime/DacInterface/ThinLockLayout.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacInterface/ThinLockLayout.cs
@@ -1,0 +1,12 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Diagnostics.Runtime.DacInterface
+{
+    internal enum ThinLockLayout
+    {
+        Legacy,
+        Large,
+        LargeWithLegacyFallback,
+    }
+}

--- a/src/Microsoft.Diagnostics.Runtime/DacLibrary.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacLibrary.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Diagnostics.Runtime
 
         public TargetProperties TargetProperties { get; }
 
-        public ClrDataProcess CreateClrDataProcess() => new(this, _clrDataProcess);
+        public ClrDataProcess CreateClrDataProcess() => new(SyncRoot, TargetProperties, _clrDataProcess);
 
         public unsafe DacLibrary(DataTarget dataTarget, string dacPath, ulong runtimeBaseAddress, ulong contractDescriptor, bool verifySignature)
         {
@@ -147,7 +147,7 @@ namespace Microsoft.Diagnostics.Runtime
                     throw new ClrDiagnosticsException($"Failure loading DAC: CreateDacInstance failed 0x{res:x}", res);
             }
 
-            _clrDataProcess = new ClrDataProcess(this, iUnk);
+            _clrDataProcess = new ClrDataProcess(OwningLibrary, SyncRoot, TargetProperties, iUnk);
         }
 
         public void Dispose()

--- a/src/Microsoft.Diagnostics.Runtime/DacLibrary.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacLibrary.cs
@@ -49,7 +49,10 @@ namespace Microsoft.Diagnostics.Runtime
             // load below operate on a full path (callers may pass a relative or non-normalized path).
             dacPath = Path.GetFullPath(dacPath);
 
-            TargetProperties = new TargetProperties(pointerSize: dataTarget.DataReader.PointerSize);
+            // This TargetProperties feeds only pointer-size address translation (ClrDataProcess/SosDac12);
+            // its ThinLockLayout is never consumed here, so the conservative Legacy layout is used. The
+            // canonical layout for thin-lock decoding is computed per-runtime in DacServiceProvider.
+            TargetProperties = new TargetProperties(ThinLockLayout.Legacy, dataTarget.DataReader.PointerSize);
 
             IDisposable? fileLock = null;
             IntPtr dacLibrary;

--- a/src/Microsoft.Diagnostics.Runtime/DacLibrary.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacLibrary.cs
@@ -147,7 +147,7 @@ namespace Microsoft.Diagnostics.Runtime
                     throw new ClrDiagnosticsException($"Failure loading DAC: CreateDacInstance failed 0x{res:x}", res);
             }
 
-            _clrDataProcess = new ClrDataProcess(OwningLibrary, SyncRoot, TargetProperties, iUnk);
+            _clrDataProcess = new ClrDataProcess(SyncRoot, TargetProperties, iUnk);
         }
 
         public void Dispose()

--- a/src/Microsoft.Diagnostics.Runtime/DataReaders/DbgEng/DbgEngDataReader.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DataReaders/DbgEng/DbgEngDataReader.cs
@@ -31,7 +31,6 @@ namespace Microsoft.Diagnostics.Runtime
         private List<ModuleInfo>? _modules;
         private int? _pointerSize;
         private Architecture? _architecture;
-        private static readonly RefCountedFreeLibrary _library = new(IntPtr.Zero);
 
         public string DisplayName { get; }
         public OSPlatform TargetPlatform => OSPlatform.Windows;
@@ -205,12 +204,12 @@ namespace Microsoft.Diagnostics.Runtime
 
         private void CreateClient(IntPtr ptr)
         {
-            _systemObjects = new DebugSystemObjects(_library, ptr);
-            _client = new DebugClient(_library, ptr, _systemObjects);
-            _control = new DebugControl(_library, ptr, _systemObjects);
-            _spaces = new DebugDataSpaces(_library, ptr, _systemObjects);
-            _advanced = new DebugAdvanced(_library, ptr, _systemObjects);
-            _symbols = new DebugSymbols(_library, ptr, _systemObjects);
+            _systemObjects = new DebugSystemObjects(ptr);
+            _client = new DebugClient(ptr, _systemObjects);
+            _control = new DebugControl(ptr, _systemObjects);
+            _spaces = new DebugDataSpaces(ptr, _systemObjects);
+            _advanced = new DebugAdvanced(ptr, _systemObjects);
+            _symbols = new DebugSymbols(ptr, _systemObjects);
 
             _client.SuppressRelease();
             _control.SuppressRelease();

--- a/src/Microsoft.Diagnostics.Runtime/DataTarget.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DataTarget.cs
@@ -32,6 +32,7 @@ namespace Microsoft.Diagnostics.Runtime
 
         private bool _disposed;
         private ImmutableArray<ClrInfo> _clrs;
+        private bool _enumerated;
         private readonly object _clrsLock = new();
         private ModuleInfo[]? _modules;
         private readonly Dictionary<string, PEImage?> _pefileCache = new(StringComparer.OrdinalIgnoreCase);
@@ -69,11 +70,11 @@ namespace Microsoft.Diagnostics.Runtime
         /// by the host, bypassing ClrMD's <see cref="IClrInfoProvider"/> runtime discovery. Use this when the
         /// host (e.g. SOS) performs its own runtime detection and DAC/cDAC construction.
         /// <para>
-        /// If a runtime with the same <see cref="ClrInfo.ModuleInfo"/> is already registered (for example one
-        /// ClrMD detected), it is replaced; otherwise the runtime is appended to <see cref="ClrVersions"/>. If
-        /// <see cref="ClrVersions"/> has not yet been queried, registering a runtime suppresses automatic
-        /// discovery, so a host that wants full control should register all runtimes before enumerating
-        /// <see cref="ClrVersions"/> (or set <see cref="DataTargetOptions.SkipRuntimeEnumeration"/>).
+        /// If a runtime with the same <see cref="ClrInfo.ModuleInfo"/> is already registered (or is later
+        /// found by ClrMD's own enumeration), the host-registered runtime takes precedence; otherwise it is
+        /// appended to <see cref="ClrVersions"/>. Registering a runtime does NOT by itself suppress ClrMD's
+        /// enumeration — set <see cref="DataTargetOptions.SkipRuntimeEnumeration"/> if the host performs
+        /// complete detection itself and does not want ClrMD to enumerate.
         /// </para>
         /// </summary>
         /// <param name="clrInfo">
@@ -287,19 +288,26 @@ namespace Microsoft.Diagnostics.Runtime
             if (_disposed)
                 throw new ObjectDisposedException(nameof(DataTarget));
 
-            if (!_clrs.IsDefault)
-                return _clrs;
+            if (_enumerated)
+                return _clrs.IsDefault ? ImmutableArray<ClrInfo>.Empty : _clrs;
 
             lock (_clrsLock)
             {
-                if (!_clrs.IsDefault)
-                    return _clrs;
+                if (_enumerated)
+                    return _clrs.IsDefault ? ImmutableArray<ClrInfo>.Empty : _clrs;
+
+                // Runtimes a host registered via AddLoadedRuntime before ClrVersions was first queried. These
+                // take precedence over anything ClrMD's own enumeration finds for the same module.
+                ImmutableArray<ClrInfo> registered = _clrs.IsDefault ? ImmutableArray<ClrInfo>.Empty : _clrs;
 
                 // A host may perform its own complete runtime detection and register runtimes via
-                // AddLoadedRuntime. In that case skip ClrMD's enumeration entirely so we don't pay for it.
+                // AddLoadedRuntime. SkipRuntimeEnumeration lets it skip ClrMD's enumeration entirely so we
+                // don't pay for it. Registering runtimes does NOT by itself suppress enumeration; only this
+                // option does (tracked separately from whether _clrs already has registered entries).
                 if (Options.SkipRuntimeEnumeration)
                 {
-                    _clrs = ImmutableArray<ClrInfo>.Empty;
+                    _enumerated = true;
+                    _clrs = registered;
                     return _clrs;
                 }
 
@@ -340,6 +348,19 @@ namespace Microsoft.Diagnostics.Runtime
                         select clrInfo);
                 }
 
+                // Overlay host-registered runtimes onto ClrMD's (sorted) enumeration: a host registration wins
+                // over an enumerated runtime for the same module (keeping its position), and host-only runtimes
+                // are appended.
+                foreach (ClrInfo host in registered)
+                {
+                    int index = clrs.FindIndex(c => ReferenceEquals(c.ModuleInfo, host.ModuleInfo));
+                    if (index >= 0)
+                        clrs[index] = host;
+                    else
+                        clrs.Add(host);
+                }
+
+                _enumerated = true;
                 _clrs = clrs.ToImmutableArray();
             }
 

--- a/src/Microsoft.Diagnostics.Runtime/DataTarget.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DataTarget.cs
@@ -32,6 +32,7 @@ namespace Microsoft.Diagnostics.Runtime
 
         private bool _disposed;
         private ImmutableArray<ClrInfo> _clrs;
+        private readonly object _clrsLock = new();
         private ModuleInfo[]? _modules;
         private readonly Dictionary<string, PEImage?> _pefileCache = new(StringComparer.OrdinalIgnoreCase);
 
@@ -117,25 +118,32 @@ namespace Microsoft.Diagnostics.Runtime
             if (clrInfo.DataTarget != this)
                 throw new InvalidOperationException("The ClrInfo was created for a different DataTarget.");
 
+            // Use a stable, non-null lock for the host-supplied DAC. When the caller does not provide one we
+            // create a single lock here (not per CreateRuntime) so repeated CreateRuntime calls on this
+            // ClrInfo share it. A host that also drives the DAC itself (e.g. SOS) should pass its own lock so
+            // its calls serialize against ClrMD's.
             clrInfo.ClrDataProcessFactory = createClrDataProcess;
-            clrInfo.DacLock = dacLock;
+            clrInfo.DacLock = dacLock ?? new object();
 
-            ImmutableArray<ClrInfo> current = _clrs.IsDefault ? ImmutableArray<ClrInfo>.Empty : _clrs;
-
-            // A given module maps to a single runtime: if a ClrInfo for the same ModuleInfo is already
-            // registered (e.g. one ClrMD detected, or a prior registration for the same module), replace it
-            // rather than adding a duplicate. ClrVersions is short, so a linear scan is fine.
-            for (int i = 0; i < current.Length; i++)
+            lock (_clrsLock)
             {
-                if (ReferenceEquals(current[i].ModuleInfo, clrInfo.ModuleInfo))
-                {
-                    _clrs = current.SetItem(i, clrInfo);
-                    return clrInfo;
-                }
-            }
+                ImmutableArray<ClrInfo> current = _clrs.IsDefault ? ImmutableArray<ClrInfo>.Empty : _clrs;
 
-            _clrs = current.Add(clrInfo);
-            return clrInfo;
+                // A given module maps to a single runtime: if a ClrInfo for the same ModuleInfo is already
+                // registered (e.g. one ClrMD detected, or a prior registration for the same module), replace it
+                // rather than adding a duplicate. ClrVersions is short, so a linear scan is fine.
+                for (int i = 0; i < current.Length; i++)
+                {
+                    if (ReferenceEquals(current[i].ModuleInfo, clrInfo.ModuleInfo))
+                    {
+                        _clrs = current.SetItem(i, clrInfo);
+                        return clrInfo;
+                    }
+                }
+
+                _clrs = current.Add(clrInfo);
+                return clrInfo;
+            }
         }
 
         /// <summary>
@@ -279,8 +287,14 @@ namespace Microsoft.Diagnostics.Runtime
             if (_disposed)
                 throw new ObjectDisposedException(nameof(DataTarget));
 
-            if (_clrs.IsDefault)
+            if (!_clrs.IsDefault)
+                return _clrs;
+
+            lock (_clrsLock)
             {
+                if (!_clrs.IsDefault)
+                    return _clrs;
+
                 // A host may perform its own complete runtime detection and register runtimes via
                 // AddLoadedRuntime. In that case skip ClrMD's enumeration entirely so we don't pay for it.
                 if (Options.SkipRuntimeEnumeration)

--- a/src/Microsoft.Diagnostics.Runtime/DataTarget.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DataTarget.cs
@@ -68,9 +68,11 @@ namespace Microsoft.Diagnostics.Runtime
         /// by the host, bypassing ClrMD's <see cref="IClrInfoProvider"/> runtime discovery. Use this when the
         /// host (e.g. SOS) performs its own runtime detection and DAC/cDAC construction.
         /// <para>
-        /// The registered runtime is appended to <see cref="ClrVersions"/>. If <see cref="ClrVersions"/> has
-        /// not yet been queried, registering a runtime suppresses automatic discovery, so a host that wants
-        /// full control should register all runtimes before enumerating <see cref="ClrVersions"/>.
+        /// If a runtime with the same <see cref="ClrInfo.ModuleInfo"/> is already registered (for example one
+        /// ClrMD detected), it is replaced; otherwise the runtime is appended to <see cref="ClrVersions"/>. If
+        /// <see cref="ClrVersions"/> has not yet been queried, registering a runtime suppresses automatic
+        /// discovery, so a host that wants full control should register all runtimes before enumerating
+        /// <see cref="ClrVersions"/> (or set <see cref="DataTargetOptions.SkipRuntimeEnumeration"/>).
         /// </para>
         /// </summary>
         /// <param name="clrInfo">
@@ -119,6 +121,19 @@ namespace Microsoft.Diagnostics.Runtime
             clrInfo.DacLock = dacLock;
 
             ImmutableArray<ClrInfo> current = _clrs.IsDefault ? ImmutableArray<ClrInfo>.Empty : _clrs;
+
+            // A given module maps to a single runtime: if a ClrInfo for the same ModuleInfo is already
+            // registered (e.g. one ClrMD detected, or a prior registration for the same module), replace it
+            // rather than adding a duplicate. ClrVersions is short, so a linear scan is fine.
+            for (int i = 0; i < current.Length; i++)
+            {
+                if (ReferenceEquals(current[i].ModuleInfo, clrInfo.ModuleInfo))
+                {
+                    _clrs = current.SetItem(i, clrInfo);
+                    return clrInfo;
+                }
+            }
+
             _clrs = current.Add(clrInfo);
             return clrInfo;
         }
@@ -266,6 +281,14 @@ namespace Microsoft.Diagnostics.Runtime
 
             if (_clrs.IsDefault)
             {
+                // A host may perform its own complete runtime detection and register runtimes via
+                // AddLoadedRuntime. In that case skip ClrMD's enumeration entirely so we don't pay for it.
+                if (Options.SkipRuntimeEnumeration)
+                {
+                    _clrs = ImmutableArray<ClrInfo>.Empty;
+                    return _clrs;
+                }
+
                 IEnumerable<ModuleInfo> modules = EnumerateModules();
                 List<ClrInfo>? clrs = null;
 

--- a/src/Microsoft.Diagnostics.Runtime/DataTarget.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DataTarget.cs
@@ -64,6 +64,66 @@ namespace Microsoft.Diagnostics.Runtime
         }
 
         /// <summary>
+        /// Registers a runtime whose DAC data-access interface (<c>IXCLRDataProcess</c>) is created and owned
+        /// by the host, bypassing ClrMD's <see cref="IClrInfoProvider"/> runtime discovery. Use this when the
+        /// host (e.g. SOS) performs its own runtime detection and DAC/cDAC construction.
+        /// <para>
+        /// The registered runtime is appended to <see cref="ClrVersions"/>. If <see cref="ClrVersions"/> has
+        /// not yet been queried, registering a runtime suppresses automatic discovery, so a host that wants
+        /// full control should register all runtimes before enumerating <see cref="ClrVersions"/>.
+        /// </para>
+        /// </summary>
+        /// <param name="clrInfo">
+        /// A <see cref="ClrInfo"/> created for this <see cref="DataTarget"/> (see
+        /// <see cref="ClrInfo(DataTarget, ModuleInfo, Version)"/>).
+        /// </param>
+        /// <param name="clrDataProcess">A host-owned <c>IXCLRDataProcess</c> pointer for the runtime.</param>
+        /// <param name="dacLock">
+        /// Optional lock serializing DAC calls. Pass the host's lock to serialize the host's own DAC usage
+        /// against ClrMD's (the DAC is not thread-safe). If <see langword="null"/>, ClrMD uses its own lock,
+        /// which only serializes ClrMD's callers.
+        /// </param>
+        /// <returns>The registered <paramref name="clrInfo"/>.</returns>
+        public ClrInfo AddLoadedRuntime(ClrInfo clrInfo, IntPtr clrDataProcess, object? dacLock = null)
+        {
+            if (clrDataProcess == IntPtr.Zero)
+                throw new ArgumentNullException(nameof(clrDataProcess));
+
+            return AddLoadedRuntime(clrInfo, () => clrDataProcess, dacLock);
+        }
+
+        /// <summary>
+        /// Registers a runtime whose DAC data-access interface (<c>IXCLRDataProcess</c>) is created lazily and
+        /// owned by the host. See <see cref="AddLoadedRuntime(ClrInfo, IntPtr, object?)"/> for details. The
+        /// factory is invoked the first time a runtime is created from <paramref name="clrInfo"/>.
+        /// </summary>
+        /// <param name="clrInfo">A <see cref="ClrInfo"/> created for this <see cref="DataTarget"/>.</param>
+        /// <param name="createClrDataProcess">
+        /// A factory returning a host-owned <c>IXCLRDataProcess</c> pointer. The host retains ownership; ClrMD
+        /// adds and releases its own reference and does not unload the underlying DAC module.
+        /// </param>
+        /// <param name="dacLock">Optional lock serializing DAC calls; see the other overload.</param>
+        /// <returns>The registered <paramref name="clrInfo"/>.</returns>
+        public ClrInfo AddLoadedRuntime(ClrInfo clrInfo, Func<IntPtr> createClrDataProcess, object? dacLock = null)
+        {
+            if (_disposed)
+                throw new ObjectDisposedException(nameof(DataTarget));
+            if (clrInfo is null)
+                throw new ArgumentNullException(nameof(clrInfo));
+            if (createClrDataProcess is null)
+                throw new ArgumentNullException(nameof(createClrDataProcess));
+            if (clrInfo.DataTarget != this)
+                throw new InvalidOperationException("The ClrInfo was created for a different DataTarget.");
+
+            clrInfo.ClrDataProcessFactory = createClrDataProcess;
+            clrInfo.DacLock = dacLock;
+
+            ImmutableArray<ClrInfo> current = _clrs.IsDefault ? ImmutableArray<ClrInfo>.Empty : _clrs;
+            _clrs = current.Add(clrInfo);
+            return clrInfo;
+        }
+
+        /// <summary>
         /// The options set for this data target.
         /// </summary>
         public DataTargetOptions Options { get; } = _options ?? new DataTargetOptions();

--- a/src/Microsoft.Diagnostics.Runtime/DataTargetOptions.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DataTargetOptions.cs
@@ -71,6 +71,14 @@ public class DataTargetOptions
     public bool ForceCompleteRuntimeEnumeration { get; set; }
 
     /// <summary>
+    /// If true, ClrMD performs no runtime enumeration at all and <see cref="DataTarget.ClrVersions"/> will be
+    /// empty unless runtimes are registered explicitly via <see cref="DataTarget.AddLoadedRuntime(ClrInfo, System.IntPtr, object)"/>.
+    /// Set this when a host performs its own complete runtime detection and does not want to pay the cost of
+    /// ClrMD's discovery. Defaults to false.
+    /// </summary>
+    public bool SkipRuntimeEnumeration { get; set; }
+
+    /// <summary>
     /// The TokenCredential to use for any Azure based symbol servers (set to null if not using one).
     /// </summary>
     public TokenCredential? SymbolTokenCredential { get; set; }

--- a/src/Microsoft.Diagnostics.Runtime/DbgEng/DebugAdvanced.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DbgEng/DebugAdvanced.cs
@@ -12,8 +12,8 @@ namespace Microsoft.Diagnostics.Runtime.DbgEng
     {
         internal static readonly Guid IID_IDebugAdvanced = new("f2df5f53-071f-47bd-9de6-5734c3fed689");
 
-        public DebugAdvanced(RefCountedFreeLibrary library, IntPtr pUnk, DebugSystemObjects sys)
-            : base(library, IID_IDebugAdvanced, pUnk)
+        public DebugAdvanced(IntPtr pUnk, DebugSystemObjects sys)
+            : base(IID_IDebugAdvanced, pUnk)
         {
             _sys = sys;
             SuppressRelease();

--- a/src/Microsoft.Diagnostics.Runtime/DbgEng/DebugClient.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DbgEng/DebugClient.cs
@@ -14,8 +14,8 @@ namespace Microsoft.Diagnostics.Runtime.DbgEng
 
         private readonly DebugSystemObjects _sys;
 
-        public DebugClient(RefCountedFreeLibrary library, IntPtr pUnk, DebugSystemObjects system)
-            : base(library, IID_IDebugClient, pUnk)
+        public DebugClient(IntPtr pUnk, DebugSystemObjects system)
+            : base(IID_IDebugClient, pUnk)
         {
             _sys = system;
             SuppressRelease();

--- a/src/Microsoft.Diagnostics.Runtime/DbgEng/DebugControl.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DbgEng/DebugControl.cs
@@ -16,8 +16,8 @@ namespace Microsoft.Diagnostics.Runtime.DbgEng
 
         private readonly DebugSystemObjects _sys;
 
-        public DebugControl(RefCountedFreeLibrary library, IntPtr pUnk, DebugSystemObjects sys)
-            : base(library, IID_IDebugControl2, pUnk)
+        public DebugControl(IntPtr pUnk, DebugSystemObjects sys)
+            : base(IID_IDebugControl2, pUnk)
         {
             _sys = sys;
             SuppressRelease();

--- a/src/Microsoft.Diagnostics.Runtime/DbgEng/DebugDataSpaces.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DbgEng/DebugDataSpaces.cs
@@ -12,8 +12,8 @@ namespace Microsoft.Diagnostics.Runtime.DbgEng
     {
         internal static readonly Guid IID_IDebugDataSpaces2 = new("7a5e852f-96e9-468f-ac1b-0b3addc4a049");
 
-        public DebugDataSpaces(RefCountedFreeLibrary library, IntPtr pUnk, DebugSystemObjects sys)
-            : base(library, IID_IDebugDataSpaces2, pUnk)
+        public DebugDataSpaces(IntPtr pUnk, DebugSystemObjects sys)
+            : base(IID_IDebugDataSpaces2, pUnk)
         {
             _sys = sys;
             SuppressRelease();

--- a/src/Microsoft.Diagnostics.Runtime/DbgEng/DebugSymbols.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DbgEng/DebugSymbols.cs
@@ -13,8 +13,8 @@ namespace Microsoft.Diagnostics.Runtime.DbgEng
     {
         internal static readonly Guid IID_IDebugSymbols3 = new("f02fbecc-50ac-4f36-9ad9-c975e8f32ff8");
 
-        public DebugSymbols(RefCountedFreeLibrary library, IntPtr pUnk, DebugSystemObjects sys)
-            : base(library, IID_IDebugSymbols3, pUnk)
+        public DebugSymbols(IntPtr pUnk, DebugSystemObjects sys)
+            : base(IID_IDebugSymbols3, pUnk)
         {
             _sys = sys;
             SuppressRelease();

--- a/src/Microsoft.Diagnostics.Runtime/DbgEng/DebugSystemObjects.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DbgEng/DebugSystemObjects.cs
@@ -13,8 +13,8 @@ namespace Microsoft.Diagnostics.Runtime.DbgEng
     {
         internal static readonly Guid IID_DebugSystemObjects3 = new("e9676e2f-e286-4ea3-b0f9-dfe5d9fc330e");
 
-        public DebugSystemObjects(RefCountedFreeLibrary library, IntPtr pUnk)
-            : base(library, IID_DebugSystemObjects3, pUnk)
+        public DebugSystemObjects(IntPtr pUnk)
+            : base(IID_DebugSystemObjects3, pUnk)
         {
             SuppressRelease();
         }

--- a/src/Microsoft.Diagnostics.Runtime/IClrInfoProvider.cs
+++ b/src/Microsoft.Diagnostics.Runtime/IClrInfoProvider.cs
@@ -1,9 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using Microsoft.Diagnostics.Runtime.AbstractDac;
-
 namespace Microsoft.Diagnostics.Runtime
 {
     public interface IClrInfoProvider
@@ -15,17 +12,5 @@ namespace Microsoft.Diagnostics.Runtime
         /// <param name="module">The module to inspect.</param>
         /// <returns>A ClrInfo if module is a CLR runtime, null otherwise.</returns>
         ClrInfo? ProvideClrInfoForModule(DataTarget dataTarget, ModuleInfo module);
-
-        /// <summary>
-        /// Creates an instance of an <see cref="IServiceProvider"/> for the given <see cref="ClrInfo"/>.
-        /// Note that this will only be called on the interface which previously provided the given ClrInfo.
-        /// </summary>
-        /// <param name="clrInfo">A ClrInfo previously returned by this same instance.</param>
-        /// <param name="providedPath">The path provided to DataTarget.CreateRuntime.</param>
-        /// <param name="ignorePathMismatch">The ignore mismatch parameter provided to DataTarget.CreateRuntime.</param>
-        /// <param name="verifySignature">If true, verify the DAC signature</param>
-        /// <returns>An <see cref="IServiceProvider"/> interface to use with the specified clr runtime that provides
-        /// <see cref="IAbstractRuntime"/> related services.</returns>
-        IServiceProvider GetDacServices(ClrInfo clrInfo, string? providedPath, bool ignorePathMismatch, bool verifySignature);
     }
 }

--- a/src/Microsoft.Diagnostics.Runtime/Implementation/DotNetClrInfoProvider.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Implementation/DotNetClrInfoProvider.cs
@@ -8,8 +8,6 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
-using Microsoft.Diagnostics.Runtime.AbstractDac;
-using Microsoft.Diagnostics.Runtime.DacImplementation;
 using Microsoft.Diagnostics.Runtime.Utilities;
 
 namespace Microsoft.Diagnostics.Runtime.Implementation
@@ -40,95 +38,6 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
         private const string c_cdacContractDescriptorExport = "DotNetRuntimeContractDescriptor";
 
         private static readonly string s_defaultAssembliesPath = AppContext.BaseDirectory;
-
-        public IServiceProvider GetDacServices(ClrInfo clrInfo, string? providedPath, bool ignoreMismatch, bool verifySignature)
-        {
-            DacLibrary library = GetDacLibraryFromPath(clrInfo, providedPath, ignoreMismatch, verifySignature);
-            return new DacServiceProvider(clrInfo, library);
-        }
-
-        private static DacLibrary GetDacLibraryFromPath(ClrInfo clrInfo, string? dacPath, bool ignoreMismatch, bool verifySignature)
-        {
-            if (dacPath is not null)
-                return CreateDacFromPath(clrInfo, dacPath, ignoreMismatch, verifySignature);
-
-            OSPlatform currentPlatform = GetCurrentPlatform();
-            Architecture currentArch = RuntimeInformation.ProcessArchitecture;
-            Exception? exception = null;
-            bool foundOne = false;
-
-            IFileLocator? locator = clrInfo.DataTarget.FileLocator;
-
-            foreach (DebugLibraryInfo dac in clrInfo.DebuggingLibraries.Where(r => r.Kind == DebugLibraryKind.Dac && r.Platform == currentPlatform && r.TargetArchitecture == currentArch))
-            {
-                foundOne = true;
-
-                // If we have a full path, use it.  We already validated that the CLR matches.
-                if (Path.GetFileName(dac.FileName) != dac.FileName)
-                {
-                    dacPath = dac.FileName;
-                }
-                else
-                {
-                    // The properties we are requesting under may not be the actual file properties, so don't request them.
-
-                    if (locator != null)
-                    {
-                        if (!dac.IndexBuildId.IsDefaultOrEmpty)
-                        {
-                            dacPath = locator.FindPEImage(dac.FileName, SymbolProperties.Coreclr, dac.IndexBuildId, clrInfo.DataTarget.DataReader.TargetPlatform, checkProperties: false);
-                        }
-                        else if (dac.IndexTimeStamp != 0 && dac.IndexFileSize != 0)
-                        {
-                            if (dac.Platform == OSPlatform.Windows)
-                                dacPath = clrInfo.DataTarget.FileLocator?.FindPEImage(dac.FileName, dac.IndexTimeStamp, dac.IndexFileSize, checkProperties: false);
-                        }
-                    }
-                }
-
-                if (dacPath is not null && File.Exists(dacPath))
-                {
-                    try
-                    {
-                        // If we get the file from the symbol server, assume mismatches are expected.  Sometimes we replace dacs on the symbol
-                        // server to fix bugs.  If it's archived under the right path, use it.
-                        return CreateDacFromPath(clrInfo, dacPath, ignoreMismatch: true, verifySignature);
-                    }
-                    catch (Exception ex)
-                    {
-                        exception ??= ex;
-                        dacPath = null;
-                    }
-                }
-            }
-
-            if (exception is not null)
-                throw exception;
-
-            // We should have had at least one dac enumerated if this is a supported scenario.
-            if (!foundOne)
-                throw new InvalidOperationException($"Debugging a '{clrInfo.DataTarget.DataReader.TargetPlatform}' crash is not supported on '{currentPlatform}'.");
-
-            if (currentPlatform == OSPlatform.Windows)
-                throw new FileNotFoundException("Could not find matching DAC for this runtime.");
-
-            throw new FileNotFoundException("Could not find matching DAC for this runtime.  Note that symbol server download of the DAC is disabled for this platform.");
-        }
-
-        private static DacLibrary CreateDacFromPath(ClrInfo clrInfo, string dacPath, bool ignoreMismatch, bool verifySignature)
-        {
-            if (!File.Exists(dacPath))
-                throw new FileNotFoundException(dacPath);
-
-            if (!ignoreMismatch && !clrInfo.IsSingleFile)
-            {
-                DataTarget.PlatformFunctions.GetFileVersion(dacPath, out int major, out int minor, out int revision, out int patch);
-                if (major != clrInfo.Version.Major || minor != clrInfo.Version.Minor || revision != clrInfo.Version.Build || patch != clrInfo.Version.Revision)
-                    throw new ClrDiagnosticsException($"Mismatched dac. Dac version: {major}.{minor}.{revision}.{patch}, expected: {clrInfo.Version}.");
-            }
-
-            return new(clrInfo.DataTarget, dacPath, clrInfo.ModuleInfo.ImageBase, clrInfo.ContractDescriptorAddress, verifySignature);
-        }
 
         public virtual ClrInfo? ProvideClrInfoForModule(DataTarget dataTarget, ModuleInfo module)
         {
@@ -355,7 +264,7 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
                                                                                  artifact.ArchivedUnder
                                                                          select artifact;
 
-            ClrInfo result = new(dataTarget, module, version, this)
+            ClrInfo result = new(dataTarget, module, version)
             {
                 Flavor = flavor,
                 DebuggingLibraries = orderedDebugLibraries.ToImmutableArray(),
@@ -493,7 +402,7 @@ namespace Microsoft.Diagnostics.Runtime.Implementation
             return false;
         }
 
-        private static OSPlatform GetCurrentPlatform()
+        internal static OSPlatform GetCurrentPlatform()
         {
             OSPlatform currentPlatform;
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))

--- a/src/Microsoft.Diagnostics.Runtime/Utilities/COMInterop/CallableComWrapper.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Utilities/COMInterop/CallableComWrapper.cs
@@ -14,6 +14,13 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
         protected IntPtr Self { get; }
         private readonly IUnknownVTable* _unknownVTable;
 
+        /// <summary>
+        /// Returns the underlying COM interface pointer without adding a reference. The caller must ensure
+        /// this wrapper (and thus its reference) outlives any use of the returned pointer, or add its own
+        /// reference first. Intended for interop hand-off scenarios.
+        /// </summary>
+        internal IntPtr DangerousGetHandle() => Self;
+
         public RefCountedFreeLibrary? Library { get; }
 
         protected void* _vtable => _unknownVTable + 1;

--- a/src/Microsoft.Diagnostics.Runtime/Utilities/COMInterop/CallableComWrapper.cs
+++ b/src/Microsoft.Diagnostics.Runtime/Utilities/COMInterop/CallableComWrapper.cs
@@ -21,8 +21,6 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
         /// </summary>
         internal IntPtr DangerousGetHandle() => Self;
 
-        public RefCountedFreeLibrary? Library { get; }
-
         protected void* _vtable => _unknownVTable + 1;
 
         protected CallableCOMWrapper(CallableCOMWrapper toClone)
@@ -35,10 +33,8 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
 
             Self = toClone.Self;
             _unknownVTable = toClone._unknownVTable;
-            Library = toClone.Library;
 
             AddRef();
-            Library?.AddRef();
         }
 
         public int AddRef()
@@ -53,11 +49,8 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
             GC.SuppressFinalize(this);
         }
 
-        protected CallableCOMWrapper(RefCountedFreeLibrary? library, in Guid desiredInterface, IntPtr pUnknown)
+        protected CallableCOMWrapper(in Guid desiredInterface, IntPtr pUnknown)
         {
-            Library = library;
-            Library?.AddRef();
-
             IUnknownVTable* tbl = *(IUnknownVTable**)pUnknown;
 
             int hr = tbl->QueryInterface(pUnknown, desiredInterface, out IntPtr pCorrectUnknown);
@@ -93,15 +86,21 @@ namespace Microsoft.Diagnostics.Runtime.Utilities
                     Release();
                 }
 
-                Library?.Release();
                 _disposed = true;
             }
         }
 
+#if DEBUG
+        // COM wrappers must be deterministically disposed. Their lifetime (and, for DAC wrappers, the DAC
+        // module that backs them) is owned by ClrRuntime/DataTarget, not by these wrappers. A finalized
+        // wrapper therefore indicates a missing Dispose. We intentionally do NOT release the COM interface
+        // here: there is no finalizer in release builds, and releasing after the backing module may already
+        // have been unloaded would call into freed code. This assert exists purely to catch leaks in debug.
         ~CallableCOMWrapper()
         {
-            Dispose(false);
+            Debug.Fail($"{GetType().FullName} was not disposed. COM wrappers must be disposed.");
         }
+#endif
 
         public void Dispose()
         {


### PR DESCRIPTION
This pull request introduces several improvements and refactorings to the ClrMD runtime detection and hosting APIs, with a focus on supporting host-supplied runtimes (such as those provided by SOS), improving test coverage, and simplifying some internal code paths. The most important changes are outlined below.

### Host-supplied runtime support and API improvements

* Refactored the `ClrInfo` class to support construction for host-supplied runtimes, allowing external hosts to provide their own `IXCLRDataProcess` and DAC lock, rather than relying solely on ClrMD's runtime detection and DAC loading. This includes adding the `ClrDataProcessFactory` and `DacLock` properties and updating runtime creation logic to use them when present. [[1]](diffhunk://#diff-d20c4b4919b941f0a7d621a219758f49e518a4f54ff208d92be2a2dad9eec872L18-L25) [[2]](diffhunk://#diff-d20c4b4919b941f0a7d621a219758f49e518a4f54ff208d92be2a2dad9eec872L35-R51) [[3]](diffhunk://#diff-d20c4b4919b941f0a7d621a219758f49e518a4f54ff208d92be2a2dad9eec872L136-R167)
* Added a new overload and logic in `DacServiceProvider` to support host-owned `IXCLRDataProcess` pointers, ensuring proper reference counting and lock sharing for thread safety.

### Test coverage enhancements

* Added comprehensive tests in `DataTargetTests.cs` to verify that host-supplied runtimes are correctly registered and replace existing entries, and that heap enumeration matches between normal and host-supplied runtimes.

### Internal refactoring and simplification

* Moved thin lock layout selection from `DacHeap` constructor arguments to `TargetProperties`, simplifying the interface and centralizing layout logic. [[1]](diffhunk://#diff-e09f7c4b751b82dc8e8204ad82dc3cbaee071db76e792c595524dbbbbead91a8L25) [[2]](diffhunk://#diff-e09f7c4b751b82dc8e8204ad82dc3cbaee071db76e792c595524dbbbbead91a8L37-L52) [[3]](diffhunk://#diff-82a4c07b77d2d6c3e474865ae60aeafe3c67d657258b5dcb47de667ae1385849R47-R79) [[4]](diffhunk://#diff-e09f7c4b751b82dc8e8204ad82dc3cbaee071db76e792c595524dbbbbead91a8L422-R413)
* Split DAC library resolution into dedicated methods (`GetDacLibraryFromPath` and `CreateDacFromPath`) in `ClrInfo` for improved readability and maintainability.

### Minor fixes and code cleanup

* Updated several wrapper and helper classes to remove unnecessary parameters and streamline initialization, such as in `ClrSymbolProviderWrapper` and `ClrModuleInfo`. [[1]](diffhunk://#diff-6ca97a50da6a27fc15163adeb9d66285c1842126f0790a7133fa42842cd7d060L385-R385) [[2]](diffhunk://#diff-3726d4f78343971ad380edb6888be9676f895ed6e1c34b12ec7b58cc30a723ccL106-R106)
* Ensured proper disposal order in test helper `Scope.Dispose` to avoid resource leaks.

These changes collectively improve ClrMD's flexibility for advanced hosting scenarios, increase test reliability, and simplify internal APIs.