### PR TITLE
fix(macos): int overflow when loading large segments

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/MacOS/MachOCoreDump.cs
+++ b/src/Microsoft.Diagnostics.Runtime/MacOS/MachOCoreDump.cs
@@ -223,7 +223,7 @@ namespace Microsoft.Diagnostics.Runtime.MacOS
             while (buffer.Length > 0 && FindSegmentContaining(address, out MachOSegment seg))
             {
                 ulong offset = address - seg.Address;
-                int len = Math.Min(buffer.Length, (int)(seg.Size - offset));
+                int len = (int)Math.Min((ulong)buffer.Length, seg.Size - offset);
                 if (len == 0)
                     break;
 


### PR DESCRIPTION
Fixes an integer overflow in `ReadMemory` caused by loading a dupm over ~2GB on MacOS platforms.

```
System.ArgumentOutOfRangeException: Specified argument was out of the range of valid values.
   at Microsoft.Diagnostics.Runtime.MacOS.MachOCoreDump.ReadMemory(UInt64 address, Span`1 buffer)
   at Microsoft.Diagnostics.Runtime.MacOS.MachOCoreReader.Read(UInt64 address, Span`1 buffer)
   at Microsoft.Diagnostics.Runtime.DacInterface.DacDataTarget.ReadVirtual(ClrDataAddress cda, IntPtr buffer, Int32 bytesRequested, Int32& bytesRead)
   at Microsoft.Diagnostics.Runtime.DacInterface.DacDataTargetCOM.IDacDataTargetVtbl.ReadVirtual(IntPtr self, UInt64 address, IntPtr buffer, Int32 bytesRequested, Int32* pBytesRead)
```