### PR TITLE
Don't dlclose the legacy DAC on non-Windows

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/DacLibrary.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacLibrary.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
 using Microsoft.Diagnostics.Runtime.DacInterface;
@@ -90,23 +89,18 @@ namespace Microsoft.Diagnostics.Runtime
                 fileLock?.Dispose();
             }
 
-            // On non-Windows platforms, calling dlclose on the DAC library can crash the process
-            // when inspecting the current process.  The DAC (libmscordaccore.so) shares internal
-            // state with the running CLR (libcoreclr.so), and unloading it corrupts that state.
-            // Suppress FreeLibrary when the target is the current process to avoid this.
+            // On non-Windows platforms, calling dlclose on the DAC library can crash the process.
+            // The DAC embeds a copy of the PAL, whose TLSInitialize() registers a pthread key
+            // with the thread-exit destructor InternalEndCurrentThreadWrapper.
+            // Once the library is unloaded with dlclose that destructor code is unmapped, but the
+            // pthread key is not removed. When any thread that entered theDAC's PAL later exits,
+            // glibc invokes the now-dangling destructor and the process crashes with SIGSEGV inside
+            // __nptl_deallocate_tsd.
             //
             // The cDAC (mscordaccore_universal) is a NativeAOT library that cannot be safely
             // unloaded on any platform, so never free it either.
-#if NET6_0_OR_GREATER
-            int currentPid = Environment.ProcessId;
-#else
-            int currentPid;
-            using (Process p = Process.GetCurrentProcess())
-                currentPid = p.Id;
-#endif
             bool suppressFree = DotNetClrInfoProvider.IsCDacFileName(dacPath)
-                                || (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-                                    && dataTarget.DataReader.ProcessId == currentPid);
+                                || !RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
             OwningLibrary = new RefCountedFreeLibrary(dacLibrary, suppressFree);
 
             IntPtr initAddr = DataTarget.PlatformFunctions.GetLibraryExport(dacLibrary, "DAC_PAL_InitializeDLL");


### PR DESCRIPTION
Intermittent (~15-20%) SIGSEGV in the test host on Linux, surfacing as `Test host process crashed` / aborted runs rather than test failures. Faulting thread:

```
#6  0x...21edc0 in ?? ()
#7  __GI___nptl_deallocate_tsd () at nptl_deallocate_tsd.c:73
#8  start_thread
```

The DAC embeds the PAL. ClrMD brings the PAL up by calling the DAC's exported `DllMain`, which initializes TLS, registering a pthread key with a destructor in the DAC. That destructor pointer lives in glibc's per-thread key table, not in the DAC. `RefCountedFreeLibrary.Release` `dlclose`s the DAC on `DataTarget` dispose, but the pthread key is never deleted. Any host thread that entered the DAC's PAL and later exits jumps into the now-unmapped destructor from `__nptl_deallocate_tsd`.

The existing suppression only covered inspecting the current process, so dump-file targets still unloaded the DAC.

### Why not tear the PAL down instead of leaking?
There is no in-process, reversible PAL teardown to call before `dlclose`:

- The DAC's own `DllMain(DLL_PROCESS_DETACH)` does not touch the PAL - it only destroys the dac mutex (`daccess.cpp` `DllMain2`). It never deletes the pthread key.
- `pthread_key_delete` only runs via `TLSCleanup`, which is reachable only on PAL init-failure unwind or the process-terminate path.
- The only public teardown entrypoint, `PAL_TerminateEx`, ends in `exit(exitCode)` - it shuts down and exits the whole process. Its sole caller is `createdump`, which is exiting anyway and passes an exit code. A long-lived host that uses ClrMD cannot call it.

### Fix
Never free the DAC on non-Windows so the destructor remains mapped. Effectively leaks one mapping per unique DAC path.

### Validation
Root cause proven by logging the DAC base + `addr2line` on the fault offset -> `InternalEndCurrentThreadWrapper`.
