### PR TITLE
Fix thin-lock layout selection for non-desktop runtimes

### DIFF
--- a/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacHeap.cs
+++ b/src/Microsoft.Diagnostics.Runtime/DacImplementation/DacHeap.cs
@@ -452,7 +452,7 @@ namespace Microsoft.Diagnostics.Runtime.DacImplementation
 
         internal static ThinLockLayout GetThinLockLayout(ClrFlavor flavor, Version version)
         {
-            if (flavor != ClrFlavor.Core)
+            if (flavor == ClrFlavor.Desktop)
                 return ThinLockLayout.Legacy;
 
             return version.Major switch


### PR DESCRIPTION
## Summary

Restrict the legacy thin-lock layout to the desktop CLR flavor.

Previously, every flavor other than Core CLR used the legacy layout. This caused other runtime flavors to decode thin-lock owner and recursion fields using the wrong bit layout.

Non-desktop flavors now select their layout based on the runtime version, matching Core CLR behavior.